### PR TITLE
ProcControl and Symtab support for ppc64le

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ CHANGELOG
 massif.out.*
 DyninstAPI*.tgz
 common/h/version.h
+Doxyfile
+doxyfiles/*

--- a/cmake/cap_arch_def.cmake
+++ b/cmake/cap_arch_def.cmake
@@ -41,16 +41,19 @@ set (CAP_DEFINES ${CAP_DEFINES}
     )
 
 elseif (PLATFORM MATCHES ppc64)
-set (ARCH_DEFINES -Darch_power -Darch_64bit)
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
-set (CAP_DEFINES ${CAP_DEFINES} 
-             -Dcap_32_64
-             -Dcap_registers
-             -Dcap_toc_64
-        -Darch_ppc_little_endian
-
-    )
+   set (ARCH_DEFINES -Darch_power -Darch_64bit)
+   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
+   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
+   set (CAP_DEFINES ${CAP_DEFINES} 
+                -Dcap_32_64
+                -Dcap_registers
+                -Dcap_toc_64
+       )
+   if (SYSPLATFORM MATCHES ppc64le)
+      set (CAP_DEFINES ${CAP_DEFINES} 
+              -Darch_ppc_little_endian
+          )
+   endif (SYSPLATFORM MATCHES ppc64le)
 elseif (PLATFORM MATCHES aarch64)
   #set (ARCH_DEFINES -Daarch_64 -Darch_64bit)
   set (ARCH_DEFINES -Darch_aarch64 -Darch_64bit)

--- a/cmake/platform_unix.cmake
+++ b/cmake/platform_unix.cmake
@@ -21,11 +21,11 @@ list (FIND VALID_PLATFORMS ${PLATFORM} PLATFORM_FOUND)
 endif()
 
 
+execute_process (COMMAND ${DYNINST_ROOT}/scripts/sysname OUTPUT_VARIABLE SYSNAME_OUT)
+string(REPLACE "\n" "" SYSPLATFORM ${SYSNAME_OUT})
+
 if (INVALID_PLATFORM)
 # Try to set it automatically
-execute_process (COMMAND ${DYNINST_ROOT}/scripts/sysname
-                 OUTPUT_VARIABLE SYSNAME_OUT
-                 )
 execute_process (COMMAND ${DYNINST_ROOT}/scripts/dynsysname ${SYSNAME_OUT}
                  OUTPUT_VARIABLE DYNSYSNAME_OUT
                  )

--- a/common/h/SymReader.h
+++ b/common/h/SymReader.h
@@ -89,7 +89,7 @@ class COMMON_EXPORT SymReader
    virtual Symbol_t getContainingSymbol(Dyninst::Offset offset) = 0;
    virtual std::string getInterpreterName() = 0;
    virtual unsigned getAddressWidth() = 0;
-   virtual int getABIVersion() const = 0;
+   virtual bool getABIVersion(int &major, int &minor) const = 0;
    virtual bool isBigEndianDataEncoding() const = 0;
    
    virtual unsigned numSegments() = 0;

--- a/common/h/SymReader.h
+++ b/common/h/SymReader.h
@@ -89,6 +89,8 @@ class COMMON_EXPORT SymReader
    virtual Symbol_t getContainingSymbol(Dyninst::Offset offset) = 0;
    virtual std::string getInterpreterName() = 0;
    virtual unsigned getAddressWidth() = 0;
+   virtual int getABIVersion() const = 0;
+   virtual bool isBigEndianDataEncoding() const = 0;
    
    virtual unsigned numSegments() = 0;
    virtual bool getSegment(unsigned num, SymSegment &reg) = 0; 

--- a/common/src/arch-power.h
+++ b/common/src/arch-power.h
@@ -656,8 +656,9 @@ typedef unsigned codeBufIndex_t;
 // xlform
 #define MTLR0raw       0x7c0803a6      /* move from link reg -- mtlw r0 */
 #define MFLR0raw       0x7c0802a6      /* move from link reg -- mflr r0 */
-#define MTLR2raw       0x7c4803a6	/* move from link reg -- mtlr r2 */
-#define MFLR2raw       0x7c4802a6	/* move from link reg -- mflr r2 */
+#define MTLR2raw       0x7c4803a6      /* move from link reg -- mtlr r2 */
+#define MFLR2raw       0x7c4802a6      /* move from link reg -- mflr r2 */
+#define MR12CTR        0x7d8903a6      /* move from r12 to CTR */
 #define BCTRraw        0x4e800420      /* bctr instrunction */
 #define BCTRLraw       0x4e800421      /* bctrl instrunction */
 #define BRraw          0x4e800020      /* br instruction */

--- a/common/src/sha1.C
+++ b/common/src/sha1.C
@@ -123,6 +123,7 @@ void SHA1Final(unsigned char digest[20], SHA1_CTX* context);
 
 /* blk0() and blk() perform the initial expand. */
 /* I got the idea of expanding during the round function from SSLeay */
+/* TODOMJM - Need to determine is this is used by proccontrol, symtab, and/or stackwalk */
 #if defined(arch_power) //Big Endian
 #define blk0(i) block->l[i]
 #else

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -41,9 +41,6 @@
 
 extern int dyn_debug_ast;
 
-extern template class boost::shared_ptr<Dyninst::PatchAPI::Snippet>;
-extern template class boost::shared_ptr<Dyninst::AST>;
-
 #include "Instruction.h"
 using namespace Dyninst::InstructionAPI;
 

--- a/dyninstAPI/src/dynProcess.C
+++ b/dyninstAPI/src/dynProcess.C
@@ -62,9 +62,6 @@ using std::vector;
 using std::string;
 using std::stringstream;
 
-extern template class boost::shared_ptr<Dyninst::ProcControlAPI::Process>;
-extern template class boost::shared_ptr<Dyninst::ProcControlAPI::Thread>;
-
 Dyninst::SymtabAPI::SymtabReaderFactory *PCProcess::symReaderFactory_;
 
 PCProcess *PCProcess::createProcess(const string file, pdvector<string> &argv,

--- a/dyninstAPI_RT/src/RTthread-power-asm.s
+++ b/dyninstAPI_RT/src/RTthread-power-asm.s
@@ -2,21 +2,6 @@
 #include "../../dyninstAPI/src/inst-power.h"
    .machine "push"      
    .machine "ppc"       
-   .globl   DYNINSTthreadIndexFAST
-   .globl   .DYNINSTthreadIndexFAST
-DYNINSTthreadIndexFAST:
-.DYNINSTthreadIndexFAST:
-   mr       3,12
-   br
-   .globl   compare_and_swap2
-   .globl   .compare_and_swap2
-compare_and_swap2:
-.compare_and_swap2:
-   lwarx    5,0,3
-   stwcx.   4,0,3
-   bne-     compare_and_swap2
-   mr       3,5
-   blr
    .machine "pop"
 
 .section .note.GNU-stack,"",@progbits

--- a/dyninstAPI_RT/src/RTthread-powerpc-asm.S
+++ b/dyninstAPI_RT/src/RTthread-powerpc-asm.S
@@ -1,44 +1,14 @@
    .file    "RTthread-powerpc-asm.S"
    .machine "push"      
+#if defined(arch_ppc_little_endian)
+   .abiversion 2
+#endif
+
 #if defined(arch_64bit)
    .machine "ppc64"       
 #else
    .machine "ppc"       
 #endif
-
-
-   .section ".text"
-   .align   2
-# /* ---------------------------------- */
-# /* unsigned DYNINSTthreadIndexFAST(); */
-# /* ---------------------------------- */
-#if defined(arch_64bit)
-   .globl   DYNINSTthreadIndexFAST
-   .section ".opd", "aw"
-   .align   3
-DYNINSTthreadIndexFAST:
-   .quad    .DYNINSTthreadIndexFAST, .TOC.@tocbase, 0
-   .size    DYNINSTthreadIndexFAST, 24
-
-   .previous
-   .globl   .DYNINSTthreadIndexFAST
-   .type    .DYNINSTthreadIndexFAST, @function
-.DYNINSTthreadIndexFAST:
-#else
-   .globl   DYNINSTthreadIndexFAST
-   .type    DYNINSTthreadIndexFAST, @function
-DYNINSTthreadIndexFAST:
-#endif
-
-   mr       3,12    # function return value = r3 = r12
-   blr              # branch via link register (function return)
-
-#if defined(arch_64bit)
-   .size    .DYNINSTthreadIndexFAST, . - .DYNINSTthreadIndexFAST
-#else
-   .size    DYNINSTthreadIndexFAST, . - DYNINSTthreadIndexFAST
-#endif
-
 
    .section ".text"
    .align   2
@@ -51,7 +21,15 @@ DYNINSTthreadIndexFAST:
 # /* Return 1 if such an atomic update occurred; */
 # /* return 0 otherwise.                         */
 # /* ------------------------------------------- */
-#if defined(arch_64bit)
+#if defined(arch_ppc_little_endian)
+   .section ".toc", "aw"
+   .section ".text"
+   .align   2
+   .p2align 4,,15
+   .globl   atomic_set
+   .type    atomic_set, @function
+atomic_set:
+#elif defined(arch_64bit)
    .globl   atomic_set
    .section ".opd", "aw"
    .align   3
@@ -84,7 +62,9 @@ atomic_set_return_0:
    addi     3,0,0               # function return value = r3 = 0
    blr                          # branch via link register (function return)
 
-#if defined(arch_64bit)
+#if defined(arch_ppc_little_endian)
+   .size    atomic_set, . - atomic_set
+#elif defined(arch_64bit)
    .size    .atomic_set, . - .atomic_set
 #else
    .size    atomic_set, . - atomic_set

--- a/dyninstAPI_RT/src/RTthread-x86.c
+++ b/dyninstAPI_RT/src/RTthread-x86.c
@@ -81,7 +81,3 @@ int tc_lock_lock(tc_lock_t *tc)
    tc->tid = me;
    return 0;
 }
-
-unsigned DYNINSTthreadIndexFAST() {
-   return 0;
-}

--- a/elf/src/Elf_X.C
+++ b/elf/src/Elf_X.C
@@ -138,7 +138,7 @@ Elf_X::Elf_X(int input, Elf_Cmd cmd, Elf_X *ref)
        if (elf_kind(elf) == ELF_K_ELF) {
           char *identp = elf_getident(elf, NULL);
           is64 = (identp && identp[EI_CLASS] == ELFCLASS64);
-           isBigEndian = (identp && identp[EI_DATA] == ELFDATA2MSB);
+          isBigEndian = (identp && identp[EI_DATA] == ELFDATA2MSB);
        }
        else if(elf_kind(elf) == ELF_K_AR) {
           char *identp = elf_getident(elf, NULL);

--- a/proccontrol/src/linux.h
+++ b/proccontrol/src/linux.h
@@ -156,7 +156,7 @@ class linux_process : public sysv_process, public unix_process, public thread_db
                                       MemUsageResp_t *resp);
 
   protected:
-   int computeAddrWidth(Dyninst::Architecture me);
+   int computeAddrWidth();
 };
 
 class linux_x86_process : public linux_process, public x86_process

--- a/proccontrol/src/loadLibrary/codegen-linux.C
+++ b/proccontrol/src/loadLibrary/codegen-linux.C
@@ -170,18 +170,3 @@ bool Codegen::generateStackUnprotect(Address var_addr, Address mprotect_addr) {
    return generateCall(mprotect_addr, args);
 }
 
-#if 0
-
-bool Codegen::findTOC(Symbol *sym, Library::ptr lib) {
-   Address baseTOC = 
-
-   return false;
-   if (proc_->getArchitecture() != Arch_ppc64) return true;
-
-
-   Address baseTOC = sym->getSymtab()->getTOCoffset(sym->getOffset());
-   baseTOC += lib->getDataLoadAddress();
-   toc_ = baseTOC;
-   return toc_ != 0;
-}
-#endif

--- a/proccontrol/src/loadLibrary/codegen-ppc.C
+++ b/proccontrol/src/loadLibrary/codegen-ppc.C
@@ -60,7 +60,7 @@ bool Codegen::generateCallPPC64(Address addr, const std::vector<Address> &args)
       reg++;      
    }
 
-   if (abiversion_ < 2) {
+   if (abimajversion_ < 2) {
       if (toc_[addr] == 0) return false;
       generatePPC64(toc_[addr], 2);
       generatePPC64(addr, 0);

--- a/proccontrol/src/loadLibrary/codegen.C
+++ b/proccontrol/src/loadLibrary/codegen.C
@@ -34,7 +34,8 @@ bool Codegen::generate() {
    buffer_.initialize(codeStart_, size);
 
    SymReader *objSymReader = proc_->llproc()->getSymReader()->openSymbolReader(proc_->llproc()->getExecutable());
-   abiversion_ = objSymReader->getABIVersion();
+   abimajversion_ = abiminversion_ = 0;
+   objSymReader->getABIVersion(abimajversion_, abiminversion_);
 
    if (!generateInt()) return false;
 

--- a/proccontrol/src/loadLibrary/codegen.C
+++ b/proccontrol/src/loadLibrary/codegen.C
@@ -25,12 +25,16 @@ bool Codegen::generate() {
    int_process *proc = proc_->llproc();
    if (!proc)
       return false;
+
    codeStart_ = proc->infMalloc(size, false, (unsigned int) 0);
    if (!codeStart_) {
       return false;
    }
 
    buffer_.initialize(codeStart_, size);
+
+   SymReader *objSymReader = proc_->llproc()->getSymReader()->openSymbolReader(proc_->llproc()->getExecutable());
+   abiversion_ = objSymReader->getABIVersion();
 
    if (!generateInt()) return false;
 
@@ -141,7 +145,7 @@ bool Codegen::generateNoops() {
          copyInt(0x90909090);
          break;
       case Arch_ppc32:
-      case Arch_ppc64:
+      case Arch_ppc64:  // MJMTODO - Assumes HostArch == TargetArch
          copyInt(0x60000000);
          copyInt(0x60000000);
          break;
@@ -162,7 +166,7 @@ bool Codegen::generateTrap() {
          break;
       case Arch_ppc32:
       case Arch_ppc64:
-         copyInt(0x7d821008);
+         copyInt(0x7d821008); // MJMTODO - Assumes HostArch == TargetArch
          break;
       case Arch_aarch64:
          copyInt(0xd4200000);

--- a/proccontrol/src/loadLibrary/codegen.h
+++ b/proccontrol/src/loadLibrary/codegen.h
@@ -74,7 +74,8 @@ class Codegen {
 
    // PPC64 only, but it's handy to stash it here
    std::map<Address, Address> toc_;
-   int abiversion_;
+   int abimajversion_;
+   int abiminversion_;
 };
 
 };

--- a/proccontrol/src/loadLibrary/codegen.h
+++ b/proccontrol/src/loadLibrary/codegen.h
@@ -74,6 +74,7 @@ class Codegen {
 
    // PPC64 only, but it's handy to stash it here
    std::map<Address, Address> toc_;
+   int abiversion_;
 };
 
 };

--- a/proccontrol/src/mmapalloc.C
+++ b/proccontrol/src/mmapalloc.C
@@ -152,76 +152,76 @@ static const unsigned char linux_ppc32_call_munmap[] = {
 };
 static const unsigned int linux_ppc32_call_munmap_size = sizeof(linux_ppc32_call_munmap);
 
-static const unsigned int linux_ppc64_mmap_flags_highest_position = 70;
-static const unsigned int linux_ppc64_mmap_flags_higher_position = 74;
-static const unsigned int linux_ppc64_mmap_flags_hi_position = 82;
-static const unsigned int linux_ppc64_mmap_flags_lo_position = 86;
-static const unsigned int linux_ppc64_mmap_size_highest_position = 30;
-static const unsigned int linux_ppc64_mmap_size_higher_position = 34;
-static const unsigned int linux_ppc64_mmap_size_hi_position = 42;
-static const unsigned int linux_ppc64_mmap_size_lo_position = 46;
-static const unsigned int linux_ppc64_mmap_addr_highest_position = 10;
-static const unsigned int linux_ppc64_mmap_addr_higher_position = 14;
-static const unsigned int linux_ppc64_mmap_addr_hi_position = 22;
-static const unsigned int linux_ppc64_mmap_addr_lo_position = 26;
 static const unsigned int linux_ppc64_mmap_start_position = 4;
-static const unsigned char linux_ppc64_call_mmap[] = {
-   0x60, 0x00, 0x00, 0x00,              // nop
-   0x38, 0x00, 0x00, 0x5a,              // li      r0,<syscall>
-   0x3c, 0x60, 0x00, 0x00,              // lis     r3,<addr_highest>
-   0x60, 0x63, 0x00, 0x00,              // ori     r3,r3,<addr_higher>
-   0x78, 0x63, 0x07, 0xc6,              // rldicr  r3,r3,0x32,0x31,
-   0x64, 0x63, 0x00, 0x00,              // oris    r3,r3,<addr_hi>
-   0x60, 0x63, 0x00, 0x00,              // ori     r3,r3,<addr_lo>
-   0x3c, 0x80, 0x00, 0x00,              // lis     r4,<size_highest>
-   0x60, 0x84, 0x00, 0x00,              // ori     r4,r4,<size_higher>
-   0x78, 0x84, 0x07, 0xc6,              // rldicr  r4,r4,0x32,0x31,
-   0x64, 0x84, 0x00, 0x00,              // oris    r4,r4,<size_hi>
-   0x60, 0x84, 0x00, 0x00,              // ori     r4,r4,<size_lo>
-   0x3c, 0xa0, 0x00, 0x00,              // lis     r5,<perms_highest>
-   0x60, 0xa5, 0x00, 0x00,              // ori     r5,r5,<perms_higher>
-   0x78, 0xa5, 0x07, 0xc6,              // rldicr  r5,r5,0x32,0x31,
-   0x64, 0xa5, 0x00, 0x00,              // oris    r5,r5,<perms_hi>
-   0x60, 0xa5, 0x00, 0x07,              // ori     r5,r5,<perms_lo>
-   0x3c, 0xc0, 0x00, 0x00,              // lis     r6,<flags_highest>
-   0x60, 0xc6, 0x00, 0x00,              // ori     r6,r6,<flags_higher>
-   0x78, 0xc6, 0x07, 0xc6,              // rldicr  r6,r6,0x32,0x31,
-   0x64, 0xc6, 0x00, 0x00,              // oris    r6,r6,<flags_hi>
-   0x60, 0xc6, 0x00, 0x00,              // ori     r6,r6,<flags_lo>
-   0x3c, 0xe0, 0x00, 0x00,              // lis     r7,<fd=-1>
-   0x7c, 0xe7, 0x3b, 0xb8,              // nand    r7,r7,r7
-   0x3d, 0x00, 0x00, 0x00,              // lis     r8,<offset>
-   0x44, 0x00, 0x00, 0x02,              // sc
-   0x7d, 0x82, 0x10, 0x08,              // trap
-   0x60, 0x00, 0x00, 0x00               // nop
+static const unsigned int linux_ppc64_mmap_addr_highest_position =    2;
+static const unsigned int linux_ppc64_mmap_addr_higher_position =     3;
+static const unsigned int linux_ppc64_mmap_addr_hi_position =         5;
+static const unsigned int linux_ppc64_mmap_addr_lo_position =         6;
+static const unsigned int linux_ppc64_mmap_size_highest_position =    7;
+static const unsigned int linux_ppc64_mmap_size_higher_position =     8;
+static const unsigned int linux_ppc64_mmap_size_hi_position =        10;
+static const unsigned int linux_ppc64_mmap_size_lo_position =        11;
+static const unsigned int linux_ppc64_mmap_flags_highest_position =  17;
+static const unsigned int linux_ppc64_mmap_flags_higher_position =   18;
+static const unsigned int linux_ppc64_mmap_flags_hi_position =       20;
+static const unsigned int linux_ppc64_mmap_flags_lo_position =       21;
+static const uint32_t linux_ppc64_call_mmap[] = {
+   /*  0 */ 0x60000000,              // nop
+   /*  1 */ 0x3800005a,              // li      r0,<syscall>
+   /*  2 */ 0x3c600000,              // lis     r3,<addr_highest>
+   /*  3 */ 0x60630000,              // ori     r3,r3,<addr_higher>
+   /*  4 */ 0x786307c6,              // rldicr  r3,r3,0x32,0x31,
+   /*  5 */ 0x64630000,              // oris    r3,r3,<addr_hi>
+   /*  6 */ 0x60630000,              // ori     r3,r3,<addr_lo>
+   /*  7 */ 0x3c800000,              // lis     r4,<size_highest>
+   /*  8 */ 0x60840000,              // ori     r4,r4,<size_higher>
+   /*  9 */ 0x788407c6,              // rldicr  r4,r4,0x32,0x31,
+   /* 10 */ 0x64840000,              // oris    r4,r4,<size_hi>
+   /* 11 */ 0x60840000,              // ori     r4,r4,<size_lo>
+   /* 12 */ 0x3ca00000,              // lis     r5,<perms_highest>
+   /* 13 */ 0x60a50000,              // ori     r5,r5,<perms_higher>
+   /* 14 */ 0x78a507c6,              // rldicr  r5,r5,0x32,0x31,
+   /* 15 */ 0x64a50000,              // oris    r5,r5,<perms_hi>
+   /* 16 */ 0x60a50007,              // ori     r5,r5,<perms_lo>
+   /* 17 */ 0x3cc00000,              // lis     r6,<flags_highest>
+   /* 18 */ 0x60c60000,              // ori     r6,r6,<flags_higher>
+   /* 19 */ 0x78c607c6,              // rldicr  r6,r6,0x32,0x31,
+   /* 20 */ 0x64c60000,              // oris    r6,r6,<flags_hi>
+   /* 21 */ 0x60c60000,              // ori     r6,r6,<flags_lo>
+   /* 22 */ 0x3ce00000,              // lis     r7,<fd=-1>
+   /* 23 */ 0x7ce73bb8,              // nand    r7,r7,r7
+   /* 24 */ 0x3d000000,              // lis     r8,<offset>
+   /* 25 */ 0x44000002,              // sc
+   /* 26 */ 0x7d821008,              // trap
+   /* 27 */ 0x60000000               // nop
 };
 static const unsigned int linux_ppc64_call_mmap_size = sizeof(linux_ppc64_call_mmap);
 
-static const unsigned int linux_ppc64_munmap_size_highest_position = 30;
-static const unsigned int linux_ppc64_munmap_size_higher_position = 34;
-static const unsigned int linux_ppc64_munmap_size_hi_position = 42;
-static const unsigned int linux_ppc64_munmap_size_lo_position = 46;
-static const unsigned int linux_ppc64_munmap_addr_highest_position = 10;
-static const unsigned int linux_ppc64_munmap_addr_higher_position = 14;
-static const unsigned int linux_ppc64_munmap_addr_hi_position = 22;
-static const unsigned int linux_ppc64_munmap_addr_lo_position = 26;
 static const unsigned int linux_ppc64_munmap_start_position = 4;
-static const unsigned char linux_ppc64_call_munmap[] = {
-   0x60, 0x00, 0x00, 0x00,              // nop
-   0x38, 0x00, 0x00, 0x5b,              // li      r0,<syscall>
-   0x3c, 0x60, 0x00, 0x00,              // lis     r3,<addr_highest>
-   0x60, 0x63, 0x00, 0x00,              // ori     r3,r3,<addr_higher>
-   0x78, 0x63, 0x07, 0xc6,              // rldicr  r3,r3,0x32,0x31,
-   0x64, 0x63, 0x00, 0x00,              // oris    r3,r3,<addr_hi>
-   0x60, 0x63, 0x00, 0x00,              // ori     r3,r3,<addr_lo>
-   0x3c, 0x80, 0x00, 0x00,              // lis     r4,<size_highest>
-   0x60, 0x84, 0x00, 0x00,              // ori     r4,r4,<size_higher>
-   0x78, 0x84, 0x07, 0xc6,              // rldicr  r4,r4,0x32,0x31,
-   0x64, 0x84, 0x00, 0x00,              // oris    r4,r4,<size_hi>
-   0x60, 0x84, 0x00, 0x00,              // ori     r4,r4,<size_lo>
-   0x44, 0x00, 0x00, 0x02,              // sc
-   0x7d, 0x82, 0x10, 0x08,              // trap
-   0x60, 0x00, 0x00, 0x00               // nop
+static const unsigned int linux_ppc64_munmap_addr_highest_position =  2;
+static const unsigned int linux_ppc64_munmap_addr_higher_position =   3;
+static const unsigned int linux_ppc64_munmap_addr_hi_position =       5;
+static const unsigned int linux_ppc64_munmap_addr_lo_position =       6;
+static const unsigned int linux_ppc64_munmap_size_highest_position =  7;
+static const unsigned int linux_ppc64_munmap_size_higher_position =   8;
+static const unsigned int linux_ppc64_munmap_size_hi_position =      10;
+static const unsigned int linux_ppc64_munmap_size_lo_position =      11;
+static const uint32_t linux_ppc64_call_munmap[] = {
+   /*  0 */ 0x60000000,              // nop
+   /*  1 */ 0x3800005b,              // li      r0,<syscall>
+   /*  2 */ 0x3c600000,              // lis     r3,<addr_highest>
+   /*  3 */ 0x60630000,              // ori     r3,r3,<addr_higher>
+   /*  4 */ 0x786307c6,              // rldicr  r3,r3,0x32,0x31,
+   /*  5 */ 0x64630000,              // oris    r3,r3,<addr_hi>
+   /*  6 */ 0x60630000,              // ori     r3,r3,<addr_lo>
+   /*  7 */ 0x3c800000,              // lis     r4,<size_highest>
+   /*  8 */ 0x60840000,              // ori     r4,r4,<size_higher>
+   /*  9 */ 0x788407c6,              // rldicr  r4,r4,0x32,0x31,
+   /* 10 */ 0x64840000,              // oris    r4,r4,<size_hi>
+   /* 11 */ 0x60840000,              // ori     r4,r4,<size_lo>
+   /* 12 */ 0x44000002,              // sc
+   /* 13 */ 0x7d821008,              // trap
+   /* 14 */ 0x60000000               // nop
 };
 static const unsigned int linux_ppc64_call_munmap_size = sizeof(linux_ppc64_call_munmap);
 
@@ -577,21 +577,21 @@ bool mmap_alloc_process::plat_createAllocationSnippet(Dyninst::Address addr, boo
       buffer = malloc(buffer_size);
       memcpy(buffer, buf_tmp, buffer_size);
 
+      uint32_t *pwords = (uint32_t *)buffer;
 
-       // Assuming endianess of debugger and debuggee match
-       *((uint16_t *) (((char *) buffer)+size_highest_position)) = (uint16_t)((uint64_t)size >> 48);
-       *((uint16_t *) (((char *) buffer)+size_higher_position)) = (uint16_t)((uint64_t)size >> 32);
-       *((uint16_t *) (((char *) buffer)+size_hi_position)) = (uint16_t)(size >> 16);
-       *((uint16_t *) (((char *) buffer)+size_lo_position)) = (uint16_t)size;
-       *((uint16_t *) (((char *) buffer)+flags_highest_position)) = (uint16_t)((uint64_t)flags >> 48);
-       *((uint16_t *) (((char *) buffer)+flags_higher_position)) = (uint16_t)((uint64_t)flags >> 32);
-       *((uint16_t *) (((char *) buffer)+flags_hi_position)) = (uint16_t)(flags >> 16);
-       *((uint16_t *) (((char *) buffer)+flags_lo_position)) = (uint16_t)flags;
-       *((uint16_t *) (((char *) buffer)+addr_highest_position)) = (uint16_t)((uint64_t)addr >> 48);
-       *((uint16_t *) (((char *) buffer)+addr_higher_position)) = (uint16_t)((uint64_t)addr >> 32);
-       *((uint16_t *) (((char *) buffer)+addr_hi_position)) = (uint16_t)(addr >> 16);
-       *((uint16_t *) (((char *) buffer)+addr_lo_position)) = (uint16_t)addr;
-
+      // MJMTODO - Assumes endianess of debugger and debuggee match
+      pwords[size_highest_position]  |= (uint32_t)(((uint64_t)size >> 48) & 0x0000ffff);
+      pwords[size_higher_position]   |= (uint32_t)(((uint64_t)size >> 32) & 0x0000ffff);
+      pwords[size_hi_position]       |= (uint32_t)(((uint64_t)size >> 16) & 0x0000ffff);
+      pwords[size_lo_position]       |= (uint32_t)((uint64_t)size & 0x0000ffff);
+      pwords[flags_highest_position] |= (uint32_t)(((uint64_t)flags >> 48) & 0x0000ffff);
+      pwords[flags_higher_position]  |= (uint32_t)(((uint64_t)flags >> 32) & 0x0000ffff);
+      pwords[flags_hi_position]      |= (uint32_t)(((uint64_t)flags >> 16) & 0x0000ffff);
+      pwords[flags_lo_position]      |= (uint32_t)((uint64_t)flags & 0x0000ffff);
+      pwords[addr_highest_position]  |= (uint32_t)(((uint64_t)addr >> 48) & 0x0000ffff);
+      pwords[addr_higher_position]   |= (uint32_t)(((uint64_t)addr >> 32) & 0x0000ffff);
+      pwords[addr_hi_position]       |= (uint32_t)(((uint64_t)addr >> 16) & 0x0000ffff);
+      pwords[addr_lo_position]       |= (uint32_t)((uint64_t)addr & 0x0000ffff);
     }else if( getTargetArch() == Arch_aarch64 ){
         const void *buf_tmp;
         unsigned int addr_size;
@@ -795,15 +795,17 @@ bool mmap_alloc_process::plat_createDeallocationSnippet(Dyninst::Address addr,
       buffer = malloc(buffer_size);
       memcpy(buffer, buf_tmp, buffer_size);
 
-      // Assuming endianess of debugger and debuggee match
-      *((uint16_t *) (((char *) buffer)+size_highest_position)) = (uint16_t)((uint64_t)size >> 48);
-      *((uint16_t *) (((char *) buffer)+size_higher_position)) = (uint16_t)((uint64_t)size >> 32);
-      *((uint16_t *) (((char *) buffer)+size_hi_position)) = (uint16_t)(size >> 16);
-      *((uint16_t *) (((char *) buffer)+size_lo_position)) = (uint16_t)size;
-      *((uint16_t *) (((char *) buffer)+addr_highest_position)) = (uint16_t)((uint64_t)addr >> 48);
-      *((uint16_t *) (((char *) buffer)+addr_higher_position)) = (uint16_t)((uint64_t)addr >> 32);
-      *((uint16_t *) (((char *) buffer)+addr_hi_position)) = (uint16_t)(addr >> 16);
-      *((uint16_t *) (((char *) buffer)+addr_lo_position)) = (uint16_t)addr;
+      uint32_t *pwords = (uint32_t *)buffer;
+
+      // MJMTODO - Assumes endianess of debugger and debuggee match
+      pwords[size_highest_position] |= (uint32_t)(((uint64_t)size >> 48) & 0x0000ffff);
+      pwords[size_higher_position]  |= (uint32_t)(((uint64_t)size >> 32) & 0x0000ffff);
+      pwords[size_hi_position]      |= (uint32_t)(((uint64_t)size >> 16) & 0x0000ffff);
+      pwords[size_lo_position]      |= (uint32_t)((uint64_t)size & 0x0000ffff);
+      pwords[addr_highest_position] |= (uint32_t)(((uint64_t)addr >> 48) & 0x0000ffff);
+      pwords[addr_higher_position]  |= (uint32_t)(((uint64_t)addr >> 32) & 0x0000ffff);
+      pwords[addr_hi_position]      |= (uint32_t)(((uint64_t)addr >> 16) & 0x0000ffff);
+      pwords[addr_lo_position]      |= (uint32_t)((uint64_t)addr & 0x0000ffff);
    }
    else if( getTargetArch() == Arch_aarch64 ) {
         const void *buf_tmp = NULL;

--- a/proccontrol/src/ppc_process.C
+++ b/proccontrol/src/ppc_process.C
@@ -58,10 +58,9 @@ unsigned ppc_process::plat_breakpointSize()
 
 void ppc_process::plat_breakpointBytes(unsigned char *buffer)
 {
-  buffer[0] = 0x7d;
-  buffer[1] = 0x82;
-  buffer[2] = 0x10;
-  buffer[3] = 0x08;
+   uint32_t *p = (uint32_t*)buffer;
+
+   *p = 0x7d821008;  // MJMTODO = Assumes host and target architecture match (and algnment)
 }
 
 bool ppc_process::plat_breakpointAdvancesPC() const

--- a/stackwalk/src/dbginfo-stepper.C
+++ b/stackwalk/src/dbginfo-stepper.C
@@ -83,6 +83,7 @@ static DwarfFrameParser::Ptr getAuxDwarfInfo(std::string s)
    DwarfHandle::ptr dwarf = DwarfHandle::createDwarfHandle(s, orig_elf);
    assert(dwarf);
 
+   // MJMTODO - Need to check whether this is supposed to work or not
    // FIXME for ppc, if we ever support debug walking on ppc
    Architecture arch;
 #if defined(arch_x86) || defined(arch_x86_64)

--- a/symlite/h/SymLite-elf.h
+++ b/symlite/h/SymLite-elf.h
@@ -86,7 +86,7 @@ class SYMLITE_EXPORT SymElf : public Dyninst::SymReader
 
    virtual bool isValidSymbol(const Symbol_t &sym);
    virtual unsigned getAddressWidth();
-   virtual int getABIVersion() const;
+   virtual bool getABIVersion(int &major, int &minor) const;
    virtual bool isBigEndianDataEncoding() const;
 
    virtual unsigned long getSymbolSize(const Symbol_t &sym);

--- a/symlite/h/SymLite-elf.h
+++ b/symlite/h/SymLite-elf.h
@@ -86,8 +86,10 @@ class SYMLITE_EXPORT SymElf : public Dyninst::SymReader
 
    virtual bool isValidSymbol(const Symbol_t &sym);
    virtual unsigned getAddressWidth();
-   virtual unsigned long getSymbolSize(const Symbol_t &sym);
+   virtual int getABIVersion() const;
+   virtual bool isBigEndianDataEncoding() const;
 
+   virtual unsigned long getSymbolSize(const Symbol_t &sym);
    virtual Section_t getSectionByName(std::string name);
    virtual Section_t getSectionByAddress(Dyninst::Address addr);
    virtual Dyninst::Address getSectionAddress(Section_t sec);

--- a/symlite/src/SymLite-elf.C
+++ b/symlite/src/SymLite-elf.C
@@ -294,9 +294,16 @@ unsigned SymElf::getAddressWidth()
    return elf->wordSize();
 }
 
-int SymElf::getABIVersion() const
+bool SymElf::getABIVersion(int &major, int &minor) const
 {
-   return (elf->e_machine() == EM_PPC64 && elf->e_flags() == 0x2) ? 2 : 1;
+   if (elf->e_machine() == EM_PPC64 && elf->e_flags() == 0x2) {
+      major = elf->e_flags();
+      minor = 0;
+      return true;
+   }
+   else {
+      return false;
+   }
 }
 
 bool SymElf::isBigEndianDataEncoding() const

--- a/symlite/src/SymLite-elf.C
+++ b/symlite/src/SymLite-elf.C
@@ -294,6 +294,16 @@ unsigned SymElf::getAddressWidth()
    return elf->wordSize();
 }
 
+int SymElf::getABIVersion() const
+{
+   return (elf->e_machine() == EM_PPC64 && elf->e_flags() == 0x2) ? 2 : 1;
+}
+
+bool SymElf::isBigEndianDataEncoding() const
+{
+   return (elf->e_endian() != 0);
+}
+
 unsigned long SymElf::getSymbolSize(const Symbol_t &sym)
 {
    GET_SYMBOL(sym, shdr, symbol, name, idx);

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -349,6 +349,9 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    const char*  getInterpreterName() const;
 
    unsigned getAddressWidth() const;
+   bool isBigEndianDataEncoding() const;
+   int getABIVersion() const;
+
    Offset getLoadOffset() const;
    Offset getEntryOffset() const;
    Offset getBaseOffset() const;

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -350,7 +350,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
    unsigned getAddressWidth() const;
    bool isBigEndianDataEncoding() const;
-   int getABIVersion() const;
+   bool getABIVersion(int &major, int &minor) const;
 
    Offset getLoadOffset() const;
    Offset getEntryOffset() const;

--- a/symtabAPI/h/SymtabReader.h
+++ b/symtabAPI/h/SymtabReader.h
@@ -78,6 +78,8 @@ class SYMTAB_EXPORT SymtabReader : public SymReader {
    virtual Symbol_t getContainingSymbol(Dyninst::Offset offset);
    virtual std::string getInterpreterName();
    virtual unsigned getAddressWidth();
+   virtual bool isBigEndianDataEncoding() const;
+   virtual int getABIVersion() const;
    
    virtual unsigned numSegments();
    virtual bool getSegment(unsigned num, SymSegment &seg); 

--- a/symtabAPI/h/SymtabReader.h
+++ b/symtabAPI/h/SymtabReader.h
@@ -79,7 +79,7 @@ class SYMTAB_EXPORT SymtabReader : public SymReader {
    virtual std::string getInterpreterName();
    virtual unsigned getAddressWidth();
    virtual bool isBigEndianDataEncoding() const;
-   virtual int getABIVersion() const;
+   virtual bool getABIVersion(int &major, int &minor) const;
    
    virtual unsigned numSegments();
    virtual bool getSegment(unsigned num, SymSegment &seg); 

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -5814,6 +5814,16 @@ Dyninst::Architecture Object::getArch()
   
 }
 
+int Object::getABIVersion() const
+{
+   return (elfHdr->e_machine() == EM_PPC64 && elfHdr->e_flags() == 0x2) ? 2 : 1;
+}
+
+bool Object::isBigEndianDataEncoding() const
+{
+   return (elfHdr->e_endian() != 0);
+}
+
 Offset Object::getTOCoffset(Offset off) const {
   if (TOC_table_.empty()) return 0;
   Offset baseTOC = TOC_table_.find(0)->second;

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -5814,9 +5814,16 @@ Dyninst::Architecture Object::getArch()
   
 }
 
-int Object::getABIVersion() const
+bool Object::getABIVersion(int &major, int &minor) const
 {
-   return (elfHdr->e_machine() == EM_PPC64 && elfHdr->e_flags() == 0x2) ? 2 : 1;
+   if (elfHdr->e_machine() == EM_PPC64 && elfHdr->e_flags() == 0x2) {
+      major = elfHdr->e_flags();
+      minor = 0;
+      return true;
+   }
+   else {
+      return false;
+   }
 }
 
 bool Object::isBigEndianDataEncoding() const

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -348,7 +348,8 @@ class Object;
 	}
 
    Dyninst::Architecture getArch();
-
+   bool isBigEndianDataEncoding() const;
+   int getABIVersion() const;
 	bool is_offset_in_plt(Offset offset) const;
     Elf_X_Shdr *getRegionHdrByAddr(Offset addr);
     int getRegionHdrIndexByAddr(Offset addr);

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -349,7 +349,7 @@ class Object;
 
    Dyninst::Architecture getArch();
    bool isBigEndianDataEncoding() const;
-   int getABIVersion() const;
+   bool getABIVersion(int &major, int &minor) const;
 	bool is_offset_in_plt(Offset offset) const;
     Elf_X_Shdr *getRegionHdrByAddr(Offset addr);
     int getRegionHdrIndexByAddr(Offset addr);

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -132,6 +132,8 @@ public:
     SYMTAB_EXPORT const std::string findModuleForSym(Symbol *sym);
     SYMTAB_EXPORT void clearSymsToMods();
     SYMTAB_EXPORT bool hasError() const;
+    SYMTAB_EXPORT virtual bool isBigEndianDataEncoding() const { return false; }
+    SYMTAB_EXPORT virtual bool isPPC64V2API() const { return false; }
     
     virtual void setTruncateLinePaths(bool value);
     virtual bool getTruncateLinePaths();

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -350,6 +350,16 @@ SYMTAB_EXPORT unsigned Symtab::getAddressWidth() const
    return address_width_;
 }
  
+SYMTAB_EXPORT int Symtab::getABIVersion() const
+{
+   return obj_private->getABIVersion();
+}
+
+SYMTAB_EXPORT bool Symtab::isBigEndianDataEncoding() const
+{
+   return obj_private->isBigEndianDataEncoding();
+}
+
 SYMTAB_EXPORT bool Symtab::isNativeCompiler() const 
 {
     return nativeCompiler; 

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -350,9 +350,9 @@ SYMTAB_EXPORT unsigned Symtab::getAddressWidth() const
    return address_width_;
 }
  
-SYMTAB_EXPORT int Symtab::getABIVersion() const
+SYMTAB_EXPORT bool Symtab::getABIVersion(int &major, int &minor) const
 {
-   return obj_private->getABIVersion();
+   return obj_private->getABIVersion(major, minor);
 }
 
 SYMTAB_EXPORT bool Symtab::isBigEndianDataEncoding() const

--- a/symtabAPI/src/SymtabReader.C
+++ b/symtabAPI/src/SymtabReader.C
@@ -129,6 +129,18 @@ unsigned SymtabReader::getAddressWidth()
    return symtab->getAddressWidth();
 }
    
+int SymtabReader::getABIVersion() const
+{
+   assert(symtab);
+   return symtab->getABIVersion();
+}
+
+bool SymtabReader::isBigEndianDataEncoding() const
+{
+   assert(symtab);
+   return symtab->isBigEndianDataEncoding();
+}
+
 unsigned SymtabReader::numSegments()
 {
    buildSegments();

--- a/symtabAPI/src/SymtabReader.C
+++ b/symtabAPI/src/SymtabReader.C
@@ -129,10 +129,10 @@ unsigned SymtabReader::getAddressWidth()
    return symtab->getAddressWidth();
 }
    
-int SymtabReader::getABIVersion() const
+bool SymtabReader::getABIVersion(int &major, int &minor) const
 {
    assert(symtab);
-   return symtab->getABIVersion();
+   return symtab->getABIVersion(major, minor);
 }
 
 bool SymtabReader::isBigEndianDataEncoding() const

--- a/symtabAPI/src/emitElf-64.C
+++ b/symtabAPI/src/emitElf-64.C
@@ -2120,11 +2120,9 @@ void emitElf64<ElfTypes>::createRelocationSections(std::vector<relocationEntry> 
             if (dynSymNameMapping.find(newRels[i].name()) != dynSymNameMapping.end()) {
                 relas[k].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRels[i].name()],
                                                           relocationEntry::getGlobalRelType(obj->getAddressWidth()));
-                assert(relas[k].r_info == ELF64_R_INFO(dynSymNameMapping[newRels[i].name()], R_X86_64_GLOB_DAT));
             } else {
                 relas[k].r_info = ElfTypes::makeRelocInfo((unsigned long) (STN_UNDEF),
                                                           relocationEntry::getGlobalRelType(obj->getAddressWidth()));
-                assert(relas[k].r_info == ELF64_R_INFO((unsigned long) (STN_UNDEF), R_X86_64_GLOB_DAT));
             }
             k++;
             m++;


### PR DESCRIPTION
These changes are required for proccontrol and symtab to be able to support the little endian ppc64 architecture.