### PR TITLE
Add initial file for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: cpp
+
+sudo: false
+
+addons:
+    apt:
+        sources:
+            - kalakris-cmake
+        packages:
+            - binutils-dev
+            - cmake
+            - libboost-system-dev
+            - libboost-thread-dev
+            - libelf-dev
+
+compiler:
+    - gcc
+
+script:
+    - mkdir work
+    - cd work
+    - cmake ..
+    - make


### PR DESCRIPTION
https://travis-ci.org/ is a continuous integration system that is free for open-source projects hosted on github.
Administrators of the repository can set it up so that it makes sure the code compiles after each new commit.
It is also possible to make pull requests dependent on not breaking the build using github status checks.
In addition to a simple build test, it would also be possible to clone the testsuite repo and make sure that all the tests pass at each commit as well.