### PR TITLE
Provided base class virtual for getABIVersion() that returns false when not implemented

### DIFF
--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -133,7 +133,7 @@ public:
     SYMTAB_EXPORT void clearSymsToMods();
     SYMTAB_EXPORT bool hasError() const;
     SYMTAB_EXPORT virtual bool isBigEndianDataEncoding() const { return false; }
-    SYMTAB_EXPORT virtual bool getABIVersion(int &major, int &minor) const { return false; }
+    SYMTAB_EXPORT virtual bool getABIVersion(int & /*major*/, int & /*minor*/) const { return false; }
     
     virtual void setTruncateLinePaths(bool value);
     virtual bool getTruncateLinePaths();

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -133,7 +133,7 @@ public:
     SYMTAB_EXPORT void clearSymsToMods();
     SYMTAB_EXPORT bool hasError() const;
     SYMTAB_EXPORT virtual bool isBigEndianDataEncoding() const { return false; }
-    SYMTAB_EXPORT virtual bool isPPC64V2API() const { return false; }
+    SYMTAB_EXPORT virtual bool getABIVersion(int &major, int &minor) const { return false; }
     
     virtual void setTruncateLinePaths(bool value);
     virtual bool getTruncateLinePaths();


### PR DESCRIPTION
Fixed forgotten rename of isPPC64V2API to getABIVersion in
Object.h.  The virtual function in this base class now returns
false indicating that it is not implemented (which is the case
for Object-nt).