### PR TITLE
Parsing fixes for ARM

### DIFF
--- a/instructionAPI/src/InstructionCategories.C
+++ b/instructionAPI/src/InstructionCategories.C
@@ -45,6 +45,7 @@ namespace Dyninst
 	return c_ReturnInsn;
       case e_call:
       case aarch64_op_bl:
+      case aarch64_op_blr:
 	return c_CallInsn;
       case e_jmp:
       case e_jb:
@@ -76,6 +77,7 @@ namespace Dyninst
       case aarch64_op_tbnz:
       case aarch64_op_cbz:
       case aarch64_op_cbnz:
+      case aarch64_op_br: 
 	return c_BranchInsn;
           case e_cmp:
           case e_cmppd:

--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -41,7 +41,6 @@
 #include "util.h"
 #include "common/src/Types.h"
 #include "dyntypes.h"
-#include "IndirectAnalyzer.h"
 
 #include <deque>
 #include <map>
@@ -952,21 +951,11 @@ bool IA_IAPI::parseJumpTable(Dyninst::ParseAPI::Function * currFunc,
 			     Dyninst::ParseAPI::Block* currBlk,
 			     std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges) const
 {
-/*
+
+    // Call platform specific jump table parser
     IA_platformDetails* jumpTableParser = makePlatformDetails(_isrc->getArch(), this);
-    bool ret = jumpTableParser->parseJumpTable(currBlk, outEdges);
+    bool ret = jumpTableParser->parseJumpTable(currFunc, currBlk, outEdges);
     delete jumpTableParser;
-*/
-
-
-    IndirectControlFlowAnalyzer icfa(currFunc, currBlk);
-    bool ret = icfa.NewJumpTableAnalysis(outEdges);
-
-    parsing_printf("Jump table parser returned %d, %d edges\n", ret, outEdges.size());
-    for (auto oit = outEdges.begin(); oit != outEdges.end(); ++oit) parsing_printf("edge target at %lx\n", oit->first);
-    // Update statistics 
-    currBlk->obj()->cs()->incrementCounter(PARSE_JUMPTABLE_COUNT);
-    if (!ret) currBlk->obj()->cs()->incrementCounter(PARSE_JUMPTABLE_FAIL);
 
     return ret;
 }

--- a/parseAPI/src/IA_aarch64Details.C
+++ b/parseAPI/src/IA_aarch64Details.C
@@ -162,3 +162,12 @@ bool IA_aarch64Details::parseJumpTable(Block* currBlk,
 	assert(0);
   return true;
 }
+
+bool IA_aarch64Details::parseJumpTable(Dyninst::ParseAPI::Function* currFunc,
+                                       Dyninst::ParseAPI::Block* currBlk,
+				       std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges) 
+{
+    parsing_printf("Jump table parsing not implmemented on ARM 64 yet\n");
+    return false;
+}
+

--- a/parseAPI/src/IA_aarch64Details.h
+++ b/parseAPI/src/IA_aarch64Details.h
@@ -58,6 +58,10 @@ namespace Dyninst
                 virtual ~IA_aarch64Details() {}
                 virtual bool parseJumpTable(Dyninst::ParseAPI::Block* currBlk,
                                             std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges);
+                virtual bool parseJumpTable(Dyninst::ParseAPI::Function* currFunc,
+		                            Dyninst::ParseAPI::Block* currBlk,
+                                            std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges);
+
             private:
                 bool findTableAddrNoTOC(const IA_IAPI* blockToCheck);
                 bool parseRelativeTableIdiom();

--- a/parseAPI/src/IA_platformDetails.h
+++ b/parseAPI/src/IA_platformDetails.h
@@ -49,6 +49,10 @@ namespace Dyninst
                 virtual ~IA_platformDetails() {}
                 virtual bool parseJumpTable(Dyninst::ParseAPI::Block* currBlk,
                         std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges) = 0;
+                virtual bool parseJumpTable(Dyninst::ParseAPI::Function * currFunc,
+		        Dyninst::ParseAPI::Block* currBlk,
+                        std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges) = 0;
+
             protected:
                 const IA_IAPI* currentBlock;
 

--- a/parseAPI/src/IA_powerDetails.C
+++ b/parseAPI/src/IA_powerDetails.C
@@ -479,6 +479,13 @@ bool IA_powerDetails::findTableBase(IA_IAPI::allInsns_t::const_iterator start,
   return true;
 }
 
+bool IA_powerDetails::parseJumpTable(Function *,
+                                     Block* currBlk,
+				     std::vector<std::pair< Address, EdgeTypeEnum> >& outEdges)
+{
+    return parseJumpTable(currBlk, outEdges);
+}
+
 
 
 // This should only be called on a known indirect branch...

--- a/parseAPI/src/IA_powerDetails.h
+++ b/parseAPI/src/IA_powerDetails.h
@@ -58,6 +58,10 @@ namespace Dyninst
                 virtual ~IA_powerDetails() {}
                 virtual bool parseJumpTable(Dyninst::ParseAPI::Block* currBlk,
                                             std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges);
+	        virtual bool parseJumpTable(Dyninst::ParseAPI::Function* currFunc,
+		                            Dyninst::ParseAPI::Block* currBlk,
+					    std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges);
+				    
             private:
                 bool findTableAddrNoTOC(const IA_IAPI* blockToCheck);
                 bool parseRelativeTableIdiom();

--- a/parseAPI/src/IA_x86Details.h
+++ b/parseAPI/src/IA_x86Details.h
@@ -66,6 +66,10 @@ namespace Dyninst
                 virtual ~IA_x86Details() {}
                 virtual bool parseJumpTable(Dyninst::ParseAPI::Block* currBlk,
                                             std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges);
+                virtual bool parseJumpTable(Dyninst::ParseAPI::Function* currFunc,
+		                            Dyninst::ParseAPI::Block* currBlk,
+                                            std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges);
+
             private:
                 bool isMovAPSTable(std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges);
                 void findThunkAndOffset(Dyninst::ParseAPI::Block * start);

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -1276,8 +1276,8 @@ Parser::parse_frame(ParseFrame & frame, bool recursive) {
             ParseCallback::insn_details insn_det;
             insn_det.insn = &ah;
 	     
-                parsing_printf("[%s:%d] curAddr 0x%lx \n",
-                    FILE__,__LINE__,curAddr);
+                parsing_printf("[%s:%d] curAddr 0x%lx: %s \n",
+                    FILE__,__LINE__,curAddr, insn_det.insn->getInstruction()->format().c_str() );
 
             if (func->_is_leaf_function) {
                 Address ret_addr;

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -1379,7 +1379,11 @@ bool Object::get_relocation_entries( Elf_X_Shdr *&rel_plt_scnp,
       // 1st plt entry is special.
       next_plt_entry_addr += plt_entry_size_;
 
-#else
+#elif defined(arch_aarch64)
+      // For ARM, the first entry should be skipped,
+      // but the first entry is in double size
+      next_plt_entry_addr += 2 * plt_entry_size_;
+#else     
       next_plt_entry_addr += 4*(plt_entry_size_); //1st 4 entries are special
 #endif
 


### PR DESCRIPTION
1. For ARM, add br as a branch instruction category and blr as a call instruction category.
2. Need to skip the first two PLT entry sizes on ARM
3. Only invoke new jump table parsing on x86. On power, we use the old heuristics. On ARM, we currently give up
4. Properly initialize decoder states when decoding operands lazily