### PR TITLE
symtabAPI: don't free cuDIE in parseLineInfoForCU

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -4891,9 +4891,6 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
     /* It's OK for a CU not to have line information. */
     if(status != DW_DLV_OK)
     {
-
-        /* Free this CU's DIE. */
-        dwarf_dealloc( dbg, cuDIE, DW_DLA_DIE );
         return;
     }
 


### PR DESCRIPTION
The cuDIE in parseLineInfoForCU is a parameter, so it shouldn't act like
it owns this.  But it was calling dwarf_dealloc when that CU had no line
info, which led to a double-free crash when the callers tried to free
that cuDIE itself.  Just return and let the proper owner do it.

The double-free was easily reproducible on Fedora 23 x86_64, test1_30.