### PR TITLE
Fix uninitialized data in rewriter elf_update

### DIFF
--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -1388,11 +1388,10 @@ void trampTrapMappings::allocateTable()
    table_header = proc()->inferiorMalloc(table_allocated * entry_size + 
                                          sizeof(trap_mapping_header));
    trap_mapping_header header;
+   memset(&header, 0, sizeof(header));
    header.signature = TRAP_HEADER_SIG;
    header.num_entries = table_mutatee_size;
    header.pos = -1;
-   header.low_entry = 0;
-   header.high_entry = 0;
 
    bool result = proc()->writeDataSpace((void *) table_header, 
                                         sizeof(trap_mapping_header),

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -561,9 +561,9 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       // Okay, that does it for the old stuff.
 
       // Now we need to get the new stuff. That's all the allocated memory. First, big
-      // buffer to hold it.
+      // buffer to hold it.  Use calloc so gaps from inferiorFree/Realloc are just zero.
 
-      void *newSectionPtr = malloc(highWaterMark_ - lowWaterMark_);
+      void *newSectionPtr = calloc(highWaterMark_ - lowWaterMark_, 1);
 
       pdvector<codeRange *> writes;
       memoryTracker_->elements(writes);

--- a/symtabAPI/src/emitElf-64.C
+++ b/symtabAPI/src/emitElf-64.C
@@ -1946,6 +1946,7 @@ bool emitElf64<ElfTypes>::createSymbolTables(vector<Symbol *> &allSymbols) {
 
         char *dynstr = (char *) malloc(dynsymbolNamesLength);
         memcpy((void *) dynstr, (void *) olddynStrData, olddynStrSize);
+        dynstr[olddynStrSize] = '\0';
         cur = olddynStrSize + 1;
         for (i = 0; i < dynsymbolStrs.size(); i++) {
             strcpy(&dynstr[cur], dynsymbolStrs[i].c_str());


### PR DESCRIPTION
Valgrind complained of uninitialized data in pwrite during elf_update.
Using --track-origins=yes found three origins to fix:

- trap_mapping_header has a padding field that was unset.  Use memset on
  the whole thing to be sure it's fully initialized.
- Parts of .dyninstInst may not be written due to gaps from inferior
  realloc or free.  Use calloc to initially zero this buffer.
- The new dynstr section leaves a byte of padding between the old and
  new data, but did not set it.  Make that NUL.