### PR TITLE
Fix rewriting interp sections and debug symbols

### DIFF
--- a/symtabAPI/h/Aggregate.h
+++ b/symtabAPI/h/Aggregate.h
@@ -96,9 +96,9 @@ class SYMTAB_EXPORT Aggregate
       name_iter typed_names_end() const;
       
      /***** Aggregate updating *****/
-      virtual bool addMangledName(std::string name, bool isPrimary);
-      virtual bool addPrettyName(std::string name, bool isPrimary);
-      virtual bool addTypedName(std::string name, bool isPrimary);
+      virtual bool addMangledName(std::string name, bool isPrimary, bool isDebug=false);
+      virtual bool addPrettyName(std::string name, bool isPrimary, bool isDebug=false);
+      virtual bool addTypedName(std::string name, bool isPrimary, bool isDebug=false);
 
       bool setModule(Module *mod);
       bool setSize(unsigned size);

--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -104,8 +104,8 @@ class SYMTAB_EXPORT FunctionBase
 
    /***** Primary name *****/
    virtual std::string getName() const = 0;
-   virtual bool addMangledName(std::string name, bool isPrimary) = 0;
-   virtual bool addPrettyName(std::string name, bool isPrimary) = 0;
+   virtual bool addMangledName(std::string name, bool isPrimary, bool isDebug=false) = 0;
+   virtual bool addPrettyName(std::string name, bool isPrimary, bool isDebug=false) = 0;
 
    /***** Opaque data object pointers, usable by user ****/
    void *getData();
@@ -173,10 +173,10 @@ class SYMTAB_EXPORT FunctionBase
    virtual unsigned getSize() const;
    virtual std::string getName() const;
    virtual Offset getOffset() const { return Aggregate::getOffset(); }
-   virtual bool addMangledName(std::string name, bool isPrimary) 
-   {return Aggregate::addMangledName(name, isPrimary);}
-   virtual bool addPrettyName(std::string name, bool isPrimary)
-   {return Aggregate::addPrettyName(name, isPrimary);}
+   virtual bool addMangledName(std::string name, bool isPrimary, bool isDebug=false)
+   {return Aggregate::addMangledName(name, isPrimary, isDebug);}
+   virtual bool addPrettyName(std::string name, bool isPrimary, bool isDebug=false)
+   {return Aggregate::addPrettyName(name, isPrimary, isDebug);}
    virtual Module* getModule() const { return module_; }
 };
 
@@ -192,8 +192,8 @@ class SYMTAB_EXPORT InlinedFunction : public FunctionBase
    typedef std::vector<std::string>::const_iterator name_iter;
    std::pair<std::string, Dyninst::Offset> getCallsite();
    virtual bool removeSymbol(Symbol *sym);
-   virtual bool addMangledName(std::string name, bool isPrimary);
-   virtual bool addPrettyName(std::string name, bool isPrimary);
+   virtual bool addMangledName(std::string name, bool isPrimary, bool isDebug=false);
+   virtual bool addPrettyName(std::string name, bool isPrimary, bool isDebug=false);
    virtual std::string getName() const;
    virtual Offset getOffset() const;
    virtual unsigned getSize() const;

--- a/symtabAPI/h/Symbol.h
+++ b/symtabAPI/h/Symbol.h
@@ -191,9 +191,10 @@ class SYMTAB_EXPORT Symbol : public Serializable,
    unsigned getSize() const { return size_; }
    Region *getRegion() const { return region_; }
 
-   bool isInDynSymtab() const { return (type_ != ST_DELETED) && isDynamic_; }
-   bool isInSymtab() const { return (type_ != ST_DELETED) && !isDynamic_; }
+   bool isInDynSymtab() const { return (type_ != ST_DELETED) && isDynamic_ && !isDebug_; }
+   bool isInSymtab() const { return (type_ != ST_DELETED) && !isDynamic_ && !isDebug_; }
    bool isAbsolute() const { return isAbsolute_; }
+   bool isDebug() const { return isDebug_; }
    bool isCommonStorage() const { return isCommonStorage_; }
 
    bool              isFunction()            const;
@@ -228,6 +229,7 @@ class SYMTAB_EXPORT Symbol : public Serializable,
    SymbolTag            tag ()               const;
    bool  setDynamic(bool d) { isDynamic_ = d; return true;}
    bool  setAbsolute(bool a) { isAbsolute_ = a; return true; }
+   bool  setDebug(bool dbg) { isDebug_ = dbg; return true; }
    bool  setCommonStorage(bool cs) { isCommonStorage_ = cs; return true; }
 
    bool  setVersionFileName(std::string &fileName);
@@ -264,6 +266,7 @@ class SYMTAB_EXPORT Symbol : public Serializable,
 
    bool          isDynamic_;
    bool          isAbsolute_;
+   bool          isDebug_;
 
    Aggregate *   aggregate_; // Pointer to Function or Variable container, if appropriate.
 

--- a/symtabAPI/src/Aggregate.C
+++ b/symtabAPI/src/Aggregate.C
@@ -167,7 +167,7 @@ bool Aggregate::addMangledNameInternal(std::string name, bool /*isPrimary*/, boo
   return true;
 }
 
-SYMTAB_EXPORT bool Aggregate::addMangledName(string name, bool isPrimary) 
+SYMTAB_EXPORT bool Aggregate::addMangledName(string name, bool isPrimary, bool isDebug)
 {
    if (!addMangledNameInternal(name, isPrimary, false))
       return false;
@@ -191,6 +191,7 @@ SYMTAB_EXPORT bool Aggregate::addMangledName(string name, bool isPrimary)
       newSym->setMangledName(name);
       module_->exec()->demangleSymbol(newSym);
       newSym->isDynamic_ = false;
+      newSym->isDebug_ = isDebug;
       module_->exec()->addSymbol(newSym);
     }
     if (dynamicSym) {
@@ -198,12 +199,13 @@ SYMTAB_EXPORT bool Aggregate::addMangledName(string name, bool isPrimary)
       newSym->setMangledName(name);
       module_->exec()->demangleSymbol(newSym);
       newSym->isDynamic_ = true;
+      newSym->isDebug_ = isDebug;
       module_->exec()->addSymbol(newSym);
     }
     return true;
  }
 
-SYMTAB_EXPORT bool Aggregate::addPrettyName(string name, bool isPrimary) 
+SYMTAB_EXPORT bool Aggregate::addPrettyName(string name, bool isPrimary, bool isDebug)
 {
     // Check to see if we're duplicating
    for (auto i = pretty_names_begin(); 
@@ -212,10 +214,10 @@ SYMTAB_EXPORT bool Aggregate::addPrettyName(string name, bool isPrimary)
        if (i->find(name) != string::npos)
 	   return false;
    }
-   return addMangledName(name, isPrimary);
+   return addMangledName(name, isPrimary, isDebug);
 }
 
-SYMTAB_EXPORT bool Aggregate::addTypedName(string name, bool isPrimary) 
+SYMTAB_EXPORT bool Aggregate::addTypedName(string name, bool isPrimary, bool isDebug)
 {
     // Check to see if we're duplicating
    for (auto i = typed_names_begin(); 
@@ -224,7 +226,7 @@ SYMTAB_EXPORT bool Aggregate::addTypedName(string name, bool isPrimary)
        if (i->find(name) != string::npos)
 	   return false;
    }
-   return addMangledName(name, isPrimary);
+   return addMangledName(name, isPrimary, isDebug);
 }
 
 bool Aggregate::changeSymbolOffset(Symbol *sym) 

--- a/symtabAPI/src/Function.C
+++ b/symtabAPI/src/Function.C
@@ -449,13 +449,13 @@ bool InlinedFunction::removeSymbol(Symbol *)
    return false;
 }
 
-bool InlinedFunction::addMangledName(std::string name, bool /*isPrimary*/)
+bool InlinedFunction::addMangledName(std::string name, bool /*isPrimary*/, bool /*isDebug*/)
 {
     name_ = name;
     return true;
 }
 
-bool InlinedFunction::addPrettyName(std::string name, bool /*isPrimary*/)
+bool InlinedFunction::addPrettyName(std::string name, bool /*isPrimary*/, bool /*isDebug*/)
 {
     name_ = name;
     return true;

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -5685,6 +5685,9 @@ bool Object::parse_all_relocations(Elf_X &elf, Elf_X_Shdr *dynsym_scnp,
             if( (*sym_it)->tag() == Symbol::TAG_INTERNAL ) {
                 continue;
             }
+            if( (*sym_it)->isDebug() ) {
+                continue;
+            }
 
             std::pair<dyn_hash_map<int, Symbol *>::iterator, bool> result;
             if( (*sym_it)->isInDynSymtab() ) {

--- a/symtabAPI/src/Object.C
+++ b/symtabAPI/src/Object.C
@@ -114,6 +114,8 @@ void print_symbols( std::vector< Symbol *>& allsymbols ) {
                 fprintf(fd, " DYN");
             if (sym->isAbsolute())
                 fprintf(fd, " ABS");
+            if (sym->isDebug())
+                fprintf(fd, " DBG");
             std::string fileName;
             std::vector<std::string> *vers;
             if (sym->getVersionFileName(fileName))

--- a/symtabAPI/src/Symbol.C
+++ b/symtabAPI/src/Symbol.C
@@ -327,10 +327,12 @@ std::ostream& Dyninst::SymtabAPI::operator<< (ostream &os, const Symbol &s)
         //<< " tag="     << (unsigned) s.tag_
                   << " tag="     << s.symbolTag2Str(s.tag_)
                   << " isAbs="   << s.isAbsolute_
+                  << " isDbg="   << s.isDebug_
                   << " isCommon=" << s.isCommonStorage_
                   << (s.isFunction() ? " [FUNC]" : "")
                   << (s.isVariable() ? " [VAR]" : "")
-                  << (s.isInSymtab() ? "[STA]" : "[DYN]")
+                  << (s.isInSymtab() ? "[STA]" : "")
+                  << (s.isInDynSymtab() ? "[DYN]" : "")
                   << " }";
 }
 
@@ -380,6 +382,7 @@ bool Symbol::operator==(const Symbol& s) const
 			&& (size_    == s.size_)
 			&& (isDynamic_ == s.isDynamic_)
 			&& (isAbsolute_ == s.isAbsolute_)
+			&& (isDebug_ == s.isDebug_)
                         && (isCommonStorage_ == s.isCommonStorage_)
 		   && (versionHidden_ == s.versionHidden_)
 		   && (mangledName_ == s.mangledName_));
@@ -405,6 +408,7 @@ Symbol::Symbol () :
   size_(0),
   isDynamic_(false),
   isAbsolute_(false),
+  isDebug_(false),
   aggregate_(NULL),
   mangledName_(Symbol::emptyString),
   tag_(TAG_UNKNOWN) ,
@@ -441,6 +445,7 @@ Symbol::Symbol(const std::string& name,
   size_(s),
   isDynamic_(d),
   isAbsolute_(a),
+  isDebug_(false),
   aggregate_(NULL),
   mangledName_(name),
   tag_(TAG_UNKNOWN),

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -572,12 +572,12 @@ bool DwarfWalker::parseSubprogram(DwarfWalker::inline_t func_type) {
    if (name_result && !curName().empty()) {
       dwarf_printf("(0x%lx) Identified function name as %s\n", id(), curName().c_str());
       if (isMangledName()) {
-	  func->addMangledName(curName(), true);
+	  func->addMangledName(curName(), true, true);
       }
       // Only keep pretty names around for inlines, which probably don't have mangled names
       else {
 	  dwarf_printf("(0x%lx) Adding as pretty name to inline\n", id());
-	  func->addPrettyName(curName(), true);
+	  func->addPrettyName(curName(), true, true);
       }
    }
 


### PR DESCRIPTION
The first commit adjusts INTERP in the program headers and section headers, to
account for added PHDR and the pagesize shift.  The second commit adds a debug
flag to Symbol so dwarf names can be easily excluded from the symbol tables.

Fixes #52.