### PR TITLE
Truncate PTRACE_GETEVENTMSG exit status to int

### DIFF
--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -430,9 +430,9 @@ bool DecoderLinux::decode(ArchEvent *ae, std::vector<Event::ptr> &events)
                                   proc->getPid(), thread->getLWP());
                     if (thread->getLWP() == proc->getPid())
 		            {
-		                unsigned long exitcode = 0x0;
+		                unsigned long eventmsg = 0x0;
 		                int result = do_ptrace((pt_req)PTRACE_GETEVENTMSG, (pid_t) thread->getLWP(),
-					        NULL, &exitcode);
+					        NULL, &eventmsg);
 		                if(result == -1)
 		                {
                             int error = errno;
@@ -441,9 +441,10 @@ bool DecoderLinux::decode(ArchEvent *ae, std::vector<Event::ptr> &events)
                                 proc->setLastError(err_exited, "Process exited during operation");
                             return false;
 		                }
+		                int exitcode = (int)eventmsg;
 		                exitcode = WEXITSTATUS(exitcode);
 
-		                pthrd_printf("Decoded event to pre-exit of process %d/%d with code %lu\n",
+		                pthrd_printf("Decoded event to pre-exit of process %d/%d with code %i\n",
 				            proc->getPid(), thread->getLWP(), exitcode);
 		                event = Event::ptr(new EventExit(EventType::Pre, exitcode));
 


### PR DESCRIPTION
The sys/wait.h macros are expecting to operate on an int, and they have
some ugly pointer macros to deal with old BSD compatibility.  But we get
an unsigned long from PTRACE_GETEVENTMSG.  Normally this work out ok,
but on big-endian ppc64 those macros end up reading the int from the
most significant bits only, which are zero.

Cast the long down to a local int first, so WEXITSTATUS works properly.

Fixes #35.