### PR TITLE
Define htobe on Windows/MSVC as a wrapper for _byteswap_ulong

### DIFF
--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -42,6 +42,12 @@
 
 #include "ExpressionConversionVisitor.h"
 
+// Assume Windows/MSVC is little-endian
+
+#if defined(_MSC_VER)
+#define htobe _byteswap_ulong
+#endif
+
 using namespace Dyninst;
 using namespace InstructionAPI;
 using namespace DataflowAPI;


### PR DESCRIPTION
Define htobe on Windows/MSVC as a wrapper for _byteswap_ulong