### PR TITLE
Set defaults for Windows first-party stack walking: library tracker

### DIFF
--- a/common/src/addrtranslate-win.C
+++ b/common/src/addrtranslate-win.C
@@ -171,5 +171,5 @@ AddressTranslateWin::AddressTranslateWin(PID pid, PROC_HANDLE phandle_) :
 
 Address AddressTranslateWin::getLibraryTrapAddrSysV()
 {
-   return 0x0;
+	return &::LoadLibraryEx;
 }

--- a/stackwalk/src/win-x86-swk.C
+++ b/stackwalk/src/win-x86-swk.C
@@ -108,6 +108,7 @@ ProcSelf::ProcSelf(std::string exe_path) :
 
 void ProcSelf::initialize()
 {
+    setDefaultLibraryTracker();
 }
 
 bool LibraryState::updateLibsArch(std::vector<std::pair<LibAddrPair, unsigned int> > &alibs)


### PR DESCRIPTION
Set defaults for Windows first-party stack walking: library tracker