### PR TITLE
Fix for #116

### DIFF
--- a/dyninstAPI/src/codegen-x86.C
+++ b/dyninstAPI/src/codegen-x86.C
@@ -1203,7 +1203,7 @@ bool insnCodeGen::modifyData(Address targetAddr, instruction &insn, codeGen &gen
     origInsn += pref_count;
 
     /* Decode the opcode */
-    if(ia32_decode_opcode(0, origInsn, instruct, NULL))
+    if(ia32_decode_opcode(0, origInsn, instruct, NULL) < 0)
         assert(!"Couldn't decode opcode of already known instruction!\n");
 
     /* Calculate the amount of opcode bytes */
@@ -1328,7 +1328,7 @@ bool insnCodeGen::modifyDisp(signed long newDisp, instruction &insn, codeGen &ge
     origInsn += pref_count;
 
     /* Decode the opcode */
-    if(ia32_decode_opcode(0, origInsn, instruct, NULL))
+    if(ia32_decode_opcode(0, origInsn, instruct, NULL) < 0)
         assert(!"Couldn't decode opcode of already known instruction!\n");
 
     /* Calculate the amount of opcode bytes */


### PR DESCRIPTION
Fixes #116. This will not cause any other issues. `ia32_decode_opcode` can return a value greater than one if it correctly decoded certain floating point instructions. Here the check only tested if it was not equal to zero. The check should have been less than zero instead.