### PR TITLE
proccontrol: fix process attachment without an exe

### DIFF
--- a/proccontrol/src/loadLibrary/codegen.C
+++ b/proccontrol/src/loadLibrary/codegen.C
@@ -33,9 +33,11 @@ bool Codegen::generate() {
 
    buffer_.initialize(codeStart_, size);
 
-   SymReader *objSymReader = proc_->llproc()->getSymReader()->openSymbolReader(proc_->llproc()->getExecutable());
    abimajversion_ = abiminversion_ = 0;
-   objSymReader->getABIVersion(abimajversion_, abiminversion_);
+   auto exe = proc_->libraries().getExecutable();
+   SymReader *objSymReader = proc_->llproc()->getSymReader()->openSymbolReader(exe->getName());
+   if (objSymReader)
+      objSymReader->getABIVersion(abimajversion_, abiminversion_);
 
    if (!generateInt()) return false;
 


### PR DESCRIPTION
This fixes two cases where the low-level process was assumed to have a valid executable path, but it may not if a process was attached without ever specifying the exe.

- In `computeAddrWidth` we can rewrite the test to work with both big- and little-endian auxv.
- In `Codegen`, we can get the executable path from the `libraries()` pool instead.

Fixes #146 
