### PR TITLE
symtabAPI: use the known type for new relocations

### DIFF
--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -2121,10 +2121,10 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
             rels[j].r_offset = newRels[i].rel_addr() + library_adjust;
             if (dynSymNameMapping.find(newRels[i].name()) != dynSymNameMapping.end()) {
                 rels[j].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRels[i].name()],
-                                                         relocationEntry::getGlobalRelType(obj->getAddressWidth()));
+                                                         newRels[i].getRelType());
             } else {
                 rels[j].r_info = ElfTypes::makeRelocInfo((unsigned long) (STN_UNDEF),
-                                                         relocationEntry::getGlobalRelType(obj->getAddressWidth()));
+                                                         newRels[i].getRelType());
             }
             j++;
             l++;
@@ -2134,10 +2134,10 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
             //if( relas[k].r_addend ) relas[k].r_addend += library_adjust;
             if (dynSymNameMapping.find(newRels[i].name()) != dynSymNameMapping.end()) {
                 relas[k].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRels[i].name()],
-                                                          relocationEntry::getGlobalRelType(obj->getAddressWidth()));
+                                                          newRels[i].getRelType());
             } else {
                 relas[k].r_info = ElfTypes::makeRelocInfo((unsigned long) (STN_UNDEF),
-                                                          relocationEntry::getGlobalRelType(obj->getAddressWidth()));
+                                                          newRels[i].getRelType());
             }
             k++;
             m++;


### PR DESCRIPTION
In emitElf::createRelocationSections(), new relocations were calling
getGlobalRelType to determine their type.  However, this didn't take the
symbol type into account, so functions on PPC64 were getting GLOB_DAT
instead of JMP_SLOT, and they didn't work at all when called.
    
Each new relocationEntry already knows its type, so use getRelType().
