### PR TITLE
Fixes make install issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif()
 if(BUILD_RTLIB)
   # Build the RT library as a separate project so we can change compilers
   message(STATUS "Configuring DyninstAPI_RT")
-  file(REMOVE_RECURSE ${RT_BINARY_DIR}/CMakeCache.txt ${RT_BINARY_DIR}/Makefile)
+  file(REMOVE_RECURSE ${RT_BINARY_DIR}/CMakeCache.txt ${RT_BINARY_DIR}/CMakeFiles ${RT_BINARY_DIR}/Makefile)
   file(MAKE_DIRECTORY ${RT_BINARY_DIR})
   if (PLATFORM MATCHES bgq)
     set (RT_C_COMPILER mpicc CACHE STRING "Compiler for runtime library")


### PR DESCRIPTION
Fixes #160. For whatever reason, if `${RT_BINARY_DIR}/CMakeFiles` isn't removed during configuration, CMake will attempt to install libdyninstAPI_RT.so from the relink directory instead of the dyninstAPI_RT directory, which causes the install to fail.