### PR TITLE
Fix operand types for vpand

### DIFF
--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -6526,7 +6526,7 @@ ia32_entry sseMapMult[][3] =
     { e_vpminub, t_done, 0, true, { Vps, Hps, Wps }, 0, s1W2R3R },
     { e_vpminub, t_done, 0, true, { Vps, Hps, Wps }, 0, s1W2R3R },
   }, { /* SSEDB_66 */
-    { e_vpand, t_done, 0, true, { Vps, Hps, Wps }, 0, s1RW2R },
+    { e_vpand, t_done, 0, true, { Vps, Hps, Wps }, 0, s1RW2R3R },
     { e_No_Entry, t_vexw, VEXW91, false, { Zz, Zz, Zz }, 0, 0 },
     { e_No_Entry, t_vexw, VEXW64, false, { Zz, Zz, Zz }, 0, 0 }
   }, { /* SSEDC_66 */


### PR DESCRIPTION
The intel developer manual specifies vpand as having operands "xmm1 xmm2
xmm3/m128". This change reflects this in dyninst.