### PR TITLE
Determine the architecture of an ELF by looking at the file header in…

### DIFF
--- a/common/h/SymReader.h
+++ b/common/h/SymReader.h
@@ -91,6 +91,7 @@ class COMMON_EXPORT SymReader
    virtual unsigned getAddressWidth() = 0;
    virtual bool getABIVersion(int &major, int &minor) const = 0;
    virtual bool isBigEndianDataEncoding() const = 0;
+   virtual Architecture getArchitecture() const = 0;
    
    virtual unsigned numSegments() = 0;
    virtual bool getSegment(unsigned num, SymSegment &reg) = 0; 

--- a/elf/h/Elf_X.h
+++ b/elf/h/Elf_X.h
@@ -36,6 +36,7 @@
 #include <map>
 #include <vector>
 #include "util.h"
+#include "dyn_regs.h"
 
 namespace Dyninst {
 
@@ -116,6 +117,8 @@ class DYNELF_EXPORT Elf_X {
     Elf_X_Shdr &get_shdr(unsigned int i);
 
     bool findDebugFile(std::string origfilename, std::string &output_name, char* &output_buffer, unsigned long &output_buffer_size);
+
+    Dyninst::Architecture getArch() const;
 
   protected:
     Elf *elf;

--- a/elf/src/Elf_X.C
+++ b/elf/src/Elf_X.C
@@ -1742,6 +1742,39 @@ bool Elf_X::findDebugFile(std::string origfilename, string &output_name, char* &
   return false;
 }
 
+// Add definitions that may not be in all elf.h files
+#if !defined(EM_K10M)
+#define EM_K10M 180
+#endif
+#if !defined(EM_L10M)
+#define EM_L10M 181
+#endif
+#if !defined(EM_AARCH64)
+#define EM_AARCH64 183
+#endif
+Dyninst::Architecture Elf_X::getArch() const
+{
+    switch(e_machine())
+    {
+        case EM_PPC:
+            return Dyninst::Arch_ppc32;
+        case EM_PPC64:
+            return Dyninst::Arch_ppc64;
+        case EM_386:
+            return Dyninst::Arch_x86;
+        case EM_X86_64:
+        case EM_K10M:
+        case EM_L10M:
+            return Dyninst::Arch_x86_64;
+        case EM_ARM:
+            return Dyninst::Arch_aarch32;
+        case EM_AARCH64:
+            return Dyninst::Arch_aarch64;
+        default:
+            return Dyninst::Arch_none;
+    }
+}
+
 // ------------------------------------------------------------------------
 // Class Elf_X_Nhdr simulates the Elf(32|64)_Nhdr structure.
 Elf_X_Nhdr::Elf_X_Nhdr()

--- a/parseAPI/src/SymLiteCodeSource.C
+++ b/parseAPI/src/SymLiteCodeSource.C
@@ -141,21 +141,7 @@ SymReaderCodeRegion::getAddressWidth() const
 Architecture
 SymReaderCodeRegion::getArch() const
 {
-#if defined(arch_power)
-    if(getAddressWidth() == 8)
-        return Arch_ppc64;
-    else
-        return Arch_ppc32;
-#elif defined(arch_x86) || defined(arch_x86_64)
-    if(getAddressWidth() == 8)
-        return Arch_x86_64;
-    else
-        return Arch_x86;
-#elif defined(arch_aarch64)
-		return Arch_aarch64;
-#else
-    return Arch_none;
-#endif
+    return _symtab->getArchitecture();
 }
 
 bool
@@ -473,21 +459,7 @@ SymReaderCodeSource::getAddressWidth() const
 Architecture
 SymReaderCodeSource::getArch() const
 {
-#if defined(arch_power)
-    if(getAddressWidth() == 8)
-        return Arch_ppc64;
-    else
-        return Arch_ppc32;
-#elif defined(arch_x86) || defined(arch_x86_64)
-    if(getAddressWidth() == 8)
-        return Arch_x86_64;
-    else
-        return Arch_x86;
-#elif defined(arch_aarch64)
-		return Arch_aarch64;
-#else
-    return Arch_none;
-#endif
+    return _symtab->getArchitecture();
 }
 
 bool

--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -146,21 +146,7 @@ SymtabCodeRegion::getAddressWidth() const
 Architecture
 SymtabCodeRegion::getArch() const
 {
-#if defined(arch_power)
-    if(getAddressWidth() == 8)
-        return Arch_ppc64;
-    else
-        return Arch_ppc32;
-#elif defined(arch_x86) || defined(arch_x86_64)
-    if(getAddressWidth() == 8)
-        return Arch_x86_64;
-    else
-        return Arch_x86;
-#elif defined(arch_aarch64)
-		return Arch_aarch64;
-#else
-    return Arch_none;
-#endif
+    return _symtab->getArchitecture();
 }
 
 bool
@@ -653,21 +639,7 @@ SymtabCodeSource::getAddressWidth() const
 Architecture
 SymtabCodeSource::getArch() const
 {
-#if defined(arch_power)
-    if(getAddressWidth() == 8)
-        return Arch_ppc64;
-    else
-        return Arch_ppc32;
-#elif defined(arch_x86) || defined(arch_x86_64)
-    if(getAddressWidth() == 8)
-        return Arch_x86_64;
-    else
-        return Arch_x86;
-#elif defined(arch_aarch64)
-		return Arch_aarch64;
-#else
-    return Arch_none;
-#endif
+    return _symtab->getArchitecture();
 }
 
 bool

--- a/symlite/h/SymLite-elf.h
+++ b/symlite/h/SymLite-elf.h
@@ -88,6 +88,7 @@ class SYMLITE_EXPORT SymElf : public Dyninst::SymReader
    virtual unsigned getAddressWidth();
    virtual bool getABIVersion(int &major, int &minor) const;
    virtual bool isBigEndianDataEncoding() const;
+   virtual Architecture getArchitecture() const;
 
    virtual unsigned long getSymbolSize(const Symbol_t &sym);
    virtual Section_t getSectionByName(std::string name);

--- a/symlite/src/SymLite-elf.C
+++ b/symlite/src/SymLite-elf.C
@@ -311,6 +311,11 @@ bool SymElf::isBigEndianDataEncoding() const
    return (elf->e_endian() != 0);
 }
 
+Architecture SymElf::getArchitecture() const
+{
+    return elf->getArch();
+}
+
 unsigned long SymElf::getSymbolSize(const Symbol_t &sym)
 {
    GET_SYMBOL(sym, shdr, symbol, name, idx);

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -235,7 +235,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool isExec() const;
    bool isStripped();
    ObjectType getObjectType() const;
-   Dyninst::Architecture getArchitecture();
+   Dyninst::Architecture getArchitecture() const;
    bool isCode(const Offset where) const;
    bool isData(const Offset where) const;
    bool isValidOffset(const Offset where) const;
@@ -604,7 +604,9 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    //Don't use obj_private, use getObject() instead.
  public:
    Object *getObject();
-    ModRangeLookup* mod_lookup();
+   const Object *getObject() const;
+   ModRangeLookup* mod_lookup();
+
  private:
    Object *obj_private;
 

--- a/symtabAPI/h/SymtabReader.h
+++ b/symtabAPI/h/SymtabReader.h
@@ -80,6 +80,7 @@ class SYMTAB_EXPORT SymtabReader : public SymReader {
    virtual unsigned getAddressWidth();
    virtual bool isBigEndianDataEncoding() const;
    virtual bool getABIVersion(int &major, int &minor) const;
+   virtual Architecture getArchitecture() const;
    
    virtual unsigned numSegments();
    virtual bool getSegment(unsigned num, SymSegment &seg); 

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -5118,38 +5118,9 @@ bool Object::getTruncateLinePaths()
     return truncateLineFilenames;
 }
 
-// Add definitions that may not be in all elf.h files
-#if !defined(EM_K10M)
-#define EM_K10M 180
-#endif
-#if !defined(EM_L10M)
-#define EM_L10M 181
-#endif
-#if !defined(EM_AARCH64)
-#define EM_AARCH64 183
-#endif
-
-Dyninst::Architecture Object::getArch()
+Dyninst::Architecture Object::getArch() const
 {
-    switch(elfHdr->e_machine())
-    {
-        case EM_PPC:
-            return Dyninst::Arch_ppc32;
-        case EM_PPC64:
-            return Dyninst::Arch_ppc64;
-        case EM_386:
-            return Dyninst::Arch_x86;
-        case EM_X86_64:
-        case EM_K10M:
-        case EM_L10M:
-            return Dyninst::Arch_x86_64;
-        case EM_ARM:
-            return Dyninst::Arch_aarch32;
-        case EM_AARCH64:
-            return Dyninst::Arch_aarch64;
-        default:
-            return Dyninst::Arch_none;
-    }
+    return elfHdr->getArch();
 }
 
 bool Object::getABIVersion(int &major, int &minor) const

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -349,7 +349,7 @@ class Object;
 	    return false;
 	}
 
-   Dyninst::Architecture getArch();
+   Dyninst::Architecture getArch() const;
    bool isBigEndianDataEncoding() const;
    bool getABIVersion(int &major, int &minor) const;
 	bool is_offset_in_plt(Offset offset) const;

--- a/symtabAPI/src/Object-nt.C
+++ b/symtabAPI/src/Object-nt.C
@@ -2353,7 +2353,15 @@ void Object::insertPrereqLibrary(std::string lib)
 
 Dyninst::Architecture Object::getArch() const
 {
-   return Dyninst::Arch_x86;
+    switch (peHdr->FileHeader.Machine)
+    {
+    case IMAGE_FILE_MACHINE_I386:
+        return Dyninst::Arch_x86;
+    case IMAGE_FILE_MACHINE_AMD64:
+        return Dyninst::Arch_x86_64;
+    default:
+        return Dyninst::Arch_none;
+    }
 }
 
 /*

--- a/symtabAPI/src/Object-nt.C
+++ b/symtabAPI/src/Object-nt.C
@@ -2351,7 +2351,7 @@ void Object::insertPrereqLibrary(std::string lib)
            getRegionPermissions() == RP_RWX);
 }
 
-Dyninst::Architecture Object::getArch()
+Dyninst::Architecture Object::getArch() const
 {
    return Dyninst::Arch_x86;
 }

--- a/symtabAPI/src/Object-nt.h
+++ b/symtabAPI/src/Object-nt.h
@@ -202,7 +202,7 @@ class Object : public AObject
     SYMTAB_EXPORT const char *interpreter_name() const { return NULL; }
     SYMTAB_EXPORT dyn_hash_map <std::string, LineInformation> &getLineInfo();
     SYMTAB_EXPORT void parseTypeInfo();
-    SYMTAB_EXPORT virtual Dyninst::Architecture getArch();   
+    SYMTAB_EXPORT virtual Dyninst::Architecture getArch() const;
     SYMTAB_EXPORT void    ParseGlobalSymbol(PSYMBOL_INFO pSymInfo);
     SYMTAB_EXPORT const std::vector<Offset> &getPossibleMains() const   { return possible_mains; }
     SYMTAB_EXPORT void getModuleLanguageInfo(dyn_hash_map<std::string, supportedLanguages> *mod_langs);

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -128,7 +128,7 @@ public:
                                                   Dyninst::MachRegisterVal & /*reg_result*/,
                                                   Dyninst::SymtabAPI::MemRegReader * /*reader*/) {return false;}
     
-    SYMTAB_EXPORT virtual Dyninst::Architecture getArch() { return Arch_none; };
+    SYMTAB_EXPORT virtual Dyninst::Architecture getArch() const { return Arch_none; };
     SYMTAB_EXPORT const std::string findModuleForSym(Symbol *sym);
     SYMTAB_EXPORT void setModuleForOffset(Offset sym_off, std::string module);
     SYMTAB_EXPORT void clearSymsToMods();

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -2847,7 +2847,7 @@ SYMTAB_EXPORT ObjectType Symtab::getObjectType() const
    return object_type_;
 }
 
-SYMTAB_EXPORT Dyninst::Architecture Symtab::getArchitecture()
+SYMTAB_EXPORT Dyninst::Architecture Symtab::getArchitecture() const
 {
    return getObject()->getArch();
 }
@@ -3298,6 +3298,11 @@ Object *Symtab::getObject()
    return NULL;
    //obj_private = new Object();
    //return obj_private;
+}
+
+const Object *Symtab::getObject() const
+{
+    return obj_private;
 }
 
 void Symtab::parseTypesNow()

--- a/symtabAPI/src/SymtabReader.C
+++ b/symtabAPI/src/SymtabReader.C
@@ -141,6 +141,11 @@ bool SymtabReader::isBigEndianDataEncoding() const
    return symtab->isBigEndianDataEncoding();
 }
 
+Architecture SymtabReader::getArchitecture() const
+{
+    return symtab->getArchitecture();
+}
+
 unsigned SymtabReader::numSegments()
 {
    buildSegments();


### PR DESCRIPTION
…stead of the compiled architecture

While the main point of your project is to do live instrumentation, it still provides very useful libraries for offline static analysis.

This change allows the user to load ELFs across architectures. For example you can now load and analyze an AArch64 ELF on an x86 machine.
