### PR TITLE
proccontrol: Synchronize additional threads found during attach

### DIFF
--- a/proccontrol/src/int_process.h
+++ b/proccontrol/src/int_process.h
@@ -273,7 +273,8 @@ class int_process
 
    bool attachThreads(bool &found_new_threads);
    bool attachThreads();
-   bool attachThreadsSync();
+   virtual bool plat_attachThreadsSync();
+
    virtual async_ret_t post_attach(bool wasDetached, std::set<response::ptr> &aresps);
    async_ret_t initializeAddressSpace(std::set<response::ptr> &async_responses);
 

--- a/proccontrol/src/int_process.h
+++ b/proccontrol/src/int_process.h
@@ -271,7 +271,9 @@ class int_process
    static bool reattach(int_processSet *pset);
    virtual bool plat_attach(bool allStopped, bool &should_sync) = 0;
 
+   bool attachThreads(bool &found_new_threads);
    bool attachThreads();
+   bool attachThreadsSync();
    virtual async_ret_t post_attach(bool wasDetached, std::set<response::ptr> &aresps);
    async_ret_t initializeAddressSpace(std::set<response::ptr> &async_responses);
 

--- a/proccontrol/src/linux.h
+++ b/proccontrol/src/linux.h
@@ -111,6 +111,7 @@ class linux_process : public sysv_process, public unix_process, public thread_db
    virtual bool plat_create();
    virtual bool plat_create_int();
    virtual bool plat_attach(bool allStopped, bool &);
+   virtual bool plat_attachThreadsSync();
    virtual bool plat_attachWillTriggerStop();
    virtual bool plat_forked();
    virtual bool plat_execed();


### PR DESCRIPTION
When additional threads are found during the attach process, we should
synchronize to their stopping point, and check for new threads again,
until no new threads are found.  This keeps a more consistent state if
threads are racing to start while we're attaching.