### PR TITLE
RT: trymmap should retry if the result is out of range

### DIFF
--- a/dyninstAPI_RT/src/RTheap.c
+++ b/dyninstAPI_RT/src/RTheap.c
@@ -91,8 +91,13 @@ static Address trymmap(size_t len, Address beg, Address end, size_t inc, int fd)
   /* until we get one that succeeds.*/
   for (addr = beg; addr + len <= end; addr += inc) {
     result = map_region((void *) addr, len, fd);
-    if (result)
+    if (result) {
+      /* Success doesn't necessarily mean it actually mapped at the hinted
+       * address.  Return if it's in range, else unmap and try again. */
+      if ((Address) result >= beg && (Address) result + len <= end)
         return (Address) result;
+      unmap_region(result, len);
+    }
   }
   return (Address) NULL;
 }


### PR DESCRIPTION
An address passed to `mmap` is just taken as a hint, and the OS may
return something wildly different if that address is not available.
This is undesirable when we're trying to create a constrained alloc.

Now we will check that the address is in the requested range before
accepting it.  Otherwise, unmap it and try a new hint.