### PR TITLE
proccontrol: scrub newly created threads that fail to attach

### DIFF
--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -3495,8 +3495,14 @@ int_thread *int_thread::createThread(int_process *proc,
    bool result = newthr->attach();
    if (!result) {
       pthrd_printf("Failed to attach to new thread %d/%d\n", proc->getPid(), lwp_id);
+      newthr->getUserState().setState(errorstate);
+      newthr->getHandlerState().setState(errorstate);
+      newthr->getGeneratorState().setState(errorstate);
+      ProcPool()->rmThread(newthr);
+      proc->threadPool()->rmThread(newthr);
       return NULL;
    }
+
    if (newthr->isUser() && newthr->getUserState().getState() == neonatal) {
 	   newthr->getUserState().setState(neonatal_intermediate);
 	   newthr->getHandlerState().setState(neonatal_intermediate);


### PR DESCRIPTION
If `int_thread::createThread` failed to actually attach to the thread,
it was leaving the thread object in the process in the `neonatal` state.
This failed assertions later when trying to stop all of the process's
threads, as it would have handler `stopped` and generator `neonatal`.

Now when a thread attach fails, it is set to `errorstate` and removed
from the active thread pools.  The assumption is that this thread simply
exited before we could attach, but we can't be sure of that without
having access to the ptrace return code (`ESRCH`).