### PR TITLE
proccontrol: fix double-increment while erasing a dead process

### DIFF
--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -453,6 +453,7 @@ bool int_process::attach(int_processSet *ps, bool reattach)
          pthrd_printf("Error waiting for attach to %d\n", proc->pid);
          procs.erase(i++);
          had_error = true;
+         continue;
       }
       i++;
    }

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -381,8 +381,10 @@ bool int_process::attach(int_processSet *ps, bool reattach)
       pthrd_printf("Attaching to threads for %d\n", proc->getPid());
       bool result = proc->attachThreads();
       if (!result) {
-         pthrd_printf("Could not attach to threads in %d--will try again\n", proc->pid);
+         pthrd_printf("Failed to attach to threads in %d\n", proc->pid);
          procs.erase(i++);
+         had_error = true;
+         continue;
       }
 
       if (reattach) {
@@ -466,7 +468,7 @@ bool int_process::attach(int_processSet *ps, bool reattach)
          continue;
       bool result = proc->plat_attachThreadsSync();
       if (!result) {
-         pthrd_printf("Failed to attach to threads in %d--now an error\n", proc->pid);
+         pthrd_printf("Failed to attach to threads in %d\n", proc->pid);
          procs.erase(i++);
          had_error = true;
          continue;


### PR DESCRIPTION
In the attach loop over waitfor_startup(), processes which fail are
erased from the set.  However, the iterator was getting incremented
again, which will skip the next process or even cause undefined behavior
if already at the end of the list.

With GCC 6.2.1, that UB manifested as an infinite loop on a self-
referential rbtree node.

The simple solution is to `continue` the loop after `erase(i++)`, as is
done in many other places with this same pattern.