### PR TITLE
Cleanup ppc (and old gcc) issues

### DIFF
--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -61,13 +61,13 @@ const StackAnalysis::Height StackAnalysis::Height::top(
    StackAnalysis::Height::uninitialized, StackAnalysis::Height::TOP);
 
 AnnotationClass<StackAnalysis::Intervals>
-        Stack_Anno_Intervals(std::string("Stack_Anno_Intervals"), nullptr);
+        Stack_Anno_Intervals(std::string("Stack_Anno_Intervals"), NULL);
 AnnotationClass<StackAnalysis::BlockEffects>
-        Stack_Anno_Block_Effects(std::string("Stack_Anno_Block_Effects"), nullptr);
+        Stack_Anno_Block_Effects(std::string("Stack_Anno_Block_Effects"), NULL);
 AnnotationClass<StackAnalysis::InstructionEffects>
-        Stack_Anno_Insn_Effects(std::string("Stack_Anno_Insn_Effects"), nullptr);
+        Stack_Anno_Insn_Effects(std::string("Stack_Anno_Insn_Effects"), NULL);
 AnnotationClass<StackAnalysis::CallEffects>
-        Stack_Anno_Call_Effects(std::string("Stack_Anno_Call_Effects"), nullptr);
+        Stack_Anno_Call_Effects(std::string("Stack_Anno_Call_Effects"), NULL);
 
 template class std::list<Dyninst::StackAnalysis::TransferFunc*>;
 template class std::map<Dyninst::Absloc, Dyninst::StackAnalysis::Height>;

--- a/dyninstAPI/src/BPatch_addressSpace.C
+++ b/dyninstAPI/src/BPatch_addressSpace.C
@@ -96,7 +96,7 @@ BPatch_function *BPatch_addressSpace::findOrCreateBPFunc(Dyninst::PatchAPI::Patc
 
    // check to see if the func_instance refers to a different
    // module, and that module contains a bpatch_func
-   BPatch_module* containing = nullptr;
+   BPatch_module* containing = NULL;
    if (fi->mod() != NULL) {
       containing = getImage()->findModule(fi->mod()->fileName().c_str());
    }

--- a/dyninstAPI/src/BPatch_type.C
+++ b/dyninstAPI/src/BPatch_type.C
@@ -47,10 +47,10 @@
 using namespace Dyninst;
 using namespace Dyninst::SymtabAPI;
 
-AnnotationClass<BPatch_cblock> CommonBlockUpPtrAnno("CommonBlockUpPtr", nullptr);
-AnnotationClass<BPatch_localVar> LocalVarUpPtrAnno("LocalVarUpPtrAnno", nullptr);
-AnnotationClass<BPatch_field> FieldUpPtrAnno("FieldUpPtrAnno", nullptr);
-AnnotationClass<BPatch_type> TypeUpPtrAnno("TypeUpPtr", nullptr);
+AnnotationClass<BPatch_cblock> CommonBlockUpPtrAnno("CommonBlockUpPtr", NULL);
+AnnotationClass<BPatch_localVar> LocalVarUpPtrAnno("LocalVarUpPtrAnno", NULL);
+AnnotationClass<BPatch_field> FieldUpPtrAnno("FieldUpPtrAnno", NULL);
+AnnotationClass<BPatch_type> TypeUpPtrAnno("TypeUpPtr", NULL);
 //static int findIntrensicType(const char *name);
 
 // This is the ID that is decremented for each type a user defines. It is

--- a/dyninstAPI/src/function.C
+++ b/dyninstAPI/src/function.C
@@ -1641,13 +1641,13 @@ void func_instance::createTMap_internal(StackMod* mod, TMap* tMap)
 }
 
 AnnotationClass<StackAnalysis::Intervals>
-        Stack_Anno_Intervals(std::string("Stack_Anno_Intervals"), nullptr);
+        Stack_Anno_Intervals(std::string("Stack_Anno_Intervals"), NULL);
 AnnotationClass<StackAnalysis::BlockEffects>
-        Stack_Anno_Block_Effects(std::string("Stack_Anno_Block_Effects"), nullptr);
+        Stack_Anno_Block_Effects(std::string("Stack_Anno_Block_Effects"), NULL);
 AnnotationClass<StackAnalysis::InstructionEffects>
-        Stack_Anno_Insn_Effects(std::string("Stack_Anno_Insn_Effects"), nullptr);
+        Stack_Anno_Insn_Effects(std::string("Stack_Anno_Insn_Effects"), NULL);
 AnnotationClass<StackAnalysis::CallEffects>
-        Stack_Anno_Call_Effects(std::string("Stack_Anno_Call_Effects"), nullptr);
+        Stack_Anno_Call_Effects(std::string("Stack_Anno_Call_Effects"), NULL);
 void func_instance::freeStackMod() {
     // Free stack analysis intervals
     StackAnalysis::Intervals *i = NULL;

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -81,8 +81,8 @@
 // For callbacks
 #include "dyninstAPI/src/mapped_object.h" 
 
-AnnotationClass<image_variable> ImageVariableUpPtrAnno("ImageVariableUpPtrAnno", nullptr);
-AnnotationClass<parse_func> ImageFuncUpPtrAnno("ImageFuncUpPtrAnno", nullptr);
+AnnotationClass<image_variable> ImageVariableUpPtrAnno("ImageVariableUpPtrAnno", NULL);
+AnnotationClass<parse_func> ImageFuncUpPtrAnno("ImageFuncUpPtrAnno", NULL);
 pdvector<image*> allImages;
 
 using namespace std;

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1159,7 +1159,6 @@ void emitImm(opCode op, Register src1, RegValue src2imm, Register dest,
     }
 }
 
-void cleanUpAndExit(int status);
 
 /* Recursive function that goes to where our instrumentation is calling
 to figure out what registers are clobbered there, and in any function
@@ -1439,7 +1438,7 @@ Register EmitterPOWER::emitCall(opCode ocode,
 	    " only 8 arguments can (currently) be passed on the POWER architecture.\n";
 	bperr( msg.c_str());
 	showErrorCallback(94,msg);
-	cleanUpAndExit(-1);
+	exit(-1);
     }
 
     // If we got the wrong register, we may need to do a 3-way swap. 

--- a/parseAPI/src/IA_powerDetails.C
+++ b/parseAPI/src/IA_powerDetails.C
@@ -514,12 +514,8 @@ bool IA_powerDetails::parseJumpTable(Block* currBlk,
   patternIter = currentBlock->curInsnIter;
   patternIter--;
   RegisterAST::Ptr jumpAddrReg;
-  static RegisterAST::Ptr linkReg(new RegisterAST(ppc32::lr));
-  static RegisterAST::Ptr countReg(new RegisterAST(ppc32::ctr));
   std::set<RegisterAST::Ptr> regs;
-  if(patternIter->second->getOperation().getID() == power_op_mtspr &&
-     (patternIter->second->isWritten(linkReg) ||
-      patternIter->second->isWritten(countReg)))
+  if(patternIter->second->getOperation().getID() == power_op_mtspr)
     {
       regs.clear();
       patternIter->second->getReadSet(regs);

--- a/proccontrol/src/DecoderWindows.C
+++ b/proccontrol/src/DecoderWindows.C
@@ -295,7 +295,7 @@ bool DecoderWindows::decode(ArchEvent *ae, std::vector<Event::ptr> &events)
                     int sig = e.u.Exception.ExceptionRecord.ExceptionCode;
                     int cause = e.u.Exception.ExceptionRecord.ExceptionInformation[0];
                     Address addr = e.u.Exception.ExceptionRecord.ExceptionInformation[1];
-                    EventSignal* evSig = nullptr;
+                    EventSignal* evSig = NULL;
                     switch (cause) {
                     case 0: evSig = new EventSignal(sig, addr, EventSignal::ReadViolation, true); break;
                     case 1: evSig = new EventSignal(sig, addr, EventSignal::WriteViolation, true); break;

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -1669,7 +1669,9 @@ void Object::load_object(bool alloc_syms)
 
         if (opd_scnp) {
             parse_opd(opd_scnp);
-        }
+        } else if (got_scnp) {
+	    // Add a single global TOC value...
+	}
 
         return;
     } // end binding contour (for "goto cleanup2")
@@ -1965,6 +1967,7 @@ void Object::parse_opd(Elf_X_Shdr *opd_hdr) {
     // special location 0 and only record differences.
     Offset baseTOC = buf[1];
     TOC_table_[0] = baseTOC;
+    create_printf("Set base TOC to %p\n", baseTOC);
 
     // Note the lack of 32/64 here: okay because the only platform with an OPD
     // is 64-bit elf.
@@ -1982,6 +1985,7 @@ void Object::parse_opd(Elf_X_Shdr *opd_hdr) {
 
         if (toc != baseTOC) {
             TOC_table_[func] = toc;
+	    create_printf("Set TOC for %p to %p\n", func, toc);
         }
         i += 2;
     }


### PR DESCRIPTION
Fixed ppc build issues, and brought jump table handling to the point where it's broken because of tables that don't match our heuristics and a lack of ppc64 semantics, rather than a state where it can't possibly work.