### PR TITLE
Fix dependency of LibDwarf

### DIFF
--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -30,7 +30,7 @@ if (UNIX)
     include(ExternalProject)
     ExternalProject_Add(LibDwarf
       PREFIX ${CMAKE_BINARY_DIR}/libdwarf
-      DEPENDS libelf_imp
+      DEPENDS LibElf
       #	URL http://reality.sgiweb.org/davea/libdwarf-20130126.tar.gz
       #	URL http://sourceforge.net/p/libdwarf/code/ci/20130126/tarball
       URL http://www.paradyn.org/libdwarf/libdwarf-20130126.tar.gz

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -20,7 +20,10 @@ if (UNIX)
 
   add_library(libelf_imp SHARED IMPORTED)
   set_property(TARGET libelf_imp
-    PROPERTY IMPORTED_LOCATION ${LIBELF_LIBRARIES}) 
+    PROPERTY IMPORTED_LOCATION ${LIBELF_LIBRARIES})
+  if(NOT LIBELF_FOUND)
+    add_dependencies(libelf_imp LibElf)
+  endif()
 
   find_package (LibDwarf)
 
@@ -30,7 +33,7 @@ if (UNIX)
     include(ExternalProject)
     ExternalProject_Add(LibDwarf
       PREFIX ${CMAKE_BINARY_DIR}/libdwarf
-      DEPENDS LibElf
+      DEPENDS libelf_imp
       #	URL http://reality.sgiweb.org/davea/libdwarf-20130126.tar.gz
       #	URL http://sourceforge.net/p/libdwarf/code/ci/20130126/tarball
       URL http://www.paradyn.org/libdwarf/libdwarf-20130126.tar.gz


### PR DESCRIPTION
Dyninst would not build on the first run when libelf and libdwarf are not installed on the system.