### PR TITLE
Remove stackanalysis assertions

### DIFF
--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -72,6 +72,16 @@ AnnotationClass<StackAnalysis::CallEffects>
 template class std::list<Dyninst::StackAnalysis::TransferFunc*>;
 template class std::map<Dyninst::Absloc, Dyninst::StackAnalysis::Height>;
 template class std::vector<Dyninst::InstructionAPI::Instruction::Ptr>;
+
+struct stackanalysis_exception : public std::runtime_error {
+    stackanalysis_exception(std::string what) : std::runtime_error(std::string("Stackanalysis failure: ") + what) {}
+};
+
+#define STACKANALYSIS_ASSERT(X) \
+if(!(X)) { \
+    throw(stackanalysis_exception(#X));\
+}
+
 //
 // Concepts:
 //
@@ -386,60 +396,67 @@ bool StackAnalysis::canGetFunctionSummary() {
 
 bool StackAnalysis::getFunctionSummary(TransferSet &summary) {
    df_init_debug();
-   genInsnEffects();
+    try {
+        genInsnEffects();
 
-   if (!canGetFunctionSummary()) {
-      stackanalysis_printf("Cannot generate function summary for %s\n",
-         func->name().c_str());
-      return false;
-   }
+        if (!canGetFunctionSummary()) {
+            stackanalysis_printf("Cannot generate function summary for %s\n",
+                                 func->name().c_str());
+            return false;
+        }
 
-   assert(!blockEffects->empty());
+        STACKANALYSIS_ASSERT(!blockEffects->empty());
 
-   stackanalysis_printf("Generating function summary for %s\n",
-      func->name().c_str());
+        stackanalysis_printf("Generating function summary for %s\n",
+                             func->name().c_str());
 
-   if (blockSummaryOutputs.empty()) {
-      summaryFixpoint();
-   }
+        if (blockSummaryOutputs.empty()) {
+            summaryFixpoint();
+        }
 
-   // Join possible values at all return edges
-   TransferSet tempSummary;
-   std::set<Block *> retBlocks;
-   getRetAndTailCallBlocks(func, retBlocks);
-   assert(!retBlocks.empty());
-   for (auto iter = retBlocks.begin(); iter != retBlocks.end(); iter++) {
-      Block *currBlock = *iter;
-      meetSummary(blockSummaryOutputs[currBlock], tempSummary);
-   }
+        // Join possible values at all return edges
+        TransferSet tempSummary;
+        std::set<Block *> retBlocks;
+        getRetAndTailCallBlocks(func, retBlocks);
+        STACKANALYSIS_ASSERT(!retBlocks.empty());
+        for (auto iter = retBlocks.begin(); iter != retBlocks.end(); iter++) {
+            Block *currBlock = *iter;
+            meetSummary(blockSummaryOutputs[currBlock], tempSummary);
+        }
 
-   // Remove identity functions for simplicity.  Also remove stack slots, except
-   // for stack slots in the caller's frame.  Remove copies from base regs to
-   // subregs when the base regs are identities since the link between base reg
-   // and subreg will be made in the caller.
-   summary.clear();
-   for (auto iter = tempSummary.begin(); iter != tempSummary.end(); iter++) {
-      const Absloc &loc = iter->first;
-      const TransferFunc &tf = iter->second;
-      if (!tf.isIdentity() && (tf.target.type() != Absloc::Stack ||
-         tf.target.off() >= 0)) {
-         if (!tf.isBaseRegCopy() && !tf.isBaseRegSIB()) {
-            summary[loc] = tf;
-         } else {
-            const MachRegister &baseReg = tf.target.reg().getBaseRegister();
-            const Absloc baseLoc(baseReg);
-            if (tempSummary.find(baseLoc) != tempSummary.end() &&
-               !tempSummary[baseLoc].isIdentity()) {
-               summary[loc] = tf;
+        // Remove identity functions for simplicity.  Also remove stack slots, except
+        // for stack slots in the caller's frame.  Remove copies from base regs to
+        // subregs when the base regs are identities since the link between base reg
+        // and subreg will be made in the caller.
+        summary.clear();
+        for (auto iter = tempSummary.begin(); iter != tempSummary.end(); iter++) {
+            const Absloc &loc = iter->first;
+            const TransferFunc &tf = iter->second;
+            if (!tf.isIdentity() && (tf.target.type() != Absloc::Stack ||
+                                     tf.target.off() >= 0)) {
+                if (!tf.isBaseRegCopy() && !tf.isBaseRegSIB()) {
+                    summary[loc] = tf;
+                } else {
+                    const MachRegister &baseReg = tf.target.reg().getBaseRegister();
+                    const Absloc baseLoc(baseReg);
+                    if (tempSummary.find(baseLoc) != tempSummary.end() &&
+                        !tempSummary[baseLoc].isIdentity()) {
+                        summary[loc] = tf;
+                    }
+                }
             }
-         }
-      }
-   }
+        }
 
-   stackanalysis_printf("Finished function summary for %s:\n%s\n",
-      func->name().c_str(), format(summary).c_str());
+        stackanalysis_printf("Finished function summary for %s:\n%s\n",
+                             func->name().c_str(), format(summary).c_str());
 
-   return true;
+        return true;
+
+    }
+    catch(...)
+    {
+        return false;
+    }
 }
 
 
@@ -532,7 +549,7 @@ void StackAnalysis::summarize() {
          }
       }
       (*intervals_)[block][block->end()] = input;
-      assert(input == blockOutputs[block]);
+      STACKANALYSIS_ASSERT(input == blockOutputs[block]);
    }
 }
 
@@ -683,7 +700,7 @@ StackAnalysis::Height StackAnalysis::getStackCleanAmount(Function *func) {
          val = 0;
       } else {
          Result imm = ops[1].getValue()->eval();
-         assert(imm.defined);
+         STACKANALYSIS_ASSERT(imm.defined);
          val = (int) imm.val.s16val;
       }
       returnCleanVals.insert(Height(val));
@@ -765,7 +782,7 @@ std::string StackAnalysis::TransferFunc::format() const {
          foundType = true;
       }
       if (isDelta()) {
-         assert(foundType);
+         STACKANALYSIS_ASSERT(foundType);
          ret << "+" << delta;
       }
    }
@@ -798,7 +815,7 @@ void StackAnalysis::findDefinedHeights(ParseAPI::Block* b, Address addr,
       // Analyze?
       if (!analyze()) return;
    }
-   assert(intervals_);
+   STACKANALYSIS_ASSERT(intervals_);
    for (AbslocState::iterator i = (*intervals_)[b][addr].begin();
       i != (*intervals_)[b][addr].end(); ++i) {
       if (i->second.isTop()) continue;
@@ -820,7 +837,7 @@ StackAnalysis::Height StackAnalysis::find(Block *b, Address addr, Absloc loc) {
       // Analyze?
       if (!analyze()) return Height();
    }
-   assert(intervals_);
+   STACKANALYSIS_ASSERT(intervals_);
 
    //(*intervals_)[b].find(addr, state);
    //  ret = (*intervals_)[b][addr][reg];
@@ -959,7 +976,7 @@ void StackAnalysis::handleXor(Instruction::Ptr insn, Block *block,
    const Offset off, TransferFuncs &xferFuncs) {
    std::vector<Operand> operands;
    insn->getOperands(operands);
-   assert(operands.size() == 2);
+   STACKANALYSIS_ASSERT(operands.size() == 2);
 
    // Handle the case where a register is being zeroed out.
    // We recognize such cases as follows:
@@ -989,11 +1006,11 @@ void StackAnalysis::handleXor(Instruction::Ptr insn, Block *block,
 
    if (insn->writesMemory()) {
       // xor mem1, reg2/imm2
-      assert(writtenSet.size() == 0);
+      STACKANALYSIS_ASSERT(writtenSet.size() == 0);
 
       // Extract the expression inside the dereference
       std::vector<Expression::Ptr> &addrExpr = children0;
-      assert(addrExpr.size() == 1);
+      STACKANALYSIS_ASSERT(addrExpr.size() == 1);
 
       // Try to determine the written memory address
       Absloc writtenLoc;
@@ -1021,7 +1038,7 @@ void StackAnalysis::handleXor(Instruction::Ptr insn, Block *block,
 
       if (readSet.size() > 0) {
          // xor mem1, reg2
-         assert(readSet.size() == 1);
+         STACKANALYSIS_ASSERT(readSet.size() == 1);
          Absloc from((*readSet.begin())->getID());
          std::map<Absloc, std::pair<long, bool>> fromRegs;
          fromRegs[writtenLoc] = std::make_pair(1, true);
@@ -1031,7 +1048,7 @@ void StackAnalysis::handleXor(Instruction::Ptr insn, Block *block,
          // xor mem1, imm2
          // Xor with immediate.  Set topBottom on target loc
          Expression::Ptr immExpr = operands[1].getValue();
-         assert(dynamic_cast<Immediate*>(immExpr.get()));
+         STACKANALYSIS_ASSERT(dynamic_cast<Immediate*>(immExpr.get()));
          xferFuncs.push_back(TransferFunc::copyFunc(writtenLoc, writtenLoc,
             true));
       }
@@ -1039,7 +1056,7 @@ void StackAnalysis::handleXor(Instruction::Ptr insn, Block *block,
    }
 
 
-   assert(writtenSet.size() == 1);
+   STACKANALYSIS_ASSERT(writtenSet.size() == 1);
    MachRegister written = (*writtenSet.begin())->getID();
    Absloc writtenLoc(written);
 
@@ -1047,7 +1064,7 @@ void StackAnalysis::handleXor(Instruction::Ptr insn, Block *block,
       // xor reg1, mem2
       // Extract the expression inside the dereference
       std::vector<Expression::Ptr> &addrExpr = children1;
-      assert(addrExpr.size() == 1);
+      STACKANALYSIS_ASSERT(addrExpr.size() == 1);
 
       // Try to determine the read memory address
       StateEvalVisitor visitor;
@@ -1085,7 +1102,7 @@ void StackAnalysis::handleXor(Instruction::Ptr insn, Block *block,
    // xor reg1, reg2/imm2
    MachRegister read;
    if (!readSet.empty()) {
-      assert(readSet.size() == 1);
+      STACKANALYSIS_ASSERT(readSet.size() == 1);
       read = (*readSet.begin())->getID();
    }
    Absloc readLoc(read);
@@ -1100,7 +1117,7 @@ void StackAnalysis::handleXor(Instruction::Ptr insn, Block *block,
    } else {
       // xor reg1, imm1
       InstructionAPI::Expression::Ptr readExpr = operands[1].getValue();
-      assert(dynamic_cast<Immediate*>(readExpr.get()));
+      STACKANALYSIS_ASSERT(dynamic_cast<Immediate*>(readExpr.get()));
       xferFuncs.push_back(TransferFunc::copyFunc(writtenLoc, writtenLoc, true));
       copyBaseSubReg(written, xferFuncs);
    }
@@ -1111,14 +1128,14 @@ void StackAnalysis::handleDiv(Instruction::Ptr insn,
    TransferFuncs &xferFuncs) {
    std::vector<Operand> operands;
    insn->getOperands(operands);
-   assert(operands.size() == 3);
+   STACKANALYSIS_ASSERT(operands.size() == 3);
 
    Expression::Ptr quotient = operands[1].getValue();
    Expression::Ptr remainder = operands[0].getValue();
    Expression::Ptr divisor = operands[2].getValue();
-   assert(dynamic_cast<RegisterAST*>(quotient.get()));
-   assert(dynamic_cast<RegisterAST*>(remainder.get()));
-   assert(!dynamic_cast<Immediate*>(divisor.get()));
+   STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(quotient.get()));
+   STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(remainder.get()));
+   STACKANALYSIS_ASSERT(!dynamic_cast<Immediate*>(divisor.get()));
 
    MachRegister quotientReg = (boost::dynamic_pointer_cast<InstructionAPI::
       RegisterAST>(quotient))->getID();
@@ -1143,10 +1160,10 @@ void StackAnalysis::handleMul(Instruction::Ptr insn,
    //     -- reg1:reg2 = reg2 * reg3/mem3
    std::vector<Operand> operands;
    insn->getOperands(operands);
-   assert(operands.size() == 2 || operands.size() == 3);
+   STACKANALYSIS_ASSERT(operands.size() == 2 || operands.size() == 3);
 
    Expression::Ptr target = operands[0].getValue();
-   assert(dynamic_cast<RegisterAST*>(target.get()));
+   STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(target.get()));
    MachRegister targetReg = (boost::dynamic_pointer_cast<InstructionAPI::
       RegisterAST>(target))->getID();
 
@@ -1160,7 +1177,7 @@ void StackAnalysis::handleMul(Instruction::Ptr insn,
 
       if (dynamic_cast<Immediate*>(multiplier.get())) {
          // Form 2
-         assert(dynamic_cast<RegisterAST*>(multiplicand.get()) ||
+         STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(multiplicand.get()) ||
             dynamic_cast<Dereference*>(multiplicand.get()));
          long multiplierVal = multiplier->eval().convert<long>();
          if (multiplierVal == 0) {
@@ -1188,8 +1205,8 @@ void StackAnalysis::handleMul(Instruction::Ptr insn,
          }
       } else {
          // Form 3
-         assert(dynamic_cast<RegisterAST*>(multiplicand.get()));
-         assert(dynamic_cast<RegisterAST*>(multiplier.get()) ||
+         STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(multiplicand.get()));
+         STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(multiplier.get()) ||
             dynamic_cast<Dereference*>(multiplier.get()));
          MachRegister multiplicandReg = boost::dynamic_pointer_cast<
             RegisterAST>(multiplicand)->getID();
@@ -1238,7 +1255,7 @@ void StackAnalysis::handlePushPop(Instruction::Ptr insn, Block *block,
                long immVal = readExpr->eval().convert<long>();
                xferFuncs.push_back(TransferFunc::absFunc(writtenLoc, immVal));
             } else {
-               assert(false);
+               STACKANALYSIS_ASSERT(false);
             }
          }
       }
@@ -1247,7 +1264,7 @@ void StackAnalysis::handlePushPop(Instruction::Ptr insn, Block *block,
 
       // Get target register
       Expression::Ptr targExpr = insn->getOperand(0).getValue();
-      assert(dynamic_cast<RegisterAST*>(targExpr.get()));
+      STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(targExpr.get()));
       MachRegister targReg = boost::dynamic_pointer_cast<RegisterAST>(
          targExpr)->getID();
       Absloc targLoc(targReg);
@@ -1277,7 +1294,7 @@ void StackAnalysis::handlePushPop(Instruction::Ptr insn, Block *block,
          bottomBaseSubReg(targReg, xferFuncs);
       }
    } else {
-      assert(false);
+      STACKANALYSIS_ASSERT(false);
    }
 }
 
@@ -1291,7 +1308,7 @@ void StackAnalysis::handleReturn(Instruction::Ptr insn,
    } else {
       fprintf(stderr, "Unhandled RET instruction: %s\n",
          insn->format().c_str());
-      assert(false);
+      STACKANALYSIS_ASSERT(false);
    }
 /*   else if (operands.size() == 1) {
       // Ret immediate
@@ -1341,7 +1358,7 @@ void StackAnalysis::handleAddSub(Instruction::Ptr insn, Block *block,
 
    std::vector<Operand> operands;
    insn->getOperands(operands);
-   assert(operands.size() == 2);
+   STACKANALYSIS_ASSERT(operands.size() == 2);
 
    std::set<RegisterAST::Ptr> readSet;
    std::set<RegisterAST::Ptr> writeSet;
@@ -1350,12 +1367,12 @@ void StackAnalysis::handleAddSub(Instruction::Ptr insn, Block *block,
 
    if (insn->writesMemory()) {
       // Cases 3 and 5
-      assert(writeSet.size() == 0);
+      STACKANALYSIS_ASSERT(writeSet.size() == 0);
 
       // Extract the expression inside the dereference
       std::vector<Expression::Ptr> addrExpr;
       operands[0].getValue()->getChildren(addrExpr);
-      assert(addrExpr.size() == 1);
+      STACKANALYSIS_ASSERT(addrExpr.size() == 1);
 
       // Try to determine the written memory address
       Absloc writtenLoc;
@@ -1382,7 +1399,7 @@ void StackAnalysis::handleAddSub(Instruction::Ptr insn, Block *block,
 
       if (readSet.size() > 0) {
          // Case 3a
-         assert(readSet.size() == 1);
+         STACKANALYSIS_ASSERT(readSet.size() == 1);
          const MachRegister &srcReg = (*readSet.begin())->getID();
          if ((signed int) srcReg.regClass() == x86::XMM ||
             (signed int) srcReg.regClass() == x86_64::XMM) {
@@ -1400,7 +1417,7 @@ void StackAnalysis::handleAddSub(Instruction::Ptr insn, Block *block,
       } else {
          // Case 5a
          Expression::Ptr immExpr = operands[1].getValue();
-         assert(dynamic_cast<Immediate*>(immExpr.get()));
+         STACKANALYSIS_ASSERT(dynamic_cast<Immediate*>(immExpr.get()));
          long immVal = immExpr->eval().convert<long>();
          xferFuncs.push_back(TransferFunc::deltaFunc(writtenLoc,
             sign * immVal));
@@ -1409,7 +1426,7 @@ void StackAnalysis::handleAddSub(Instruction::Ptr insn, Block *block,
    }
 
    // Cases 1, 2, and 4
-   assert(writeSet.size() == 1);
+   STACKANALYSIS_ASSERT(writeSet.size() == 1);
    const MachRegister &written = (*writeSet.begin())->getID();
    Absloc writtenLoc(written);
 
@@ -1425,7 +1442,7 @@ void StackAnalysis::handleAddSub(Instruction::Ptr insn, Block *block,
       // Extract the expression inside the dereference
       std::vector<Expression::Ptr> addrExpr;
       operands[1].getValue()->getChildren(addrExpr);
-      assert(addrExpr.size() == 1);
+      STACKANALYSIS_ASSERT(addrExpr.size() == 1);
 
       // Try to determine the read memory address
       StateEvalVisitor visitor;
@@ -1507,8 +1524,8 @@ void StackAnalysis::handleLEA(Instruction::Ptr insn,
    std::set<RegisterAST::Ptr> writtenSet;
    insn->getOperand(0).getWriteSet(writtenSet);
    insn->getOperand(1).getReadSet(readSet);
-   assert(writtenSet.size() == 1);
-   assert(readSet.size() == 0 || readSet.size() == 1 || readSet.size() == 2);
+   STACKANALYSIS_ASSERT(writtenSet.size() == 1);
+   STACKANALYSIS_ASSERT(readSet.size() == 0 || readSet.size() == 1 || readSet.size() == 2);
    MachRegister written = (*writtenSet.begin())->getID();
    Absloc writeloc(written);
 
@@ -1519,7 +1536,7 @@ void StackAnalysis::handleLEA(Instruction::Ptr insn,
 
    if (readSet.size() == 0) {
       // op1: imm
-      assert(typeid(*srcExpr) == typeid(Immediate));
+      STACKANALYSIS_ASSERT(typeid(*srcExpr) == typeid(Immediate));
       long immVal = srcExpr->eval().convert<long>();
       xferFuncs.push_back(TransferFunc::absFunc(writeloc, immVal));
       retopBaseSubReg(written, xferFuncs);
@@ -1533,32 +1550,32 @@ void StackAnalysis::handleLEA(Instruction::Ptr insn,
             // op1: imm + reg * imm
             deltaExpr = children[0];
             Expression::Ptr scaleIndexExpr = children[1];
-            assert(dynamic_cast<BinaryFunction*>(scaleIndexExpr.get()));
+            STACKANALYSIS_ASSERT(dynamic_cast<BinaryFunction*>(scaleIndexExpr.get()));
             children.clear();
             scaleIndexExpr->getChildren(children);
 
             regExpr = children[0];
             scaleExpr = children[1];
-            assert(dynamic_cast<RegisterAST*>(regExpr.get()));
-            assert(dynamic_cast<Immediate*>(scaleExpr.get()));
+            STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(regExpr.get()));
+            STACKANALYSIS_ASSERT(dynamic_cast<Immediate*>(scaleExpr.get()));
             foundScale = true;
             foundDelta = true;
          } else if (dynamic_cast<RegisterAST*>(children[0].get())) {
             // op1: reg + imm
             regExpr = children[0];
             deltaExpr = children[1];
-            assert(dynamic_cast<RegisterAST*>(regExpr.get()));
-            assert(dynamic_cast<Immediate*>(deltaExpr.get()));
+            STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(regExpr.get()));
+            STACKANALYSIS_ASSERT(dynamic_cast<Immediate*>(deltaExpr.get()));
             foundDelta = true;
          } else {
-            assert(false);
+            STACKANALYSIS_ASSERT(false);
          }
       } else if (children.size() == 0) {
          // op1: reg
          regExpr = srcExpr;
-         assert(dynamic_cast<RegisterAST*>(regExpr.get()));
+         STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(regExpr.get()));
       } else {
-         assert(false);
+         STACKANALYSIS_ASSERT(false);
       }
 
       MachRegister reg = (boost::dynamic_pointer_cast<InstructionAPI::
@@ -1590,34 +1607,34 @@ void StackAnalysis::handleLEA(Instruction::Ptr insn,
       Expression::Ptr baseExpr, indexExpr, scaleExpr, deltaExpr;
       bool foundDelta = false;
 
-      assert(children.size() == 2);
+      STACKANALYSIS_ASSERT(children.size() == 2);
       if (dynamic_cast<Immediate*>(children[1].get())) {
          // op1: reg + reg * imm + imm
          // Extract the delta and continue on to get base, index, and scale
          deltaExpr = children[1];
          Expression::Ptr sibExpr = children[0];
-         assert(dynamic_cast<BinaryFunction*>(sibExpr.get()));
+         STACKANALYSIS_ASSERT(dynamic_cast<BinaryFunction*>(sibExpr.get()));
          children.clear();
          sibExpr->getChildren(children);
-         assert(children.size() == 2);
+         STACKANALYSIS_ASSERT(children.size() == 2);
          foundDelta = true;
       }
 
       // op1: reg + reg * imm
       baseExpr = children[0];
       Expression::Ptr scaleIndexExpr = children[1];
-      assert(dynamic_cast<BinaryFunction*>(scaleIndexExpr.get()));
+      STACKANALYSIS_ASSERT(dynamic_cast<BinaryFunction*>(scaleIndexExpr.get()));
 
       // Extract the index and scale
       children.clear();
       scaleIndexExpr->getChildren(children);
-      assert(children.size() == 2);
+      STACKANALYSIS_ASSERT(children.size() == 2);
       indexExpr = children[0];
       scaleExpr = children[1];
 
-      assert(dynamic_cast<RegisterAST*>(baseExpr.get()));
-      assert(dynamic_cast<RegisterAST*>(indexExpr.get()));
-      assert(dynamic_cast<Immediate*>(scaleExpr.get()));
+      STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(baseExpr.get()));
+      STACKANALYSIS_ASSERT(dynamic_cast<RegisterAST*>(indexExpr.get()));
+      STACKANALYSIS_ASSERT(dynamic_cast<Immediate*>(scaleExpr.get()));
 
       MachRegister base = (boost::dynamic_pointer_cast<InstructionAPI::
          RegisterAST>(baseExpr))->getID();
@@ -1631,7 +1648,7 @@ void StackAnalysis::handleLEA(Instruction::Ptr insn,
          delta = extractDelta(deltaRes);
       }
 
-      assert(base.isValid() && index.isValid() && scale != -1);
+      STACKANALYSIS_ASSERT(base.isValid() && index.isValid() && scale != -1);
 
       // Consolidate when possible
       if (base == index) {
@@ -1647,7 +1664,7 @@ void StackAnalysis::handleLEA(Instruction::Ptr insn,
       xferFuncs.push_back(TransferFunc::sibFunc(fromRegs, delta, writeloc));
       copyBaseSubReg(written, xferFuncs);
    } else {
-      assert(false);
+      STACKANALYSIS_ASSERT(false);
    }
 }
 
@@ -1784,7 +1801,7 @@ void StackAnalysis::handleMov(Instruction::Ptr insn, Block *block,
    // Extract operands
    std::vector<Operand> operands;
    insn->getOperands(operands);
-   assert(operands.size() == 2);
+   STACKANALYSIS_ASSERT(operands.size() == 2);
 
    // Extract written/read register sets
    std::set<RegisterAST::Ptr> writtenRegs;
@@ -1794,12 +1811,12 @@ void StackAnalysis::handleMov(Instruction::Ptr insn, Block *block,
 
 
    if (insn->writesMemory()) {
-      assert(writtenRegs.size() == 0);
+      STACKANALYSIS_ASSERT(writtenRegs.size() == 0);
 
       // Extract the expression inside the dereference
       std::vector<Expression::Ptr> addrExpr;
       operands[0].getValue()->getChildren(addrExpr);
-      assert(addrExpr.size() == 1);
+      STACKANALYSIS_ASSERT(addrExpr.size() == 1);
 
       // Try to determine the written memory address
       Absloc writtenLoc;
@@ -1826,7 +1843,7 @@ void StackAnalysis::handleMov(Instruction::Ptr insn, Block *block,
 
       if (readRegs.size() > 0) {
          // Case 4a
-         assert(readRegs.size() == 1);
+         STACKANALYSIS_ASSERT(readRegs.size() == 1);
          const MachRegister &reg = (*readRegs.begin())->getID();
          if ((signed int) reg.regClass() == x86::XMM ||
             (signed int) reg.regClass() == x86_64::XMM) {
@@ -1839,7 +1856,7 @@ void StackAnalysis::handleMov(Instruction::Ptr insn, Block *block,
       } else {
          // Case 5a
          Expression::Ptr immExpr = operands[1].getValue();
-         assert(dynamic_cast<Immediate*>(immExpr.get()));
+         STACKANALYSIS_ASSERT(dynamic_cast<Immediate*>(immExpr.get()));
          long immVal = immExpr->eval().convert<long>();
          xferFuncs.push_back(TransferFunc::absFunc(writtenLoc, immVal));
       }
@@ -1849,7 +1866,7 @@ void StackAnalysis::handleMov(Instruction::Ptr insn, Block *block,
 
    // Only Cases 1, 2, and 3 can reach this point.
    // As a result, we know there's exactly one written register.
-   assert(writtenRegs.size() == 1);
+   STACKANALYSIS_ASSERT(writtenRegs.size() == 1);
    const MachRegister &written = (*writtenRegs.begin())->getID();
    Absloc writtenLoc(written);
 
@@ -1864,7 +1881,7 @@ void StackAnalysis::handleMov(Instruction::Ptr insn, Block *block,
       // Extract the expression inside the dereference
       std::vector<Expression::Ptr> addrExpr;
       operands[1].getValue()->getChildren(addrExpr);
-      assert(addrExpr.size() == 1);
+      STACKANALYSIS_ASSERT(addrExpr.size() == 1);
 
       // Try to determine the read memory address
       StateEvalVisitor visitor;
@@ -1900,7 +1917,7 @@ void StackAnalysis::handleMov(Instruction::Ptr insn, Block *block,
    // As a result, we know there's either 0 or 1 read registers
    MachRegister read;
    if (!readRegs.empty()) {
-      assert(readRegs.size() == 1);
+      STACKANALYSIS_ASSERT(readRegs.size() == 1);
       read = (*readRegs.begin())->getID();
    }
    Absloc readLoc(read);
@@ -1919,7 +1936,7 @@ void StackAnalysis::handleMov(Instruction::Ptr insn, Block *block,
    } else {
       // Case 2
       InstructionAPI::Expression::Ptr readExpr = operands[1].getValue();
-      assert(dynamic_cast<Immediate*>(readExpr.get()));
+      STACKANALYSIS_ASSERT(dynamic_cast<Immediate*>(readExpr.get()));
       long readValue = readExpr->eval().convert<long>();
       xferFuncs.push_back(TransferFunc::absFunc(writtenLoc, readValue));
       retopBaseSubReg(written, xferFuncs);
@@ -1929,12 +1946,12 @@ void StackAnalysis::handleMov(Instruction::Ptr insn, Block *block,
 void StackAnalysis::handleZeroExtend(Instruction::Ptr insn, Block *block,
    const Offset off, TransferFuncs &xferFuncs) {
    // In x86/x86_64, zero extends can't write to memory
-   assert(!insn->writesMemory());
+   STACKANALYSIS_ASSERT(!insn->writesMemory());
 
    // Extract operands
    std::vector<Operand> operands;
    insn->getOperands(operands);
-   assert(operands.size() == 2);
+   STACKANALYSIS_ASSERT(operands.size() == 2);
 
    // Extract written/read register sets
    std::set<RegisterAST::Ptr> writtenRegs;
@@ -1942,7 +1959,7 @@ void StackAnalysis::handleZeroExtend(Instruction::Ptr insn, Block *block,
    operands[0].getWriteSet(writtenRegs);
    operands[1].getReadSet(readRegs);
 
-   assert(writtenRegs.size() == 1);
+   STACKANALYSIS_ASSERT(writtenRegs.size() == 1);
    const MachRegister &written = (*writtenRegs.begin())->getID();
    Absloc writtenLoc(written);
 
@@ -1951,7 +1968,7 @@ void StackAnalysis::handleZeroExtend(Instruction::Ptr insn, Block *block,
       // Extract the expression inside the dereference
       std::vector<Expression::Ptr> addrExpr;
       operands[1].getValue()->getChildren(addrExpr);
-      assert(addrExpr.size() == 1);
+      STACKANALYSIS_ASSERT(addrExpr.size() == 1);
 
       // Try to determine the read memory address
       StateEvalVisitor visitor;
@@ -1982,7 +1999,7 @@ void StackAnalysis::handleZeroExtend(Instruction::Ptr insn, Block *block,
       return;
    }
 
-   assert(readRegs.size() == 1);
+   STACKANALYSIS_ASSERT(readRegs.size() == 1);
    Absloc readLoc((*readRegs.begin())->getID());
 
    xferFuncs.push_back(TransferFunc::copyFunc(readLoc, writtenLoc));
@@ -1996,12 +2013,12 @@ void StackAnalysis::handleSignExtend(Instruction::Ptr insn, Block *block,
    // to change the value...
 
    // In x86/x86_64, sign extends can't write to memory
-   assert(!insn->writesMemory());
+   STACKANALYSIS_ASSERT(!insn->writesMemory());
 
    // Extract operands
    std::vector<Operand> operands;
    insn->getOperands(operands);
-   assert(operands.size() == 2);
+   STACKANALYSIS_ASSERT(operands.size() == 2);
 
    // Extract written/read register sets
    std::set<RegisterAST::Ptr> writtenRegs;
@@ -2009,7 +2026,7 @@ void StackAnalysis::handleSignExtend(Instruction::Ptr insn, Block *block,
    operands[0].getWriteSet(writtenRegs);
    operands[1].getReadSet(readRegs);
 
-   assert(writtenRegs.size() == 1);
+   STACKANALYSIS_ASSERT(writtenRegs.size() == 1);
    const MachRegister &written = (*writtenRegs.begin())->getID();
    Absloc writtenLoc(written);
 
@@ -2018,7 +2035,7 @@ void StackAnalysis::handleSignExtend(Instruction::Ptr insn, Block *block,
       // Extract the expression inside the dereference
       std::vector<Expression::Ptr> addrExpr;
       operands[1].getValue()->getChildren(addrExpr);
-      assert(addrExpr.size() == 1);
+      STACKANALYSIS_ASSERT(addrExpr.size() == 1);
 
       // Try to determine the read memory address
       StateEvalVisitor visitor;
@@ -2050,7 +2067,7 @@ void StackAnalysis::handleSignExtend(Instruction::Ptr insn, Block *block,
       return;
    }
 
-   assert(readRegs.size() == 1);
+   STACKANALYSIS_ASSERT(readRegs.size() == 1);
    Absloc readLoc((*readRegs.begin())->getID());
 
    xferFuncs.push_back(TransferFunc::copyFunc(readLoc, writtenLoc, true));
@@ -2066,7 +2083,7 @@ void StackAnalysis::handleSpecialSignExtend(Instruction::Ptr insn,
    // Extract written/read register sets
    std::set<RegisterAST::Ptr> writtenRegs;
    insn->getWriteSet(writtenRegs);
-   assert(writtenRegs.size() == 1);
+   STACKANALYSIS_ASSERT(writtenRegs.size() == 1);
    MachRegister writtenReg = (*writtenRegs.begin())->getID();
    MachRegister readReg;
    if (writtenReg == x86_64::rax) readReg = x86_64::eax;
@@ -2074,7 +2091,7 @@ void StackAnalysis::handleSpecialSignExtend(Instruction::Ptr insn,
    else if (writtenReg == x86_64::ax) readReg = x86_64::al;
    else if (writtenReg == x86::eax) readReg = x86::ax;
    else if (writtenReg == x86::ax) readReg = x86::al;
-   else assert(false);
+   else STACKANALYSIS_ASSERT(false);
 
    Absloc writtenLoc(writtenReg);
    Absloc readLoc(readReg);
@@ -2261,7 +2278,7 @@ bool StackAnalysis::handleNormalCall(Instruction::Ptr insn, Block *block,
                if (tf.target.off() < 0) {
                   fprintf(stderr, "Function summary writes to own frame\n");
                   fprintf(stderr, "%s\n", tf.format().c_str());
-                  assert(false);
+                  STACKANALYSIS_ASSERT(false);
                }
                int newOff = tf.target.off() + (int) spHeight.height();
                tf.target = Absloc(newOff, 0, NULL);
@@ -2427,7 +2444,7 @@ bool StackAnalysis::handleJump(Instruction::Ptr insn, Block *block, Offset off,
                if (tf.target.off() < 0) {
                   fprintf(stderr, "Function summary writes to own frame\n");
                   fprintf(stderr, "%s\n", tf.format().c_str());
-                  assert(false);
+                  STACKANALYSIS_ASSERT(false);
                }
                int newOff = tf.target.off() + (int) spHeight.height();
                tf.target = Absloc(newOff, 0, NULL);
@@ -2563,7 +2580,7 @@ void StackAnalysis::createEntryInput(AbslocState &input) {
    input[Absloc(sp())] = Height(-1 * word_size);
    if (sp() == x86_64::rsp) input[Absloc(x86_64::esp)] = Height(-word_size);
 #else
-   assert(0 && "Unimplemented architecture");
+   STACKANALYSIS_ASSERT(0 && "Unimplemented architecture");
 #endif
 }
 
@@ -2766,7 +2783,7 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::meet(
    if (lhs.isTop() && !lhs.isRetop()) return rhs;
    if (rhs.isTop() && !rhs.isRetop()) return lhs;
 
-   assert(lhs.target == rhs.target);
+   STACKANALYSIS_ASSERT(lhs.target == rhs.target);
    if (lhs == rhs) return lhs;
 
    TransferFunc ret;
@@ -2778,7 +2795,7 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::meet(
          rhs.isSIB()) {
          ret = rhs;
       } else {
-         assert(false);
+         STACKANALYSIS_ASSERT(false);
       }
    } else if (lhs.isCopy()) {
       if (rhs.isAbs()) {
@@ -2813,7 +2830,7 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::meet(
          ret = rhs;
          ret.fromRegs[lhs.from] = std::make_pair(1, true);
       } else {
-         assert(false);
+         STACKANALYSIS_ASSERT(false);
       }
    } else if (lhs.isBottom()) {
       ret = lhs;
@@ -2824,7 +2841,7 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::meet(
          rhs.isSIB()) {
          ret = rhs;
       } else {
-         assert(false);
+         STACKANALYSIS_ASSERT(false);
       }
    } else if (lhs.isSIB()) {
       if (rhs.isAbs()) {
@@ -2866,10 +2883,10 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::meet(
             }
          }
       } else {
-         assert(false);
+         STACKANALYSIS_ASSERT(false);
       }
    } else {
-      assert(false);
+      STACKANALYSIS_ASSERT(false);
    }
    return ret;
 }
@@ -2926,7 +2943,7 @@ bool StackAnalysis::TransferFunc::isSIB() const {
 // uninitialized, or bottom; no deltas.
 StackAnalysis::Height StackAnalysis::TransferFunc::apply(
    const AbslocState &inputs) const {
-   assert(target.isValid());
+   STACKANALYSIS_ASSERT(target.isValid());
    // Bottom stomps everything
    if (isBottom()) {
       return Height::bottom;
@@ -2983,7 +3000,7 @@ StackAnalysis::Height StackAnalysis::TransferFunc::apply(
 
    if (isAbs()) {
       // We cannot be a copy, as the absolute removes that.
-      assert(!isCopy());
+      STACKANALYSIS_ASSERT(!isCopy());
       // Apply the absolute
       // NOTE: an absolute is not a stack height, set input to top
       //input = abs;
@@ -2991,7 +3008,7 @@ StackAnalysis::Height StackAnalysis::TransferFunc::apply(
    }
    if (isCopy()) {
       // Cannot be absolute
-      assert(!isAbs());
+      STACKANALYSIS_ASSERT(!isAbs());
       // Copy the input value from whatever we're a copy of.
       AbslocState::const_iterator iter2 = inputs.find(from);
       if (iter2 != inputs.end()) input = iter2->second;
@@ -3019,9 +3036,9 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::summaryAccumulate(
    if (findTarget != inputs.end()) {
       input = findTarget->second;
    }
-   if (input.target.isValid()) assert(input.target == target);
+   if (input.target.isValid()) STACKANALYSIS_ASSERT(input.target == target);
    input.target = target; // Default constructed TransferFuncs won't have this
-   assert(target.isValid());
+   STACKANALYSIS_ASSERT(target.isValid());
 
    // Bottom stomps everything
    if (isBottom()) {
@@ -3113,7 +3130,7 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::summaryAccumulate(
             }
          } else {
             TransferFunc fromRegFunc = findLoc->second;
-            assert(!fromRegFunc.isBottom());  // Should be special case
+            STACKANALYSIS_ASSERT(!fromRegFunc.isBottom());  // Should be special case
             if (fromRegFunc.isSIB()) {
                // Replace registers and update scales
                for (auto regIter = fromRegFunc.fromRegs.begin();
@@ -3213,11 +3230,11 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::summaryAccumulate(
 
       if (orig.isAbs()) {
          // We reset the height, so we don't care about the inflow height
-         assert(!orig.isCopy());
+         STACKANALYSIS_ASSERT(!orig.isCopy());
          input = orig;
          input.target = target;
          input.topBottom = false;
-         assert(input.target.isValid());
+         STACKANALYSIS_ASSERT(input.target.isValid());
 
          if (isDelta()) {
             input.delta += delta;
@@ -3225,10 +3242,10 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::summaryAccumulate(
          return input;
       }
       if (orig.isCopy()) {
-         assert(!orig.isAbs());
+         STACKANALYSIS_ASSERT(!orig.isAbs());
          input = orig;
          input.target = target;
-         assert(input.target.isValid());
+         STACKANALYSIS_ASSERT(input.target.isValid());
 
          if (isDelta()) {
             input.delta += delta;
@@ -3268,13 +3285,13 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::summaryAccumulate(
       // the delta if it's defined.
       input.from = orig.target;
       input.abs = uninitialized;
-      assert(!orig.isDelta());
+      STACKANALYSIS_ASSERT(!orig.isDelta());
       input.delta = 0;
       input.topBottom = isTopBottomOrig || orig.isTopBottom();
       input.fromRegs.clear();
    }
 
-   assert(!isDelta());
+   STACKANALYSIS_ASSERT(!isDelta());
 
    if (isRetop()) {
       input = *this;
@@ -3300,7 +3317,7 @@ void StackAnalysis::SummaryFunc::apply(const AbslocState &in,
    // Apply in parallel since all summary funcs are from the start of the block
    for (TransferSet::const_iterator iter = accumFuncs.begin();
       iter != accumFuncs.end(); ++iter) {
-      assert(iter->first.isValid());
+      STACKANALYSIS_ASSERT(iter->first.isValid());
       out[iter->first] = iter->second.apply(in);
       if (out[iter->first].isTop()) {
          out.erase(iter->first);
@@ -3317,7 +3334,7 @@ void StackAnalysis::SummaryFunc::accumulate(const TransferSet &in,
 
    // Apply in parallel since all summary funcs are from the start of the block
    for (auto iter = accumFuncs.begin(); iter != accumFuncs.end(); ++iter) {
-      assert(iter->first.isValid());
+      STACKANALYSIS_ASSERT(iter->first.isValid());
       out[iter->first] = iter->second.summaryAccumulate(in);
       if (out[iter->first].isTop() && !out[iter->first].isRetop()) {
          out.erase(iter->first);
@@ -3351,10 +3368,10 @@ void StackAnalysis::SummaryFunc::validate() const {
    for (TransferSet::const_iterator iter = accumFuncs.begin(); 
       iter != accumFuncs.end(); ++iter) {
       const TransferFunc &func = iter->second;
-      assert(func.target.isValid());
-      if (func.isCopy()) assert(!func.isAbs());
-      if (func.isAbs()) assert(!func.isCopy());
-      if (func.isBottom()) assert(!func.isCopy());
+      STACKANALYSIS_ASSERT(func.target.isValid());
+      if (func.isCopy()) STACKANALYSIS_ASSERT(!func.isAbs());
+      if (func.isAbs()) STACKANALYSIS_ASSERT(!func.isCopy());
+      if (func.isBottom()) STACKANALYSIS_ASSERT(!func.isCopy());
    }
 }
 
@@ -3401,7 +3418,7 @@ long StackAnalysis::extractDelta(Result deltaRes) {
          delta = (long)deltaRes.convert<int64_t>();
          break;
       default:
-         assert(0);
+         STACKANALYSIS_ASSERT(0);
    }
    return delta;
 }


### PR DESCRIPTION
Wrap stackanalysis in a try-catch per function analyzed, and replace assertions with exceptions.