### PR TITLE
arm64: remove syscall tracing workaround

### DIFF
--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -1512,34 +1512,6 @@ bool linux_thread::plat_cont()
    int result;
    if (hasPostponedSyscallEvent())
    {
-/* This should be turned on to solve the arm kernel bug.
- * When it recognize the syscall enter event, insert a bp as the fake
- * syscall exit stop.
- */
-#if defined(arch_aarch64) && defined(SYSCALL_EXIT_BREAKPOINT)
-       if( postponed_syscall_event->event_ext == PTRACE_EVENT_FORK ||
-           postponed_syscall_event->event_ext == PTRACE_EVENT_CLONE ){
-            //install bp
-            Dyninst::MachRegisterVal addr;
-            result = plat_getRegister(MachRegister::getPC(this->llproc()->getTargetArch()), addr);
-            if (!result) {
-               fprintf(stderr, "Failed to read PC address upon crash\n");
-            }
-            pthrd_printf("Got SIGTRAP at %lx\n", addr);
-            pthrd_printf("Installing breakpoint for postpone syscall at %lx\n", addr);
-
-            this->BPptr_fakeSyscallExitBp = Breakpoint::ptr();
-            //int_breakpoint *fakeSyscallExitBp = new int_breakpoint(Breakpoint::ptr());
-            int_breakpoint *fakeSyscallExitBp = new int_breakpoint(this->BPptr_fakeSyscallExitBp);
-            fakeSyscallExitBp->setThreadSpecific(this->thread());
-            fakeSyscallExitBp->setOneTimeBreakpoint(true);
-            //this->llproc()->addBreakpoint(addr, fakeSyscallExitBp);
-            this->proc()->addBreakpoint(addr, this->BPptr_fakeSyscallExitBp);
-            this->addr_fakeSyscallExitBp = addr;
-            this->isSet_fakeSyscallExitBp = true;
-       }
-#endif
-
       pthrd_printf("Calling PTRACE_SYSCALL on %d with signal %d\n", lwp, tmpSignal);
       result = do_ptrace((pt_req) PTRACE_SYSCALL, lwp, NULL, data);
    }

--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -2414,7 +2414,11 @@ bool linux_thread::plat_getRegister(Dyninst::MachRegister reg, Dyninst::MachRegi
    result = do_ptrace((pt_req) PTRACE_PEEKUSER, lwp, (void *) (unsigned long) offset, NULL);
 #endif
    //unsigned long result = do_ptrace((pt_req) PTRACE_PEEKUSER, lwp, (void *) (unsigned long) offset, NULL);
-   if (errno != 0) {
+#if defined(arch_aarch64)
+   if (ret != 0) {
+#else
+   if (result != 0) {
+#endif
       int error = errno;
       perr_printf("Error reading registers from %d: %s\n", lwp, strerror(errno));
       //pthrd_printf("ARM-Info: offset(%d-%d)\n", (void *)(unsigned long)offset, offset/8);


### PR DESCRIPTION
After the commit 04d7e098f541769721d7511d56aea4b976fd29fd, in both 32-bit and 64-bit ARM kernels have the capability of tracing a syscall in the fast path as well (ie changing the flag during the syscall execution is allowed). Remove the workaround introduced as part of  commit 215d0f967a259cf883c903965ac490851e665170 .

cc @cuviper 