### PR TITLE
Fix omitting leading 0's when concatenating hex bytes in stringstream

### DIFF
--- a/elf/src/Elf_X.C
+++ b/elf/src/Elf_X.C
@@ -1692,7 +1692,7 @@ bool Elf_X::findDebugFile(std::string origfilename, string &output_name, char* &
               buildid_path << "/usr/lib/debug/.build-id/"
                  << hex << setfill('0') << setw(2) << (unsigned)desc[0] << '/';
               for (unsigned long j = 1; j < note.n_descsz(); ++j)
-                 buildid_path << (unsigned)desc[j];
+                 buildid_path << setw(2) << (unsigned)desc[j];
               buildid_path << ".debug";
               debugFileFromBuildID = buildid_path.str();
               break;


### PR DESCRIPTION
Dear Dyninst-team,

when building the path to separate files with debug information, the code omits leading zeros when concatenating hex bytes into a stringstream. (Problem is that setw() is not persistent). For example:

/usr/lib/debug/.build-id/d5/5c98c7fc69cfc0fc2504bc1df8a81fe7e255f9.debug <-- correct path
/usr/lib/debug/.build-id/d5/5c98c7fc69cfc0fc254bc1df8a81fe7e255f9.debug <-- path build in Elf_X::findDebugFile where the zero in the 0x04 byte is omitted.


