### PR TITLE
Enhance DWARF parser to recognize (and skip) DW_TAG_member entries for static fields

### DIFF
--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -255,6 +255,7 @@ namespace Dyninst {
             bool getFrameBase();
             bool getReturnType(bool hasSpecification, Type *&returnType);
             bool addFuncToContainer(Type *returnType);
+            bool isStaticStructMember(std::vector<VariableLocation> &locs, bool &isStatic);
             virtual bool findType(Type *&, bool defaultToVoid);
             bool findAnyType(Dwarf_Attribute typeAttribute,
                              Dwarf_Bool is_info, Type *&type);


### PR DESCRIPTION
Dear dyninst team,

since DWARF3, static fields in C++ classes are represented by DW_TAG_variable entries and (newly added) DW_TAG_member entries. (Happened with GCC 6.2.1 here.) We found this note/issue on it: http://www.dwarfstd.org/ShowIssue.php?issue=161118.1

This seems not to be covered by dyninst yet when parsing structures: they are exposed as fields but with offset -1 in SymtabAPI. If I am not mistaken, fields exposed by SymtabAPI with offset == -1 can then be either constants or static fields.

As these fields are not part of the structures but global variables instead, we added a check to skip these newly added entries during DWARF parsing. What do you think about it?

We stumbled across this when parsing DWARF generated by GCC 6.2.1 from the following (the cyclic dependency was not handled by our code):

`class A {
    ...
    static A a;
    ...
};`