### PR TITLE
Fix build error on arm64

### DIFF
--- a/cmake/cap_arch_def.cmake
+++ b/cmake/cap_arch_def.cmake
@@ -57,7 +57,7 @@ elseif (PLATFORM MATCHES ppc64)
 elseif (PLATFORM MATCHES aarch64)
   #set (ARCH_DEFINES -Daarch_64 -Darch_64bit)
   set (ARCH_DEFINES -Darch_aarch64 -Darch_64bit)
-  set (CAP_DEFINES ${CAP_DEFINES} -Dcap_32_64 -Dcap_registers)
+  set (CAP_DEFINES ${CAP_DEFINES} -Dcap_32_64 -Dcap_registers -Dcap_stack_mods)
 endif (PLATFORM MATCHES i386)
 
 if (PLATFORM MATCHES linux)

--- a/dyninstAPI/src/Relocation/Widgets/StackModWidget.C
+++ b/dyninstAPI/src/Relocation/Widgets/StackModWidget.C
@@ -74,7 +74,7 @@ string StackModWidget::format() const {
 }
 
 bool StackModPatch::apply(codeGen &gen, CodeBuffer *) {
-#if defined(cap_stack_mods)
+#if defined(cap_stack_mods) && !defined(arch_aarch64)
     instruction ugly_insn(orig_insn->ptr());
     if (gen.modifiedStackFrame()) {
         relocation_cerr << "  Calling modifyDisp" << endl;

--- a/dyninstAPI/src/StackMod/StackModChecker.C
+++ b/dyninstAPI/src/StackMod/StackModChecker.C
@@ -35,7 +35,7 @@
 #include "BPatch_object.h"
 #include "BPatch_point.h"
 
-#if defined(arch_x86) || defined(arch_x86_64)
+#if defined(arch_x86) || defined(arch_x86_64) || defined(arch_aarch64)
 #include "inst-x86.h"
 #elif defined(arch_power)
 #include "inst-power.h"

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -857,7 +857,7 @@ bool AstNode::allocateCanaryRegister(codeGen& gen,
 }
 
 
-#if defined(cap_stack_mods)
+#if defined(cap_stack_mods) && !defined(arch_aarch64)
 bool AstStackInsertNode::generateCode_phase2(codeGen &gen, bool noCost,
         Address &,
         Register &)


### PR DESCRIPTION
It seems the cap_stack_mods capability is expected to work with only the x86 architecture and its variants though, due to the recent merge requires other arches like arm64 be built with it. This fixes Issue #304.

    