### PR TITLE
Update AssignmentConverter instantiation to make use of stack analysis explicit.

### DIFF
--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -353,7 +353,7 @@ namespace {
 
         if (ss_addr == 0) {
             // Get all of the assignments that happen in this instruction
-            AssignmentConverter conv(true);
+            AssignmentConverter conv(true, true);
             vector<Assignment::Ptr> assigns;
             conv.convert(r8_def,r8_def_addr,f,b,assigns);
 

--- a/parseAPI/src/IA_power.C
+++ b/parseAPI/src/IA_power.C
@@ -165,7 +165,7 @@ bool IA_IAPI::sliceReturn(ParseAPI::Block* bit, Address ret_addr, ParseAPI::Func
 
   parsing_printf(" sliceReturn ret 0x%lx address 0x%lx func %s addr 0x%lx \n", ret_addr, bit->lastInsnAddr(), func->name().c_str(), func->addr() );
   AST::Ptr pcDef;
-  AssignmentConverter converter(true);
+  AssignmentConverter converter(true, true);
   vector<Assignment::Ptr>::iterator ait;
   vector<Assignment::Ptr> assgns;
   PPCReturnPredicates preds;


### PR DESCRIPTION
Fixed a couple of cases where I hadn't updated construction sites to account for lack of default args.