### PR TITLE
getVsysInfo() return NULL on arm64

### DIFF
--- a/stackwalk/src/linux-swk.C
+++ b/stackwalk/src/linux-swk.C
@@ -96,7 +96,7 @@ int P_gettid()
 
 vsys_info *Dyninst::Stackwalker::getVsysInfo(ProcessState *ps)
 {
-#if defined(arch_x86_64)
+#if defined(arch_x86_64) || defined(arch_aarch64)
    if (ps->getAddressWidth() == 8)
       return NULL;
 #endif


### PR DESCRIPTION
On arm64 the vsyscall page has been deprecated for some time, just return NULL as done on 64-bit x86 platforms.