### PR TITLE
Fix test_basic test error

### DIFF
--- a/stackwalk/src/linux-swk.C
+++ b/stackwalk/src/linux-swk.C
@@ -96,7 +96,7 @@ int P_gettid()
 
 vsys_info *Dyninst::Stackwalker::getVsysInfo(ProcessState *ps)
 {
-#if defined(arch_x86_64)
+#if defined(arch_x86_64) || defined(arch_aarch64)
    if (ps->getAddressWidth() == 8)
       return NULL;
 #endif

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -250,7 +250,8 @@ void DwarfParseActions::setModuleFromName(std::string moduleName)
 bool DwarfWalker::buildSrcFiles(Dwarf_Debug dbg, Dwarf_Die entry, StringTablePtr srcFiles) {
    Dwarf_Signed cnt = 0;
     char** srcFileList;
-   DWARF_ERROR_RET(dwarf_srcfiles(entry, &srcFileList, &cnt, NULL));
+   Dwarf_Error error;
+   DWARF_ERROR_RET(dwarf_srcfiles(entry, &srcFileList, &cnt, &error));
 
    if(!srcFiles->empty()) {
         return true;


### PR DESCRIPTION
Calling dwarf_srcfiles with error being NULL triggers an error when
deallocating. Fix it by adding an argument to dwarf_srcfiles.
Tested with libdwarf,
```
libdwarf.aarch64                     20161001-1.fc25                     @fedora
```
on Mustang. Please see for more technical background analyzed by William Cohen at:
```
https://bugzilla.redhat.com/show_bug.cgi?id=1316695
```

Unlike x86, Fedora 25 aarch64 still has an old version of libdwarf.