### PR TITLE
Suppress debug message when no vsyscall page was found on arm64

### DIFF
--- a/dyninstAPI/src/linux-aarch64.C
+++ b/dyninstAPI/src/linux-aarch64.C
@@ -85,18 +85,7 @@ Address PCProcess::getTOCoffsetInfo(func_instance *func) {
 }
 
 bool PCProcess::getOPDFunctionAddr(Address &addr) {
-    bool result = true;
-    if( getAddressWidth() == 8 ) {
-        Address resultAddr = 0;
-        if( !readDataSpace((const void *)addr, getAddressWidth(),
-                    (void *)&resultAddr, false) )
-        {
-            result = false;
-        }else{
-            addr = resultAddr;
-       }
-    }
-    return result;
+    return true;
 }
 
 AstNodePtr PCProcess::createUnprotectStackAST() {

--- a/stackwalk/src/linux-swk.C
+++ b/stackwalk/src/linux-swk.C
@@ -308,7 +308,7 @@ void SigHandlerStepperImpl::registerStepperGroup(StepperGroup *group)
    vsys_info *vsyscall = getVsysInfo(ps);
    if (!vsyscall)
    {
-#if !defined(arch_x86_64)
+#if !defined(arch_x86_64) && !defined(arch_aarch64)
       sw_printf("[%s:%u] - Odd.  Couldn't find vsyscall page. Signal handler"
                 " stepping may not work\n", FILE__, __LINE__);
 #endif


### PR DESCRIPTION
`getVsysInfo()` on arm64 has recently changed to return NULL. The test_stack_1 test works on my local x86 box. 