### PR TITLE
Fix 9.3.0 incompatibilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
 script:
     - if [ "$CC" == "clang" ]; then export CC=$HOME/llvm-$LLVM_VERSION/bin/clang; export CXX=$HOME/llvm-$LLVM_VERSION/bin/clang++; fi
     - if [ "$CC" == "gcc" ]; then export CC=gcc-4.9; export CXX=g++-4.9; fi
+    - find /usr -name 'libelf.*'
     - mkdir work
     - cd work
     - cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 env:
     global:
         - LLVM_VERSION=3.7.0
-        - LD_LIBRARY_PATH=$HOME/clang-$LLVM_VERSION/lib:$LD_LIBRARY_PATH
+        - LD_LIBRARY_PATH=$HOME/clang-$LLVM_VERSION/lib:/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ addons:
             - libboost-thread1.55-dev
             - cmake
             - elfutils
+            - libelf1
+            - libelf-dev
             - g++-4.9
 
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
             - libboost-system1.55-dev
             - libboost-thread1.55-dev
             - cmake
-            - libelf-dev
+            - elfutils
             - g++-4.9
 
 compiler:

--- a/cmake/Modules/FindLibElf.cmake
+++ b/cmake/Modules/FindLibElf.cmake
@@ -35,7 +35,7 @@ find_path (LIBELF_INCLUDE_DIR
 
 find_library (LIBELF_LIBRARIES
     NAMES
-      elf.so.1
+      libelf.so.1
     HINTS
       ${LIBELF_LIBRARIES}
     PATHS

--- a/cmake/Modules/FindLibElf.cmake
+++ b/cmake/Modules/FindLibElf.cmake
@@ -35,7 +35,7 @@ find_path (LIBELF_INCLUDE_DIR
 
 find_library (LIBELF_LIBRARIES
     NAMES
-      elf
+      elf.so.1
     HINTS
       ${LIBELF_LIBRARIES}
     PATHS

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -8,8 +8,8 @@ if (UNIX)
       PREFIX ${CMAKE_BINARY_DIR}/libelf
       URL https://sourceware.org/elfutils/ftp/0.168/elfutils-0.168.tar.bz2
       CONFIGURE_COMMAND <SOURCE_DIR>/configure --enable-shared --prefix=${CMAKE_BINARY_DIR}/libelf
-      BUILD_COMMAND make
-      INSTALL_COMMAND make install
+      BUILD_COMMAND make -C libelf
+      INSTALL_COMMAND make -C libelf install
       )
     set(LIBELF_INCLUDE_DIR ${CMAKE_BINARY_DIR}/libelf/include)
     set(LIBELF_LIBRARIES ${CMAKE_BINARY_DIR}/libelf/lib/libelf.so)


### PR DESCRIPTION
Removed accidental requirement for `--std=c++11`/support of `auto` to use Dyninst public headers.
Updated CMake libelf check to only recognize libelf.so.1.
