### PR TITLE
Fixes for API and dependency issues in 9.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 env:
     global:
         - LLVM_VERSION=3.7.0
-        - LD_LIBRARY_PATH=$HOME/clang-$LLVM_VERSION/lib:$LD_LIBRARY_PATH
+        - LD_LIBRARY_PATH=$HOME/clang-$LLVM_VERSION/lib:/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
 
 addons:
     apt:
@@ -18,6 +18,8 @@ addons:
             - libboost-system1.55-dev
             - libboost-thread1.55-dev
             - cmake
+            - elfutils
+            - libelf1
             - libelf-dev
             - g++-4.9
 
@@ -38,6 +40,7 @@ before_install:
 script:
     - if [ "$CC" == "clang" ]; then export CC=$HOME/llvm-$LLVM_VERSION/bin/clang; export CXX=$HOME/llvm-$LLVM_VERSION/bin/clang++; fi
     - if [ "$CC" == "gcc" ]; then export CC=gcc-4.9; export CXX=g++-4.9; fi
+    - find /usr -name 'libelf.*'
     - mkdir work
     - cd work
     - cmake ..

--- a/cmake/Modules/FindLibElf.cmake
+++ b/cmake/Modules/FindLibElf.cmake
@@ -35,7 +35,7 @@ find_path (LIBELF_INCLUDE_DIR
 
 find_library (LIBELF_LIBRARIES
     NAMES
-      elf
+      libelf.so.1
     HINTS
       ${LIBELF_LIBRARIES}
     PATHS

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -8,8 +8,8 @@ if (UNIX)
       PREFIX ${CMAKE_BINARY_DIR}/libelf
       URL https://sourceware.org/elfutils/ftp/0.168/elfutils-0.168.tar.bz2
       CONFIGURE_COMMAND <SOURCE_DIR>/configure --enable-shared --prefix=${CMAKE_BINARY_DIR}/libelf
-      BUILD_COMMAND make
-      INSTALL_COMMAND make install
+      BUILD_COMMAND make -C libelf
+      INSTALL_COMMAND make -C libelf install
       )
     set(LIBELF_INCLUDE_DIR ${CMAKE_BINARY_DIR}/libelf/include)
     set(LIBELF_LIBRARIES ${CMAKE_BINARY_DIR}/libelf/lib/libelf.so)


### PR DESCRIPTION
Dyninst 9.3.0 has two major problems:

1) Users were accidentally required to use the C++11 standard when building tools that use SymtabAPI, directly or indirectly.
2) While we removed libelf.so.0 support, our dependency infrastructure and CI settings would still try to use libelf.so.0.

Both of these are now fixed: we require libelf.so.1 to be present, and the spurious use of `auto` in public headers has been removed (along with some dead code).
