### PR TITLE
[DWARF] Allow parsing unnamed structs/unions/classes; allow parsing members of unions that have no location information

### DIFF
--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -1244,9 +1244,14 @@ bool DwarfWalker::parseMember() {
    std::vector<VariableLocation> locs;
    Address initialStackValue = 0;
    if (!decodeLocationList(DW_AT_data_member_location, &initialStackValue, locs)) return false;
-   if (locs.empty()) {	   
-      dwarf_printf("(0x%lx) Skipping member as no location is given.\n", id()); 
-      return true;
+   if (locs.empty()) {
+	if (curEnclosure()->getUnionType()) {
+		/* GCC generates DW_TAG_union_type without DW_AT_data_member_location */
+		if (!constructConstantVariableLocation((Address) 0, locs)) return false;
+	} else {
+		dwarf_printf("(0x%lx) Skipping member as no location is given.\n", id()); 
+		return true;
+	}
    }
 
    /* DWARF stores offsets in bytes unless the member is a bit field.

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -1175,6 +1175,30 @@ bool DwarfWalker::parseStructUnionClass() {
           tag() == DW_TAG_union_type ||
           tag() == DW_TAG_class_type);
    if (!findName(curName())) return false;
+   if (!nameDefined()) {
+      /* anonymous unions, structs and classes are explicitely labelled */
+      Dwarf_Unsigned lineNumber;
+      bool hasLineNumber = false;
+      std::string fileName;  
+      if (!getLineInformation(lineNumber, hasLineNumber, fileName)) return false;
+      stringstream ss;
+      ss << "{anonymous ";
+      switch (tag()) {
+      case DW_TAG_structure_type:
+         ss << "struct";
+	 break;
+      case DW_TAG_union_type:
+         ss << "union";
+	 break;
+      case DW_TAG_class_type:
+         ss << "class";
+	 break;
+      }
+      if (fileName.length() && hasLineNumber)
+	     ss << " at " << fileName << ":" << lineNumber;
+      ss << "}";
+      curName() = ss.str();
+   }
 
    bool isDeclaration = false;
    if (!hasDeclaration(isDeclaration)) return false;


### PR DESCRIPTION
Hi Dyninst-team,

we just noticed that the DWARF parser rejects any structs, unions or classes without a name attribute. The first patch makes the name for them optional: at least structs and unions are often unnamed in C. Maybe classes should still require a name attribute?

The second patch regards our previous pull request #299 -- we are not certain about DWARF in general, but GCC generates members of unions without any location information. This is for example the case for the typedef Elf64_Dyn in ld-linux.so on our Debian computer:

```
<1><9dbfd>: Abbrev Number: 14 (DW_TAG_union_type)
    <9dbfe>   DW_AT_byte_size   : 8
    <9dbff>   DW_AT_decl_file   : 3
    <9dc00>   DW_AT_decl_line   : 803
    <9dc02>   DW_AT_sibling     : <0x9dc1f>
 <2><9dc06>: Abbrev Number: 15 (DW_TAG_member)
    <9dc07>   DW_AT_name        : (indirect string, offset: 0x16a): d_val
    <9dc0b>   DW_AT_decl_file   : 3
    <9dc0c>   DW_AT_decl_line   : 805
    <9dc0e>   DW_AT_type        : <0x9d978>
 <2><9dc12>: Abbrev Number: 15 (DW_TAG_member)
    <9dc13>   DW_AT_name        : (indirect string, offset: 0x479a): d_ptr
    <9dc17>   DW_AT_decl_file   : 3
    <9dc18>   DW_AT_decl_line   : 806
    <9dc1a>   DW_AT_type        : <0x9d999>
 <2><9dc1e>: Abbrev Number: 0
 <1><9dc1f>: Abbrev Number: 11 (DW_TAG_structure_type)
    <9dc20>   DW_AT_byte_size   : 16
    <9dc21>   DW_AT_decl_file   : 3
    <9dc22>   DW_AT_decl_line   : 800
    <9dc24>   DW_AT_sibling     : <0x9dc43>
 <2><9dc28>: Abbrev Number: 12 (DW_TAG_member)
    <9dc29>   DW_AT_name        : (indirect string, offset: 0x29d0): d_tag
    <9dc2d>   DW_AT_decl_file   : 3
    <9dc2e>   DW_AT_decl_line   : 802
    <9dc30>   DW_AT_type        : <0x9d983>
    <9dc34>   DW_AT_data_member_location: 0
 <2><9dc35>: Abbrev Number: 12 (DW_TAG_member)
    <9dc36>   DW_AT_name        : (indirect string, offset: 0x1f5a): d_un
    <9dc3a>   DW_AT_decl_file   : 3
    <9dc3b>   DW_AT_decl_line   : 807
    <9dc3d>   DW_AT_type        : <0x9dbfd>
    <9dc41>   DW_AT_data_member_location: 8
 <2><9dc42>: Abbrev Number: 0
 <1><9dc43>: Abbrev Number: 13 (DW_TAG_typedef)
    <9dc44>   DW_AT_name        : (indirect string, offset: 0x3f1): Elf64_Dyn
    <9dc48>   DW_AT_decl_file   : 3
    <9dc49>   DW_AT_decl_line   : 808
    <9dc4b>   DW_AT_type        : <0x9dc1f>
```

