### PR TITLE
Fix jump table analysis for lulesh 

### DIFF
--- a/parseAPI/src/BoundFactData.C
+++ b/parseAPI/src/BoundFactData.C
@@ -691,6 +691,12 @@ static bool IsTableIndex(set<uint64_t> &values) {
 }
 
 void BoundValue::MemoryRead(Block* b, int readSize) {
+        if (interval.stride == 0) {
+            // This is a read to variable, not a table read
+	    *this = BoundValue::top;
+            return;
+        }
+
 	if (interval != StridedInterval::top) {
 		Address memAddrLow = (Address)interval.low;
 		Address memAddrHigh = (Address)interval.high;

--- a/parseAPI/src/IndirectASTVisitor.C
+++ b/parseAPI/src/IndirectASTVisitor.C
@@ -514,7 +514,10 @@ AST::Ptr JumpTableFormatVisitor::visit(DataflowAPI::RoseAST *ast) {
 }
 
 bool PerformTableRead(BoundValue &target, set<int64_t> & jumpTargets, CodeSource *cs) {
-
+    if (target.tableReadSize > 0 && target.interval.stride == 0) {
+        // This is a PC-relative read to variable, not a table read
+        return false;
+    }
     Address tableBase = (Address)target.interval.low;
     Address tableLastEntry = (Address)target.interval.high;
     int addressWidth = cs->getAddressWidth();


### PR DESCRIPTION
A memory access to a known address should be considered as a variable, rather than a table read. So, the jump table analysis should not try to read the content of the variable, but try to determine whether the variable is bounded and used as a jump table index