### PR TITLE
Support 32-bit builds in Jenkins

### DIFF
--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -39,7 +39,7 @@ if (UNIX)
       URL http://www.paradyn.org/libdwarf/libdwarf-20130126.tar.gz
       #	GIT_REPOSITORY git://git.code.sf.net/p/libdwarf/code libdwarf-code
       #	GIT_TAG 20130126
-      CONFIGURE_COMMAND CFLAGS=-I${LIBELF_INCLUDE_DIR} LDFLAGS=-L${CMAKE_BINARY_DIR}/libelf/lib <SOURCE_DIR>/libdwarf/configure --enable-shared
+      CONFIGURE_COMMAND env CFLAGS=${CMAKE_C_FLAGS}\ -I${LIBELF_INCLUDE_DIR} LDFLAGS=-L${CMAKE_BINARY_DIR}/libelf/lib <SOURCE_DIR>/libdwarf/configure --enable-shared
       BUILD_COMMAND make
       INSTALL_DIR ${CMAKE_BINARY_DIR}/libdwarf
       INSTALL_COMMAND mkdir -p <INSTALL_DIR>/include && mkdir -p <INSTALL_DIR>/lib && install <SOURCE_DIR>/libdwarf/libdwarf.h <INSTALL_DIR>/include && install <SOURCE_DIR>/libdwarf/dwarf.h <INSTALL_DIR>/include && install <BINARY_DIR>/libdwarf.so <INSTALL_DIR>/lib
@@ -56,6 +56,9 @@ if (UNIX)
   add_library(libdwarf_imp SHARED IMPORTED)
   set_property(TARGET libdwarf_imp 
     PROPERTY IMPORTED_LOCATION ${LIBDWARF_LIBRARIES})
+  if(NOT LIBDWARF_FOUND)
+    add_dependencies(libdwarf_imp LibDwarf)
+  endif()
 
   if (NOT USE_GNU_DEMANGLER)
     find_package (LibIberty)
@@ -66,19 +69,23 @@ if (UNIX)
       ExternalProject_Add(LibIberty
 	PREFIX ${CMAKE_BINARY_DIR}/binutils
 	URL http://ftp.gnu.org/gnu/binutils/binutils-2.23.tar.gz
-	CONFIGURE_COMMAND CFLAGS=-fPIC CPPFLAGS=-fPIC PICFLAG=-fPIC <SOURCE_DIR>/libiberty/configure --prefix=${CMAKE_BINARY_DIR}/libiberty --enable-shared
+	CONFIGURE_COMMAND env CFLAGS=${CMAKE_C_FLAGS}\ -fPIC CPPFLAGS=-fPIC PICFLAG=-fPIC <SOURCE_DIR>/libiberty/configure --prefix=${CMAKE_BINARY_DIR}/libiberty --enable-shared
 	BUILD_COMMAND make all
 	INSTALL_DIR ${CMAKE_BINARY_DIR}/libiberty
 	INSTALL_COMMAND install <BINARY_DIR>/libiberty.a <INSTALL_DIR>
 	)
       set(IBERTY_LIBRARIES ${CMAKE_BINARY_DIR}/libiberty/libiberty.a)
       set(IBERTY_FOUND TRUE)
+      set(IBERTY_BUILD TRUE)
     endif()
 
     message(STATUS "Using libiberty ${IBERTY_LIBRARIES}")
     add_library(libiberty_imp STATIC IMPORTED)
     set_property(TARGET libiberty_imp
       PROPERTY IMPORTED_LOCATION ${IBERTY_LIBRARIES})
+    if(IBERTY_BUILD)
+      add_dependencies(libiberty_imp LibIberty)
+    endif()
   endif()
 
   find_package (ThreadDB)

--- a/common/h/dyntypes.h
+++ b/common/h/dyntypes.h
@@ -124,8 +124,13 @@
 
 namespace Dyninst
 {
-   typedef uintptr_t Address;
-   typedef uintptr_t Offset;
+#if defined(_WIN64)
+    typedef uintptr_t Address;
+    typedef uintptr_t Offset;
+#else
+    typedef unsigned long Address;
+    typedef unsigned long Offset;
+#endif
 
 #if defined(_MSC_VER)
    typedef int PID;

--- a/common/src/Types.h
+++ b/common/src/Types.h
@@ -170,7 +170,7 @@ using namespace Dyninst;
 static const Address ADDR_NULL = (Address)(0);
 #else
 #define ADDR_NULL (0)
-typedef uintptr_t Address;
+typedef unsigned long Address;
 #endif
 /* Note the inherent assumption that the size of a "long" integer matches
    that of an address (void*) on every supported Paradyn/Dyninst system!

--- a/dyninstAPI/h/BPatch_instruction.h
+++ b/dyninstAPI/h/BPatch_instruction.h
@@ -69,7 +69,7 @@ class BPATCH_DLL_EXPORT BPatch_instruction {
  public:
 
   BPatch_instruction(internal_instruction *insn,
-	  uintptr_t _addr);
+	  Dyninst::Address _addr);
   virtual ~BPatch_instruction();
 
   void getInstruction(const unsigned char *&_buffer, unsigned char &_length);

--- a/dyninstAPI/h/BPatch_memoryAccess_NP.h
+++ b/dyninstAPI/h/BPatch_memoryAccess_NP.h
@@ -121,27 +121,27 @@ class BPATCH_DLL_EXPORT BPatch_memoryAccess : public BPatch_instruction
   static BPatch_memoryAccess* init_tables();
 
   // initializes only the first access; #bytes is a constant
-  BPatch_memoryAccess(internal_instruction *, uintptr_t _addr,
+  BPatch_memoryAccess(internal_instruction *, Dyninst::Address _addr,
 		      bool _isLoad, bool _isStore, unsigned int _bytes,
 		      long _imm, int _ra, int _rb, unsigned int _scale = 0,
 		      int _cond = -1, bool _nt = false);
 
   // initializes only the first access; #bytes is an expression w/scale
-  BPatch_memoryAccess(internal_instruction *insn, uintptr_t _addr,
+  BPatch_memoryAccess(internal_instruction *insn, Dyninst::Address _addr,
                       bool _isinternal_Load, bool _isStore,
                       long _imm_s, int _ra_s, int _rb_s, unsigned int _scale_s,
                       long _imm_c, int _ra_c, int _rb_c, unsigned int _scale_c,
                       int _cond, bool _nt, int _preFcn = -1);
 
   // initializes only the first access; #bytes is an expression
-  BPatch_memoryAccess(internal_instruction *insn, uintptr_t _addr,
+  BPatch_memoryAccess(internal_instruction *insn, Dyninst::Address _addr,
 		      bool _isLoad, bool _isStore, bool _isPrefetch,
 		      long _imm_s, int _ra_s, int _rb_s,
 		      long _imm_c, int _ra_c, int _rb_c,
 		      unsigned short _preFcn);
 
   // initializes only the first access; #bytes is an expression & not a prefetch
-  BPatch_memoryAccess(internal_instruction *insn, uintptr_t _addr,
+  BPatch_memoryAccess(internal_instruction *insn, Dyninst::Address _addr,
 		      bool _isLoad, bool _isStore, long _imm_s, int _ra_s, int _rb_s,
 		      long _imm_c, int _ra_c, int _rb_c);
 
@@ -156,14 +156,14 @@ class BPATCH_DLL_EXPORT BPatch_memoryAccess : public BPatch_instruction
               int _cond, bool _nt);
 
   // initializes both accesses; #bytes is a constant
-  BPatch_memoryAccess(internal_instruction *insn, uintptr_t _addr,
+  BPatch_memoryAccess(internal_instruction *insn, Dyninst::Address _addr,
                       bool _isLoad, bool _isStore, unsigned int _bytes,
                       long _imm, int _ra, int _rb, unsigned int _scale,
                       bool _isLoad2, bool _isStore2, unsigned int _bytes2,
                       long _imm2, int _ra2, int _rb2, unsigned int _scale2);
 
   // initializes both accesses; #bytes is an expression & not a prefetch
-  BPatch_memoryAccess(internal_instruction *insn, uintptr_t _addr, bool _isLoad, bool _isStore,
+  BPatch_memoryAccess(internal_instruction *insn, Dyninst::Address _addr, bool _isLoad, bool _isStore,
                       long _imm_s, int _ra_s, int _rb_s, unsigned int _scale_s,
                       long _imm_c, int _ra_c, int _rb_c, unsigned int _scale_c,
                       bool _isLoad2, bool _isStore2, long _imm2_s, int _ra2_s, 

--- a/dyninstAPI/src/BPatch_memoryAccess.C
+++ b/dyninstAPI/src/BPatch_memoryAccess.C
@@ -33,10 +33,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../../common/src/Types.h"
 #include "BPatch_memoryAccess_NP.h"
 #include "BPatch_Vector.h"
 #include "BPatch_point.h"
-#include "../../common/src/Types.h"
 
 BPatch_addrSpec_NP::BPatch_addrSpec_NP(long _imm, int _ra, int _rb, int _scale) :
    imm(_imm), 


### PR DESCRIPTION
Jenkins now has a `dyninst-build32` target using `CFLAGS=-m32`, but it needs this cmake fix to pass the flags to external projects.  I also cherry-picked the `Address`/`Offset` change from `v9.3.x`.