### PR TITLE
dyninst parses some function symbol as knownData

### DIFF
--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -65,8 +65,19 @@ SymtabCodeRegion::SymtabCodeRegion(
     st->getAllSymbols(symbols);
     for (auto sit = symbols.begin(); sit != symbols.end(); ++sit)
         if ( (*sit)->getRegion() == reg && (*sit)->getType() != SymtabAPI::Symbol::ST_FUNCTION) {
-	    knownData[(*sit)->getOffset()] = (*sit)->getOffset() + (*sit)->getSize();
-	}
+            bool skip = false;
+            for (auto dupit = symbols.begin(); dupit != symbos.end(); ++dupit) {
+                if ((*dupit)->getRegion() == reg
+                    && (*dupit)->getOffset() == (*sit)->getOffset()
+                    && (*dupit)->getType == SymtabAPI::Symbol::ST_FUNCTION) {
+                    skip = true;
+                    break;
+                }
+            }
+            if (true == skip) continue;
+
+            knownData[(*sit)->getOffset()] = (*sit)->getOffset() + (*sit)->getSize();
+	    }
 }
 
 void

--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -66,7 +66,7 @@ SymtabCodeRegion::SymtabCodeRegion(
     for (auto sit = symbols.begin(); sit != symbols.end(); ++sit)
         if ( (*sit)->getRegion() == reg && (*sit)->getType() != SymtabAPI::Symbol::ST_FUNCTION) {
             bool skip = false;
-            for (auto dupit = symbols.begin(); dupit != symbos.end(); ++dupit) {
+            for (auto dupit = symbols.begin(); dupit != symbols.end(); ++dupit) {
                 if ((*dupit)->getRegion() == reg
                     && (*dupit)->getOffset() == (*sit)->getOffset()
                     && (*dupit)->getType == SymtabAPI::Symbol::ST_FUNCTION) {

--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -69,7 +69,7 @@ SymtabCodeRegion::SymtabCodeRegion(
             for (auto dupit = symbols.begin(); dupit != symbols.end(); ++dupit) {
                 if ((*dupit)->getRegion() == reg
                     && (*dupit)->getOffset() == (*sit)->getOffset()
-                    && (*dupit)->getType == SymtabAPI::Symbol::ST_FUNCTION) {
+                    && (*dupit)->getType() == SymtabAPI::Symbol::ST_FUNCTION) {
                     skip = true;
                     break;
                 }
@@ -77,7 +77,7 @@ SymtabCodeRegion::SymtabCodeRegion(
             if (true == skip) continue;
 
             knownData[(*sit)->getOffset()] = (*sit)->getOffset() + (*sit)->getSize();
-	    }
+        }
 }
 
 void


### PR DESCRIPTION
If symbol A and B share the same Region and Offset, A's type is
FUNCTION, however B is not, it will casue bug that the B's address
will be added into @KnownData. Here we double check whether there
existing another symbol who shares the same Region and Offset with
the current, but its type is FUNCTION, we should prevent the symbol's
address from being added into @knownData.

symbol "__aesni_set_encrypt_key"(type: NOTYPE) and
"aesni_set_encrypt"(type: FUNCTION) in libcrypto.so.1.1 meet
the condition.