### PR TITLE
Some necessary changes for overlapping text regions

### DIFF
--- a/parseAPI/h/CFG.h
+++ b/parseAPI/h/CFG.h
@@ -548,7 +548,12 @@ class PARSER_EXPORT Function : public allocatable, public AnnotatableSparse {
     {
         bool operator()(const Function * f1, const Function * f2) const
         {
-            return f1->addr() < f2->addr();
+            if (f1->region() < f2->region()) return true;
+            else if (f1->region() == f2->region() &&
+                     f1->addr() < f2->addr()) {
+               return true;
+            }
+            return false;
         }
     };
 


### PR DESCRIPTION
Dyninst doesn't fully support binaries that contain text regions
with overlapping address ranges, e.g. CUBINs. This patch adds
necessary but not complete support for this case.