### PR TITLE
Add linux-vdso64.so.1 to the library blacklist.

### DIFF
--- a/common/src/addrtranslate-sysv.C
+++ b/common/src/addrtranslate-sysv.C
@@ -800,6 +800,7 @@ bool AddressTranslateSysV::refresh()
          continue;
       }
       if (obj_name == "linux-vdso.so.1" ||
+	  obj_name == "linux-vdso64.so.1" ||
           obj_name == "linux-gate.so.1") 
       {
          continue;


### PR DESCRIPTION
Ignore linux-vdso64.so.1, which is the vdso variant on some ppc64 linux.