### PR TITLE
Fix sh_info for VERNEED section

### DIFF
--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -1438,7 +1438,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newdata->d_align = 4;
             updateStrLinkShdr.push_back(newshdr);
             newshdr->sh_flags = SHF_ALLOC;
-            newshdr->sh_info = 2;
+            newshdr->sh_info = verneednum;
             updateDynamic(DT_VERNEED, newshdr->sh_addr);
         }
         else if (newSecs[i]->getRegionType() == Region::RT_SYMVERDEF) {


### PR DESCRIPTION
This field used to contain verneednum, but now is hardcoded to 2.
This changes restores the original correct behavior.

Closes #405