### PR TITLE
Sun RPC Interfaces are removed in latest glibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ include (${DYNINST_ROOT}/cmake/shared.cmake)
 configure_file(cmake/version.h.in common/h/dyninstversion.h)
 include_directories(${PROJECT_BINARY_DIR})
 include_directories(${PROJECT_BINARY_DIR}/common/h)
+include_directories("/usr/include/tirpc/")
 set (HEADER_DIRS common
     dataflowAPI
     dyninstAPI

--- a/common/src/linuxHeaders.h
+++ b/common/src/linuxHeaders.h
@@ -281,7 +281,7 @@ inline bool_t P_xdr_string(XDR *x, char **h, const u_int maxsize) {
 inline void P_xdrrec_create(XDR *x, const u_int send_sz, const u_int rec_sz,
 			    const caddr_t handle, 
 			    xdr_rd_func read_r, xdr_wr_func write_f) {
-  xdrrec_create(x, send_sz, rec_sz, handle, (int(*)(char*, char*, int))read_r, (int(*)(char*, char*, int))write_f);}
+  xdrrec_create(x, send_sz, rec_sz, handle, (int(*)(void*, void*, int))read_r, (int(*)(void*, void*, int))write_f);}
 inline bool_t P_xdrrec_endofrecord(XDR *x, int now) { 
   return (xdrrec_endofrecord(x, now));}
 inline bool_t P_xdrrec_skiprecord(XDR *x) { return (xdrrec_skiprecord(x));}

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -2513,8 +2513,8 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData, unsigned size, Elf_D
 
     if (!object->hasReldyn() && !object->hasReladyn()) {
         if (object->getRelType() == Region::RT_REL) {
-            new_dynamic_entries.push_back(make_pair(DT_REL, 0));
-            new_dynamic_entries.push_back(make_pair(DT_RELSZ, 0));
+            new_dynamic_entries.push_back(std::pair<long, long>(DT_REL, 0));
+            new_dynamic_entries.push_back(std::pair<long, long>(DT_RELSZ, 0));
 
             dynamicSecData[DT_REL].push_back(dynsecData + curpos);
             dynsecData[curpos].d_tag = DT_NULL;


### PR DESCRIPTION
This is a simpler fix for "Subject: dyninst does not build with Fedora 28 glibc"