### PR TITLE
Modification to x86 emitter to support SW out of inst frames.

### DIFF
--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -2390,29 +2390,38 @@ void EmitterAMD64::emitStackAlign(int offset, codeGen &gen)
    int saveSlot2 =    8 + AMD64_STACK_ALIGNMENT;
 
    bool saveFlags = false;
+   Register scratch =  gen.rs()->getScratchRegister(gen);
+   // If we cannot allocate a scratch register, use RAX.
+   // It will be restored at the end anyway
+   if (scratch == REG_NULL)
+      scratch = REGNUM_RAX;
+
    if (gen.rs()->checkVolatileRegisters(gen, registerSlot::live)) {
       saveFlags = true;   // We need to save the flags register
       off += 8;           // Allocate stack space to store the flags
    }
 
    emitLEA(REGNUM_RSP, Null_Register, 0, -off, REGNUM_RSP, gen);
-   emitStoreRelative(REGNUM_RAX, saveSlot1, REGNUM_RSP, 8, gen);
+   emitStoreRelative(scratch, saveSlot1, REGNUM_RSP, 8, gen);
    if (saveFlags) {
       emitSimpleInsn(0x9f, gen);
       emitSaveO(gen);
-      emitStoreRelative(REGNUM_RAX, saveSlot2, REGNUM_RSP, 8, gen);
+      emitStoreRelative(scratch, saveSlot2, REGNUM_RSP, 8, gen);
    }
-   emitLEA(REGNUM_RSP, Null_Register, 0, off, REGNUM_RAX, gen);
+   emitLEA(REGNUM_RSP, Null_Register, 0, off, scratch, gen);
+ 
    emitOpRegImm8_64(0x83, EXTENDED_0x83_AND, REGNUM_RSP,
                     -AMD64_STACK_ALIGNMENT, true, gen);
-   emitStoreRelative(REGNUM_RAX, 0, REGNUM_RSP, 8, gen);
+   emitStoreRelative(scratch, 0, REGNUM_RSP, 8, gen);
    if (saveFlags) {
-      emitLoadRelative(REGNUM_RAX, -off+saveSlot2, REGNUM_RAX, 8, gen);
+      emitLoadRelative(scratch, -off+saveSlot2, scratch, 8, gen);
       emitRestoreO(gen);
       emitSimpleInsn(0x9e, gen);
-      emitLoadRelative(REGNUM_RAX, 0, REGNUM_RSP, 8, gen);
+      emitLoadRelative(scratch, 0, REGNUM_RSP, 8, gen);
    }
-   emitLoadRelative(REGNUM_RAX, -off+saveSlot1, REGNUM_RAX, 8, gen);
+   emitLoadRelative(scratch, -off+saveSlot1, scratch, 8, gen);
+
+
 }
 
 bool EmitterAMD64::emitBTSaves(baseTramp* bt,  codeGen &gen)
@@ -2444,8 +2453,9 @@ bool EmitterAMD64::emitBTSaves(baseTramp* bt,  codeGen &gen)
    bool saveFlags = gen.rs()->checkVolatileRegisters(gen, registerSlot::live);
    bool createFrame = !bt || bt->needsFrame() || useFPRs;
    bool saveOrigAddr = createFrame && bt->instP();
-
-   //	printf("Saving registers ...\n");
+   // Stores the offset to the location of the previous SP stored 
+   // in the stack when a frame is created. 
+   uint64_t sp_offset = 0;
    int num_saved = 0;
    int num_to_save = 0;
    //Calculate the number of registers we'll save
@@ -2459,6 +2469,8 @@ bool EmitterAMD64::emitBTSaves(baseTramp* bt,  codeGen &gen)
    }
    if (createFrame) {
       num_to_save++; //will save rbp
+      num_to_save++; //Saving SP
+      num_to_save++; //Saving Flag Variable
    }
    if (saveOrigAddr) {
       num_to_save++; //Stack slot for return value, no actual save though
@@ -2478,6 +2490,9 @@ bool EmitterAMD64::emitBTSaves(baseTramp* bt,  codeGen &gen)
       emitLEA(REGNUM_RSP, Null_Register, 0,
                 -AMD64_RED_ZONE, REGNUM_RSP, gen);
       instFrameSize += AMD64_RED_ZONE;
+      // In cases where redzone offset is skipped without alignment
+      // the previous frame's SP is just the redzone skip + REG_COUNT * 8
+      sp_offset += AMD64_RED_ZONE;
    }
 
    
@@ -2511,23 +2526,44 @@ bool EmitterAMD64::emitBTSaves(baseTramp* bt,  codeGen &gen)
 
    // push a return address for stack walking
    if (saveOrigAddr) {
-      // FIXME use a scratch register!
-      emitMovImmToReg64(REGNUM_RAX, bt->instP()->addr_compat(), true, gen);
-      emitPushReg64(REGNUM_RAX, gen);
-      gen.markRegDefined(REGNUM_RAX);
+      Register origTmp = gen.rs()->getScratchRegister(gen);
+      emitMovImmToReg64(origTmp, bt->instP()->addr_compat(), true, gen);
+      emitPushReg64(origTmp, gen);
+      gen.markRegDefined(origTmp);
       num_saved++;
    }
 
    // Push RBP...
    if (createFrame)
    {
-      // set up a fresh stack frame
+      Register itchy = gen.rs()->getScratchRegister(gen);
+
+      // add an offset each register saved so far.
+      sp_offset += (8 * num_saved);
+      // If stack alignment is used, pull the original SP from the stack
+      // this location is sp_offset.
+      if (alignStack) {
+        emitLoadRelative(itchy, sp_offset, REGNUM_RSP, 8, gen);
+        emitPushReg64(itchy, gen);
+      } else {
+        // Otherwise, the previous SP is exactly SP+sp_offset away
+        emitLEA(REGNUM_RSP, Null_Register, 0, sp_offset, itchy, gen);
+        emitPushReg64(itchy, gen);
+      }
+      // Special Word to help stackwalker know in First Party mode that
+      // it is attempting to walk out of an inst frame.
+      emitMovImmToReg64(itchy, 0xBEEFDEAD, true, gen);
+      emitPushReg64(itchy, gen);
+      gen.rs()->freeRegister(itchy);
+
+        // set up a fresh stack frame
       // pushl %rbp        (0x55)
       // movl  %rsp, %rbp  (0x48 0x89 0xe5)
       emitSimpleInsn(0x55, gen);
       gen.rs()->markSavedRegister(REGNUM_RBP, 0);
       num_saved++;
-
+      num_saved++;
+      num_saved++;
       // And track where it went
       (*gen.rs())[REGNUM_RBP]->liveState = registerSlot::spilled;
       (*gen.rs())[REGNUM_RBP]->spilledState = registerSlot::framePointer;
@@ -2693,6 +2729,11 @@ bool EmitterAMD64::emitBTRestores(baseTramp* bt, codeGen &gen)
    if (createFrame) {
       // tear down the stack frame (LEAVE)
       emitSimpleInsn(0xC9, gen);
+      // Pop the Previous SP and Special Word off of the stack, discard them
+      Register itchy = gen.rs()->getScratchRegister(gen);
+      emitPopReg64(itchy, gen);
+      emitPopReg64(itchy, gen);
+      gen.rs()->freeRegister(itchy);
    }
 
    // pop "fake" return address


### PR DESCRIPTION
This patch contains changes to the emitter to support first party stackwalking out of inst's frames. For inst frames to be walkable, instrimentation frames must be enabled.

The following changes were made to support this:

- Insertion of the previous SP into the stack at a known location (2 slots above the FP).
- Insertion of a special word into the stack such that stackwalker can easily identify that this frame is an inst frame (and to select the correct walker). BEEFDEAD is located at +1 slot away from FP.
- The poping of these values from the stack at frame teardown.
- Fixes to the emitter to use scratch registers where hard coded ones were present before.

Total performance impact of this patch is an extra 5 instruction. 3 on frame creation, 2 on destruction.