### PR TITLE
Add CMakeLists.txt for each subdirectory test.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,34 +1,9 @@
+add_subdirectory(unstrip)
 
-
-add_executable(unstrip unstrip/unstrip.C
-                       unstrip/util.C
-                       unstrip/types.C
-                       unstrip/semanticDescriptor.C
-                       unstrip/database.C
-                       unstrip/fingerprint.C
-                       unstrip/callback.C)
-add_dependencies(unstrip parseAPI symtabAPI instructionAPI common)
-target_link_libraries(unstrip parseAPI symtabAPI instructionAPI common)
-file(COPY unstrip/ddb.db DESTINATION ${INSTALL_BIN_DIR})
-file(COPY unstrip/params.db DESTINATION ${INSTALL_BIN_DIR})
-file(COPY unstrip/unistd.db DESTINATION ${INSTALL_BIN_DIR})
-
-add_executable(codeCoverage codeCoverage/codeCoverage.C)
-add_dependencies(codeCoverage dyninstAPI patchAPI parseAPI symtabAPI instructionAPI pcontrol common)
-target_link_libraries(codeCoverage dyninstAPI patchAPI parseAPI symtabAPI instructionAPI pcontrol common)
-
-add_library(Inst SHARED codeCoverage/libInst.C)
+add_subdirectory(codeCoverage)
 
 add_executable(cfg_to_dot ../parseAPI/doc/example.cc)
 add_dependencies(cfg_to_dot parseAPI symtabAPI)
-target_link_libraries(cfg_to_dot parseAPI symtabAPI
-        )
-#add_executable(retee)
-
-install (TARGETS cfg_to_dot unstrip codeCoverage Inst
-        RUNTIME DESTINATION ${INSTALL_BIN_DIR}
-        LIBRARY DESTINATION ${INSTALL_LIB_DIR}
-        ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
-        PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR})
+target_link_libraries(cfg_to_dot parseAPI symtabAPI)
    
 

--- a/examples/codeCoverage/CMakeLists.txt
+++ b/examples/codeCoverage/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(codeCoverage codeCoverage.C)
+add_dependencies(codeCoverage dyninstAPI patchAPI parseAPI symtabAPI instructionAPI pcontrol common)
+target_link_libraries(codeCoverage dyninstAPI patchAPI parseAPI symtabAPI instructionAPI pcontrol common)
+add_library(Inst SHARED libInst.C)
+
+install (TARGETS codeCoverage
+        RUNTIME DESTINATION ${INSTALL_BIN_DIR}
+        LIBRARY DESTINATION ${INSTALL_LIB_DIR}
+        ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
+        PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR})

--- a/examples/unstrip/CMakeLists.txt
+++ b/examples/unstrip/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_executable(unstrip unstrip.C
+                       util.C
+                       types.C
+                       semanticDescriptor.C
+                       database.C
+                       fingerprint.C
+                       callback.C)
+add_dependencies(unstrip parseAPI symtabAPI instructionAPI common)
+target_link_libraries(unstrip parseAPI symtabAPI instructionAPI common)
+file(COPY ddb.db DESTINATION ${INSTALL_BIN_DIR})
+file(COPY params.db DESTINATION ${INSTALL_BIN_DIR})
+file(COPY unistd.db DESTINATION ${INSTALL_BIN_DIR})
+
+install (TARGETS unstrip
+        RUNTIME DESTINATION ${INSTALL_BIN_DIR}
+        LIBRARY DESTINATION ${INSTALL_LIB_DIR}
+        ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
+        PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR})


### PR DESCRIPTION
On linux there are directories examples/unstrip and examples/codeCoverage.
A make attempts to link executables having the same name as the directories.  This change creates individual unstrip/CMakeLists.txt and examples/CMakeLists.txt, referenced from the containing examples/CMakeLists.txt, each of which link the executable in the containing test subdirectory,

% make -i  # to force make to continue after failure
[ 94%] Linking CXX executable codeCoverage
/usr/bin/ld: cannot open output file codeCoverage: Is a directory
collect2: error: ld returned 1 exit status
[ 96%] Linking CXX executable unstrip
/usr/bin/ld: cannot open output file unstrip: Is a directory
collect2: error: ld returned 1 exit status
