### PR TITLE
Fix for crashing on relocating at unistrumentable points

### DIFF
--- a/dyninstAPI/src/Relocation/Widgets/InstWidget.C
+++ b/dyninstAPI/src/Relocation/Widgets/InstWidget.C
@@ -55,6 +55,9 @@ TrackerElement *InstWidget::tracker() const {
    // Addr depends on the tramp type - pre, post, etc.
    // But we can't actually determine that with at-insn
    // instPs; fix when Wenbin fixes the instP data structure.
+   if (point_->block_compat() == NULL)
+      return NULL;
+
    e = new InstTracker(point_->addr_compat(), point_->tramp(), point_->block_compat(), point_->func());
    
    return e;


### PR DESCRIPTION
This fix is to address issue #455. When an unistrimentable point is selected for instrimenation
the behaviour Dyninst will now exhibit is the following:

1. InsertSnippet will return NULL if not in an insertion set and an illegal when parameter is used

2. If in an insertion set, InsertSnippet will return an object to the instrimentation. However when the set
   is closed the insertion of that point will fail. It will either fail and continue to the next point (if
   the insertion set closure is set to continue past errors) or roll back all prior insertions.
.