### PR TITLE
register index and size fix for modrm where mod=0 and not SIB or disp

### DIFF
--- a/instructionAPI/src/InstructionDecoder-x86.C
+++ b/instructionAPI/src/InstructionDecoder-x86.C
@@ -252,7 +252,13 @@ namespace Dyninst
                 }
 
              } else{
-                e = makeRegisterExpression(makeRegisterID(locs->modrm_rm, op_d, locs->rex_r));
+		unsigned int regType;
+                if(ia32_is_mode_64())
+			regType = (addrSizePrefixPresent) ? op_d : op_q;
+                else
+			regType = (addrSizePrefixPresent) ? op_w : op_d;
+                e = makeRegisterExpression(makeRegisterID(locs->modrm_rm,
+                        regType, locs->rex_b));
              }
 
              if(opType == op_lea)


### PR DESCRIPTION
Tested on a handful of binaries, appears to fix the register decoding problem mentioned in #461 