### PR TITLE
avoid infinite loop on bad DWARF CFI record

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -4302,8 +4302,6 @@ public:
 
 void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
 {
-    std::vector<open_statement> open_statements;
-    
     /* Acquire this CU's source lines. */
     Dwarf_Lines * lineBuffer;
     size_t lineCount;
@@ -4448,36 +4446,6 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
             cout << "dwarf_linebeginstatement failed" << endl;
             continue;
         }
-#if 0
-        std::vector<open_statement> tmp;
-        for(auto stmt = open_statements.begin();
-                stmt != open_statements.end();
-                ++stmt)
-        {
-            stmt->end_addr = current_statement.start_addr;
-            if(stmt->string_table_index != current_statement.string_table_index ||
-                    stmt->line_number != current_statement.line_number ||
-                    isEndOfSequence)
-            {
-                li_for_module->addLine((unsigned int)(stmt->string_table_index),
-                                       (unsigned int)(stmt->line_number),
-                                       (unsigned int)(stmt->column_number),
-                                       stmt->start_addr,
-                                       stmt->end_addr);
-            }
-            else
-            {
-                tmp.push_back(*stmt);
-            }
-        }
-        open_statements.swap(tmp);
-        if(isEndOfSequence) {
-            open_statements.clear();
-        } else
-        if(isStatement) {
-            open_statements.push_back(current_statement);
-        }
-#else
 	if (current_line.uninitialized()) {
 	  current_line = current_statement;
 	} else {
@@ -4494,7 +4462,6 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
 	if (isEndOfSequence) {
 	  current_line.reset();
 	}
-#endif
     } /* end iteration over source line entries. */
 
 /* Free this CU's source lines. */

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -4854,12 +4854,21 @@ bool sort_dbg_map(const Object::DbgAddrConversion_t &a,
 
 bool Object::convertDebugOffset(Offset off, Offset &new_off)
 {
+    int hi = DebugSectionMap.size();
+
+    if (hi == 0) {
+      // DebugSectionMap is empty; handle this case separately 
+      DbgSectionMapSorted = true;
+      return true;
+    }
+
+    // invariant: DebugSectionMap is non-empty
+
     if (!DbgSectionMapSorted) {
         std::sort(DebugSectionMap.begin(), DebugSectionMap.end(), sort_dbg_map);
         DbgSectionMapSorted = true;
     }
 
-    int hi = DebugSectionMap.size();
     int low = 0;
     int cur = -1;
 

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -4265,12 +4265,38 @@ void Object::parseStabFileLineInfo()
     //  haveParsedFileMap[ key ] = true;
 } /* end parseStabFileLineInfo() */
 
-struct open_statement {
-    Dwarf_Word string_table_index;
-    Dwarf_Addr start_addr;
-    Dwarf_Addr end_addr;
-    int line_number;
-    int column_number;
+class open_statement {
+public:
+  open_statement() { reset(); };
+  Dwarf_Addr noAddress() { return (Dwarf_Addr) ~0; }
+  bool uninitialized() {
+    return start_addr == noAddress();
+  };
+  void reset() {
+    string_table_index = -1;
+    start_addr = noAddress();
+    end_addr = noAddress();
+    line_number = 0;
+    column_number = 0;
+  };
+  bool sameFileLineColumn(const open_statement &rhs) {
+    return ((string_table_index == rhs.string_table_index) &&
+	    (line_number == rhs.line_number) &&
+            (column_number == rhs.column_number));
+  };
+  void operator=(const open_statement &rhs) {
+    string_table_index = rhs.string_table_index;
+    start_addr = rhs.start_addr;
+    end_addr = rhs.end_addr;
+    line_number = rhs.line_number;
+    column_number = rhs.column_number;
+  };
+public:
+  Dwarf_Word string_table_index;
+  Dwarf_Addr start_addr;
+  Dwarf_Addr end_addr;
+  int line_number;
+  int column_number;
 };
 
 
@@ -4351,6 +4377,7 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
     dwarf_highpc(&cuDIE, &cu_high_pc);
 
     /* Iterate over this CU's source lines. */
+    open_statement current_line;
     open_statement current_statement;
     for(size_t i = 0; i < lineCount; i++ )
     {
@@ -4421,6 +4448,7 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
             cout << "dwarf_linebeginstatement failed" << endl;
             continue;
         }
+#if 0
         std::vector<open_statement> tmp;
         for(auto stmt = open_statements.begin();
                 stmt != open_statements.end();
@@ -4449,6 +4477,24 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
         if(isStatement) {
             open_statements.push_back(current_statement);
         }
+#else
+	if (current_line.uninitialized()) {
+	  current_line = current_statement;
+	} else {
+	      current_line.end_addr = current_statement.start_addr;
+	      if (!current_line.sameFileLineColumn(current_statement) ||
+		  isEndOfSequence) {
+                li_for_module->addLine((unsigned int)(current_line.string_table_index),
+                                       (unsigned int)(current_line.line_number),
+                                       (unsigned int)(current_line.column_number),
+                                       current_line.start_addr, current_line.end_addr);
+		current_line = current_statement;
+	      }
+	}
+	if (isEndOfSequence) {
+	  current_line.reset();
+	}
+#endif
     } /* end iteration over source line entries. */
 
 /* Free this CU's source lines. */

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3411,8 +3411,14 @@ int read_except_table_gcc3(
         // If no more CFI entries left in the section 
         if(res==1 && next_offset==(Dwarf_Off)-1) break;
         
-        // On error, skip to the next CFI entry 
-        if(res==-1) continue;
+        // CFI error
+        if(res == -1) {
+	  if (offset != saved_cur_offset) {
+            continue; // Soft error, skip to the next CFI entry
+          }
+          // Since offset didn't advance, we can't skip this CFI entry and need to quit
+          return false; 
+        }
 
         if(dwarf_cfi_cie_p(&entry))
         {


### PR DESCRIPTION
This patch avoids an infinite loop by returning false when dwarf_next_cfi returns -1 and doesn't advance the offset. The patch addresses only the infinite loop symptom and doesn't attempt to explore its cause.

Since there were other commits related to this code between the commit mentioned above and the latest commit by @sashanicolas , either of the following cases seem possible

- the CFI information was always bad, but the code never encountered it all, or
- the reader got corrupted with recent changes to that good CFI info looks bad.

I did not investigate which case it is. Since Sasha was working here, I am sure that he knows more about this than me and is better equipped to address deeper semantic issues that may need attention.