### PR TITLE
symtab: fix memory error in Statement::getFile

### DIFF
--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -100,7 +100,7 @@ namespace Dyninst{
 
 			Offset startAddr() const { return first;}
 			Offset endAddr() const {return second;}
-			std::string getFile() const;
+			const std::string& getFile() const;
 			unsigned int getFileIndex() const { return file_index_; }
 			unsigned int getLine()const {return line_;}
 			unsigned int getColumn() const { return column_; }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -65,7 +65,7 @@ StringTablePtr Statement::getStrings_() const {
 void Statement::setStrings_(StringTablePtr strings) {
     Statement::strings_ = strings;
 }
-std::string Statement::getFile() const {
+const std::string& Statement::getFile() const {
     if(strings_) {
         if(file_index_ < strings_->size()) {
             // can't be ->[] on shared pointer to multi_index container or compiler gets confused
@@ -74,7 +74,9 @@ std::string Statement::getFile() const {
         }
 
     }
-    return "";
+    // This string will be pointed to, so it has to persist.
+    static std::string emptyStr;
+    return emptyStr;
 }
 
 


### PR DESCRIPTION
When used through BPatch_statement::filename() or various other internal code, the function Statement::getFile was causing memory errors.

This is because it returned a new string object that contains a copy of the string in the string map. If this copy is then just used to call .c_str and discarded, the returned pointer is dangling at the caller.