### PR TITLE
Open debug file in read/write mode to get a writable mmap.

### DIFF
--- a/elf/src/Elf_X.C
+++ b/elf/src/Elf_X.C
@@ -1627,11 +1627,11 @@ static bool loadDebugFileFromDisk(string name, char* &output_buffer, unsigned lo
       return false;
    if (S_ISDIR(fileStat.st_mode))
       return false;
-   int fd = open(name.c_str(), O_RDONLY);
+   int fd = open(name.c_str(), O_RDWR);
    if (fd == -1)
       return false;
 
-   char *buffer = (char *) mmap(NULL, fileStat.st_size, PROT_READ, MAP_SHARED, fd, 0);
+   char *buffer = (char *) mmap(NULL, fileStat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
    close(fd);
    if (!buffer)
       return false;


### PR DESCRIPTION
Write privilege is necessary for newer elfutils because
function elf_compress() transparently uncompresses data
and thus has to rewrite the ELF header with the new data
size for consistency.

This patch fixes dyninst issue #436,
"processCreate - immediate crash".