### PR TITLE
Fix segfault in BPatch_point::getCalledFunction().

### DIFF
--- a/dyninstAPI/src/BPatch_point.C
+++ b/dyninstAPI/src/BPatch_point.C
@@ -220,16 +220,17 @@ BPatch_function *BPatch_point::getCalledFunction()
            return NULL;
    }
 
+   assert(point->block());
    func_instance *_func = point->block()->callee();
+   if (!_func) {
+       parsing_printf("findCallee failed in getCalledFunction\n");
+           return NULL;
+   }
    if (_func->getPowerPreambleFunc() != NULL) {
        func_instance * preambleFunc = _func->getPowerPreambleFunc();
        return addSpace->findOrCreateBPFunc(preambleFunc, NULL);
    }
 
-   if (!_func) {
-       parsing_printf("findCallee failed in getCalledFunction\n");
-           return NULL;
-   }
    return addSpace->findOrCreateBPFunc(_func, NULL);
 }
 


### PR DESCRIPTION
In function BPatch_point::getCalledFunction() move the test for a
nullptr-valued _func in front of the first dereference of the pointer.

Add an assert() in analogy to BPatch_point::getCalledFunctionName()
to guard against further surprises.

This fixes issue #489.