### PR TITLE
as needed, add -fopenmp flag when linking executables

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,6 +21,13 @@ add_dependencies(cfg_to_dot parseAPI symtabAPI instructionAPI common dynDwarf dy
 target_link_libraries(cfg_to_dot parseAPI symtabAPI instructionAPI common dynDwarf dynElf ${Boost_LIBRARIES})
 #add_executable(retee)
 
+if (USE_OpenMP MATCHES "ON")
+set_target_properties (unstrip PROPERTIES LINK_FLAGS "-fopenmp")
+set_target_properties (codeCoverage PROPERTIES LINK_FLAGS "-fopenmp")
+set_target_properties (cfg_to_dot PROPERTIES LINK_FLAGS "-fopenmp")
+endif()
+
+
 install (TARGETS cfg_to_dot unstrip codeCoverage Inst
         RUNTIME DESTINATION ${INSTALL_BIN_DIR}
         LIBRARY DESTINATION ${INSTALL_LIB_DIR}

--- a/parseThat/CMakeLists.txt
+++ b/parseThat/CMakeLists.txt
@@ -1,4 +1,9 @@
 add_executable(parseThat src/parseThat.C src/config.C src/ipc.C src/record.C src/strlist.C src/reglist.C src/log.C src/utils.C src/sha1.C src/dyninstCore.C src/dyninstCompat.v5.C)
 add_definitions(-DHAVE_BPATCH_PROCESS_H)
+
+if (USE_OpenMP MATCHES "ON")
+set_target_properties (parseThat PROPERTIES LINK_FLAGS "-fopenmp")
+endif()
+
 target_link_private_libraries(parseThat dyninstAPI patchAPI parseAPI instructionAPI stackwalk symtabAPI common pcontrol dynDwarf dynElf ${Boost_LIBRARIES})
 install(TARGETS parseThat RUNTIME DESTINATION bin)


### PR DESCRIPTION
When USE_OpenMP=on, dyninst executables (parseThat and executables in examples) don't link without using -fopenmp as a link flag. Add this in the appropriate CMakeLists.txt files.