### PR TITLE
Use PRIx64 macros for long long results for i686.

### DIFF
--- a/instructionAPI/h/Result.h
+++ b/instructionAPI/h/Result.h
@@ -449,10 +449,10 @@ namespace Dyninst
 	    snprintf(hex, 20, "%x", val.s32val);
 	    break;
 	  case u64:
-	    snprintf(hex, 20, "%lx", val.u64val);
+	    snprintf(hex, 20, "%" PRIx64, val.u64val);
 	    break;
 	  case s64:
-	    snprintf(hex, 20, "%lx", val.s64val);
+	    snprintf(hex, 20, "%" PRIx64, val.s64val);
 	    break;
 	  case sp_float:
 	    snprintf(hex, 20, "%f", val.floatval);
@@ -464,10 +464,10 @@ namespace Dyninst
 	    snprintf(hex, 20, "%x", val.bitval);
 	    break;
 	  case u48:
-	    snprintf(hex, 20, "%lx", val.s48val);
+	    snprintf(hex, 20, "%" PRIx64, val.s48val);
 	    break;
 	  case s48:
-	    snprintf(hex, 20, "%lx", val.s48val);
+	    snprintf(hex, 20, "%" PRIx64, val.s48val);
 	    break;
      case m512:
 	    snprintf(hex, 20, "%p", val.m512val);

--- a/instructionAPI/h/Result.h
+++ b/instructionAPI/h/Result.h
@@ -42,6 +42,7 @@
    typedef unsigned __int64 uint64_t;
    typedef unsigned __int32 uint32_t;
    typedef unsigned __int16 uint16_t;
+#  define  PRIx64  "lx"
 #endif
 #include <assert.h>
 


### PR DESCRIPTION
Fix a problem on i686 and other 32 bit machines by using PRIx64 for long long.  The other snprintf could be likewise changed to use PRIxNN but long long is the only problematic one..