### PR TITLE
Don't use system header <> syntax for dyninst includes

### DIFF
--- a/instructionAPI/h/ArchSpecificFormatters.h
+++ b/instructionAPI/h/ArchSpecificFormatters.h
@@ -34,7 +34,7 @@
 #include <map>
 #include <vector>
 #include <string>
-#include <dyn_regs.h>
+#include "dyn_regs.h"
 
 namespace Dyninst {
     namespace InstructionAPI {

--- a/instructionAPI/h/RegisterIDs.h
+++ b/instructionAPI/h/RegisterIDs.h
@@ -35,7 +35,7 @@
 #include <map>
 #include "util.h"
 #include "Result.h"
-#include <dyntypes.h>
+#include "dyntypes.h"
 namespace Dyninst
 {
   namespace InstructionAPI


### PR DESCRIPTION
Fedora installs dyninst includes into /usr/include/dyninst; thus any file included from within another dyninst include will not be found if the <HEADER> syntax is used since that syntax only searches system includes and /usr/include/dyninst is not a standard system include.  Using "HEADER" syntax (search same containing directory solves the problem.  There are only two cases of this so I'm guess it was an accident as opposed to an intentional decision.