### PR TITLE
Fix several bugs in common/src/pathName.C

### DIFF
--- a/common/src/addrtranslate-linux.C
+++ b/common/src/addrtranslate-linux.C
@@ -189,7 +189,7 @@ string AddressTranslateSysV::getExecName()
    if (exec_name.empty()) {
       char name[64];
       snprintf(name, 64, "/proc/%d/exe", pid);
-      exec_name = resolve_file_path(name);
+      exec_name = std::move(resolve_file_path(name));
    }
    return exec_name;
 }

--- a/common/src/addrtranslate-sysv.C
+++ b/common/src/addrtranslate-sysv.C
@@ -869,7 +869,7 @@ FCNode::FCNode(string f, dev_t d, ino_t i, SymbolReaderFactory *factory_) :
    symreader(NULL),
    factory(factory_)
 {
-   filename = resolve_file_path(f.c_str());
+   filename = resolve_file_path(std::move(f));
 }
 
 string FCNode::getFilename() {

--- a/common/src/addrtranslate-sysv.C
+++ b/common/src/addrtranslate-sysv.C
@@ -869,7 +869,7 @@ FCNode::FCNode(string f, dev_t d, ino_t i, SymbolReaderFactory *factory_) :
    symreader(NULL),
    factory(factory_)
 {
-   filename = resolve_file_path(std::move(f));
+   filename = std::move(resolve_file_path(std::move(f)));
 }
 
 string FCNode::getFilename() {

--- a/common/src/pathName.C
+++ b/common/src/pathName.C
@@ -39,16 +39,13 @@
 #include <boost/algorithm/string/trim.hpp>
 
 #if defined(os_windows) //ccw 20 july 2000 : 29 mar 2001
-
-#define S_ISDIR(x) ((x) & _S_IFDIR)
-
+	#define S_ISDIR(x) ((x) & _S_IFDIR)
 #else
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
-#include <pwd.h>
+	#include <sys/types.h>
+	#include <sys/stat.h>
+	#include <unistd.h>
+	#include <pwd.h>
+#endif
 
 std::string expand_tilde_pathname(const std::string &dir) {
 #ifdef os_windows

--- a/common/src/pathName.C
+++ b/common/src/pathName.C
@@ -34,6 +34,9 @@
 #include <assert.h>
 #include <limits.h>
 #include "common/src/pathName.h"
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/trim.hpp>
 
 #if defined(os_windows) //ccw 20 july 2000 : 29 mar 2001
 
@@ -276,8 +279,6 @@ bool executableFromArgv0AndPathAndCwd(std::string &result,
 #else
 #define PATH_SEP ('/')
 #endif
-
-#include <boost/filesystem.hpp>
 
 std::string extract_pathname_tail(const std::string &path)
 {

--- a/common/src/pathName.C
+++ b/common/src/pathName.C
@@ -42,10 +42,6 @@
 
 #define S_ISDIR(x) ((x) & _S_IFDIR)
 
-std::string expand_tilde_pathname(const std::string &dir) {
-   return dir;
-}
-
 #else
 
 #include <sys/types.h>
@@ -55,6 +51,10 @@ std::string expand_tilde_pathname(const std::string &dir) {
 #include <pwd.h>
 
 std::string expand_tilde_pathname(const std::string &dir) {
+#ifdef os_windows
+	// no-op on Windows
+	return dir;
+#else
    // e.g. convert "~tamches/hello" to "/u/t/a/tamches/hello",
    // or convert "~/hello" to same.
    // In the spirit of Tcl_TildeSubst
@@ -108,8 +108,8 @@ std::string expand_tilde_pathname(const std::string &dir) {
    std::string result = std::string(pwPtr->pw_dir) + std::string(ptr);
    endpwent();
    return result;
-}
 #endif
+}
 
 static std::string concat_pathname_components_simple(const std::string &comp1, const std::string &comp2)
 {

--- a/common/src/pathName.C
+++ b/common/src/pathName.C
@@ -270,13 +270,6 @@ bool executableFromArgv0AndPathAndCwd(std::string &result,
    return false;
 }
 
-#if defined(os_windows)
-#define PATH_SEP ('\\')
-#define SECOND_PATH_SEP ('/')
-#else
-#define PATH_SEP ('/')
-#endif
-
 std::string extract_pathname_tail(const std::string &path)
 {
     boost::filesystem::path p(path);

--- a/common/src/pathName.C
+++ b/common/src/pathName.C
@@ -102,7 +102,7 @@ std::string expand_tilde_pathname(const std::string &dir) {
       return dir; // something better needed...
    }
 
-   std::string result = std::string(pwPtr->pw_dir) + std::string(ptr);
+   std::string result = std::string(pwPtr->pw_dir) + (ptr ? ptr : "");
    endpwent();
    return result;
 #endif

--- a/common/src/pathName.C
+++ b/common/src/pathName.C
@@ -276,58 +276,55 @@ std::string extract_pathname_tail(const std::string &path)
     return p.filename().string();
 }
 
-#if !defined (os_windows)
-static
-char *resolve_file_path_local(const char *fname, char *resolved_path)
-{
-   // (1) realpath doesn't always return errors when the last element
-   // of fname doesn't exist -- make sure it exists first to allow
-   // consistent results of this function across platforms
-   struct stat stat_buf;
-   if( -1 == stat(fname, &stat_buf) ) {
-       return NULL;
-   }
-
-   // (2)  use realpath() to resolve any . or ..'s, or symbolic links
-   if (NULL == realpath(fname, resolved_path)) {
-      return NULL;
-   }
-
-   // (3) if no slashes, try CWD
-   if (!strpbrk(resolved_path, "/\\")) {
-      char cwd[PATH_MAX];
-      if (NULL == getcwd(cwd, PATH_MAX)) {
-         return NULL;
-      }
-      char resolved_path_bak[PATH_MAX];
-      strcpy(resolved_path_bak, resolved_path);
-      sprintf(resolved_path, "%s/%s", cwd, resolved_path_bak);
-   }
-
-   // (4) if it has a tilde, expand tilde pathname
-   if (!strpbrk(resolved_path, "~")) {
-      std::string td_pathname = std::string(resolved_path);
-      std::string no_td_pathname = expand_tilde_pathname(td_pathname);
-      strcpy(resolved_path, no_td_pathname.c_str());
-   }
-
-   return resolved_path;
+std::string resolve_file_path(char const* path) {
+	return resolve_file_path(std::string{path});
 }
+std::string resolve_file_path(std::string path) {
+	namespace ba = boost::algorithm;
+	namespace bf = boost::filesystem;
 
-std::string resolve_file_path(const char *fname) {
-    char path_buf[PATH_MAX];
-    char *result = resolve_file_path_local(fname, path_buf);
-    if ( result == NULL ) {
-        return std::string();
-    }
-    std::string ret = result;
-    return ret;
-}
+	// Remove all leading and trailing spaces in-place.
+	ba::trim(path);
 
-#else
-std::string resolve_file_path(const char *fname) {
-    assert(!"UNIMPLEMENTED ON WINDOWS");
-    return std::string("");
-}
+#ifndef os_windows
+	// On Linux-like OSes, collapse doubled directory separators
+	// similar to POSIX `realpath`. On Windows, '//' is a (possibly)
+	// meaningful separator, so don't change it.
+	ba::replace_all(path, "//", "/");
 #endif
 
+	// If it has a tilde, expand tilde pathname
+	// This is a no-op on Windows
+	if(path.find("~") != std::string::npos) {
+		path = std::move(expand_tilde_pathname(path));
+	}
+
+	// Convert to a boost::filesystem::path
+	// This makes a copy of `path`.
+	auto boost_path = bf::path(path);
+
+	// bf::canonical (see below) requires that the path exists.
+	if(!bf::exists(boost_path)) {
+		return {};
+	}
+
+	/* Make the path canonical
+	 *
+	 * This converts the path to an absolute path (relative to the
+	 * current working directory) that has no symbolic links, '.',
+	 * or '..' elements and strips trailing directory separator.
+	 *
+	 * NOTE: makes a copy of the path.
+	 */
+	boost::system::error_code ec;
+	auto canonical_path = bf::canonical(boost_path, ec);
+	if(ec != boost::system::errc::success) {
+		return {};
+	}
+
+	/* This is a bit strange, but is most optimal as it is the only
+	 * member string-conversion function that does not inhibit moving
+	 * the return value out (required here by C++11).
+	 */
+	return canonical_path.string<std::string>();
+}

--- a/common/src/pathName.h
+++ b/common/src/pathName.h
@@ -63,5 +63,6 @@ bool executableFromArgv0AndPathAndCwd(std::string &result,
 				      const std::string &cwd);
 COMMON_EXPORT std::string extract_pathname_tail(const std::string &path);
 
-COMMON_EXPORT std::string resolve_file_path(const char *fname);
+COMMON_EXPORT std::string resolve_file_path(char const* path);
+COMMON_EXPORT std::string resolve_file_path(std::string);
 #endif

--- a/common/src/serialize-bin.C
+++ b/common/src/serialize-bin.C
@@ -424,7 +424,7 @@ SerFile::SerFile(std::string fname, iomode_t mode, bool verbose) :
 	iomode_(mode), 
 	noisy(verbose) 
 {
-        std::string file_path = resolve_file_path(fname.c_str());
+        std::string file_path = resolve_file_path(std::move(fname));
         if( file_path.empty() )
 	{
 		char msg[1024];

--- a/dyninstAPI/src/freebsd.C
+++ b/dyninstAPI/src/freebsd.C
@@ -223,7 +223,7 @@ bool AddressSpace::getDyninstRTLibName() {
                      std::string(modifier) +
                      std::string(suffix);
 
-    dyninstRT_name = resolve_file_path(dyninstRT_name.c_str());
+    dyninstRT_name = resolve_file_path(dyninstRT_name);
 
     startup_printf("Dyninst RT Library name set to '%s'\n",
             dyninstRT_name.c_str());

--- a/dyninstAPI/src/freebsd.C
+++ b/dyninstAPI/src/freebsd.C
@@ -223,7 +223,7 @@ bool AddressSpace::getDyninstRTLibName() {
                      std::string(modifier) +
                      std::string(suffix);
 
-    dyninstRT_name = resolve_file_path(dyninstRT_name);
+    dyninstRT_name = std::move(resolve_file_path(dyninstRT_name));
 
     startup_printf("Dyninst RT Library name set to '%s'\n",
             dyninstRT_name.c_str());

--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -1125,7 +1125,7 @@ bool linux_process::plat_execed()
 
    char proc_exec_name[128];
    snprintf(proc_exec_name, 128, "/proc/%d/exe", getPid());
-   executable = resolve_file_path(proc_exec_name);
+   executable = std::move(resolve_file_path(proc_exec_name));
    return true;
 }
 

--- a/proccontrol/src/loadLibrary/codegen-freebsd.C
+++ b/proccontrol/src/loadLibrary/codegen-freebsd.C
@@ -27,7 +27,7 @@ bool Codegen::generateInt() {
     if (!objSymReader) {
       return false;
     }
-    std::string interp = resolve_file_path(objSymReader->getInterpreterName().c_str());
+    std::string interp = resolve_file_path(objSymReader->getInterpreterName());
 
     objSymReader = proc_->llproc()->getSymReader()->openSymbolReader(interp);
     if (!objSymReader) {
@@ -43,7 +43,7 @@ bool Codegen::generateInt() {
     // But we still need the load addr...
     bool found = false;
     for (auto li = proc_->libraries().begin(); li != proc_->libraries().end(); ++li) {
-      std::string canonical = resolve_file_path((*li)->getName().c_str());
+      std::string canonical = resolve_file_path((*li)->getName());
       if (canonical == interp) {
 	found = true;
 	dlopenAddr += (*li)->getLoadAddress();


### PR DESCRIPTION
This fixes several bugs, adds a couple new features, and does a bit of cleanup. 70c9c93 contains a set of unit tests based on Catch2, and is not intended to be merged. It is here for discussion only. I will rebase it out when this is ready to be merged.

FIXED:
1. Tilde expansion is done _before_ the existence check.
	Since `stat` does not do shell expansions, resolve_file_path("~")
	always returned an empty string instead of the expanded path.

2. Tilde detection logic was inverted

3. Remove possible buffer overflow when making path relative to CWD

ADDED features:
1. Removes leading and trailing whitespace

2. Add basic support for Windows file system by using Boost::filesystem
	Expansion of Windows-specific shell variables, e.g. %HOME%, is _not_
	supported.

3. Leverage move semantics to reduce copying
	This reduces the maximum number of string copies from 5 to 3. When
	resolve_file_path is invoked with an r-value, there are only two
	copies.