### PR TITLE
Adjust Dyninst to support injecting CFGs for CUBINs

### DIFF
--- a/parseAPI/h/CFG.h
+++ b/parseAPI/h/CFG.h
@@ -341,7 +341,7 @@ public:
     void getFuncs(std::vector<Function *> & funcs);
     template<class OutputIterator> void getFuncs(OutputIterator result); 
 
-    virtual getInsns(Insns &insns) const;
+    virtual void getInsns(Insns &insns) const;
     InstructionAPI::Instruction getInsn(Offset o) const;
 
     bool wasUserAdded() const;

--- a/parseAPI/h/CFG.h
+++ b/parseAPI/h/CFG.h
@@ -314,7 +314,7 @@ public:
     inline Address start() const { return _start; }
     inline Address end() const { return _end; }
     inline Address lastInsnAddr() const {  return _lastInsn; }
-    inline Address last() const {  return lastInsnAddr(); }
+    virtual Address last() const {  return lastInsnAddr(); }
     inline Address size() const {  return _end - _start; }
     bool containsAddr(Address addr) const {   return addr >= _start && addr < _end; }
 
@@ -341,7 +341,7 @@ public:
     void getFuncs(std::vector<Function *> & funcs);
     template<class OutputIterator> void getFuncs(OutputIterator result); 
 
-    void getInsns(Insns &insns) const;
+    virtual getInsns(Insns &insns) const;
     InstructionAPI::Instruction getInsn(Offset o) const;
 
     bool wasUserAdded() const;
@@ -611,6 +611,10 @@ class PARSER_EXPORT Function : public allocatable, public AnnotatableSparse, pub
             CodeRegion *codereg) const;
 
     static void destroy(Function *f);
+
+    /*** Internal parsing methods and state ***/
+    void add_block(Block *b);
+
  private:
     void delayed_link_return(CodeObject * co, Block * retblk);
     void finalize();
@@ -693,9 +697,6 @@ class PARSER_EXPORT Function : public allocatable, public AnnotatableSparse, pub
     /** same as previous two fields, but for postdominator tree */
     mutable std::map<Block*, std::set<Block*>*> immediatePostDominates;
     mutable std::map<Block*, Block*> immediatePostDominator;
-
-    /*** Internal parsing methods and state ***/
-    void add_block(Block *b);
 
     friend void Edge::uninstall();
     friend class Parser;


### PR DESCRIPTION
Hi @mxz297 , I talked with John today. We thought that an "CodeSource provides no CodeRegions" doesn't indicate that we cannot use `CodeObject` and `CodeSource`'s interfaces to parse external sources, which is exactly we have done on the cuda code.

The changes in the newest commit perhaps makes the logic satisfy your requirement. If `_parse_state` is not unparsable, then we iterate every code region to check overlapped conditions and create a `OverlappingParseData` object. Otherwise, we create a `StandardParseData`.