### PR TITLE
Remove undefined behavior from bit-shifting code

### DIFF
--- a/dataflowAPI/rose/semantics/DispatcherPowerpc.C
+++ b/dataflowAPI/rose/semantics/DispatcherPowerpc.C
@@ -54,18 +54,20 @@ public:
     // Builds mask of 1's from the bit value starting at mb_value to me_value.
     // See page 71 of PowerPC manual.
     uint32_t build_mask(uint8_t mb_value, uint8_t me_value) {
-        uint32_t mask = 0;
-        if (mb_value <= me_value) {
-            // PowerPC counts bits from the left.
-            for(int i=mb_value; i <= me_value;  i++)
-                mask |= (1 << (31-i));
-        } else {
-            for(int i=mb_value; i <= 31;  i++)
-                mask |= (1 << (31-i));
-            for(int i=0; i <= me_value; i++)
-                mask |= (1 << (31-i));
-        }
-        return mask;
+    	uint32_t mask = 0;
+    	constexpr uint32_t max_bit_pos{31}, sentinnel{1};
+
+    	if (mb_value <= me_value) {
+    		// PowerPC counts bits from the left.
+    		for (int i = mb_value; i <= me_value; i++)
+    			mask |= (sentinnel << (max_bit_pos - i));
+    	} else {
+    		for (auto i = mb_value; i <= max_bit_pos; i++)
+    			mask |= (sentinnel << (max_bit_pos - i));
+    		for (uint8_t i = 0; i <= me_value; i++)
+    			mask |= (sentinnel << (max_bit_pos - i));
+    	}
+    	return mask;
     }
 
 };

--- a/dyninstAPI/src/codegen-aarch64.C
+++ b/dyninstAPI/src/codegen-aarch64.C
@@ -835,7 +835,7 @@ bool insnCodeGen::modifyData(Address target,
 
     if (((raw >> 24) & 0x1F) == 0x10) {
         Address offset;
-        if((raw >> 31) & 0x1) {
+        if((static_cast<uint32_t>(raw) >> 31) & 0x1) {
             target &= 0xFFFFF000;
             Address cur = gen.currAddr() & 0xFFFFF000;
             offset = isneg ? (cur - target) : (target - cur);

--- a/dyninstAPI/src/codegen-x86.C
+++ b/dyninstAPI/src/codegen-x86.C
@@ -267,9 +267,9 @@ void insnCodeGen::generateBranch(codeGen &gen,
 {
    // Branches have sizes...
    if (disp32 >= 0)
-      assert ((unsigned)disp32 < unsigned(1<<31));
+      assert ((unsigned)disp32 < (unsigned(1)<<31));
    else
-      assert ((unsigned)(-disp32) < unsigned(1<<31));
+      assert ((unsigned)(-disp32) < (unsigned(1)<<31));
 
    GET_PTR(insn, gen);
    *insn++ = 0xE9;

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -33,7 +33,7 @@
  * $Id: inst-x86.C,v 1.289 2008/09/11 20:14:14 mlam Exp $
  */
 #include <iomanip>
-
+#include <cstdint>
 #include <limits.h>
 #include "common/src/headers.h"
 #include <unordered_map>
@@ -710,7 +710,7 @@ bool can_do_relocation(PCProcess *proc,
 
 
 
-#define MAX_BRANCH	(0x1<<31)
+#define MAX_BRANCH	(static_cast<uint32_t>(1)<<31)
 
 Address getMaxBranch() {
   return (Address)MAX_BRANCH;

--- a/instructionAPI/src/InstructionDecoder-aarch64.h
+++ b/instructionAPI/src/InstructionDecoder-aarch64.h
@@ -207,7 +207,7 @@ namespace Dyninst {
 
             int highest_set_bit(int32_t val) {
                 for (int bit_index = 31; bit_index >= 0; bit_index--)
-                    if (((val >> bit_index) & 0x1) == 0x1)
+                    if (((static_cast<uint32_t>(val) >> bit_index) & 0x1) == 0x1)
                         return bit_index + 1;
 
                 return -1;
@@ -215,7 +215,7 @@ namespace Dyninst {
 
             int lowest_set_bit(int32_t val) {
                 for (int bit_index = 0; bit_index <= 31; bit_index++)
-                    if (((val >> bit_index) & 0x1) == 0x1)
+                    if (((static_cast<uint32_t>(val) >> bit_index) & 0x1) == 0x1)
                         return bit_index + 1;
 
                 return -1;


### PR DESCRIPTION
Overflow of signed integer arithmetic (including shifting) is
undefined behavior in C++. Compilers are allowed to exploit
this UB for optimization purposes up to and including not
emitting any opcodes.

These were found using cppcheck.