### PR TITLE
Add some explicit casts from boost::tribool to bool for some code in

### DIFF
--- a/dataflowAPI/rose/util/Message.C
+++ b/dataflowAPI/rose/util/Message.C
@@ -212,7 +212,7 @@ MesgProps::print(std::ostream &o) const {
 
     o <<", isBuffered=";
     if (!indeterminate(isBuffered)) {
-        o <<(((bool) isBuffered) ? "yes" : "no");
+        o <<(isBuffered ? "yes" : "no");
     } else {
         o <<"undef";
     }
@@ -247,7 +247,7 @@ MesgProps::print(std::ostream &o) const {
     
     o <<", useColor=";
     if (!indeterminate(useColor)) {
-        o <<(((bool) useColor) ? "yes" : "no");
+        o <<(useColor ? "yes" : "no");
     } else {
         o <<"undef";
     }
@@ -730,7 +730,7 @@ Prefix::toString(const Mesg &mesg, const MesgProps &props) const {
     std::string separator = "";
 
     std::string endColor;
-    if (((bool) props.useColor) && props.importance) {
+    if (props.useColor && props.importance) {
         const ColorSpec &cs = colorSet_[*props.importance];
         if (!cs.isDefault()) {
             const char *semi = "";
@@ -743,7 +743,7 @@ Prefix::toString(const Mesg &mesg, const MesgProps &props) const {
                 retval <<semi <<(40+cs.background);
                 semi = ";";
             }
-            if ((bool) cs.bold)
+            if (cs.bold)
                 retval <<semi <<"1";
             retval <<"m";
             endColor = "\033[m";
@@ -1123,7 +1123,7 @@ StreamBuf::bake() {
         destination_->bakeDestinations(message_.properties(), baked_/*out*/);
         anyUnbuffered_ = false;
         for (BakedDestinations::const_iterator bi=baked_.begin(); bi!=baked_.end() && !anyUnbuffered_; ++bi)
-            anyUnbuffered_ = (bool) !bi->second.isBuffered;
+            anyUnbuffered_ = static_cast<bool>(!bi->second.isBuffered);
         isBaked_ = true;
     }
 }

--- a/dataflowAPI/rose/util/Message.C
+++ b/dataflowAPI/rose/util/Message.C
@@ -212,7 +212,7 @@ MesgProps::print(std::ostream &o) const {
 
     o <<", isBuffered=";
     if (!indeterminate(isBuffered)) {
-        o <<(isBuffered ? "yes" : "no");
+        o <<(((bool) isBuffered) ? "yes" : "no");
     } else {
         o <<"undef";
     }
@@ -247,7 +247,7 @@ MesgProps::print(std::ostream &o) const {
     
     o <<", useColor=";
     if (!indeterminate(useColor)) {
-        o <<(useColor ? "yes" : "no");
+        o <<(((bool) useColor) ? "yes" : "no");
     } else {
         o <<"undef";
     }
@@ -730,7 +730,7 @@ Prefix::toString(const Mesg &mesg, const MesgProps &props) const {
     std::string separator = "";
 
     std::string endColor;
-    if (props.useColor && props.importance) {
+    if (((bool) props.useColor) && props.importance) {
         const ColorSpec &cs = colorSet_[*props.importance];
         if (!cs.isDefault()) {
             const char *semi = "";
@@ -743,7 +743,7 @@ Prefix::toString(const Mesg &mesg, const MesgProps &props) const {
                 retval <<semi <<(40+cs.background);
                 semi = ";";
             }
-            if (cs.bold)
+            if ((bool) cs.bold)
                 retval <<semi <<"1";
             retval <<"m";
             endColor = "\033[m";
@@ -1123,7 +1123,7 @@ StreamBuf::bake() {
         destination_->bakeDestinations(message_.properties(), baked_/*out*/);
         anyUnbuffered_ = false;
         for (BakedDestinations::const_iterator bi=baked_.begin(); bi!=baked_.end() && !anyUnbuffered_; ++bi)
-            anyUnbuffered_ = !bi->second.isBuffered;
+            anyUnbuffered_ = (bool) !bi->second.isBuffered;
         isBaked_ = true;
     }
 }

--- a/dataflowAPI/rose/util/Message.h
+++ b/dataflowAPI/rose/util/Message.h
@@ -386,7 +386,8 @@ struct SAWYER_EXPORT ColorSpec {
     ColorSpec(AnsiColor fg, AnsiColor bg, bool bold): foreground(fg), background(bg), bold(bold) {}
 
     /** Returns true if this object is in its default-constructed state. */
-    bool isDefault() const { return COLOR_DEFAULT==foreground && COLOR_DEFAULT==background && (bool) !bold; }
+    bool isDefault() const { return COLOR_DEFAULT==foreground && COLOR_DEFAULT==background
+                                    && static_cast<bool>(!bold); }
 };
 
 /** Colors to use for each message importance.

--- a/dataflowAPI/rose/util/Message.h
+++ b/dataflowAPI/rose/util/Message.h
@@ -386,7 +386,7 @@ struct SAWYER_EXPORT ColorSpec {
     ColorSpec(AnsiColor fg, AnsiColor bg, bool bold): foreground(fg), background(bg), bold(bold) {}
 
     /** Returns true if this object is in its default-constructed state. */
-    bool isDefault() const { return COLOR_DEFAULT==foreground && COLOR_DEFAULT==background && !bold; }
+    bool isDefault() const { return COLOR_DEFAULT==foreground && COLOR_DEFAULT==background && (bool) !bold; }
 };
 
 /** Colors to use for each message importance.


### PR DESCRIPTION
dataflowAPI/rose/util/Message.[Ch].  This was breaking the build when
using boost >= 1.69.

----------

The places where this fails is bizarre.  For example, this fails with
the message, "cannot convert 'boost::logic::tribool' to 'bool'".

```
boost::tribool tb;
bool b = tb;
```

However, adding an explict cast succeeds.  WTF!?

```
boost::tribool tb;
bool b = (bool) tb;
```

Also, g++ seems to be ok with an implicit conversion inside if().
(Again, WTF!?)  But I added an explicit cast for that case just to be
safe.

```
-      if (cs.bold)
+      if ((bool) cs.bold)
```

I think the above diff is not strictly necessary.  But it can't hurt
and it protects against some later compiler being more strict and
breaking this usage.

Also, from looking at the code in boost/logic, tribool certainly tries
to provide an automatic conversion from tribool to bool.  So, I'm not
sure why any of this fails in the first place.  I suspect a flaw in
the tribool implementation, but we're a bit outside of my C++
knowledge here.

Anyway, all the casts are harmless, so it's an easy and safe fix.
"Safe and effective," just like the label says.  :-)

I plan to submit a PR to fix this for 10.0.0 in spack.

I checked the Sawyer repo on github (matzke1).  They have no mention
of this problem, but it clearly will affect them too.  I'll alert them
after I attend to spack.