### PR TITLE
Do not put newly added functions to .dynsym, which may cause the load

### DIFF
--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -322,18 +322,7 @@ Function *Symtab::createFunction(std::string name,
                                  sz,
                                  false,
                                  false);
-    Symbol *dynSym = new Symbol(name,
-                                Symbol::ST_FUNCTION,
-                                Symbol::SL_GLOBAL,
-                                Symbol::SV_DEFAULT,
-                                offset,
-                                mod,
-                                reg,
-                                sz,
-                                true,
-                                false);
-
-    if (!addSymbol(statSym) || !addSymbol(dynSym)) {
+    if (!addSymbol(statSym)) {
         return NULL;
     }
     


### PR DESCRIPTION
to behave abnormally due to duplicated symbols.

Note that adding symbols to .dynsym can be a legit use case, where
we expose hidden functions in shared libraries. But this use case
needs more development to support.