### PR TITLE
Add --enable-install-elfh when building elfutils from source

### DIFF
--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -9,7 +9,7 @@ if (UNIX)
     ExternalProject_Add(LibElf
       PREFIX ${CMAKE_BINARY_DIR}/elfutils
       URL https://sourceware.org/elfutils/ftp/elfutils-latest.tar.bz2
-      CONFIGURE_COMMAND CFLAGS=-g <SOURCE_DIR>/configure --enable-shared --prefix=${CMAKE_BINARY_DIR}/elfutils
+      CONFIGURE_COMMAND CFLAGS=-g <SOURCE_DIR>/configure --enable-install-elfh --enable-shared --prefix=${CMAKE_BINARY_DIR}/elfutils
       BUILD_COMMAND make
       INSTALL_COMMAND make install
       )


### PR DESCRIPTION
When building elfutils from source n systems that have old elfutils,
Dyninst couldn't find the correct version of elf.h due to it not
being copied from the elfutils build source directory to the include
directory. In the Feb 15 2019 release of elfutils, this flag was
added to fix this.