### PR TITLE
Elfutil version check

### DIFF
--- a/cmake/Modules/FindLibElf.cmake
+++ b/cmake/Modules/FindLibElf.cmake
@@ -51,13 +51,34 @@ find_library (LIBELF_LIBRARIES
       ENV LIBRARY_PATH
       ENV LD_LIBRARY_PATH)
 
-include (FindPackageHandleStandardArgs)
-
-
-# handle the QUIETLY and REQUIRED arguments and set LIBELF_FOUND to TRUE if all listed variables are TRUE
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibElf DEFAULT_MSG
-    LIBELF_LIBRARIES
-    LIBELF_INCLUDE_DIR)
-
-
-# mark_as_advanced(LIBELF_INCLUDE_DIRS LIBELF_LIBRARIES)
+# Enforce required version, if enabled
+if(LibElf_FIND_VERSION AND LIBELF_LIBRARIES)
+	get_filename_component(LibElf_realpath ${LIBELF_LIBRARIES} REALPATH)
+	string(REGEX MATCH "libelf\\-(.+)\\.so$" res ${LibElf_realpath})
+	
+	# The library version number is stored in CMAKE_MATCH_1
+	set(LibELf_version ${CMAKE_MATCH_1})
+	
+	if(NOT res OR NOT ${LibELf_version})
+		message(WARNING "Found libelf library '${LibElf_realpath}', but does not match known name format")
+		set(LibElf_FOUND FALSE)
+		set(LIBELF_FOUND FALSE)
+		return()
+	endif()
+	
+	if(${LibELf_version} VERSION_LESS ${LibElf_FIND_VERSION})
+		message(WARNING "Found libelf version '${LibELf_version}', but required version '${LibElf_FIND_VERSION}'")
+		set(LibElf_FOUND FALSE)
+		set(LIBELF_FOUND FALSE)
+		return()
+	endif()
+	set(LIBELF_FOUND TRUE)
+	set(LibElf_FOUND TRUE)
+	message(STATUS "Found libelf '${LibELf_version}' in '${LibElf_realpath}'")
+	return()
+else()
+	include (FindPackageHandleStandardArgs)
+	
+	#handle the QUIETLY and REQUIRED arguments and set LIBELF_FOUND to TRUE if all listed variables are TRUE
+	find_package_handle_standard_args(LibElf LIBELF_LIBRARIES LIBELF_INCLUDE_DIR)
+endif()

--- a/cmake/Modules/FindLibElf.cmake
+++ b/cmake/Modules/FindLibElf.cmake
@@ -11,11 +11,6 @@
 #  Redistribution and use is allowed according to the terms of the New
 #  BSD license.
 #  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
-#
-
-if (LIBELF_LIBRARIES AND LIBELF_INCLUDE_DIRS)
-  set (LibElf_FIND_QUIETLY TRUE)
-endif (LIBELF_LIBRARIES AND LIBELF_INCLUDE_DIRS)
 
 find_path (LIBELF_INCLUDE_DIR
     NAMES

--- a/cmake/Modules/FindLibElf.cmake
+++ b/cmake/Modules/FindLibElf.cmake
@@ -25,6 +25,7 @@ find_path (LIBELF_INCLUDE_DIR
     PATHS
       /usr/include
       /usr/include/libelf
+      /usr/include/x86_64-linux-gnu
       /usr/local/include
       /usr/local/include/libelfls 
       /opt/local/include
@@ -43,6 +44,7 @@ find_library (LIBELF_LIBRARIES
       /usr/lib64
       /usr/local/lib
       /usr/local/lib64
+      /usr/lib/x86_64-linux-gnu
       /opt/local/lib
       /opt/local/lib64
       /sw/lib

--- a/cmake/Modules/FindLibElf.cmake
+++ b/cmake/Modules/FindLibElf.cmake
@@ -36,7 +36,7 @@ find_path (LIBELF_INCLUDE_DIR
 
 find_library (LIBELF_LIBRARIES
     NAMES
-      libelf.so.1
+      libelf.so
     HINTS
       ${LIBELF_LIBRARIES}
     PATHS


### PR DESCRIPTION
Enforce the version check for the elfutils shared library. Add the Ubuntu-specific directories /usr/{lib,include}/x86_64-linux-gnu. Search for libelf.so instead of libelf.so.1 to increase likelihood of finding a symlink.