### PR TITLE
Implement ARMv8 IMFC and Load/Store Shared

### DIFF
--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -28,8 +28,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-//#warning "This file is not implemented yet!"
-
 #include "common/src/headers.h"
 #include "dyninstAPI/h/BPatch_memoryAccess_NP.h"
 #include "dyninstAPI/src/image.h"
@@ -646,7 +644,6 @@ Register EmitterAARCH64::emitCall(opCode op,
 
     //Address of function to call in scratch register
     Register scratch = gen.rs()->getScratchRegister(gen);
-    // Register s1 = gen.rs()->getScratchRegister(gen, noCost);
     assert(scratch != REG_NULL && "cannot get a scratch register");
     gen.markRegDefined(scratch);
     if (gen.addrSpace()->edit() != NULL && gen.func()->obj() != callee->obj()) {
@@ -1399,9 +1396,6 @@ bool EmitterAARCH64::emitCallInstruction(codeGen &gen, func_instance *callee, bo
 
 void EmitterAARCH64::emitLoadShared(opCode op, Register dest, const image_variable *var, bool is_local, int size,
                                     codeGen &gen, Address offset) {
-    //assert(0); //Not implemented
-    //return;
-    
     // create or retrieve jump slot
     Address addr;
     int stackSize = 0;
@@ -1417,11 +1411,7 @@ void EmitterAARCH64::emitLoadShared(opCode op, Register dest, const image_variab
     }
 
     // load register with address from jump slot
-
-    // printf("emitLoadShared addr 0x%lx curr adress 0x%lx offset %ld 0x%lx size %d\n", 
-    //        addr, gen.currAddr(), addr - gen.currAddr()+4, addr - gen.currAddr()+4, size);
     Register scratchReg = gen.rs()->getScratchRegister(gen, true);
-
     assert(scratchReg != REG_NULL && "cannot get a scratch register");
 
     emitMovePCToReg(scratchReg, gen);
@@ -1442,27 +1432,14 @@ void EmitterAARCH64::emitLoadShared(opCode op, Register dest, const image_variab
             emitLoadRelative(dest, varOffset, scratchReg, gen.width(), gen);
         } else {
             assert(0 && "reached invalid else branch");
-
-            // Move address of the variable into the register - load effective address
-            //dest = effective address of pc+offset ;
-            //insnCodeGen::generateImm (gen, CAUop, dest, 0, BOT_HI (varOffset));
-            //insnCodeGen::generateImm (gen, ORILop, dest, dest, BOT_LO (varOffset));
-            //insnCodeGen::generateAddReg (gen, CAXop, dest, dest, scratchReg);
         }
     }
 
     assert(stackSize <= 0 && "stack not empty at the end");
-
-    return;
 }
 
 void
 EmitterAARCH64::emitStoreShared(Register source, const image_variable *var, bool is_local, int size, codeGen &gen) {
-    //assert(0); //Not implemented
-    //return;
-    //
-    // l: from POWER
-    //
     // create or retrieve jump slot
     Address addr;
     int stackSize = 0;
@@ -1473,16 +1450,12 @@ EmitterAARCH64::emitStoreShared(Register source, const image_variable *var, bool
         addr = (Address)var->getOffset();
     }
 
-    printf("emitStoreRelative addr 0x%lx curr adress 0x%lx offset %ld 0x%lx size %d\n",
-            addr, gen.currAddr(), addr - gen.currAddr()+4, addr - gen.currAddr()+4, size);
-
     // load register with address from jump slot
     Register scratchReg = gen.rs()->getScratchRegister(gen, true);
     assert(scratchReg != REG_NULL && "cannot get a scratch register");
 
     emitMovePCToReg(scratchReg, gen);
     Address varOffset = addr - gen.currAddr() + 4;
-    printf("varOffset: %lu\n", varOffset);
 
     if(!is_local) {
         pdvector<Register> exclude;
@@ -1496,15 +1469,9 @@ EmitterAARCH64::emitStoreShared(Register source, const image_variable *var, bool
     }
 
     assert(stackSize <= 0 && "stack not empty at the end");
-
-    return;
 }
 
 Address Emitter::getInterModuleVarAddr(const image_variable *var, codeGen &gen) {
-    // assert(0); //Not implemented
-    //
-    // l: FROM POWER
-
     AddressSpace *addrSpace = gen.addrSpace();
     if (!addrSpace)
         assert(0 && "No AddressSpace associated with codeGen object");
@@ -1574,9 +1541,6 @@ Address EmitterAARCH64::emitMovePCToReg(Register dest, codeGen &gen) {
 }
 
 Address Emitter::getInterModuleFuncAddr(func_instance *func, codeGen &gen) {
-    // assert(0); //Not implemented
-    // return NULL;
-    
     // from POWER64 getInterModuleFuncAddr
 
     AddressSpace *addrSpace = gen.addrSpace();

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -661,8 +661,8 @@ Register EmitterAARCH64::emitCall(opCode op,
         // Register s1 = gen.rs()->getScratchRegister(gen, noCost);
         assert(scratch != REG_NULL);
         gen.markRegDefined(scratch);
-        if (gen.func()->obj() != callee->obj()) {
-            // TODO: need to check if we are in rewriter mode
+        if (gen.func()->obj() != callee->obj() && gen.addrSpace()->edit() != NULL) {
+            // gen.as.edit() checks if we are in rewriter mode
             Address dest = getInterModuleFuncAddr(callee, gen);
             insnCodeGen::loadImmIntoReg<Address>(gen, scratch, dest);
 
@@ -1366,13 +1366,8 @@ bool EmitterAARCH64Dyn::emitTOCCommon(block_instance *block, bool call, codeGen 
 
 // TODO 32/64-bit?
 bool EmitterAARCH64Stat::emitPLTCall(func_instance *callee, codeGen &gen) {
-    // assert(0); //Not implemented
-    // return emitPLTCommon(callee, true, gen);
-
-    // l: working on it...
-    Address dest = getInterModuleFuncAddr(callee, gen);
-    // TBD
-    return true;
+    assert(0); //Not implemented
+    return emitPLTCommon(callee, true, gen);
 }
 
 bool EmitterAARCH64Stat::emitPLTJump(func_instance *callee, codeGen &gen) {
@@ -1446,7 +1441,7 @@ Address Emitter::getInterModuleFuncAddr(func_instance *func, codeGen &gen) {
     // assert(0); //Not implemented
     // return NULL;
     
-    // l: copied from POWER64 getInterModuleFuncAddr
+    // from POWER64 getInterModuleFuncAddr
 
     AddressSpace *addrSpace = gen.addrSpace();
     if (!addrSpace)

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -661,7 +661,7 @@ Register EmitterAARCH64::emitCall(opCode op,
         // Register s1 = gen.rs()->getScratchRegister(gen, noCost);
         assert(scratch != REG_NULL);
         gen.markRegDefined(scratch);
-        if (gen.func()->obj() != callee->obj() && gen.addrSpace()->edit() != NULL) {
+        if (gen.addrSpace()->edit() != NULL && gen.func()->obj() != callee->obj()) {
             // gen.as.edit() checks if we are in rewriter mode
             Address dest = getInterModuleFuncAddr(callee, gen);
             insnCodeGen::loadImmIntoReg<Address>(gen, scratch, dest);

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -1425,7 +1425,6 @@ void EmitterAARCH64::emitLoadShared(opCode op, Register dest, const image_variab
     //assert(0); //Not implemented
     //return;
     
-    /*
     // create or retrieve jump slot
     Address addr;
     int stackSize = 0;
@@ -1442,7 +1441,7 @@ void EmitterAARCH64::emitLoadShared(opCode op, Register dest, const image_variab
 
     // load register with address from jump slot
 
-    inst_printf("emitLoadShared addr 0x%lx curr adress 0x%lx offset %ld 0x%lx size %d\n", 
+    printf("emitLoadShared addr 0x%lx curr adress 0x%lx offset %ld 0x%lx size %d\n", 
             addr, gen.currAddr(), addr - gen.currAddr()+4, addr - gen.currAddr()+4, size);
     Register scratchReg = gen.rs()->getScratchRegister(gen, true);
 
@@ -1457,7 +1456,10 @@ void EmitterAARCH64::emitLoadShared(opCode op, Register dest, const image_variab
         if(!is_local && (var != NULL)){
             emitLoadRelative(dest, varOffset, scratchReg, gen.width(), gen);
             // Deference the pointer to get the variable
-            emitLoadRelative(dest, 0, dest, size, gen);
+            // emitLoadRelative(dest, 0, dest, size, gen);
+            // Offset mode to load back to itself
+            printf("Fallback to offset mode\n");
+            insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, dest, dest, 0, 8, insnCodeGen::Offset);
         } else {
             emitLoadRelative(dest, varOffset, scratchReg, size, gen);
         }
@@ -1465,19 +1467,20 @@ void EmitterAARCH64::emitLoadShared(opCode op, Register dest, const image_variab
         if(!is_local && (var != NULL)){
             emitLoadRelative(dest, varOffset, scratchReg, gen.width(), gen);
         } else {
+            printf("oops, reached else branch\n");
+            assert(0);
 
             // Move address of the variable into the register - load effective address
             //dest = effective address of pc+offset ;
-            insnCodeGen::generateImm (gen, CAUop, dest, 0, BOT_HI (varOffset));
-            insnCodeGen::generateImm (gen, ORILop, dest, dest, BOT_LO (varOffset));
-            insnCodeGen::generateAddReg (gen, CAXop, dest, dest, scratchReg);
+            //insnCodeGen::generateImm (gen, CAUop, dest, 0, BOT_HI (varOffset));
+            //insnCodeGen::generateImm (gen, ORILop, dest, dest, BOT_LO (varOffset));
+            //insnCodeGen::generateAddReg (gen, CAXop, dest, dest, scratchReg);
         }
     }
 
     if (stackSize > 0)
         assert(0);
 
-    */
     return;
 }
 

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -1194,7 +1194,7 @@ bool EmitterAARCH64::emitLoadRelative(Register dest, Address offset, Register ba
     //l: need to test it
 
     insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, dest,
-            base, offset, size, insnCodeGen::Post);
+            base, offset, size, insnCodeGen::Pre);
 
     gen.markRegDefined(dest);
 }

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -663,14 +663,14 @@ Register EmitterAARCH64::emitCall(opCode op,
         gen.markRegDefined(scratch);
         if (gen.func()->obj() != callee->obj()) {
             printf("Entering if-clause, InterModule Function call\n");
-            Register s1 = gen.rs()->getRegByName("r2");
+            //Register s1 = gen.rs()->getRegByName("r2");
             //Register s1 = gen.rs()->getScratchRegister(gen, noCost, true);
-            assert(s1 != REG_NULL);
-            gen.markRegDefined(s1);
+            //assert(s1 != REG_NULL);
+            //gen.markRegDefined(s1);
             Address dest = getInterModuleFuncAddr(callee, gen);
-            insnCodeGen::loadImmIntoReg<Address>(gen, s1, dest);
+            insnCodeGen::loadImmIntoReg<Address>(gen, scratch, dest);
 
-            insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, scratch, s1, 0, 8, insnCodeGen::Post);
+            insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, scratch, scratch, 0, 8, insnCodeGen::Offset);
             //insnCodeGen::generateTrap(gen);
         } else {
             insnCodeGen::loadImmIntoReg<Address>(gen, scratch, callee->addr());

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -662,16 +662,11 @@ Register EmitterAARCH64::emitCall(opCode op,
         assert(scratch != REG_NULL);
         gen.markRegDefined(scratch);
         if (gen.func()->obj() != callee->obj()) {
-            printf("Entering if-clause, InterModule Function call\n");
-            //Register s1 = gen.rs()->getRegByName("r2");
-            //Register s1 = gen.rs()->getScratchRegister(gen, noCost, true);
-            //assert(s1 != REG_NULL);
-            //gen.markRegDefined(s1);
+            // TODO: need to check if we are in rewriter mode
             Address dest = getInterModuleFuncAddr(callee, gen);
             insnCodeGen::loadImmIntoReg<Address>(gen, scratch, dest);
 
             insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, scratch, scratch, 0, 8, insnCodeGen::Offset);
-            //insnCodeGen::generateTrap(gen);
         } else {
             insnCodeGen::loadImmIntoReg<Address>(gen, scratch, callee->addr());
         }
@@ -1505,7 +1500,6 @@ Address Emitter::getInterModuleFuncAddr(func_instance *func, codeGen &gen) {
         // add write new relocation symbol/entry
         binEdit->addDependentRelocation(relocation_address, referring);
     }
-    printf("passed relocation address: %llu\n", relocation_address);
     return relocation_address;
 }
 

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -1175,11 +1175,6 @@ bool EmitterAARCH64::emitCallRelative(Register dest, Address offset, Register ba
 }
 
 bool EmitterAARCH64::emitLoadRelative(Register dest, Address offset, Register base, int size, codeGen &gen) {
-    //assert(0); //Not implemented
-    //return true;
-    //
-    //l: need to test it
-
     insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, dest,
             base, offset, size, insnCodeGen::Pre);
 
@@ -1189,14 +1184,8 @@ bool EmitterAARCH64::emitLoadRelative(Register dest, Address offset, Register ba
 
 
 void EmitterAARCH64::emitStoreRelative(Register source, Address offset, Register base, int size, codeGen &gen) {
-    //return true;
-    // assert(0); //Not implemented
-    //
-    // l: need to test later
     insnCodeGen::generateMemAccess(gen, insnCodeGen::Store, source,
             base, offset, size, insnCodeGen::Pre);
-
-    //gen.markRegDefined(base);
 }
 
 bool EmitterAARCH64::emitMoveRegToReg(registerSlot *src,
@@ -1540,7 +1529,7 @@ Address Emitter::getInterModuleVarAddr(const image_variable *var, codeGen &gen) 
 
     if (syms.size() == 0) {
         char msg[256];
-        sprintf(msg, "%s[%d]:  internal error:  cannot find symbol %s"
+        snprintf(msg, sizeof(msg), "%s[%d]:  internal error:  cannot find symbol %s"
                 , __FILE__, __LINE__, var->symTabName().c_str());
         showErrorCallback(80, msg);
         assert(0);
@@ -1573,13 +1562,6 @@ Address Emitter::getInterModuleVarAddr(const image_variable *var, codeGen &gen) 
 }
 
 Address EmitterAARCH64::emitMovePCToReg(Register dest, codeGen &gen) {
-    //assert(0); //Not implemented
-    //insnCodeGen::generateBranch(gen, gen.currAddr(), gen.currAddr() + 4, true); // blrl
-    //Address ret = gen.currAddr();
-    //return ret;
-    //
-    //l: working on it
-
     instruction insn;
     insn.clear();
 
@@ -1623,7 +1605,7 @@ Address Emitter::getInterModuleFuncAddr(func_instance *func, codeGen &gen) {
 
     if (syms.size() == 0) {
         char msg[256];
-        sprintf(msg, "%s[%d]:  internal error:  cannot find symbol %s"
+        snprintf(msg, sizeof(msg), "%s[%d]:  internal error:  cannot find symbol %s"
                 , __FILE__, __LINE__, func->symTabName().c_str());
         showErrorCallback(80, msg);
         assert(0);


### PR DESCRIPTION
This PR implements the following for **Dyninst AArch64 Rewriter mode**:
- Inter Module Function Address calculation
- Inter Module Function Call
- Inter Module Variable Address Calculation
- emitLoadShared
- emitStoreShared
- Move PC to Register

Description for IMFC can be found in #545 

Current limitations:
- Unable to spill and restore registers if none is available.

## Test Result
### Test result before this PR
(on the current ARMv8 branch)
none of the rewriter passes. 

### Test result after this PR
**With testsuite master branch:** 
```bash
for i in `seq 1 41`; do ./runTests -rewriter -test test1_$i; done
```
**30 out of 41** tests of group 1 pass, (with 6 fail, 5 crash) as in #545 

**With testsuite pic_fix branch:**
```bash
for i in `seq 1 41`; do ./test_driver -rewriter -g++ -test test1_$i; done
```
**33 out of 43** tests of group 1 pass, (with 2 fail, 8 crash)

### Test screenshot
![image](https://user-images.githubusercontent.com/10568668/53762552-0879f800-3e8e-11e9-84e6-83e589c8b7a3.png)

This also closes #522 
