### PR TITLE
Fix bad interactions between patchAPI and parseAPI

### DIFF
--- a/dyninstAPI/h/BPatch_snippet.h
+++ b/dyninstAPI/h/BPatch_snippet.h
@@ -517,7 +517,7 @@ class BPATCH_DLL_EXPORT BPatch_effectiveAddressExpr : public BPatch_snippet
   //  BPatch_effectiveAddressExpr:: BPatch_effectiveAddressExpr
   //  Construct a snippet representing an effective address.
 
-  BPatch_effectiveAddressExpr(int _which = 0);
+  BPatch_effectiveAddressExpr(int _which = 0, int size = 8);
 };
 
 

--- a/dyninstAPI/src/BPatch_snippet.C
+++ b/dyninstAPI/src/BPatch_snippet.C
@@ -541,7 +541,7 @@ BPatch_arithExpr::BPatch_arithExpr(BPatch_unOp op,
 
           BPatch_type *type = const_cast<BPatch_type *> (lOperand.ast_wrapper->getType());
           if (!type || (type->getDataClass() != BPatch_dataPointer)) {
-              ast_wrapper->setType(BPatch::bpatch->stdTypes->findType("int"));
+              ast_wrapper->setType(BPatch::bpatch->stdTypes->findType("long"));
           } else {
               ast_wrapper->setType(type->getConstituentType());
 //              ast_wrapper->setType(dynamic_cast<BPatch_typePointer *>(type)->getConstituentType());
@@ -793,7 +793,7 @@ BPatch_regExpr::BPatch_regExpr(unsigned int value)
     assert(BPatch::bpatch != NULL);
     ast_wrapper->setTypeChecking(BPatch::bpatch->isTypeChecked());
 
-    BPatch_type *type = BPatch::bpatch->stdTypes->findType("int");
+    BPatch_type *type = BPatch::bpatch->stdTypes->findType("long");
     assert(type != NULL);
 
     ast_wrapper->setType(type);

--- a/dyninstAPI/src/BPatch_snippet.C
+++ b/dyninstAPI/src/BPatch_snippet.C
@@ -1523,7 +1523,7 @@ BPatch_breakPointExpr::BPatch_breakPointExpr()
  *
  * Construct a snippet representing an effective address.
  */
-BPatch_effectiveAddressExpr::BPatch_effectiveAddressExpr(int _which)
+BPatch_effectiveAddressExpr::BPatch_effectiveAddressExpr(int _which, int size)
 {
 #if defined(i386_unknown_nt4_0)
   assert(_which >= 0 && _which <= 2);
@@ -1532,7 +1532,7 @@ BPatch_effectiveAddressExpr::BPatch_effectiveAddressExpr(int _which)
 #else
   assert(_which >= 0 && _which <= (int) BPatch_instruction::nmaxacc_NP);
 #endif
-  ast_wrapper = AstNodePtr(AstNode::memoryNode(AstNode::EffectiveAddr, _which));
+  ast_wrapper = AstNodePtr(AstNode::memoryNode(AstNode::EffectiveAddr, _which, size));
 };
 
 

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -250,8 +250,8 @@ AstNodePtr AstNode::funcCallNode(Address addr, pdvector<AstNodePtr > &args) {
     return AstNodePtr(new AstCallNode(addr, args));
 }
 
-AstNodePtr AstNode::memoryNode(memoryType ma, int which) {
-    return AstNodePtr(new AstMemoryNode(ma, which));
+AstNodePtr AstNode::memoryNode(memoryType ma, int which, int size) {
+    return AstNodePtr(new AstMemoryNode(ma, which, size));
 }
 
 AstNodePtr AstNode::miniTrampNode(AstNodePtr tramp) {
@@ -474,7 +474,8 @@ AstVariableNode::AstVariableNode(vector<AstNodePtr>&ast_wrappers, vector<pair<Of
 }
 
 AstMemoryNode::AstMemoryNode(memoryType mem,
-                             unsigned which) :
+                             unsigned which,
+                             int size) :
     AstNode(),
     mem_(mem),
     which_(which) {
@@ -485,7 +486,19 @@ AstMemoryNode::AstMemoryNode(memoryType mem,
 
     switch(mem_) {
     case EffectiveAddr:
-        bptype = BPatch::bpatch->stdTypes->findType("void *");
+        switch (size) {
+            case 1:
+                bptype = BPatch::bpatch->stdTypes->findType("char");
+                break;
+            case 2:
+                bptype = BPatch::bpatch->stdTypes->findType("short");
+                break;
+            case 4:
+                bptype = BPatch::bpatch->stdTypes->findType("int");
+                break;
+            default:
+                bptype = BPatch::bpatch->stdTypes->findType("long");
+        }
         break;
     case BytesAccessed:
         bptype = BPatch::bpatch->stdTypes->findType("int");

--- a/dyninstAPI/src/ast.h
+++ b/dyninstAPI/src/ast.h
@@ -219,7 +219,7 @@ class AstNode : public Dyninst::PatchAPI::Snippet {
    static AstNodePtr operandNode(operandType ot, AstNodePtr ast);
    static AstNodePtr operandNode(operandType ot, const image_variable* iv);
 
-   static AstNodePtr memoryNode(memoryType ot, int which);
+   static AstNodePtr memoryNode(memoryType ot, int which, int size = 8);
 
    static AstNodePtr sequenceNode(pdvector<AstNodePtr > &sequence);
         
@@ -825,7 +825,7 @@ class AstMiniTrampNode : public AstNode {
 
 class AstMemoryNode : public AstNode {
  public:
-    AstMemoryNode(memoryType mem, unsigned which);
+    AstMemoryNode(memoryType mem, unsigned which, int size);
 	bool canBeKept() const;
 
    virtual std::string format(std::string indent);

--- a/parseAPI/src/CFGModifier.C
+++ b/parseAPI/src/CFGModifier.C
@@ -159,6 +159,7 @@ Block *CFGModifier::split(Block *b, Address a, bool trust, Address newlast) {
    ret->updateEnd(b->_end);
    ret->_lastInsn = b->_lastInsn;
    ret->_parsed = true;
+   b->obj()->parser->_parse_data->record_block(ret->region(), ret);
    
    b->updateEnd(a);
    b->_lastInsn = newlast;


### PR DESCRIPTION
The general problem is that when users use patchAPI to modify CFG, some of the modification is not properly updated in parseAPI data structures.