### PR TITLE
supporting line map information for dyninst instrumented binaries 

### DIFF
--- a/common/src/headers.h
+++ b/common/src/headers.h
@@ -62,6 +62,7 @@
 #include "common/src/vxworksHeaders.h"
 
 #endif  /* architecture specific */
+#define DYNINST_STR_TBL_FID_OFFSET 2000000 // anyone creates more than 2 million files in a project?
 
 typedef enum {
    RRVsuccess,

--- a/common/src/headers.h
+++ b/common/src/headers.h
@@ -62,7 +62,6 @@
 #include "common/src/vxworksHeaders.h"
 
 #endif  /* architecture specific */
-#define DYNINST_STR_TBL_FID_OFFSET 2000000 // anyone creates more than 2 million files in a project?
 
 typedef enum {
    RRVsuccess,

--- a/dataflowAPI/rose/ExtentMap.C
+++ b/dataflowAPI/rose/ExtentMap.C
@@ -6,6 +6,7 @@
 #include "util/StringUtility.h"
 #include "ExtentMap.h"
 #include <boost/foreach.hpp>
+#include <stdio.h>
 
 #define DUMP_FIELD_WIDTH        64
 
@@ -82,8 +83,10 @@ Extent
 ExtentMap::allocate_best_fit(rose_addr_t size)
 {
     iterator found = best_fit(size, begin());
-    if (found==end())
+    if (found==end()) {
+        printf("ExtentMap::allocate_best_fit %lu throws bad_alloc\n", size);
         throw std::bad_alloc();
+    }
     Extent retval(found->first.first(), size);
     erase(retval);
     return retval;
@@ -94,8 +97,10 @@ Extent
 ExtentMap::allocate_first_fit(rose_addr_t size)
 {
     iterator found = first_fit(size, begin());
-    if (found==end())
+    if (found==end()) {
+        printf("ExtentMap::allocate_first_fit %lu throws bad_alloc\n", size);
         throw std::bad_alloc();
+    }
     Extent retval(found->first.first(), size);
     erase(retval);
     return retval;

--- a/dyninstAPI/src/BPatch.C
+++ b/dyninstAPI/src/BPatch.C
@@ -140,7 +140,6 @@ BPatch::BPatch()
     extern bool init();
 
     // Save a pointer to the one-and-only bpatch object.
-    printf("constructor for BPatch is called: %p == %p ? \n", &bpatch, &(BPatch::bpatch));
     if (bpatch == NULL){
        bpatch = this;
     }

--- a/dyninstAPI/src/BPatch_addressSpace.C
+++ b/dyninstAPI/src/BPatch_addressSpace.C
@@ -276,7 +276,6 @@ BPatch_function * BPatchSnippetHandle::getFunc()
 
 BPatch_image * BPatch_addressSpace::getImage()
 {
-   printf("get image\n");
    return image;
 }
 

--- a/dyninstAPI/src/BPatch_binaryEdit.C
+++ b/dyninstAPI/src/BPatch_binaryEdit.C
@@ -208,7 +208,6 @@ bool BPatch_binaryEdit::writeFile(const char * outFile)
     // in each one.
     std::vector<AddressSpace *> as;
     getAS(as);
-    printf("address space number: %d\n", as.size());   
     bool ret = true;
 
     /* PatchAPI stuffs */
@@ -240,7 +239,6 @@ bool BPatch_binaryEdit::writeFile(const char * outFile)
        continue;
 
      std::string newname = bin->getMappedObject()->fileName();
-     printf("BPatch_binaryEdit::writeFile(), newname: %s\n", newname.c_str());
      if( !bin->writeFile(newname) ) return false;
    }
    return ret;

--- a/dyninstAPI/src/BPatch_binaryEdit.C
+++ b/dyninstAPI/src/BPatch_binaryEdit.C
@@ -273,7 +273,6 @@ void BPatch_binaryEdit::getAS(std::vector<AddressSpace *> &as)
 
 void BPatch_binaryEdit::beginInsertionSet()
 {
-    printf("BPatch_binaryEdit::beginInsertionSet()\n");  
     return;
 }
 

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -680,7 +680,6 @@ bool AddressSpace::findFuncsByAll(const std::string &funcname,
                                   const std::string &libname) { // = "", btw
     
    unsigned starting_entries = res.size(); // We'll return true if we find something
-   cout << "AddressSpace::findFuncsByAll func: " << funcname << " lib: " << libname <<  " mapped object number: " << mapped_objects.size() << endl;
    for (unsigned i = 0; i < mapped_objects.size(); i++) {
       if (libname == "" ||
           mapped_objects[i]->fileName() == libname.c_str() ||
@@ -760,7 +759,6 @@ func_instance *AddressSpace::findOnlyOneFunction(const string &name,
    pdvector<func_instance *> allFuncs;
 
    if (!findFuncsByAll(name.c_str(), allFuncs, lib.c_str())) {
-      cerr << "AddressSpace::findOnlyOneFunction, func: " << name << " lib: " << lib << " returns null " << endl;
       return NULL;
    }
 

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -875,7 +875,6 @@ void BinaryEdit::buildLineMapReloc(pdvector<std::pair<Address, SymtabAPI::LineNo
             int cur_file_index = (int)stmt.getFileIndex();
             int cur_line = (int)stmt.getLine();
             int cur_column = (int)stmt.getColumn(); 
-            
             if (cur_file_index == last_file_index && cur_line == last_line && 
                     cur_column == last_column) {
                 // the instruction byte at curr_origAddr is associated with the same source code location
@@ -974,6 +973,7 @@ void* BinaryEdit::serializeLineMap(pdvector<std::pair<Address, SymtabAPI::LineNo
         uint32_t file_index = (uint32_t)stmt.getFileIndex();
         uint32_t line_number = (uint32_t)stmt.getLine();
         uint32_t column_number = (uint32_t)stmt.getColumn();
+        cout << "serializing... inst addr: " << hex << inst_addr << dec << " file index: " << file_index << " file name: " << stmt.getFile() << endl;
         memcpy((char*)chunk + offset, &inst_addr, sizeof(uint64_t));//pack the address
         offset += sizeof(uint64_t);
         memcpy((char*)chunk + offset, &file_index, sizeof(uint32_t));

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -726,7 +726,7 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       }
       free(lineMapChunk);
       free(stringTableChunk);
-   return true;
+    return true;
 }
 
 Address BinaryEdit::maxAllocedAddr() {

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -505,8 +505,6 @@ void addTrapTable_win(newSectionPtr, Address tableAddr)
 bool BinaryEdit::writeFile(const std::string &newFileName) 
 {
    // Step 1: changes. 
-
-      cout << "write file: " << newFileName << endl;
       inst_printf(" writing %s ... \n", newFileName.c_str());
 
       Symtab *symObj = mobj->parse_img()->getObject();
@@ -519,8 +517,8 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
 
       if( symObj->isStaticBinary() && isDirty() ) {
          if( !doStaticBinarySpecialCases() ) {
-	   cerr << "Failed to write file " << newFileName << ": static binary handler failed" << endl;
-	   return false;
+	        cerr << "Failed to write file " << newFileName << ": static binary handler failed" << endl;
+	        return false;
          }
       }
 
@@ -539,7 +537,6 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       // Now, we need to copy in the memory of the new segments
       for (unsigned i = 0; i < oldSegs.size(); i++) {
          codeRange *segRange = NULL;
-         printf("old region name: %s memory offset: 0x%lx \n", oldSegs[i]->getRegionName().c_str(), oldSegs[i]->getMemOffset());
          if (!memoryTracker_->find(oldSegs[i]->getMemOffset(), segRange)) {
 #if 0
             // Looks like BSS
@@ -554,7 +551,6 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
 	 memoryTracker* mt = dynamic_cast<memoryTracker*>(segRange);
 	 assert(mt);
 	 if(mt->dirty) {
-         printf("mt->dirty, old region name: %s  set ptr to raw data 0x%lx, size: %lu\n", oldSegs[i]->getRegionName().c_str(),segRange->get_local_ptr(), oldSegs[i]->getMemSize());
             oldSegs[i]->setPtrToRawData(segRange->get_local_ptr(), oldSegs[i]->getMemSize());
 	 }
 	 
@@ -566,7 +562,6 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       // Now we need to get the new stuff. That's all the allocated memory. First, big
       // buffer to hold it.  Use calloc so gaps from inferiorFree/Realloc are just zero.
 
-      printf("highWatermark: 0x%lx lowWaterMark: 0x%lx\n", highWaterMark_, lowWaterMark_);
       void *newSectionPtr = calloc(highWaterMark_ - lowWaterMark_, 1);
 
       pdvector<codeRange *> writes;
@@ -620,12 +615,10 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
 
       
       if (mobj == getAOut()) {
-         printf("mobj == getAOut(), add dynamic symbol relocations\n");
          // Add dynamic symbol relocations
          for (unsigned i=0; i < dependentRelocations.size(); i++) {
             Address to = dependentRelocations[i]->getAddress();
             Symbol *referring = dependentRelocations[i]->getReferring();
-            printf("dependent relocation - symbol name: %s address: 0x%lx\n", referring->getPrettyName().c_str(), to);
             /*
               if (!symObj->isStaticBinary() && !symObj->hasReldyn() && !symObj->hasReladyn()) {
               Address addr = referring->getOffset();
@@ -671,37 +664,16 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       pdvector<Symbol *> newSyms;
       buildDyninstSymbols(newSyms, newSec, symObj->getOrCreateModule("dyninstInst",
                                                                      lowWaterMark_));
-      pdvector<std::pair<Address, SymtabAPI::LineNoTuple> > newLineMap;
-      buildInstrumentedLineMap(newLineMap);
       
-      for (uint64_t i = 0; i < newLineMap.size(); ++i) {
-        cout << hex << "\t" << newLineMap[i].first << dec << " file number: " << newLineMap[i].second.getFileIndex() << " file: " << newLineMap[i].second.getFile() << " line: " <<  newLineMap[i].second.getLine() << " column: " << newLineMap[i].second.getColumn() << endl;
-      }
-    
-      size_t lineMapChunkSize = 0;
-      size_t stringTableChunkSize = 0;
-      std::pair<void*,void*> chunks = serializeLineMap(newLineMap, lineMapChunkSize, stringTableChunkSize);
-      void* lineMapChunk = chunks.first;
-      void* stringTableChunk = chunks.second;
-    
-      symObj->addRegion(0,
-                        lineMapChunk,
-                        lineMapChunkSize,
-                        ".dyninstLineMap",
-                        Region::RT_DATA,
-                        true);
-
-      symObj->addRegion(0,
-                        stringTableChunk,
-                        stringTableChunkSize,
-                        ".dyninstStringTable",
-                        Region::RT_DATA,
-                        true); 
 
       for (unsigned i = 0; i < newSyms.size(); i++) {
          symObj->addSymbol(newSyms[i]);
       }
+
+      pdvector<std::pair<Address, SymtabAPI::LineNoTuple> > newLineMap;
+      buildInstrumentedLineMap(newLineMap);
          
+      auto chunks = symObj->addDyninstLineInfo(newLineMap); 
       // Okay, now...
       // Hand textSection and newSection to DynSymtab.
         
@@ -724,8 +696,8 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
          showErrorCallback(109, Symtab::printError(lastError));
          return false;
       }
-      free(lineMapChunk);
-      free(stringTableChunk);
+      free(chunks.first);
+      free(chunks.second);
     return true;
 }
 
@@ -922,6 +894,7 @@ void BinaryEdit::buildLineMapInst(pdvector<std::pair<Address, SymtabAPI::LineNoT
     }  
 }
 
+
 // Build a list of linemaps for instrumented binary
 // each instruction address in the instrumented binary gets its linemap in the original binary 
 
@@ -960,106 +933,6 @@ void BinaryEdit::buildInstrumentedLineMap(pdvector<std::pair<Address, SymtabAPI:
             }
         }  
    }
-}
-
-/* write the new linemap info 
- * because the file index is relative for each module, i.e., not a global file index inside a global string table, a safer way that ensures we get the correct (filename, line) information is to directly store the file name strings inside our seperate table, and build our own file index, which would be visible to every module
- */
-std::pair<void*,void*> BinaryEdit::serializeLineMap(pdvector<std::pair<Address, SymtabAPI::LineNoTuple> >& newLineMap, size_t& lmChunkSize, size_t& stChunkSize) 
-{
-    // first we preprocess the newLineMap vector, such that we assign each file name with our own file index
-    uint32_t file_id = DYNINST_STR_TBL_FID_OFFSET; // starting with the offset such that we know this is our own id, don't mess up with the default file index 
-    uint32_t num_records = (uint32_t) newLineMap.size();
-    std::map<std::string, uint32_t> fileMap;
-    for (const auto& item : newLineMap) {
-       auto filename = item.second.getFile(); 
-       if(fileMap.find(filename) != fileMap.end()) { // have already seen this file, lets make sure we don't create duplicate 
-           continue;    
-       } else {
-           //otherwise assign our own file id to it 
-          fileMap[filename] = file_id++;// use the current file_id and then increment the file_id 
-       }
-    }
-    /* now we prepare the memory chunk that stores the line mapping using our own file id 
-     schema for the linemap chunk: |uint32_t number of records | uint64_t: 1st record low address inclusive | uint32_t: 1st filename index | uint32_t: 1st record line no | uint32_t: 1st record column no | uint64_t: 2nd record low address inclusive | .... | 
-     */
-    size_t payload_size = sizeof(uint32_t) + (sizeof(uint64_t) + sizeof(uint32_t) * 3) * num_records; 
-    cerr << "serializeLineMap called " << newLineMap.size() <<  " payload size: " << payload_size <<  " number of records: " << num_records << endl;
-    void* chunk = calloc(1, payload_size);
-    if (chunk == NULL) {
-        cerr << "calloc for linemap failed" << endl;
-        exit(-1);
-    }
-    lmChunkSize = payload_size;
-    memcpy(chunk, (char*)&num_records, sizeof(uint32_t));
-    uint32_t offset = sizeof(uint32_t);
-    for (int i = 0; i < num_records; ++i) {
-        uint64_t inst_addr = (uint64_t)newLineMap[i].first;
-        SymtabAPI::LineNoTuple stmt = newLineMap[i].second;
-        if (fileMap.find(stmt.getFile()) == fileMap.end()) {
-            cout << "impossible: cannot find file " << stmt.getFile() << " in file map" << endl; 
-            continue;
-        } 
-        uint32_t file_index = fileMap[stmt.getFile()];
-        uint32_t line_number = (uint32_t)stmt.getLine(); 
-        uint32_t column_number = (uint32_t)stmt.getColumn();
-        cout << "serializing... inst addr: " << hex << inst_addr << dec << " file index: " << file_index << " file name: " << stmt.getFile() << endl;
-        memcpy((char*)chunk + offset, &inst_addr, sizeof(uint64_t));//pack the address
-        offset += sizeof(uint64_t);
-        memcpy((char*)chunk + offset, &file_index, sizeof(uint32_t));
-        offset += sizeof(uint32_t);
-        memcpy((char*)chunk + offset, &line_number, sizeof(uint32_t));
-        offset += sizeof(uint32_t);
-        memcpy((char*)chunk + offset, &column_number, sizeof(uint32_t));
-        offset += sizeof(uint32_t); // update the offset     
-    } 
-    void* lm_chunk = chunk; // remember the starting address, remember to release the memory afte writing to the region.
-
-    chunk = NULL; // forget about it 
-    // now we prepare the string table chunk that stores the file names, we need to subtract the offset to make it starting at 0
-    // schema: | uint32_t: num files | uint32_t: 1st filename offset | uint32_t: 1st filename length | uint32_t: 2nd filename offset | ... | uint32_t: last filename offset | uint32_t: last filename length | filename 1 | filename 2 | ... | last filename | 
-    // first we should sort the file name by the file index 
-    std::vector<std::pair<std::string, uint32_t> > tmp_vec;
-    for (auto& item : fileMap) {
-        tmp_vec.push_back(item);
-    }
-    sort(tmp_vec.begin(), tmp_vec.end(), [](const std::pair<std::string, uint32_t>& v1, const std::pair<std::string, uint32_t>& v2) { return v1.second < v2.second; });
-    uint32_t num_files = (uint32_t)fileMap.size();
-    cout << "serializing... num files: " << num_files << endl;
-    payload_size = 0;
-    vector<uint32_t> file_sizes;
-    for (auto& item : tmp_vec) { // sorted by file index
-        cout << "file: " << item.first << " index: " << item.second << endl;
-        auto file_size = item.first.size();
-        payload_size += file_size;
-        file_sizes.push_back((uint32_t)file_size);
-    }
-    payload_size += num_files; // include the '\0' terminator
-    size_t header_size = sizeof(uint32_t) * (1 + num_files * 2);
-    size_t total_byte_size = payload_size + header_size;
-    stChunkSize = total_byte_size;
-    chunk = calloc(1, total_byte_size);
-    if (chunk == NULL) {
-        cerr << "calloc for string table failed " << endl;
-        exit(-1);
-    } 
-    memcpy(chunk, (char*)&num_files, sizeof(uint32_t)); 
-    offset = (uint32_t)header_size;
-    for (int i = 0; i < num_files; ++i) {
-       uint32_t current_file_size = (uint32_t)file_sizes[i];
-       memcpy((char*)chunk + sizeof(uint32_t) + i * sizeof(uint32_t) * 2, (char*)&offset, sizeof(uint32_t));
-       memcpy((char*)chunk + sizeof(uint32_t) + i * sizeof(uint32_t) * 2 + sizeof(uint32_t), (char*)&current_file_size, sizeof(uint32_t));
-       offset += current_file_size + 1; // add '\0' 
-    }
-    offset = 0;
-    for (auto& item : tmp_vec) {
-       auto file_str = item.first.c_str();
-       size_t current_file_size = strlen(file_str);
-       memcpy((char*)chunk + header_size + offset, file_str, current_file_size + 1);
-       offset += current_file_size + 1;
-    }
-    void* st_chunk = chunk;   
-    return std::make_pair(lm_chunk, st_chunk);
 }
 
 // Build a list of symbols describing instrumentation and relocated functions. 

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -993,7 +993,7 @@ std::pair<void*,void*> BinaryEdit::serializeLineMap(pdvector<std::pair<Address, 
     }
     lmChunkSize = payload_size;
     memcpy(chunk, (char*)&num_records, sizeof(uint32_t));
-    int offset = sizeof(uint32_t);
+    uint32_t offset = sizeof(uint32_t);
     for (int i = 0; i < num_records; ++i) {
         uint64_t inst_addr = (uint64_t)newLineMap[i].first;
         SymtabAPI::LineNoTuple stmt = newLineMap[i].second;
@@ -1045,7 +1045,7 @@ std::pair<void*,void*> BinaryEdit::serializeLineMap(pdvector<std::pair<Address, 
         exit(-1);
     } 
     memcpy(chunk, (char*)&num_files, sizeof(uint32_t)); 
-    uint32_t offset = (uint32_t)header_size;
+    offset = (uint32_t)header_size;
     for (int i = 0; i < num_files; ++i) {
        uint32_t current_file_size = (uint32_t)file_sizes[i];
        memcpy((char*)chunk + sizeof(uint32_t) + i * sizeof(uint32_t) * 2, (char*)&offset, sizeof(uint32_t));

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -698,8 +698,6 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
                         Region::RT_DATA,
                         true); 
 
-      free(lineMapChunk);
-      free(stringTableChunk);
       for (unsigned i = 0; i < newSyms.size(); i++) {
          symObj->addSymbol(newSyms[i]);
       }
@@ -726,6 +724,8 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
          showErrorCallback(109, Symtab::printError(lastError));
          return false;
       }
+      free(lineMapChunk);
+      free(stringTableChunk);
    return true;
 }
 

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -958,7 +958,7 @@ void BinaryEdit::buildInstrumentedLineMap(pdvector<std::pair<Address, SymtabAPI:
 void* BinaryEdit::serializeLineMap(pdvector<std::pair<Address, SymtabAPI::LineNoTuple> >& newLineMap, size_t& chunkSize) 
 {
     uint32_t num_records = (uint32_t) newLineMap.size();
-    size_t payload_size = sizeof(uint32_t) + (sizeof(uint64_t) + sizeof(uint16_t) * 3) * num_records;
+    size_t payload_size = sizeof(uint32_t) + (sizeof(uint64_t) + sizeof(uint32_t) * 3) * num_records;
     cerr << "serializeLineMap called " << newLineMap.size() <<  " payload size: " << payload_size <<  " number of records: " << num_records << endl;
     void* chunk = calloc(1, payload_size);
     if (chunk == NULL) {
@@ -971,17 +971,17 @@ void* BinaryEdit::serializeLineMap(pdvector<std::pair<Address, SymtabAPI::LineNo
     for (int i = 0; i < num_records; ++i) {
         uint64_t inst_addr = (uint64_t)newLineMap[i].first;
         SymtabAPI::LineNoTuple stmt = newLineMap[i].second;
-        uint16_t file_index = (uint16_t)stmt.getFileIndex();
-        uint16_t line_number = (uint16_t)stmt.getLine();
-        uint16_t column_number = (uint16_t)stmt.getColumn();
+        uint32_t file_index = (uint32_t)stmt.getFileIndex();
+        uint32_t line_number = (uint32_t)stmt.getLine();
+        uint32_t column_number = (uint32_t)stmt.getColumn();
         memcpy((char*)chunk + offset, &inst_addr, sizeof(uint64_t));//pack the address
         offset += sizeof(uint64_t);
-        memcpy((char*)chunk + offset, &file_index, sizeof(uint16_t));
-        offset += sizeof(uint16_t);
-        memcpy((char*)chunk + offset, &line_number, sizeof(uint16_t));
-        offset += sizeof(uint16_t);
-        memcpy((char*)chunk + offset, &column_number, sizeof(uint16_t));
-        offset += sizeof(uint16_t); // update the offset     
+        memcpy((char*)chunk + offset, &file_index, sizeof(uint32_t));
+        offset += sizeof(uint32_t);
+        memcpy((char*)chunk + offset, &line_number, sizeof(uint32_t));
+        offset += sizeof(uint32_t);
+        memcpy((char*)chunk + offset, &column_number, sizeof(uint32_t));
+        offset += sizeof(uint32_t); // update the offset     
     } 
     return chunk;
 }

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -856,7 +856,7 @@ void BinaryEdit::buildLineMapReloc(pdvector<std::pair<Address, SymtabAPI::LineNo
                 // the instruction byte at curr_origAddr is associated with the same source code location
                 continue;
             } else {
-                stmt.setInstPointAddr(origAddr);
+                stmt.setInstPointAddr_(origAddr);
                 last_file_index = cur_file_index;
                 last_line = cur_line;
                 last_column = cur_column;

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -37,7 +37,6 @@
 #include "os.h"
 #include "instPoint.h"
 #include "function.h"
-#define INST_LINE_OFFSET 10000000
 using namespace Dyninst::SymtabAPI;
 
 // #define USE_ADDRESS_MAPS
@@ -857,6 +856,7 @@ void BinaryEdit::buildLineMapReloc(pdvector<std::pair<Address, SymtabAPI::LineNo
                 // the instruction byte at curr_origAddr is associated with the same source code location
                 continue;
             } else {
+                stmt.setInstPointAddr(origAddr);
                 last_file_index = cur_file_index;
                 last_line = cur_line;
                 last_column = cur_column;
@@ -882,7 +882,7 @@ void BinaryEdit::buildLineMapInst(pdvector<std::pair<Address, SymtabAPI::LineNoT
     module->getSourceLines(lines, origAddr);
     if (lines.size() != 0) {
         SymtabAPI::LineNoTuple stmt = lines[0];
-        stmt.setLine(stmt.getLine() + INST_LINE_OFFSET); 
+        stmt.setInstPointAddr_(origAddr);
         newLineMap.push_back(std::make_pair(relocAddr, stmt)); 
     }  
 }

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -31,7 +31,6 @@
 // $Id: binaryEdit.C,v 1.26 2008/10/28 18:42:44 bernat Exp $
 
 #include "binaryEdit.h"
-#include "common/src/headers.h"
 #include "mapped_object.h"
 #include "mapped_module.h"
 #include "debug.h"

--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -235,7 +235,7 @@ class BinaryEdit : public AddressSpace {
 
     void buildLineMapInst(pdvector<std::pair<Address, SymtabAPI::LineNoTuple> > & newLineMap, Address origAddr, Address relocAddr, unsigned strandSize, const Relocation::TrackerElement* tracker);
 
-    void* serializeLineMap(pdvector<std::pair<Address, SymtabAPI::LineNoTuple> >& newLineMap, size_t& chunkSize);
+    std::pair<void*,void*> serializeLineMap(pdvector<std::pair<Address, SymtabAPI::LineNoTuple> >& newLineMap, size_t& lmChunkSize, size_t& stChunkSize);
 
     mapped_object *mobj;
     std::vector<BinaryEdit *> rtlib;

--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -235,8 +235,6 @@ class BinaryEdit : public AddressSpace {
 
     void buildLineMapInst(pdvector<std::pair<Address, SymtabAPI::LineNoTuple> > & newLineMap, Address origAddr, Address relocAddr, unsigned strandSize, const Relocation::TrackerElement* tracker);
 
-    std::pair<void*,void*> serializeLineMap(pdvector<std::pair<Address, SymtabAPI::LineNoTuple> >& newLineMap, size_t& lmChunkSize, size_t& stChunkSize);
-
     mapped_object *mobj;
     std::vector<BinaryEdit *> rtlib;
     std::vector<BinaryEdit *> siblings;

--- a/dyninstAPI/src/mapped_object.C
+++ b/dyninstAPI/src/mapped_object.C
@@ -464,7 +464,6 @@ void mapped_object::set_short_name() {
 
 const pdvector<func_instance *> *mapped_object::findFuncVectorByPretty(const std::string &funcname)
 {
-   cout << "mapped_object::findFuncVectorByPretty " << funcname << endl;
    if (funcname.c_str() == 0) return NULL;
    // First, check the underlying image.
    const pdvector<parse_func *> *img_funcs = parse_img()->findFuncVectorByPretty(funcname);

--- a/patchAPI/src/Command.C
+++ b/patchAPI/src/Command.C
@@ -74,7 +74,6 @@ void BatchCommand::remove(CommandList::iterator c) {
 }
 
 bool BatchCommand::run() {
-  printf("BatchCommand::run()\n");
   std::set<CommandList::iterator> remove_set;
   for (CommandList::iterator i = to_do_.begin(); i != to_do_.end();) {
     done_.push_front(*i);
@@ -98,7 +97,6 @@ bool BatchCommand::undo() {
 bool Patcher::run() {
 
   // We implicitly add the instrumentation engine
-  printf("Patcher::run()\n");
   Instrumenter* inst = mgr_->instrumenter();
   add(inst);
 
@@ -125,7 +123,6 @@ bool Patcher::run() {
    snippet instance list */
 
 bool PushFrontCommand::run() {
-  printf("pushFrontCommand::run()\n");
   instance_ = pt_->pushFront(snip_);
   return true;
 }
@@ -138,7 +135,6 @@ bool PushFrontCommand::undo() {
    snippet instance list */
 
 bool PushBackCommand::run() {
-  printf("pushBackCommand::run()\n");
   instance_ = pt_->pushBack(snip_);
   return true;
 }

--- a/symtabAPI/h/LineInformation.h
+++ b/symtabAPI/h/LineInformation.h
@@ -47,7 +47,7 @@ class SYMTAB_EXPORT LineInformation :
 {
 public:
     typedef RangeLookupTypes< Statement> traits;
-    typedef RangeLookupTypes< Statement >::type impl_t; // the impl_t is actually the multi_index_container
+    typedef RangeLookupTypes< Statement >::type impl_t; 
     typedef impl_t::index<Statement::addr_range>::type::const_iterator const_iterator;
     typedef impl_t::index<Statement::line_info>::type::const_iterator const_line_info_iterator;
     typedef traits::value_type Statement_t;
@@ -75,7 +75,7 @@ public:
 
       /* You MUST NOT deallocate the strings returned. */
       bool getSourceLines(Offset addressInRange, std::vector<Statement_t> &lines);
-    bool getSourceLines(Offset addressInRange, std::vector<Statement> &lines);
+      bool getSourceLines(Offset addressInRange, std::vector<Statement> &lines);
 
       bool getAddressRanges( const char * lineSource, unsigned int LineNo, std::vector< AddressRange > & ranges );
       const_line_info_iterator begin_by_source() const;
@@ -93,7 +93,7 @@ public:
       void dump();
 
       virtual ~LineInformation();
-        StringTablePtr strings_;
+      StringTablePtr strings_;
    protected:
 public:
     StringTablePtr getStrings() ;

--- a/symtabAPI/h/LineInformation.h
+++ b/symtabAPI/h/LineInformation.h
@@ -64,7 +64,12 @@ public:
                   unsigned int lineOffset,
                   Offset lowInclusiveAddr,
                   Offset highExclusiveAddr );
-
+      bool addLine(unsigned int fileIndex,
+                   unsigned int lineNo,
+                   unsigned int lineOffset,
+                   Offset lowInclusiveAddr,
+                   Offset highExclusiveAddr,
+                   uint64_t instPointAddr);
       void addLineInfo(LineInformation *lineInfo);	      
 
       bool addAddressRange( Offset lowInclusiveAddr, 

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -70,8 +70,8 @@ namespace Dyninst{
                 instrument_point_addr_ = 0;
 			}
 
-			Statement(int file_index, unsigned int line, unsigned int col = 0,
-					  Offset start_addr = (Offset) -1L, Offset end_addr = (Offset) -1L, uint64_t ipa = 0) :
+			Statement(int file_index, unsigned int line, uint64_t ipa, unsigned int col = 0,
+					  Offset start_addr = (Offset) -1L, Offset end_addr = (Offset) -1L) :
 					AddressRange(start_addr, end_addr),
 					file_index_(file_index),
 					line_(line),

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -83,13 +83,7 @@ namespace Dyninst{
 
             void setExtraStringTable_(void* string_table_);
 
-            void lookupExtraStringTable(uint32_t index, string& filename) const;
-
-        private:
-
-            void setDyninstFileName(std::string& name_);
-
-            const string& getDyninstFileName() const;
+            void lookupExtraStringTable(uint32_t index, std::string& filename) const;
 
 		public:
 

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -262,6 +262,8 @@ namespace Dyninst{
 			bool ranges_finalized;
 
 			void finalizeOneRange(Address ext_s, Address ext_e) const;
+
+            bool dyninst_linemap_parsed;
 		};
 		template <typename OS>
 		OS& operator<<(OS& os, const Module& m)

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -80,7 +80,7 @@ namespace Dyninst{
 
 			void setStrings_(StringTablePtr strings_);
 
-            void setFileName(std::string& filename_);
+            void setFileName_(std::string& filename_);
 
 		public:
 

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -73,6 +73,7 @@ namespace Dyninst{
 			unsigned int column_;
 			StringTablePtr strings_;
             void * extra_string_table_; // the string table we added
+            std::string dyninst_file_name_;
 		public:
 			StringTablePtr getStrings_() const;
 
@@ -82,7 +83,14 @@ namespace Dyninst{
 
             void setExtraStringTable_(void* string_table_);
 
-            void lookupExtraStringTable(uint32_t index, void* buf) const;
+            void lookupExtraStringTable(uint32_t index, string& filename) const;
+
+        private:
+
+            void setDyninstFileName(std::string& name_);
+
+            const string& getDyninstFileName() const;
+
 		public:
 
 			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { extra_string_table_ = NULL; }

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -85,7 +85,7 @@ namespace Dyninst{
             std::string& lookupExtraStringTable(int index);
 		public:
 
-			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { string_table_ = NULL; }
+			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { extra_string_table_ = NULL; }
 			struct StatementLess {
 				bool operator () ( const Statement &lhs, const Statement &rhs ) const;
 			};

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -80,7 +80,7 @@ namespace Dyninst{
 
 			void setStrings_(StringTablePtr strings_);
 
-            void setFileName(string& filename_);
+            void setFileName(std::string& filename_);
 
 		public:
 
@@ -276,7 +276,7 @@ namespace Dyninst{
 
             void* string_table;
 
-            string& lookupExtraStringTable(uint32_t index);
+            std::string& lookupExtraStringTable(uint32_t index);
 		};
 
 		template <typename OS>

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -219,6 +219,8 @@ namespace Dyninst{
 
             bool parseDyninstLineInformation();
 
+            bool getDyninstLines(std::vector<Statement::Ptr>& dynLines) 
+
 			LineInformation* parseLineInformation();
             
 
@@ -257,6 +259,8 @@ namespace Dyninst{
 			StringTablePtr strings_;
 		public:
 			StringTablePtr & getStrings() ;
+            bool dyninstLineMapParsed() { return dyninst_linemap_parsed; } 
+            void getDyninstRelocateFunc(std::vector<Address>& funcs) { for (int i = 0; i < dyninst_relocate_funcs.size(); ++i) funcs.push_back(dyninst_relocate_funcs[i]); }
 
 		private:
 			bool ranges_finalized;
@@ -264,6 +268,8 @@ namespace Dyninst{
 			void finalizeOneRange(Address ext_s, Address ext_e) const;
 
             bool dyninst_linemap_parsed;
+
+            std::vector<Address> dyninst_relocate_funcs; 
 		};
 		template <typename OS>
 		OS& operator<<(OS& os, const Module& m)

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -82,7 +82,7 @@ namespace Dyninst{
 
             void setExtraStringTable_(void* string_table_);
 
-            std::string lookupExtraStringTable(uint32_t index) const;
+            void lookupExtraStringTable(uint32_t index, void* buf) const;
 		public:
 
 			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { extra_string_table_ = NULL; }

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -219,7 +219,7 @@ namespace Dyninst{
 
             bool parseDyninstLineInformation();
 
-            bool getDyninstLines(std::vector<Statement::Ptr>& dynLines) 
+            bool getDyninstLines(std::vector<Statement::Ptr>& dynLines);
 
 			LineInformation* parseLineInformation();
             

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -72,10 +72,15 @@ namespace Dyninst{
 			unsigned int line_;
 			unsigned int column_;
 			StringTablePtr strings_;
+            void * string_table_; // the string table we added
 		public:
 			StringTablePtr getStrings_() const;
 
 			void setStrings_(StringTablePtr strings_);
+
+            void* getStringTable_() const;
+
+            void setStringTable_(void* string_table_);
 
 		public:
 
@@ -260,7 +265,7 @@ namespace Dyninst{
 		public:
 			StringTablePtr & getStrings() ;
             bool dyninstLineMapParsed() { return dyninst_linemap_parsed; } 
-            void getDyninstRelocateFunc(std::vector<Address>& funcs) { for (int i = 0; i < dyninst_relocate_funcs.size(); ++i) funcs.push_back(dyninst_relocate_funcs[i]); }
+            void * getStringTable();    
 
 		private:
 			bool ranges_finalized;
@@ -269,8 +274,9 @@ namespace Dyninst{
 
             bool dyninst_linemap_parsed;
 
-            std::vector<Address> dyninst_relocate_funcs; 
+            void* string_table;
 		};
+
 		template <typename OS>
 		OS& operator<<(OS& os, const Module& m)
 		{

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -67,6 +67,18 @@ namespace Dyninst{
 					column_(col)
 			{
                 dyninst_file_name_ = std::string("<unknown file>");
+                instrument_point_addr_ = 0;
+			}
+
+			Statement(int file_index, unsigned int line, unsigned int col = 0,
+					  Offset start_addr = (Offset) -1L, Offset end_addr = (Offset) -1L, uint64_t ipa) :
+					AddressRange(start_addr, end_addr),
+					file_index_(file_index),
+					line_(line),
+					column_(col),
+                    instrument_point_addr_(ipa)
+			{
+                dyninst_file_name_ = std::string("<unknown file>");
 			}
 
 			unsigned int file_index_; // Maybe this should be module?
@@ -74,6 +86,7 @@ namespace Dyninst{
 			unsigned int column_;
 			StringTablePtr strings_;
             std::string dyninst_file_name_;
+            uint64_t instrument_point_addr_;  
 
 		public:
 			StringTablePtr getStrings_() const;
@@ -82,9 +95,12 @@ namespace Dyninst{
 
             void setFileName_(std::string filename_);
 
+            void setInstPointAddr_(uint64_t point_addr_);
+
+
 		public:
 
-			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { dyninst_file_name_ = std::string("<unknown file>"); }
+			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { dyninst_file_name_ = std::string("<unknown file>"); instrument_point_addr_ = 0;}
 
 			struct StatementLess {
 				bool operator () ( const Statement &lhs, const Statement &rhs ) const;
@@ -109,6 +125,7 @@ namespace Dyninst{
 			unsigned int getFileIndex() const { return file_index_; }
 			unsigned int getLine()const {return line_;}
 			unsigned int getColumn() const { return column_; }
+            uint64_t getInstPointAddr() const { return instrument_point_addr_; }
 			struct addr_range {};
 			struct line_info {};
 			struct upper_bound {};

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -265,8 +265,10 @@ namespace Dyninst{
 			StringTablePtr strings_;
 		public:
 			StringTablePtr & getStrings() ;
+
             bool dyninstLineMapParsed() { return dyninst_linemap_parsed; } 
-            void * getStringTable();    
+
+
 		private:
 			bool ranges_finalized;
 
@@ -274,9 +276,8 @@ namespace Dyninst{
 
             bool dyninst_linemap_parsed;
 
-            void* string_table;
+            std::string getDyninstFileName(size_t index);
 
-            std::string lookupExtraStringTable(uint32_t index);
 		};
 
 		template <typename OS>

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -82,7 +82,7 @@ namespace Dyninst{
 
             void setExtraStringTable_(void* string_table_);
 
-            std::string& lookupExtraStringTable(uint32_t index) const;
+            std::string lookupExtraStringTable(uint32_t index) const;
 		public:
 
 			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { extra_string_table_ = NULL; }

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -80,7 +80,7 @@ namespace Dyninst{
 
 			void setStrings_(StringTablePtr strings_);
 
-            void setFileName_(std::string& filename_);
+            void setFileName_(std::string filename_);
 
 		public:
 

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -276,7 +276,7 @@ namespace Dyninst{
 
             void* string_table;
 
-            std::string& lookupExtraStringTable(uint32_t index);
+            std::string lookupExtraStringTable(uint32_t index);
 		};
 
 		template <typename OS>

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -82,7 +82,7 @@ namespace Dyninst{
 
             void setExtraStringTable_(void* string_table_);
 
-            std::string& lookupExtraStringTable(int index);
+            std::string& lookupExtraStringTable(uint32_t index);
 		public:
 
 			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { extra_string_table_ = NULL; }

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -71,7 +71,7 @@ namespace Dyninst{
 			}
 
 			Statement(int file_index, unsigned int line, unsigned int col = 0,
-					  Offset start_addr = (Offset) -1L, Offset end_addr = (Offset) -1L, uint64_t ipa) :
+					  Offset start_addr = (Offset) -1L, Offset end_addr = (Offset) -1L, uint64_t ipa = 0) :
 					AddressRange(start_addr, end_addr),
 					file_index_(file_index),
 					line_(line),

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -66,14 +66,13 @@ namespace Dyninst{
 					line_(line),
 					column_(col)
 			{
+                dyninst_file_name_ = std::string("<unknown file>");
 			}
 
 			unsigned int file_index_; // Maybe this should be module?
 			unsigned int line_;
 			unsigned int column_;
 			StringTablePtr strings_;
-            void * extra_string_table_; // the string table we added
-
             std::string dyninst_file_name_;
 
 		public:
@@ -81,15 +80,12 @@ namespace Dyninst{
 
 			void setStrings_(StringTablePtr strings_);
 
-            void* getExtraStringTable_() const;
-
-            void setExtraStringTable_(void* string_table_);
-
-            void lookupExtraStringTable(uint32_t index) const;
+            void setFileName(string& filename_);
 
 		public:
 
-			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { extra_string_table_ = NULL; }
+			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { dyninst_file_name_ = std::string("<unknown file>"); }
+
 			struct StatementLess {
 				bool operator () ( const Statement &lhs, const Statement &rhs ) const;
 			};
@@ -279,6 +275,8 @@ namespace Dyninst{
             bool dyninst_linemap_parsed;
 
             void* string_table;
+
+            string& lookupExtraStringTable(uint32_t index);
 		};
 
 		template <typename OS>

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -73,7 +73,9 @@ namespace Dyninst{
 			unsigned int column_;
 			StringTablePtr strings_;
             void * extra_string_table_; // the string table we added
+
             std::string dyninst_file_name_;
+
 		public:
 			StringTablePtr getStrings_() const;
 
@@ -83,7 +85,7 @@ namespace Dyninst{
 
             void setExtraStringTable_(void* string_table_);
 
-            void lookupExtraStringTable(uint32_t index, std::string& filename) const;
+            void lookupExtraStringTable(uint32_t index) const;
 
 		public:
 

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -82,7 +82,7 @@ namespace Dyninst{
 
             void setExtraStringTable_(void* string_table_);
 
-            std::string& lookupExtraStringTable(uint32_t index);
+            std::string& lookupExtraStringTable(uint32_t index) const;
 		public:
 
 			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { extra_string_table_ = NULL; }

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -72,19 +72,20 @@ namespace Dyninst{
 			unsigned int line_;
 			unsigned int column_;
 			StringTablePtr strings_;
-            void * string_table_; // the string table we added
+            void * extra_string_table_; // the string table we added
 		public:
 			StringTablePtr getStrings_() const;
 
 			void setStrings_(StringTablePtr strings_);
 
-            void* getStringTable_() const;
+            void* getExtraStringTable_() const;
 
-            void setStringTable_(void* string_table_);
+            void setExtraStringTable_(void* string_table_);
 
+            std::string& lookupExtraStringTable(int index);
 		public:
 
-			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  {}
+			Statement() : AddressRange(0,0), file_index_(0), line_(0), column_(0)  { string_table_ = NULL; }
 			struct StatementLess {
 				bool operator () ( const Statement &lhs, const Statement &rhs ) const;
 			};
@@ -266,7 +267,6 @@ namespace Dyninst{
 			StringTablePtr & getStrings() ;
             bool dyninstLineMapParsed() { return dyninst_linemap_parsed; } 
             void * getStringTable();    
-
 		private:
 			bool ranges_finalized;
 

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -95,12 +95,13 @@ typedef Dyninst::ProcessReader MemRegReader;
 
 typedef struct DyninstLineMapRecord {
     DyninstLineMapRecord() {} 
-    DyninstLineMapRecord(uint64_t la, uint32_t fi, uint32_t ln, uint32_t cn):
-        addr(la), file_index(fi), line_number(ln), column_number(cn) { }
+    DyninstLineMapRecord(uint64_t la, uint32_t fi, uint32_t ln, uint32_t cn, uint64_t ipa):
+        addr(la), file_index(fi), line_number(ln), column_number(cn), inst_point_addr(ipa) { }
     uint64_t addr; 
     uint32_t file_index;
     uint32_t line_number;
     uint32_t column_number;
+    uint64_t inst_point_addr;
 } DyninstLineMapRecord;
 
 
@@ -110,13 +111,24 @@ typedef struct LineMapInfoEntry {
     unsigned int column_number;
     Address low_addr_inc;
     Address high_addr_exc;
+    uint64_t inst_point_addr;
     LineMapInfoEntry(unsigned int fi, unsigned int ln, unsigned int cn, Address la, Address hi) {
         file_index = fi;
         line_number = ln;
         column_number = cn;
         low_addr_inc = la;
         high_addr_exc = hi; 
+        inst_point_addr = 0;
     } 
+    LineMapInfoEntry(unsigned int fi, unsigned int ln, unsigned int cn, Address la, Address hi, uint64_t ipa) {
+        file_index = fi;
+        line_number = ln;
+        column_number = cn;
+        low_addr_inc = la;
+        high_addr_exc = hi; 
+        inst_point_addr = ipa;
+    } 
+
 } LineMapInfoEntry;
 
 

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -92,6 +92,21 @@ typedef IBSTree< ModRange > ModRangeLookup;
 typedef IBSTree<FuncRange> FuncRangeLookup;
 typedef Dyninst::ProcessReader MemRegReader;
 
+typedef struct LineMapInfoEntry {
+    unsigned int file_index;
+    unsigned int line_number;
+    unsigned int column_number;
+    Address low_addr_inc;
+    Address high_addr_exc;
+    LineMapInfoEntry(unsigned int fi, unsigned int ln, unsigned int cn, Address la, Address hi) {
+        file_index = fi;
+        line_number = ln;
+        column_number = cn;
+        low_addr_inc = la;
+        high_addr_exc = hi; 
+    } 
+} LineMapInfoEntry;
+
 class SYMTAB_EXPORT Symtab : public LookupInterface,
                public Serializable,
                public AnnotatableSparse
@@ -260,7 +275,8 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    void setTruncateLinePaths(bool value);
    bool getTruncateLinePaths();
    void forceFullLineInfoParse();
-   
+
+
    /***** Type Information *****/
    virtual bool findType(Type *&type, std::string name);
    virtual Type *findType(unsigned type_id);
@@ -368,6 +384,8 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
    Archive *getParentArchive() const;
 
+   std::vector<LineMapInfoEntry> &getAllRelocatedSymbols();  
+
    /***** Error Handling *****/
    static SymtabError getLastSymtabError();
    static void setSymtabError(SymtabError new_err);
@@ -425,6 +443,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
    bool addFunctionRange(FunctionBase *fbase, Dyninst::Offset next_start);
 
+   void extractAllRelocatedSymbols();    
    // Used by binaryEdit.C...
  public:
 
@@ -624,6 +643,8 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
  private:
     unsigned _ref_cnt;
 
+ private:
+    std::vector<LineMapInfoEntry> vAllRelocatedSymbols_; 
 };
 
 /**

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -43,6 +43,7 @@
 #include "IBSTree.h"
 
 #include "dyninstversion.h"
+#include "common/src/headers.h"
 
 #include "pfq-rwlock.h"
 
@@ -385,6 +386,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    Archive *getParentArchive() const;
 
    std::vector<LineMapInfoEntry> &getAllRelocatedSymbols();  
+   void* getStringTable();
 
    /***** Error Handling *****/
    static SymtabError getLastSymtabError();
@@ -444,6 +446,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool addFunctionRange(FunctionBase *fbase, Dyninst::Offset next_start);
 
    void extractAllRelocatedSymbols();    
+   void extractDyninstStringTable();
    // Used by binaryEdit.C...
  public:
 
@@ -645,6 +648,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
  private:
     std::vector<LineMapInfoEntry> vAllRelocatedSymbols_; 
+    void* stringTablePtr_;
 };
 
 /**

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -657,7 +657,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
     unsigned _ref_cnt;
 
  public:
-    void addDyninstLineInfo(std::vector<std::pair<Address, LineNoTuple>>& lineMap);
+    std::pair<void*, void*> addDyninstLineInfo(std::vector<std::pair<Address, LineNoTuple>>& lineMap);
     void extractDyninstLineInfo();
 
  private:
@@ -667,7 +667,8 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
 class SYMTAB_EXPORT DyninstLineInfoManager {
         
-    DyninstLineInfoManager() {} 
+    DyninstLineInfoManager(); 
+    DyninstLineInfoManager(SymtabAPI::Symtab* symtab);
     DyninstLineInfoManager(SymtabAPI::Symtab* symtab, std::vector<std::pair<Address, SymtabAPI::LineNoTuple>>& lm);
     public:
         void* writeStringTable(const char* stringTableName = ".dyninstStringTable");  

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -94,6 +94,7 @@ typedef IBSTree<FuncRange> FuncRangeLookup;
 typedef Dyninst::ProcessReader MemRegReader;
 
 typedef struct DyninstLineMapRecord {
+    DyninstLineMapRecord() {} 
     DyninstLineMapRecord(uint64_t la, uint32_t fi, uint32_t ln, uint32_t cn):
         addr(la), file_index(fi), line_number(ln), column_number(cn) { }
     uint64_t addr; 
@@ -396,9 +397,9 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
    Archive *getParentArchive() const;
 
-   std::vector<LineMapInfoEntry>& getAllRelocatedSymbols() const;  
+   std::vector<LineMapInfoEntry>& getAllRelocatedSymbols() ;  
 
-   std::vector<std::string>& getAllFileNames() const;
+   std::vector<std::string>& getAllFileNames();
 
    /***** Error Handling *****/
    static SymtabError getLastSymtabError();
@@ -667,6 +668,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
 class SYMTAB_EXPORT DyninstLineInfoManager {
         
+  public:
     DyninstLineInfoManager(); 
     DyninstLineInfoManager(SymtabAPI::Symtab* symtab);
     DyninstLineInfoManager(SymtabAPI::Symtab* symtab, std::vector<std::pair<Address, SymtabAPI::LineNoTuple>>& lm);

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -43,7 +43,6 @@
 #include "IBSTree.h"
 
 #include "dyninstversion.h"
-#include "common/src/headers.h"
 
 #include "pfq-rwlock.h"
 
@@ -71,7 +70,8 @@ class MappedFile;
 #define SYM_MAJOR DYNINST_MAJOR_VERSION
 #define SYM_MINOR DYNINST_MINOR_VERSION
 #define SYM_BETA  DYNINST_PATCH_VERSION
- 
+
+#define DYNINST_STR_TBL_FID_OFFSET 2000000
 namespace Dyninst {
 
    struct SymSegment;

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -115,8 +115,12 @@ bool LineInformation::getSourceLines(Offset addressInRange,
         }
         ++start_addr_valid;
     }
-    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << addressInRange << std::dec << " size of lines: " << lines.size() << " file: " << lines[0]->getFileIndex() << " line: " << lines[0]->getLine() << " col: " << lines[0]->getColumn() <<  std::endl;
+    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << addressInRange << std::dec << " size of lines: " << lines.size() << std::endl;
+    if (lines.size() > 0) {
+      std::cerr << " file: " << lines[0]->getFileIndex() << " line: " << lines[0]->getLine() << " col: " << lines[0]->getColumn() <<  std::endl;
+    }
     return true;
+
 } /* end getLinesFromAddress() */
 
 bool LineInformation::getSourceLines( Offset addressInRange,

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -58,7 +58,7 @@ bool LineInformation::addLine( unsigned int lineSource,
       Offset lowInclusiveAddr, 
       Offset highExclusiveAddr ) 
 {
-    Statement* the_stmt = new Statement(lineSource, lineNo, lineOffset,
+    Statement* the_stmt = new Statement(lineSource, lineNo, 0, lineOffset,
                                         lowInclusiveAddr, highExclusiveAddr);
     Statement::Ptr insert_me(the_stmt);
     insert_me->setStrings_(strings_);

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -115,7 +115,7 @@ bool LineInformation::getSourceLines(Offset addressInRange,
         }
         ++start_addr_valid;
     }
-    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << addressInRange << std::dec << " size of lines: " << lines.size() << std::endl;
+    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << addressInRange << std::dec << " size of lines: " << lines.size() << " file: " << lines[0]->getFileIndex() << " line: " << lines[0]->getLine() << " col: " << lines[0]->getColumn() <<  std::endl;
     return true;
 } /* end getLinesFromAddress() */
 

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -62,9 +62,10 @@ bool LineInformation::addLine( unsigned int lineSource,
                                         lowInclusiveAddr, highExclusiveAddr);
     Statement::Ptr insert_me(the_stmt);
     insert_me->setStrings_(strings_);
-   return insert( insert_me).second;
+   return insert( insert_me).second; 
 
 } /* end setLineToAddressRangeMapping() */
+
 bool LineInformation::addLine( std::string lineSource,
                                unsigned int lineNo,
                                unsigned int lineOffset,
@@ -109,13 +110,13 @@ bool LineInformation::getSourceLines(Offset addressInRange,
     const_iterator end_addr_valid = impl_t::upper_bound(addressInRange );
     while(start_addr_valid != end_addr_valid && start_addr_valid != end())
     {
-        if(*(*start_addr_valid) == addressInRange) // *start_addr_valid is Statement::Ptr, which is Statement*
+        if(*(*start_addr_valid) == addressInRange) 
         {
             lines.push_back(*start_addr_valid);
         }
         ++start_addr_valid;
     }
-    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << addressInRange << std::dec << " size of lines: " << lines.size() << std::endl;
+    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << "0x" << addressInRange << std::dec << " size of lines: " << lines.size() << std::endl;
     if (lines.size() > 0) {
       std::cerr << " file: " << lines[0]->getFileIndex() << " line: " << lines[0]->getLine() << " col: " << lines[0]->getColumn() <<  std::endl;
     }

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -105,7 +105,7 @@ std::string print(const Dyninst::SymtabAPI::Statement& stmt)
 bool LineInformation::getSourceLines(Offset addressInRange,
                                      vector<Statement_t> &lines)
 {
-    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << addressInRange << std::dec << " size of lines: " << lines.size() << endl;
+    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << addressInRange << std::dec << " size of lines: " << lines.size() << std::endl;
     const_iterator start_addr_valid = project<Statement::addr_range>(get<Statement::upper_bound>().lower_bound(addressInRange ));
     const_iterator end_addr_valid = impl_t::upper_bound(addressInRange );
     while(start_addr_valid != end_addr_valid && start_addr_valid != end())

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -116,12 +116,7 @@ bool LineInformation::getSourceLines(Offset addressInRange,
         }
         ++start_addr_valid;
     }
-    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << "0x" << addressInRange << std::dec << " size of lines: " << lines.size() << std::endl;
-    if (lines.size() > 0) {
-      std::cerr << " file: " << lines[0]->getFileIndex() << " line: " << lines[0]->getLine() << " col: " << lines[0]->getColumn() <<  std::endl;
-    }
     return true;
-
 } /* end getLinesFromAddress() */
 
 bool LineInformation::getSourceLines( Offset addressInRange,

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -105,6 +105,7 @@ std::string print(const Dyninst::SymtabAPI::Statement& stmt)
 bool LineInformation::getSourceLines(Offset addressInRange,
                                      vector<Statement_t> &lines)
 {
+    cerr << "LineInforation::getSourceLines addr: " << hex << addressInRange << dec << " size of lines: " << lines.size() << endl;
     const_iterator start_addr_valid = project<Statement::addr_range>(get<Statement::upper_bound>().lower_bound(addressInRange ));
     const_iterator end_addr_valid = impl_t::upper_bound(addressInRange );
     while(start_addr_valid != end_addr_valid && start_addr_valid != end())

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -105,7 +105,7 @@ std::string print(const Dyninst::SymtabAPI::Statement& stmt)
 bool LineInformation::getSourceLines(Offset addressInRange,
                                      vector<Statement_t> &lines)
 {
-    cerr << "LineInforation::getSourceLines addr: " << hex << addressInRange << dec << " size of lines: " << lines.size() << endl;
+    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << addressInRange << std::dec << " size of lines: " << lines.size() << endl;
     const_iterator start_addr_valid = project<Statement::addr_range>(get<Statement::upper_bound>().lower_bound(addressInRange ));
     const_iterator end_addr_valid = impl_t::upper_bound(addressInRange );
     while(start_addr_valid != end_addr_valid && start_addr_valid != end())

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -74,8 +74,8 @@ bool LineInformation::addLine( unsigned int lineSource,
       Offset highExclusiveAddr,
       uint64_t instPointAddr) 
 {
-    Statement* the_stmt = new Statement(lineSource, lineNo, lineOffset,
-                                        lowInclusiveAddr, highExclusiveAddr, instPointAddr);
+    Statement* the_stmt = new Statement(lineSource, lineNo, instPointAddr, lineOffset,
+                                        lowInclusiveAddr, highExclusiveAddr);
     Statement::Ptr insert_me(the_stmt);
     insert_me->setStrings_(strings_);
    return insert( insert_me).second; 

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -105,7 +105,6 @@ std::string print(const Dyninst::SymtabAPI::Statement& stmt)
 bool LineInformation::getSourceLines(Offset addressInRange,
                                      vector<Statement_t> &lines)
 {
-    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << addressInRange << std::dec << " size of lines: " << lines.size() << std::endl;
     const_iterator start_addr_valid = project<Statement::addr_range>(get<Statement::upper_bound>().lower_bound(addressInRange ));
     const_iterator end_addr_valid = impl_t::upper_bound(addressInRange );
     while(start_addr_valid != end_addr_valid && start_addr_valid != end())
@@ -116,6 +115,7 @@ bool LineInformation::getSourceLines(Offset addressInRange,
         }
         ++start_addr_valid;
     }
+    std::cerr << "LineInforation::getSourceLines addr: " << std::hex << addressInRange << std::dec << " size of lines: " << lines.size() << std::endl;
     return true;
 } /* end getLinesFromAddress() */
 

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -66,6 +66,21 @@ bool LineInformation::addLine( unsigned int lineSource,
 
 } /* end setLineToAddressRangeMapping() */
 
+
+bool LineInformation::addLine( unsigned int lineSource,
+      unsigned int lineNo, 
+      unsigned int lineOffset, 
+      Offset lowInclusiveAddr, 
+      Offset highExclusiveAddr,
+      uint64_t instPointAddr) 
+{
+    Statement* the_stmt = new Statement(lineSource, lineNo, lineOffset,
+                                        lowInclusiveAddr, highExclusiveAddr, instPointAddr);
+    Statement::Ptr insert_me(the_stmt);
+    insert_me->setStrings_(strings_);
+   return insert( insert_me).second; 
+} 
+
 bool LineInformation::addLine( std::string lineSource,
                                unsigned int lineNo,
                                unsigned int lineOffset,

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -268,6 +268,7 @@ bool Module::parseDyninstLineInformation()
                            (unsigned int)(column_number), 
                            inst_addr, next_inst_addr);
                     
+        dyninst_relocate_funcs.push_back(inst_addr);
     }
     return true;
 }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -66,7 +66,7 @@ void Statement::setStrings_(StringTablePtr strings) {
     Statement::strings_ = strings;
 }
 const std::string& Statement::getFile() const {
-    cout << "calling Statement::getFile() file index: " <<  file_index << " strings size: " << strings_->size() <<  endl;
+    cout << "calling Statement::getFile() file index: " <<  file_index_ << " strings size: " << strings_->size() <<  endl;
     if(strings_) {
         if(file_index_ < strings_->size()) {
             // can't be ->[] on shared pointer to multi_index container or compiler gets confused

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -259,6 +259,7 @@ bool Module::parseDyninstLineInformation()
     vector<LineMapInfoEntry> linemap = symObj->getAllRelocatedSymbols();
     // we still insert these to leverage the multi-index lookup data structure 
     for (int i = 0; i < linemap.size(); ++i) {
+       cout << "adding rec to lineInfo_ -- low_addr: " << hex << " 0x" << linemap[i].low_addr_inc << " high_addr: 0x" << linemap[i].high_addr_exc << dec << endl;
        lineInfo_->addLine(linemap[i].file_index,  // here the file index is with offset
                           linemap[i].line_number,
                           linemap[i].column_number,

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -274,7 +274,6 @@ bool Module::parseDyninstLineInformation()
 
 
 LineInformation *Module::parseLineInformation() {
-    cerr << "parseLineInformation: strings_ size: " << strings_->size() << " module name: " << fileName() << endl;
     if (exec()->getArchitecture() != Arch_cuda &&
 	(exec()->getObject()->hasDebugInfo() || !info_.empty())) {
         // Allocate if none
@@ -308,6 +307,7 @@ LineInformation *Module::parseLineInformation() {
         parseDyninstLineInformation(); // read the extra .dyninstLineMap section, propagate the line map info into the lineInfo_ that should have already been created
         dyninst_linemap_parsed = true;
     }
+    cerr << "parseLineInformation: strings_ size: " << strings_->size() << " module name: " << fileName() << endl;
     return lineInfo_;
 }
 

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -191,7 +191,7 @@ bool Module::getAddressRanges(std::vector<AddressRange >&ranges,
    return false;
 }
 
-string& Module::lookupExtraStringTable(uint32_t index) {
+string Module::lookupExtraStringTable(uint32_t index) {
     char buf[512];
     buf[0] = '\0';
     uint32_t num_files = 0;

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -80,7 +80,7 @@ void Statement::lookupExtraStringTable(uint32_t index, void* buf) const {
     memcpy(&num_files, extra_string_table_, sizeof(uint32_t));
     if (index >= num_files) {
        cerr << "Statement::lookupExtraStringTable query index " << index << " out of range " << num_files << endl;
-       buf[0] = '\0';
+       return;
     }
     uint32_t offset = 0;
     uint32_t filename_length = 0;
@@ -103,6 +103,7 @@ const std::string& Statement::getFile() const {
               } else {
                  uint32_t real_index = (uint32_t)file_index_ - DYNINST_STR_TBL_FID_OFFSET; 
                  char buf[128];
+                 buf[0] = '\0';
                  Statement::lookupExtraStringTable(real_index, buf); 
                  std::stringstream ss;
                  ss << buf;

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -66,7 +66,7 @@ void Statement::setStrings_(StringTablePtr strings) {
     Statement::strings_ = strings;
 }
 
-void Statement::setFileName_(std::string& filename) {
+void Statement::setFileName_(std::string filename) {
     dyninst_file_name_ = filename;     
 }
 

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -74,10 +74,9 @@ void Statement::setExtraStringTable_(void* string_table) {
     Statement::extra_string_table_ = string_table;
 } 
 
-std::string Statement::lookupExtraStringTable(uint32_t index) const {
+void Statement::lookupExtraStringTable(uint32_t index, void* buf) const {
     cout << "lookup extra string table -- index: " << index << " ptr: " << hex << extra_string_table_ << dec << endl;
     uint32_t num_files = 0;
-    char buf[512];
     memcpy(&num_files, extra_string_table_, sizeof(uint32_t));
     if (index >= num_files) {
        cerr << "Statement::lookupExtraStringTable query index " << index << " out of range " << num_files << endl;
@@ -90,11 +89,6 @@ std::string Statement::lookupExtraStringTable(uint32_t index) const {
     memcpy(&offset, (char*)extra_string_table_ + header_offset, sizeof(uint32_t));
     memcpy(&filename_length, (char*)extra_string_table_ + header_offset + sizeof(uint32_t), sizeof(uint32_t));
     memcpy(buf, (char*)extra_string_table_ + offset, filename_length + 1);
-    std::stringstream ss;
-    ss << buf;
-    std::string res(ss.str().c_str());
-    cout << "extra string result: " << res << endl;
-    return res;
 }
 
 const std::string& Statement::getFile() const {
@@ -109,7 +103,13 @@ const std::string& Statement::getFile() const {
                  cerr << "error, pointer to string table not set " << endl; 
               } else {
                  uint32_t real_index = (uint32_t)file_index_ - DYNINST_STR_TBL_FID_OFFSET; 
-                 return Statement::lookupExtraStringTable(real_index);
+                 char buf[128];
+                 Statement::lookupExtraStringTable(real_index, buf); 
+                 std::stringstream ss;
+                 ss << buf;
+                 std::string res(ss.str().c_str());
+                 cout << "extra string result: " << res << endl;
+                 return res;
               }
           }  
         }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -101,11 +101,11 @@ const std::string& Statement::getFile() const {
               if (extra_string_table_ == NULL) {
                  cerr << "error, pointer to string table not set " << endl; 
               } else {
-                  /*
                  uint32_t real_index = (uint32_t)file_index_ - DYNINST_STR_TBL_FID_OFFSET; 
                  char buf[128];
                  buf[0] = '\0';
                  Statement::lookupExtraStringTable(real_index, buf); 
+                  /*
                  std::string res = "";
                  std::stringstream ss;
                  ss << buf;

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -239,7 +239,7 @@ bool Module::getSourceLines(std::vector<Statement::Ptr> &lines, Offset addressIn
       auto stmt = lines[originalSize];  
       auto file_index = stmt->getFileIndex();
       if (file_index >= DYNINST_STR_TBL_FID_OFFSET) {
-          cout << "we get the dyninst file index " << file_index << endl;    
+          cout << "[1] we get the dyninst file index " << file_index << endl;    
           stmt->setExtraStringTable_(this->string_table); // set the pointer to string table chunk  
       } 
       return true;
@@ -261,7 +261,7 @@ bool Module::getSourceLines(std::vector<LineNoTuple> &lines, Offset addressInRan
       auto stmt = lines[originalSize]; 
       auto file_index = stmt.getFileIndex();
       if (file_index >= DYNINST_STR_TBL_FID_OFFSET) {
-          cout << "we get the dyninst file index " << file_index << endl;
+          cout << "[2] we get the dyninst file index " << file_index << endl;
           lines[originalSize].setExtraStringTable_(this->string_table);  
       }
       return true;

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -101,15 +101,19 @@ const std::string& Statement::getFile() const {
               if (extra_string_table_ == NULL) {
                  cerr << "error, pointer to string table not set " << endl; 
               } else {
+                  /*
                  uint32_t real_index = (uint32_t)file_index_ - DYNINST_STR_TBL_FID_OFFSET; 
                  char buf[128];
                  buf[0] = '\0';
                  Statement::lookupExtraStringTable(real_index, buf); 
+                 std::string res = "";
                  std::stringstream ss;
                  ss << buf;
                  std::string res(ss.str().c_str());
                  cout << "extra string result: " << res << endl;
                  return res;
+                 */
+                 return string("");
               }
           }  
         }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -74,7 +74,7 @@ void Statement::setExtraStringTable_(void* string_table) {
     Statement::extra_string_table_ = string_table;
 } 
 
-void Statement::lookupExtraStringTable(uint32_t index, std::string& filename) const {
+void Statement::lookupExtraStringTable(uint32_t index) const {
     cout << "lookup extra string table -- index: " << index << " ptr: " << hex << extra_string_table_ << dec << endl;
     char buf[512];
     buf[0] = '\0';
@@ -93,7 +93,7 @@ void Statement::lookupExtraStringTable(uint32_t index, std::string& filename) co
     std::stringstream ss;
     ss << buf;
     std::string res(ss.str().c_str());
-    filename = res;
+    dyninst_file_name_ = res;
 }
 
 const std::string& Statement::getFile() const {
@@ -108,8 +108,8 @@ const std::string& Statement::getFile() const {
                  cerr << "error, pointer to string table not set " << endl; 
               } else {
                  uint32_t real_index = (uint32_t)file_index_ - DYNINST_STR_TBL_FID_OFFSET; 
-                 dyninst_file_name_ = "";
-                 Statement::lookupExtraStringTable(real_index, dyninst_file_name_); 
+                 dyninst_file_name_ = string("");
+                 Statement::lookupExtraStringTable(real_index); 
                  cout << "dyninst file name: " << dyninst_file_name_ << endl;
                  return dyninst_file_name_;
               }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -304,7 +304,10 @@ LineInformation *Module::parseLineInformation() {
         objectLevelLineInfo = true;
         lineInfo_ = exec()->getObject()->parseLineInfoForObject(strings_);
     } 
-    parseDyninstLineInformation(); // read the extra .dyninstLineMap section, propagate the line map info into the lineInfo_ that should have already been created
+    if (dyninst_linemap_parsed == false) {
+        parseDyninstLineInformation(); // read the extra .dyninstLineMap section, propagate the line map info into the lineInfo_ that should have already been created
+        dyninst_linemap_parsed = true;
+    }
     return lineInfo_;
 }
 
@@ -435,6 +438,7 @@ Module::Module() :
    strings_(new StringTable),
     ranges_finalized(false)
 {
+    dyninst_linemap_parsed = false;
 }
 
 Module::Module(const Module &mod) :
@@ -453,6 +457,7 @@ Module::Module(const Module &mod) :
     ranges_finalized(mod.ranges_finalized)
 
 {
+    dyninst_linemap_parsed = false;
 }
 
 Module::~Module()

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -74,7 +74,7 @@ void Statement::setExtraStringTable_(void* string_table) {
     Statement::extra_string_table_ = string_table;
 } 
 
-std::string& Statement::lookupExtraStringTable(uint32_t index) {
+std::string& Statement::lookupExtraStringTable(uint32_t index) const {
     uint32_t num_files = 0;
     char buf[512];
     memcpy(&num_files, extra_string_table_, sizeof(uint32_t));
@@ -91,7 +91,8 @@ std::string& Statement::lookupExtraStringTable(uint32_t index) {
     memcpy(buf, (char*)extra_string_table_ + offset, filename_length + 1);
     std::stringstream ss;
     ss << buf;
-    return std::string(ss.str().c_str());
+    std::string res(ss.str().c_str());
+    return res;
 }
 
 const std::string& Statement::getFile() const {
@@ -106,7 +107,7 @@ const std::string& Statement::getFile() const {
                  cerr << "error, pointer to string table not set " << endl; 
               } else {
                  uint32_t real_index = (uint32_t)file_index_ - DYNINST_STR_TBL_FID_OFFSET; 
-                 return Statement::lookupExtraStringTable((int)real_index);
+                 return Statement::lookupExtraStringTable(real_index);
               }
           }  
         }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -66,6 +66,9 @@ void Statement::setStrings_(StringTablePtr strings) {
     Statement::strings_ = strings;
 }
 
+void Statement::setFileName_(std::string& filename) {
+    dyninst_file_name_ = filename;     
+}
 
 const std::string& Statement::getFile() const {
     if(strings_) {
@@ -226,7 +229,7 @@ bool Module::getSourceLines(std::vector<Statement::Ptr> &lines, Offset addressIn
           cout << "[1] we get the dyninst file index " << file_index << endl;    
           std::string dyninst_filename = lookupExtraStringTable(file_index - DYNINST_STR_TBL_FID_OFFSET);
           // we should set the dyninst file name here
-          stmt->setFileName(dyninst_filename);
+          stmt->setFileName_(dyninst_filename);
       } 
       return true;
    }
@@ -249,7 +252,7 @@ bool Module::getSourceLines(std::vector<LineNoTuple> &lines, Offset addressInRan
       if (file_index >= DYNINST_STR_TBL_FID_OFFSET) {
           cout << "[2] we get the dyninst file index " << file_index << endl;
           std::string dyninst_filename = lookupExtraStringTable(file_index - DYNINST_STR_TBL_FID_OFFSET);
-          lines[originalSize].setFileName(dyninst_filename);  
+          lines[originalSize].setFileName_(dyninst_filename);  
       }
       return true;
    }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -105,6 +105,14 @@ const std::string& Statement::getFile() const {
                  char buf[128];
                  buf[0] = '\0';
                  Statement::lookupExtraStringTable(real_index, buf); 
+                 string res = "";
+                 int i = 0;
+                 while (i != '\0') {
+                     res.push_back(buf[i]);
+                     i++;
+                 }
+                 res.push_back('\0');
+                 return res;
                   /*
                  std::string res = "";
                  std::stringstream ss;
@@ -113,7 +121,6 @@ const std::string& Statement::getFile() const {
                  cout << "extra string result: " << res << endl;
                  return res;
                  */
-                 return string("");
               }
           }  
         }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -66,14 +66,6 @@ void Statement::setStrings_(StringTablePtr strings) {
     Statement::strings_ = strings;
 }
 
-void* Statement::getExtraStringTable_() const {
-    return extra_string_table_;
-}
-
-void Statement::setExtraStringTable_(void* string_table) {
-    Statement::extra_string_table_ = string_table;
-} 
-
 
 const std::string& Statement::getFile() const {
     if(strings_) {
@@ -203,7 +195,7 @@ string& Module::lookupExtraStringTable(uint32_t index) {
     char buf[512];
     buf[0] = '\0';
     uint32_t num_files = 0;
-    memcpy(&num_files, extra_string_table_, sizeof(uint32_t));
+    memcpy(&num_files, string_table, sizeof(uint32_t));
     if (index >= num_files) {
        cerr << "Statement::lookupExtraStringTable query index " << index << " out of range " << num_files << endl;
        return std::string("<unknown file>");  
@@ -211,9 +203,9 @@ string& Module::lookupExtraStringTable(uint32_t index) {
     uint32_t offset = 0;
     uint32_t filename_length = 0;
     size_t header_offset = sizeof(uint32_t) + index * sizeof(uint32_t) * 2; 
-    memcpy(&offset, (char*)extra_string_table_ + header_offset, sizeof(uint32_t));
-    memcpy(&filename_length, (char*)extra_string_table_ + header_offset + sizeof(uint32_t), sizeof(uint32_t));
-    memcpy(buf, (char*)extra_string_table_ + offset, filename_length + 1);
+    memcpy(&offset, (char*)string_table + header_offset, sizeof(uint32_t));
+    memcpy(&filename_length, (char*)string_table + header_offset + sizeof(uint32_t), sizeof(uint32_t));
+    memcpy(buf, (char*)string_table + offset, filename_length + 1);
     std::stringstream ss;
     ss << buf;
     return ss.str();
@@ -256,7 +248,8 @@ bool Module::getSourceLines(std::vector<LineNoTuple> &lines, Offset addressInRan
       auto file_index = stmt.getFileIndex();
       if (file_index >= DYNINST_STR_TBL_FID_OFFSET) {
           cout << "[2] we get the dyninst file index " << file_index << endl;
-          lines[originalSize].setExtraStringTable_(this->string_table);  
+          std::string dyninst_filename = lookupExtraStringTable(file_index - DYNINST_STR_TBL_FID_OFFSET);
+          lines[originalSize].setFileName(dyninst_filename);  
       }
       return true;
    }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -244,19 +244,19 @@ bool Module::parseDyninstLineInformation()
     int offset = sizeof(uint32_t); 
     uint64_t inst_addr;
     uint64_t next_inst_addr;
-    uint16_t file_index;
-    uint16_t line_number;
-    uint16_t column_number;  
+    uint32_t file_index;
+    uint32_t line_number;
+    uint32_t column_number;  
     for (int i = 0; i < num_records; ++i) { // read memory
         memcpy(&inst_addr, (char*)rawData + offset, sizeof(uint64_t));
         offset += sizeof(uint64_t);
-        memcpy(&file_index,(char*)rawData + offset, sizeof(uint16_t));
-        offset += sizeof(uint16_t);
-        memcpy(&line_number, (char*)rawData + offset, sizeof(uint16_t));
-        offset += sizeof(uint16_t);
-        memcpy(&column_number,(char*)rawData + offset,sizeof(uint16_t));
-        offset += sizeof(uint16_t);  
-        cout << "inst addr: " << hex << inst_addr << dec << " file index: " << file_index << " line number: " << line_number << " column number: " << column_number << endl;
+        memcpy(&file_index,(char*)rawData + offset, sizeof(uint32_t));
+        offset += sizeof(uint32_t);
+        memcpy(&line_number, (char*)rawData + offset, sizeof(uint32_t));
+        offset += sizeof(uint32_t);
+        memcpy(&column_number,(char*)rawData + offset,sizeof(uint32_t));
+        offset += sizeof(uint32_t);  
+        cout << "i: " << i << "/" << num_records << "inst addr: " << hex << inst_addr << dec << " file index: " << file_index << " line number: " << line_number << " column number: " << column_number << endl;
         if (i < num_records - 1) { // not the last record 
             memcpy(&next_inst_addr,(char*)rawData + offset, sizeof(uint64_t));
             // might be inefficient to peak the next instruction address and read it again

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -75,6 +75,7 @@ void Statement::setExtraStringTable_(void* string_table) {
 } 
 
 std::string& Statement::lookupExtraStringTable(uint32_t index) const {
+    cout << "lookup extra string table -- index: " << index << " ptr: " << hex << extra_string_table_ << dec << endl;
     uint32_t num_files = 0;
     char buf[512];
     memcpy(&num_files, extra_string_table_, sizeof(uint32_t));
@@ -92,6 +93,7 @@ std::string& Statement::lookupExtraStringTable(uint32_t index) const {
     std::stringstream ss;
     ss << buf;
     std::string res(ss.str().c_str());
+    cout << "extra string result: " << res << endl;
     return res;
 }
 
@@ -111,7 +113,7 @@ const std::string& Statement::getFile() const {
               }
           }  
         }
-    } 
+    } // we assume that strings_ is always not null  
     // This string will be pointed to, so it has to persist.
     static std::string emptyStr;
     return emptyStr;

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -66,6 +66,7 @@ void Statement::setStrings_(StringTablePtr strings) {
     Statement::strings_ = strings;
 }
 const std::string& Statement::getFile() const {
+    cout << "calling Statement::getFile() file index: " <<  file_index << " strings size: " << strings_->size() <<  endl;
     if(strings_) {
         if(file_index_ < strings_->size()) {
             // can't be ->[] on shared pointer to multi_index container or compiler gets confused

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -74,8 +74,10 @@ void Statement::setExtraStringTable_(void* string_table) {
     Statement::extra_string_table_ = string_table;
 } 
 
-void Statement::lookupExtraStringTable(uint32_t index, void* buf) const {
+void Statement::lookupExtraStringTable(uint32_t index, std::string& filename) const {
     cout << "lookup extra string table -- index: " << index << " ptr: " << hex << extra_string_table_ << dec << endl;
+    char buf[512];
+    buf[0] = '\0';
     uint32_t num_files = 0;
     memcpy(&num_files, extra_string_table_, sizeof(uint32_t));
     if (index >= num_files) {
@@ -88,6 +90,10 @@ void Statement::lookupExtraStringTable(uint32_t index, void* buf) const {
     memcpy(&offset, (char*)extra_string_table_ + header_offset, sizeof(uint32_t));
     memcpy(&filename_length, (char*)extra_string_table_ + header_offset + sizeof(uint32_t), sizeof(uint32_t));
     memcpy(buf, (char*)extra_string_table_ + offset, filename_length + 1);
+    std::stringstream ss;
+    ss << buf;
+    std::string res(ss.str().c_str());
+    filename = res;
 }
 
 const std::string& Statement::getFile() const {
@@ -102,26 +108,10 @@ const std::string& Statement::getFile() const {
                  cerr << "error, pointer to string table not set " << endl; 
               } else {
                  uint32_t real_index = (uint32_t)file_index_ - DYNINST_STR_TBL_FID_OFFSET; 
-                 char buf[128];
-                 buf[0] = '\0';
-                 Statement::lookupExtraStringTable(real_index, buf); 
-                 string res = "";
-                 int i = 0;
-                 while (i < 128 & buf[i] != '\0') {
-                     res.push_back(buf[i]);
-                     i++;
-                 }
-                 res.push_back('\0');
-                 cout << "res: " << res << endl;
-                 return res;
-                  /*
-                 std::string res = "";
-                 std::stringstream ss;
-                 ss << buf;
-                 std::string res(ss.str().c_str());
-                 cout << "extra string result: " << res << endl;
-                 return res;
-                 */
+                 dyninst_file_name_ = "";
+                 Statement::lookupExtraStringTable(real_index, dyninst_file_name_); 
+                 cout << "dyninst file name: " << dyninst_file_name_ << endl;
+                 return dyninst_file_name_;
               }
           }  
         }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -74,7 +74,7 @@ void Statement::setExtraStringTable_(void* string_table) {
     Statement::extra_string_table_ = string_table;
 } 
 
-std::string& Statement::lookupExtraStringTable(uint32_t index) const {
+std::string Statement::lookupExtraStringTable(uint32_t index) const {
     cout << "lookup extra string table -- index: " << index << " ptr: " << hex << extra_string_table_ << dec << endl;
     uint32_t num_files = 0;
     char buf[512];

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -259,7 +259,6 @@ bool Module::parseDyninstLineInformation()
     vector<LineMapInfoEntry> linemap = symObj->getAllRelocatedSymbols();
     // we still insert these to leverage the multi-index lookup data structure 
     for (int i = 0; i < linemap.size(); ++i) {
-       cout << "adding rec to lineInfo_ -- low_addr: " << hex << " 0x" << linemap[i].low_addr_inc << " high_addr: 0x" << linemap[i].high_addr_exc << dec << endl;
        lineInfo_->addLine(linemap[i].file_index,  // here the file index is with offset
                           linemap[i].line_number,
                           linemap[i].column_number,
@@ -604,12 +603,10 @@ void Module::finalizeRanges()
 void Module::finalizeOneRange(Address ext_s, Address ext_e) const {
     ModRange* r = new ModRange(ext_s, ext_e, const_cast<Module*>(this));
     ModRangeLookup* lookup = exec_->mod_lookup();
-//    cout << "Inserting range " << std::hex << (*r) << std::dec << endl;
     lookup->insert(r);
 }
 
 void Module::addDebugInfo(Module::DebugInfoT info) {
-//    cout << "Adding CU DIE to " << fileName() << endl;
     info_.push_back(info);
 
 }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -207,10 +207,11 @@ bool Module::getSourceLines(std::vector<LineNoTuple> &lines, Offset addressInRan
    unsigned int originalSize = lines.size();
 
     LineInformation *lineInformation = parseLineInformation();
-
 //    cout << "Module " << fileName() << " searching for line info in " << lineInformation << endl;
-   if (lineInformation)
+   if (lineInformation) {
+      cout << *(lineInformation->getStrings()) << endl;
       lineInformation->getSourceLines( addressInRange, lines );
+   }
 
    if ( lines.size() != originalSize )
       return true;

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -107,7 +107,7 @@ const std::string& Statement::getFile() const {
                  Statement::lookupExtraStringTable(real_index, buf); 
                  string res = "";
                  int i = 0;
-                 while (i != '\0' && i < 128) {
+                 while (i < 128 & buf[i] != '\0') {
                      res.push_back(buf[i]);
                      i++;
                  }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -107,11 +107,12 @@ const std::string& Statement::getFile() const {
                  Statement::lookupExtraStringTable(real_index, buf); 
                  string res = "";
                  int i = 0;
-                 while (i != '\0') {
+                 while (i != '\0' && i < 128) {
                      res.push_back(buf[i]);
                      i++;
                  }
                  res.push_back('\0');
+                 cout << "res: " << res << endl;
                  return res;
                   /*
                  std::string res = "";

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -616,7 +616,3 @@ void Module::addDebugInfo(Module::DebugInfoT info) {
 StringTablePtr & Module::getStrings() {
     return strings_;
 }
-
-void * Module::getStringTable() {
-    return string_table;
-}

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -74,13 +74,14 @@ void Statement::setExtraStringTable_(void* string_table) {
     Statement::extra_string_table_ = string_table;
 } 
 
-std::string& Statement::lookupExtraStringTable(int index) {
+std::string& Statement::lookupExtraStringTable(uint32_t index) {
     uint32_t num_files = 0;
     char buf[512];
     memcpy(&num_files, extra_string_table_, sizeof(uint32_t));
     if (index >= num_files) {
        cerr << "Statement::lookupExtraStringTable query index " << index << " out of range " << num_files << endl;
-       return ""; 
+       std::string emptyStr;
+       return emptyStr;
     }
     uint32_t offset = 0;
     uint32_t filename_length = 0;
@@ -90,7 +91,7 @@ std::string& Statement::lookupExtraStringTable(int index) {
     memcpy(buf, (char*)extra_string_table_ + offset, filename_length + 1);
     std::stringstream ss;
     ss << buf;
-    return ss.str();
+    return std::string(ss.str().c_str());
 }
 
 const std::string& Statement::getFile() const {
@@ -105,7 +106,7 @@ const std::string& Statement::getFile() const {
                  cerr << "error, pointer to string table not set " << endl; 
               } else {
                  uint32_t real_index = (uint32_t)file_index_ - DYNINST_STR_TBL_FID_OFFSET; 
-                 return lookupExtraStringTable(real_index);
+                 return Statement::lookupExtraStringTable((int)real_index);
               }
           }  
         }

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -80,8 +80,7 @@ void Statement::lookupExtraStringTable(uint32_t index, void* buf) const {
     memcpy(&num_files, extra_string_table_, sizeof(uint32_t));
     if (index >= num_files) {
        cerr << "Statement::lookupExtraStringTable query index " << index << " out of range " << num_files << endl;
-       std::string emptyStr;
-       return emptyStr;
+       buf[0] = '\0';
     }
     uint32_t offset = 0;
     uint32_t filename_length = 0;

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -274,7 +274,7 @@ bool Module::parseDyninstLineInformation()
 
 
 LineInformation *Module::parseLineInformation() {
-    cerr << "parseLineInformation: strings_ size: " << strings_->size() << endl;
+    cerr << "parseLineInformation: strings_ size: " << strings_->size() << " module name: " << fileName() << endl;
     if (exec()->getArchitecture() != Arch_cuda &&
 	(exec()->getObject()->hasDebugInfo() || !info_.empty())) {
         // Allocate if none

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -223,7 +223,7 @@ bool Module::getSourceLines(std::vector<Statement::Ptr> &lines, Offset addressIn
       auto file_index = stmt->getFileIndex();
       auto inst_point_addr = stmt->getInstPointAddr();
       std::stringstream buffer;
-      buffer << std::hex << "0x" << inst_point_addr;
+      buffer << std::hex << ":0x" << inst_point_addr;
       if (file_index >= DYNINST_STR_TBL_FID_OFFSET) {
           file_index -= DYNINST_STR_TBL_FID_OFFSET; 
           // we should set the dyninst file name here

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2483,7 +2483,6 @@ bool Object::fix_global_symbol_modules_static_dwarf() {
         if (!DwarfWalker::findDieName(dbg, cu_die, modname)) {
             modname = associated_symtab->file(); // default module
         }
-        cerr << "Processing CU DIE for " << modname << " offset: " << next_cu_off << endl;
         Address tempModLow;
         Address modLow = 0;
         if (DwarfWalker::findConstant(DW_AT_low_pc, tempModLow, &cu_die, dbg)) {

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3909,7 +3909,6 @@ bool Object::emitDriver(string fName, std::set<Symbol *> &allSymbols, unsigned) 
                                                                                 associated_symtab);
         bool ok = em->createSymbolTables(allSymbols);
         if (ok) {
-            printf("createSymbolTables ok\n");
             ok = em->driver(fName);
         }
         delete em;

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -1789,7 +1789,7 @@ SYMTAB_EXPORT Archive *Symtab::getParentArchive() const {
     return parentArchive_;
 }
 
-SYMTAB_EXPORT std::vector<Address> &Symtab::getAllRelocatedSymbols() {
+SYMTAB_EXPORT std::vector<LineMapInfoEntry> &Symtab::getAllRelocatedSymbols() {
     return vAllRelocatedSymbols_;
 }
 

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -3718,7 +3718,7 @@ SYMTAB_EXPORT void* DyninstLineInfoManager::writeLineMapInfo(const char* lineMap
         uint32_t file_index = fileMap_[filename];
         uint32_t line_number = (uint32_t)stmt.getLine();
         uint32_t column_number = (uint32_t)stmt.getColumn(); 
-        uint64_t inst_point_addr = stmt.getInstPointAddr_();
+        uint64_t inst_point_addr = stmt.getInstPointAddr();
         DyninstLineMapRecord rec(inst_addr, file_index, line_number, column_number, inst_point_addr);
         memcpy((char*)chunk + offset, &rec, sizeof(DyninstLineMapRecord));  
         offset += sizeof(DyninstLineMapRecord);

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -2368,7 +2368,7 @@ void Symtab::extractAllRelocatedSymbols()
    Region* linemapSec = NULL;
    findRegion(linemapSec, ".dyninstLineMap");
    if (linemapSec == NULL) {
-       std::cerr << "Symtab cannot find .dyninstLineMap" << std::endl;
+       //std::cerr << "Symtab cannot find .dyninstLineMap" << std::endl;
        return;
    }       
    void* rawData = linemapSec->getPtrToRawData();

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -2416,7 +2416,7 @@ void Symtab::extractAllRelocatedSymbols()
        } else {
            next_inst_addr = INT_MAX;
        }
-       cout << "extracting... inst_addr: " << hex << inst_addr << dec << " file index " << file_index << " adjusted: " << file_index - DYNINST_STR_TBL_FID_OFFSET << " line: " << line_number << endl;
+       cout << "extracting... inst_addr: " << hex << inst_addr << dec << " file index " << file_index << " adjusted: " << file_index - DYNINST_STR_TBL_FID_OFFSET << " line: " << line_number << " col: " << column_number << endl;
        LineMapInfoEntry entry(file_index, line_number, column_number, inst_addr, next_inst_addr); 
        vAllRelocatedSymbols_.emplace_back(entry);
    }

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -3718,7 +3718,8 @@ SYMTAB_EXPORT void* DyninstLineInfoManager::writeLineMapInfo(const char* lineMap
         uint32_t file_index = fileMap_[filename];
         uint32_t line_number = (uint32_t)stmt.getLine();
         uint32_t column_number = (uint32_t)stmt.getColumn(); 
-        DyninstLineMapRecord rec(inst_addr, file_index, line_number, column_number);
+        uint64_t inst_point_addr = stmt.getInstPointAddr_();
+        DyninstLineMapRecord rec(inst_addr, file_index, line_number, column_number, inst_point_addr);
         memcpy((char*)chunk + offset, &rec, sizeof(DyninstLineMapRecord));  
         offset += sizeof(DyninstLineMapRecord);
     }
@@ -3755,12 +3756,13 @@ SYMTAB_EXPORT std::vector<LineMapInfoEntry> DyninstLineInfoManager::readLineMapI
        unsigned int fi = (unsigned int) rec.file_index;
        unsigned int ln = (unsigned int) rec.line_number;
        unsigned int cn = (unsigned int) rec.column_number;
+       uint64_t ipa = (uint64_t)rec.inst_point_addr;
        Address la = (Address) rec.addr;
        Address hi = INT_MAX;
        if (i < tmp_vec.size() - 1)  {
          hi = (Address)tmp_vec[i + 1].addr;
        }
-       LineMapInfoEntry entry(fi, ln, cn, la, hi);
+       LineMapInfoEntry entry(fi, ln, cn, la, hi, ipa);
        result.emplace_back(entry);
     } 
     return result;

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -3670,9 +3670,9 @@ SYMTAB_EXPORT std::vector<std::string> DyninstLineInfoManager::readStringTable(c
     assert(symtab_ != NULL);
     Region* stringTableSec = NULL;
     symtab_->findRegion(stringTableSec, stringTableName);
+    std::vector<std::string> result;
     if (stringTableSec == NULL) {
-        std::cerr << "Symtab cannot find section " << stringTableName << std::endl;
-        exit(-1);
+        return result;
     }       
     void * rawData = stringTableSec->getPtrToRawData();
     uint32_t chunk_size = 0;
@@ -3684,7 +3684,6 @@ SYMTAB_EXPORT std::vector<std::string> DyninstLineInfoManager::readStringTable(c
         exit(-1);
     }
     memcpy(buffer, (char*)rawData + sizeof(uint32_t), chunk_size);
-    std::vector<std::string> result;
     std::string bufstr = std::string((char*)buffer); // convert to string 
     std::string delimiter = "|";
     std::string filename = "";
@@ -3738,9 +3737,9 @@ SYMTAB_EXPORT std::vector<LineMapInfoEntry> DyninstLineInfoManager::readLineMapI
     assert(symtab_ != NULL);
     Region* linemapSec = NULL;
     symtab_->findRegion(linemapSec, lineMapName);
+   std::vector<LineMapInfoEntry> result;
    if (linemapSec == NULL) {
-       std::cerr << "Symtab cannot find section " << lineMapName << std::endl;
-       exit(-1);
+       return result;
    }       
    void* rawData = linemapSec->getPtrToRawData(); // get the pointer to the chunk 
    uint32_t num_records;
@@ -3748,7 +3747,6 @@ SYMTAB_EXPORT std::vector<LineMapInfoEntry> DyninstLineInfoManager::readLineMapI
    int offset = sizeof(uint32_t);
    DyninstLineMapRecord rec; 
    std::vector<DyninstLineMapRecord> tmp_vec;
-   std::vector<LineMapInfoEntry> result;
    for (int i = 0; i < num_records; ++i) {
        memcpy(&rec, (char*)rawData + offset, sizeof(DyninstLineMapRecord));
        offset += sizeof(DyninstLineMapRecord); 

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -3478,8 +3478,6 @@ SYMTAB_EXPORT bool Symtab::addExternalSymbolReference(Symbol *externalSym, Regio
         relocationEntry localRel)
 {
     // Adjust this to the correct value
-    printf("Symtab::addExternalSymbolReference - symbol name: %s target addr: 0x%lx rel addr: 0x%lx\n", 
-            externalSym->getPrettyName().c_str(), localRel.target_addr(), localRel.rel_addr());
     localRel.setRegionType(getObject()->getRelType());
 
     // Create placeholder Symbol for external Symbol reference

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -2376,6 +2376,9 @@ void Symtab::extractDyninstLineInfo()
     DyninstLineInfoManager mngr(this); // create the manager   
     vAllRelocatedSymbols_ = mngr.readLineMapInfo(); // read the line map information 
     vAllFileNames_ = mngr.readStringTable();  // read the string table 
+    for (auto& filename : vAllFileNames_) { 
+      cout << "extract filename: " << filename << endl; 
+    }
 }
 
 

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -2376,9 +2376,6 @@ void Symtab::extractDyninstLineInfo()
     DyninstLineInfoManager mngr(this); // create the manager   
     vAllRelocatedSymbols_ = mngr.readLineMapInfo(); // read the line map information 
     vAllFileNames_ = mngr.readStringTable();  // read the string table 
-    for (auto& filename : vAllFileNames_) { 
-      cout << "extract filename: " << filename << endl; 
-    }
 }
 
 


### PR DESCRIPTION
Line map information for dyninst instrumented binaries.  The modification basically does the following:
At instrumentation phase,
1. Get the code relocation information from CodeTracker. 
2. Get the line map information of an instruction being relocated. Associate the line map with the relocated instruction. If the relocated instruction is added for instrumentation, add an offset to the line number. By doing this, we could know that the instruction is not the original instruction from user program, but is added by Dyninst.  
3. Collect the file names and make our own string table. Because file ids are not global and are related to each module. This makes life easier. 
4. Write the dyninst line map into a ".dyninstLineMap" region in the instrumented binary, encoded as a list of  [start_addr, file_id, line_number, column_number] 
5. Write our own string table into a ".dyninstStringTable" region.

For line map information queries, hpcstruct as an example:
1. Upon construction of class Symtab, extract the dyninst line map and string table by reading region ".dyninstLineMap" and ".dyninstStringTable"
2. Add the extracted line information into LineInformation , so that we can leverage the query function inside LineInformation::getSourceLines().

