### PR TITLE
Fix compilation of thread_db_process

### DIFF
--- a/proccontrol/src/int_thread_db.C
+++ b/proccontrol/src/int_thread_db.C
@@ -1801,13 +1801,13 @@ bool thread_db_thread::getTLSPtr(Dyninst::Address &addr)
 //Empty place holder functions in-case we're built on a machine without libthread_db.so
 
 thread_db_process::thread_db_process(Dyninst::PID p, std::string e, std::vector<std::string> a, std::vector<std::string> envp, std::map<int, int> f) :
-   int_threadTracking(p, e, a, envp, f)
+	int_process(p, e, a, envp, f)
 {
   cerr << "Thread DB process constructor" << endl;
 }
 
 thread_db_process::thread_db_process(Dyninst::PID pid_, int_process *p) :
-   int_threadTracking(pid_, p)
+	int_process(pid_, p)
 {
 }
 

--- a/proccontrol/src/int_thread_db.h
+++ b/proccontrol/src/int_thread_db.h
@@ -352,6 +352,9 @@ class thread_db_process : virtual public int_process
                                   bool &);
     bool threaddb_isTrackingThreads();
     ThreadTracking *threaddb_getThreadTracking() ;
+    bool setTrackThreads(bool b, std::set<std::pair<int_breakpoint *, Address> > &bps,
+		    bool &add_bp);
+    bool isTrackingThreads();
 };
 #endif
 


### PR DESCRIPTION
On a machine without libthread_db.so, the placeholder class
had missing member functions and the contructors were calling
wrong base constructors.