### PR TITLE
Convert ThreadDB error message to info message

### DIFF
--- a/cmake/cap_arch_def.cmake
+++ b/cmake/cap_arch_def.cmake
@@ -151,7 +151,7 @@ else (PLATFORM STREQUAL i386-unknown-linux2.4)
 endif (PLATFORM STREQUAL i386-unknown-linux2.4)
 
 if (THREAD_DB_FOUND)
-message ("-- Enabling ThreadDB support")
+message (STATUS "-- Enabling ThreadDB support")
 set (CAP_DEFINES ${CAP_DEFINES} -Dcap_thread_db)
 endif (THREAD_DB_FOUND)
 


### PR DESCRIPTION
By default, the cmake 'message' command generates an error message. This converts it to an informational message.