### PR TITLE
Remove assertions for jump table analysis

### DIFF
--- a/common/src/dyn_regs.C
+++ b/common/src/dyn_regs.C
@@ -563,6 +563,16 @@ COMMON_EXPORT bool Dyninst::isSegmentRegister(int regClass)
    return 0 != (regClass & x86::SEG);
 }
 
+
+/* This function should has a boolean return value
+ * to indicate whether there is a corresponding
+ * ROSE register.
+ *
+ * Since historically, this function does not 
+ * have a return value. We set c to -1 to represent
+ * error cases
+ */
+
 void MachRegister::getROSERegister(int &c, int &n, int &p)
 {
    // Rose: class, number, position
@@ -818,7 +828,8 @@ void MachRegister::getROSERegister(int &c, int &n, int &p)
 		 n = x86_flag_of;
 		 break;
 	       default:
-		 assert(0);
+                 c = -1;
+                 return; 
 		 break;
       }
                break;
@@ -905,8 +916,8 @@ void MachRegister::getROSERegister(int &c, int &n, int &p)
                }
                break;
                default:
-                   assert(!"unknown register type!");
-                   break;
+                   c = -1;
+                   return;
            }
            return;
        }
@@ -975,8 +986,8 @@ void MachRegister::getROSERegister(int &c, int &n, int &p)
                            p = armv8_pstatefield_c;
                            break;
                        default:
-                           assert(!"unknown flag type!");
-                           break;
+                           c = -1;
+                           return;
                    }
                }
                    break;
@@ -1052,7 +1063,8 @@ void MachRegister::getROSERegister(int &c, int &n, int &p)
       break;
       case Arch_aarch64:
       {
-          assert(0);
+          c = -1;
+          return;
         }
       default:
         p = x86_regpos_unknown;

--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -144,8 +144,12 @@ void ExpressionConversionVisitor::visit(InstructionAPI::Immediate *immed) {
 
 void ExpressionConversionVisitor::visit(RegisterAST *regast) {
     // has no children
-
-    m_stack.push_front(archSpecificRegisterProc(regast, addr, size));
+    SgAsmExpression* reg = archSpecificRegisterProc(regast, addr, size);
+    if (reg == NULL) {
+        roseExpression = NULL;
+        return;
+    }
+    m_stack.push_front(reg);
     roseExpression = m_stack.front();
     return;
 }
@@ -267,7 +271,7 @@ SgAsmExpression *ExpressionConversionVisitor::archSpecificRegisterProc(Instructi
                 return constAddrExpr;
             }
             machReg.getROSERegister(regClass, regNum, regPos);
-
+            if (regClass < 0) return NULL;
             return new SgAsmx86RegisterReferenceExpression((X86RegisterClass) regClass,
                                                            regNum,
                                                            (X86PositionInRegister) regPos);
@@ -279,6 +283,7 @@ SgAsmExpression *ExpressionConversionVisitor::archSpecificRegisterProc(Instructi
             int regPos;
 	    SgAsmDirectRegisterExpression *dre;
             machReg.getROSERegister(regClass, regNum, regPos);
+            if (regClass < 0) return NULL;
 	    if (regClass == powerpc_regclass_cr) {
 	        // ROSE treats CR as one register, so regNum is always 0. 
 		// CR0 to CR7 are 8 subfields within CR.
@@ -301,7 +306,7 @@ SgAsmExpression *ExpressionConversionVisitor::archSpecificRegisterProc(Instructi
 		return NULL;
 
             machReg.getROSERegister(regClass, regNum, regPos);
-
+            if (regClass < 0) return NULL;
             SgAsmDirectRegisterExpression *dre = new SgAsmDirectRegisterExpression(RegisterDescriptor(regClass, regNum, regPos, machReg.size() * 8));
             dre->set_type(new SgAsmIntegerType(ByteOrder::ORDER_LSB, machReg.size() * 8, false));
             return dre;

--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -91,7 +91,9 @@ SgAsmInstruction *RoseInsnFactory::convert(const Instruction &insn, uint64_t add
        ++opi, ++i) {
       InstructionAPI::Operand &currOperand = *opi;
 //       std::cerr << "Converting operand " << currOperand.format(arch(), addr) << std::endl;
-      roperands->append_operand(convertOperand(currOperand.getValue(), addr, insn.size()));
+      SgAsmExpression *converted = convertOperand(currOperand.getValue(), addr, insn.size());
+      if (converted == NULL) return NULL;
+      roperands->append_operand(converted);
   }  
   rinsn->set_operandList(roperands);
   return rinsn;

--- a/dataflowAPI/src/SymEval.C
+++ b/dataflowAPI/src/SymEval.C
@@ -435,6 +435,7 @@ bool SymEval::expandInsn(const Instruction &insn,
             SymEvalPolicy policy(res, addr, insn.getArch(), insn);
             RoseInsnX86Factory fac(Arch_x86);
             roseInsn = fac.convert(insn, addr);
+            if (roseInsn == NULL) return false;
 
             SymbolicExpansion exp;
             exp.expandX86(roseInsn, policy);
@@ -449,6 +450,7 @@ bool SymEval::expandInsn(const Instruction &insn,
             SymEvalPolicy_64 policy(res, addr, insn.getArch(), insn);
             RoseInsnX86Factory fac(Arch_x86_64);
             roseInsn = fac.convert(insn, addr);
+            if (roseInsn == NULL) return false;
 
             SymbolicExpansion exp;
             exp.expandX86_64(roseInsn, policy);
@@ -463,6 +465,7 @@ bool SymEval::expandInsn(const Instruction &insn,
 	case Arch_ppc32: {
             RoseInsnPPCFactory fac;
             roseInsn = fac.convert(insn, addr);
+            if (roseInsn == NULL) return false;
 
             SymbolicExpansion exp;
             const RegisterDictionary *reg_dict = RegisterDictionary::dictionary_powerpc();
@@ -480,6 +483,7 @@ bool SymEval::expandInsn(const Instruction &insn,
 	case Arch_ppc64: {
             RoseInsnPPCFactory fac;
             roseInsn = fac.convert(insn, addr);
+            if (roseInsn == NULL) return false;
 
             SymbolicExpansion exp;
             const RegisterDictionary *reg_dict = RegisterDictionary::dictionary_powerpc();
@@ -498,6 +502,7 @@ bool SymEval::expandInsn(const Instruction &insn,
         case Arch_aarch64: {
             RoseInsnArmv8Factory fac(Arch_aarch64);
             roseInsn = fac.convert(insn, addr);
+            if (roseInsn == NULL) return false;
 
             SymbolicExpansion exp;
             const RegisterDictionary *reg_dict = RegisterDictionary::dictionary_armv8();


### PR DESCRIPTION
Remove assertions in code for translating Dyninst::MachRegister to ROSE Register. In addition, passing the error code back to jump table analysis. 

This PR is essentially for getting HPCToolkit working with a LLNL application.