### PR TITLE
Fix DwarfFrameParser, decodeDwarfExpression and DwarfResult

### DIFF
--- a/dwarf/h/dwarfFrameParser.h
+++ b/dwarf/h/dwarfFrameParser.h
@@ -97,34 +97,7 @@ public:
 
 private:
 
-    bool getRegAtFrame_aux(Address pc,
-            Dwarf_Frame* frame, 
-            Dwarf_Half dwarf_reg,
-            MachRegister orig_reg,
-            DwarfResult &cons,
-            Address &lowpc,
-            FrameErrors_t &err_result);
-
-    bool getFDE(Address pc, 
-            Dwarf_Frame* &frame, 
-            Address &low,
-            Address &high,
-            FrameErrors_t &err_result);
-
-    bool getDwarfReg(MachRegister reg,
-            Dwarf_Frame* frame, 
-            Dwarf_Half &dwarf_reg,
-            FrameErrors_t &err_result);
-
-/*    bool handleExpression(Address pc,
-            Dwarf_Sword registerNum,
-            MachRegister origReg,
-            Architecture arch,
-            DwarfResult &cons,
-            bool &done,
-            FrameErrors_t &err_result);*/
-
-    void setupFdeData();
+    void setupCFIData();
 
     struct frameParser_key
     {

--- a/dwarf/h/dwarfHandle.h
+++ b/dwarf/h/dwarfHandle.h
@@ -1,28 +1,28 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
@@ -80,7 +80,7 @@ class DYNDWARF_EXPORT DwarfHandle {
    ~DwarfHandle();
 
    static DwarfHandle::ptr createDwarfHandle(
-           std::string filename_, Elf_X *file_, 
+           std::string filename_, Elf_X *file_,
            void *e=NULL /*, Dwarf_Handler err_func_ = defaultErrFunc*/);
 
    Elf_X *origFile();
@@ -89,6 +89,7 @@ class DYNDWARF_EXPORT DwarfHandle {
    Dwarf **type_dbg();
    Dwarf **frame_dbg();
    DwarfFrameParserPtr frameParser();
+   const std::string& getDebugFilename() { return debug_filename; }
 };
 
 }

--- a/dwarf/h/dwarfResult.h
+++ b/dwarf/h/dwarfResult.h
@@ -84,7 +84,7 @@ public:
     virtual void pushUnsignedVal(Dyninst::MachRegisterVal constant) = 0;
     virtual void pushSignedVal(Dyninst::MachRegisterVal constant) = 0;
     virtual void pushOp(Operator op) = 0;
-    virtual void pushOp(Operator op, unsigned ref) = 0;
+    virtual void pushOp(Operator op, long long ref) = 0;
 
     // The frame base is the logical top of the stack as reported
     // in the function's debug info
@@ -119,7 +119,7 @@ public:
     virtual void pushUnsignedVal(Dyninst::MachRegisterVal constant);
     virtual void pushSignedVal(Dyninst::MachRegisterVal constant);
     virtual void pushOp(Operator op);
-    virtual void pushOp(Operator op, unsigned ref);
+    virtual void pushOp(Operator op, long long ref);
 
     // DWARF logical "frame base", which may be the result of an expression
     // in itself. TODO: figure out what info we need to carry around so we
@@ -141,9 +141,10 @@ class DYNDWARF_EXPORT ConcreteDwarfResult : public DwarfResult {
 
 public:
     ConcreteDwarfResult(ProcessReader *r, Architecture a, 
-            Address p, ::Dwarf * d) :
+            Address p, Dwarf * d, Elf * e) :
         DwarfResult(a), reader(r), 
-        pc(p), dbg(d) {};
+        pc(p), dbg(d), dbg_eh_frame(e) {};
+    ConcreteDwarfResult() : DwarfResult(Arch_none) {};
     virtual ~ConcreteDwarfResult() {};
 
     virtual void pushReg(Dyninst::MachRegister reg);
@@ -151,7 +152,7 @@ public:
     virtual void pushUnsignedVal(Dyninst::MachRegisterVal constant);
     virtual void pushSignedVal(Dyninst::MachRegisterVal constant);
     virtual void pushOp(Operator op);
-    virtual void pushOp(Operator op, unsigned ref);
+    virtual void pushOp(Operator op, long long ref);
 
     // DWARF logical "frame base", which may be the result of an expression
     // in itself. TODO: figure out what info we need to carry around so we
@@ -168,7 +169,8 @@ private:
 
     // For getting access to other expressions
     Address pc;
-    ::Dwarf * dbg;
+    Dwarf * dbg;
+    Elf * dbg_eh_frame;
 
     // Dwarf lets you access within the "stack", so we model 
     // it as a vector.

--- a/dwarf/src/dwarfFrameParser.C
+++ b/dwarf/src/dwarfFrameParser.C
@@ -27,6 +27,8 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <typeinfo>
+#include <string.h>
 #include "dwarfFrameParser.h"
 #include "dwarfExprParser.h"
 #include "dwarfResult.h"
@@ -38,8 +40,6 @@
 #include "debug_common.h" // dwarf_printf
 #include <libelf.h>
 
-//#define DW_FRAME_CFA_COL3 ((Dwarf_Half) -1)
-#define DW_FRAME_CFA_COL3               1036
 using namespace Dyninst;
 using namespace DwarfDyninst;
 using namespace std;
@@ -91,7 +91,7 @@ DwarfFrameParser::~DwarfFrameParser()
 
 bool DwarfFrameParser::hasFrameDebugInfo()
 {
-    setupFdeData();
+    setupCFIData();
     return fde_dwarf_status == dwarf_status_ok;
 }
 
@@ -102,7 +102,7 @@ bool DwarfFrameParser::getRegValueAtFrame(
         ProcessReader *reader,
         FrameErrors_t &err_result)
 {
-    ConcreteDwarfResult cons(reader, arch, pc, dbg);
+    ConcreteDwarfResult cons(reader, arch, pc, dbg, dbg_eh_frame);
 
     dwarf_printf("Getting concrete value for %s at 0x%lx\n",
             reg.name().c_str(), pc);
@@ -127,7 +127,7 @@ bool DwarfFrameParser::getRegRepAtFrame(
         Address pc,
         Dyninst::MachRegister reg,
         VariableLocation &loc,
-        FrameErrors_t &err_result) 
+        FrameErrors_t &err_result)
 {
     SymbolicDwarfResult cons(loc, arch);
 
@@ -157,7 +157,7 @@ bool DwarfFrameParser::getRegsForFunction(
         std::pair<Address, Address> range,
         Dyninst::MachRegister reg,
         std::vector<VariableLocation> &locs,
-        FrameErrors_t &err_result) 
+        FrameErrors_t &err_result)
 {
     locs.clear();
     dwarf_printf("Entry to getRegsForFunction at 0x%lx, range end 0x%lx, reg %s\n", range.first, range.second, reg.name().c_str());
@@ -165,15 +165,15 @@ bool DwarfFrameParser::getRegsForFunction(
 
     /**
      * Initialize the FDE and CIE data.  This is only really done once,
-     * after which setupFdeData will immediately return.
+     * after which setupCFIData will immediately return.
      **/
-    setupFdeData();
+    setupCFIData();
     if (!cfi_data.size()) {
         dwarf_printf("\t No FDE data, ret false\n");
         err_result = FE_Bad_Frame_Data;
         return false;
     }
-    
+
     for(size_t i=0; i<cfi_data.size(); i++)
     {
         auto next_pc = range.first;
@@ -209,17 +209,18 @@ bool DwarfFrameParser::getRegAtFrame(
         Address pc,
         Dyninst::MachRegister reg,
         DwarfResult &cons,
-        FrameErrors_t &err_result) 
+        FrameErrors_t &err_result)
 {
 
     err_result = FE_No_Error;
 
     dwarf_printf("getRegAtFrame for 0x%lx, %s\n", pc, reg.name().c_str());
+
     /**
      * Initialize the FDE and CIE data.  This is only really done once,
-     * after which setupFdeData will immediately return.
+     * after which setupCFIData will immediately return.
      **/
-    setupFdeData();
+    setupCFIData();
     if (!cfi_data.size()) {
         dwarf_printf("\t No FDE data, ret false\n");
         err_result = FE_Bad_Frame_Data;
@@ -227,31 +228,156 @@ bool DwarfFrameParser::getRegAtFrame(
     }
 
     int not_found = 0; // if not found FDE covering PC, increment
+
+    // this for goes for each cfi_data to look for the frame at pc
+    // the first one it finds, use it and break out of the for
     for(size_t i=0; i<cfi_data.size(); i++)
     {
         Dwarf_Frame * frame = NULL;
         int result = dwarf_cfi_addrframe(cfi_data[i], pc, &frame);
         if (result != 0) // 0 is success, not found FDE covering PC is returned -1
         {
-            not_found++;
+            not_found++; //there can be 2 not found since cfi_data can have side 2
             continue;
         }
-        // FDE found so make not_found=0
+
+        dwarf_printf("Found frame info in cfi_data[%zu], cfi_data.size=%zu \n", i, cfi_data.size());
+
+        // FDE found so make not_found=0 (FALSE), in case it was true because
+        // a previous loop
         not_found=0;
 
+        // user can request CFA (same as FrameBase), ReturnAddr, or any register
+        // use dwarf_frame_info to get the register number for ReturnAddr
         Dwarf_Addr start_pc, end_pc;
-        dwarf_frame_info(frame, &start_pc, &end_pc, NULL); 
+        int dwarf_reg = dwarf_frame_info(frame, &start_pc, &end_pc, NULL);
+        if (reg != Dyninst::ReturnAddr &&
+                reg != Dyninst::FrameBase &&
+                reg != Dyninst::CFA )
+            dwarf_reg = reg.getDwarfEnc();
 
+        // now get the rule for the register reg
+        // if its CFA (same as FrameBase) use dwarf_frame_cfa
+        // else use dwarf_frame_register
         Dwarf_Op * ops;
         size_t nops;
-        result = dwarf_frame_cfa(frame, &ops, &nops);
-        if (result != 0)
-            return false;
+        if (reg == Dyninst::FrameBase || reg == Dyninst::CFA)
+        {
+            dwarf_printf("\t reg is FrameBase(CFA)\n");
 
-        if (!DwarfDyninst::decodeDwarfExpression(ops, nops, NULL, cons, arch)) {
-            //dwarf_printf("\t Failed to decode dwarf expr, ret false\n");
-            return false;
+            result = dwarf_frame_cfa(frame, &ops, &nops);
+            if (result != 0 || nops == 0)
+            {
+                err_result = FE_Frame_Read_Error;
+                return false;
+            }
+            dwarf_printf("\t\t nops=%zu\n",nops);
+
+            if (!DwarfDyninst::decodeDwarfExpression(ops, nops, NULL, cons, arch)) {
+                err_result = FE_Frame_Eval_Error;
+                dwarf_printf("\t Failed to decode dwarf expr, ret false\n");
+                return false;
+            }
+            return true;
         }
+        else // get location description for dwarf_reg (which can be RA or reg(n))
+        {
+            dwarf_printf("\t parameter reg is %s\n", reg.name().c_str());
+            dwarf_printf("\t dwarf_reg (or column in CFI table) is %d\n", dwarf_reg);
+
+            Dwarf_Op ops_mem[3];
+            result = dwarf_frame_register (frame, dwarf_reg, ops_mem, &ops, &nops);
+
+            if (result != 0)
+            {
+                err_result = FE_Frame_Read_Error;
+                return false;
+            }
+
+            // case of undefined
+            if(nops == 0 && ops == ops_mem)
+            {
+                dwarf_printf("\t case of undefined rule, treats as same_value\n");
+#if defined(arch_aarch64)
+                reg = MachRegister::getArchRegFromAbstractReg(reg, arch);
+                dwarf_printf("\t aarch64 converted register reg=%s\n", reg.name().c_str());
+#endif
+                // Dyninst treats as same_value ???
+                cons.readReg(reg);
+                return true; // true because undefined is a valid output
+            }
+
+            // case of same_value
+            if(nops == 0 && ops == NULL)
+            {
+                dwarf_printf("\t case of same_value rule\n");
+#if defined(arch_aarch64)
+                reg = MachRegister::getArchRegFromAbstractReg(reg, arch);
+                dwarf_printf("\t aarch64 converted register reg=%s\n", reg.name().c_str());
+#endif
+                cons.readReg(reg);
+                return true;
+            }
+
+            // translate dwarf reg to machine reg
+            //Dyninst::MachRegister dyn_register = MachRegister::DwarfEncToReg(dwarf_reg, arch);
+            //cons.readReg(dyn_register);
+
+            ConcreteDwarfResult aux_cdr;
+            // if is concrete, add Deref as last operation if there isn't DW_OP_stack_value
+            if(typeid(cons)==typeid(aux_cdr))
+            {
+                // if last operation is not DW_OP_stack_value
+                if(ops[nops-1].atom != DW_OP_stack_value)
+                {
+                    // add DW_OP_deref
+                    Dwarf_Op * newOps = new Dwarf_Op[nops+1];
+                    memcpy(newOps, ops, nops * sizeof(Dwarf_Op));
+                    ops = newOps;
+                    ops[nops] = {DW_OP_deref, 0, 0, 0};
+                    nops++;
+                }
+            }
+
+            // decode location description, rule dependes on some register
+            if (!DwarfDyninst::decodeDwarfExpression(ops, nops, NULL, cons, arch)) {
+                err_result = FE_Frame_Eval_Error;
+                dwarf_printf("\t Failed to decode dwarf expr, ret false\n");
+                return false;
+            }
+
+            // Check if cons is Concrete, because there's no need to
+            // search CFA again
+            if(typeid(cons)==typeid(aux_cdr)) return true;
+
+            // From here cons is SymbolicDwarfResult
+
+            // check case of *ops = {DW_OP_call_frame_cfa, DW_OP_stack_value}
+            // this case would produce wrong frameoffset. The correct value
+            // of reg should be getting the CFA at the beginning of the FDE range
+            // and not at pc. So if this is the case, ignore the subsequent call
+            // to getRegAtFrame(pc, CFA).
+            if(nops==2)
+                if(ops[0].atom==DW_OP_call_frame_cfa &&
+                        ops[1].atom== DW_OP_stack_value)
+                {
+                    auto sdr = dynamic_cast<SymbolicDwarfResult &>(cons);
+                    VariableLocation& loc = sdr.val();
+                    if(loc.mr_reg == Dyninst::CFA) loc.mr_reg = reg;
+                    return true;
+                }
+
+            // CFA (or FrameBase) is always associated ???
+            // usar outro cons
+            if (!getRegAtFrame(pc, Dyninst::CFA, cons, err_result)) {
+                assert(err_result != FE_No_Error);
+                return false;
+            }
+
+            return true;
+        }
+
+        break; // if found in the first cfi_data, no need to check in the second
     }
 
     if(not_found){
@@ -261,141 +387,9 @@ bool DwarfFrameParser::getRegAtFrame(
 
     return true;
 
-    /**
-     * Get the FDE at this PC.  The FDE contains the rules for getting
-     * registers at the given PC in this frame.
-     **/
-    /*Dwarf_Frame * frame;
-    Address u1, u2;
-    if (!getFDE(pc, frame, u1, u2, err_result)) {
-        dwarf_printf("\t No FDE at 0x%lx, ret false\n", pc);
-        assert(err_result != FE_No_Error);
-        return false;
-    }
-
-    //unique_ptr<Dwarf_Frame, decltype(std::free)*> frame_ptr(frame, &std::free);
-
-    Dwarf_Half dwarf_reg;
-    if (!getDwarfReg(reg, frame, dwarf_reg, err_result)) {
-        dwarf_printf("\t Failed to convert %s to dwarf reg, ret false\n",
-                reg.name().c_str());
-        assert(err_result != FE_No_Error);
-        return false;
-    }
-
-    Address ignored;
-    return getRegAtFrame_aux(pc, frame, dwarf_reg, reg, cons, 
-            ignored, err_result);
-            */
 }
 
-bool DwarfFrameParser::getRegAtFrame_aux(Address pc,
-        Dwarf_Frame * frame,
-        Dwarf_Half dwarf_reg,
-        MachRegister /*orig_reg*/,
-        DwarfResult &cons,
-        Address & lowpc,
-        FrameErrors_t &err_result) 
-{
-    int result;
-    //Dwarf_Error err;
-
-    int width = getArchAddressWidth(arch);
-    dwarf_printf("getRegAtFrame_aux for 0x%lx, addr width %d\n", pc, width);
-
-    //Dwarf_Small value_type;
-    //Dwarf_Sword offset_relevant, register_num, offset_or_block_len;
-    //Dwarf_Ptr block_ptr;
-    Dwarf_Addr row_pc;
-
-    Dwarf_Op ops_mem[3];
-    Dwarf_Op * ops;
-    size_t nops;
-
-    /**
-     * Decode the rule that describes how to get dwarf_reg at pc.
-     **/
-    if (dwarf_reg != DW_FRAME_CFA_COL3) {
-        dwarf_printf("\tNot col3 reg, using default\n");
-        result = dwarf_frame_register(frame, dwarf_reg, ops_mem, &ops, &nops);
-    }
-    else {
-        dwarf_printf("\tcol3 reg, using CFA\n");
-        result = dwarf_frame_cfa(frame, &ops, &nops);
-    }
-
-    if (result != 0) {
-        err_result = FE_Bad_Frame_Data;
-        return false;
-    }
-
-    dwarf_frame_info(frame, NULL, &row_pc, NULL); 
-    lowpc = (Address) row_pc;
-
-    if (!decodeDwarfExpression(ops, nops, NULL, cons, arch)) {
-        dwarf_printf("\t Failed to decode dwarf expr, ret false\n");
-        err_result = FE_Frame_Eval_Error;
-        return false;
-    }
-
-/*    switch(value_type) 
-    {
-        // For a val offset, the value of the register is (other_reg + const)
-        case DW_EXPR_VAL_OFFSET:
-        case DW_EXPR_OFFSET:
-            dwarf_printf("\tHandling val_offset or offset\n");
-            if (offset_relevant) {
-                dwarf_printf("\t Offset relevant, adding %d\n", offset_or_block_len);
-                cons.pushSignedVal(offset_or_block_len);
-                cons.pushOp(DwarfResult::Add);
-            }
-
-            if (offset_relevant && dwarf_reg != DW_FRAME_CFA_COL3) {
-                dwarf_printf("\t Reg not CFA and offset relevant: indirect\n");
-                indirect = true;
-            }
-            dwarf_printf("\t Done handling val_offset or offset\n");
-            break;
-        case DW_EXPR_VAL_EXPRESSION:
-        case DW_EXPR_EXPRESSION: 
-            {
-                dwarf_printf("\t Handling val_expression or expression\n");
-                Dwarf_Op* llbuf = NULL;
-                size_t listlen  = 0; 
-                //result = dwarf_loclist_from_expr(dbg, block_ptr, offset_or_block_len, &llbuf, &listlen, &err);
-                int result = dwarf_getlocation(&attr, &llbuf, &listlen);
-                if (result != 0) {
-                    dwarf_printf("\t Failed to get loclist, ret false\n");
-                    err_result = FE_Frame_Read_Error;
-                    return false;
-                }
-
-    if (!decodeDwarfExpression(llbuf, listlen, NULL, cons, arch)) {
-        dwarf_printf("\t Failed to decode dwarf expr, ret false\n");
-        err_result = FE_Frame_Eval_Error;
-        return false;
-    }
-
-                if (value_type == DW_EXPR_EXPRESSION) {
-                    dwarf_printf("\t Handling expression, adding indirect\n");
-                    indirect = true;
-                }
-                break;
-            }
-        default:
-            err_result = FE_Bad_Frame_Data;
-            return false;
-    }
-
-    if (indirect) {
-        dwarf_printf("\t Adding a dereference to handle \"address of\" operator\n");
-        cons.pushOp(DwarfResult::Deref, width);
-    }*/
-    return true;
-}
-
-
-void DwarfFrameParser::setupFdeData()
+void DwarfFrameParser::setupCFIData()
 {
     if (fde_dwarf_status == dwarf_status_ok ||
         fde_dwarf_status == dwarf_status_error)
@@ -418,7 +412,7 @@ void DwarfFrameParser::setupFdeData()
     {
         cfi_data.push_back(cfi);
     }
-    
+
     // Try to get dwarf data from .eh_frame
     cfi = nullptr;
     cfi = dwarf_getcfi_elf(dbg_eh_frame);
@@ -426,7 +420,7 @@ void DwarfFrameParser::setupFdeData()
     {
         cfi_data.push_back(cfi);
     }
-    
+
     // Verify if it got any dwarf data
     if (!cfi_data.size()) {
         fde_dwarf_status = dwarf_status_error;
@@ -435,128 +429,4 @@ void DwarfFrameParser::setupFdeData()
         fde_dwarf_status = dwarf_status_ok;
     }
 }
-
-
-bool DwarfFrameParser::getFDE(Address pc, Dwarf_Frame* &frame,
-        Address &low, Address &high, FrameErrors_t &err_result) 
-{
-    /*
-    dwarf_printf("Getting Frame for 0x%lx\n", pc);
-
-    Dwarf_Addr lowpc = 0, hipc = 0;
-    bool found = false;
-
-    for (size_t cur_cfi=0; cur_cfi < cfi_data.size(); cur_cfi++)
-    {
-        for (size_t cur_entry =0; cur_entry < cfi_data[cur_cfi].cfi_entries.size(); cur_entry++)
-        {
-            auto& cfi_entry = cfi_data[cur_cfi].cfi_entries[cur_entry];
-            
-            // if this entry is a CIE, skip
-            if(dwarf_cfi_cie_p(&cfi_entry))
-            {
-                continue;
-            }
-
-            lowpc = *cfi_entry.fde.start;
-            hipc = *cfi_entry.fde.end;
-            if (pc < lowpc || pc > hipc)
-            {
-                continue;
-            }
-
-            dwarf_printf("\t Got range 0x%lx..0x%lx\n", lowpc, hipc);
-
-            low = (Address) lowpc;
-            high = (Address) hipc;
-            if(!dwarf_cfi_addrframe(cfi_data[cur_cfi].cfi, pc, &frame))
-            {
-                continue;
-            }
-            found = true;
-            break;
-        }
-
-        if (found)
-        {
-            break;
-        }
-    }
-
-    if (!found)
-    {
-        dwarf_printf("\tEntry not found, ret false\n");
-        err_result = FE_No_Frame_Entry;
-        return false;
-    }
-    return true;
-    */
-}
-
-bool DwarfFrameParser::getDwarfReg(
-        Dyninst::MachRegister reg, Dwarf_Frame* frame, 
-        Dwarf_Half &dwarf_reg, FrameErrors_t & /*err_result*/)
-{
-    if (reg == Dyninst::ReturnAddr) {
-        dwarf_reg = dwarf_frame_info(frame, NULL, NULL, NULL); 
-    }
-    else if (reg == Dyninst::FrameBase || reg == Dyninst::CFA) {
-        dwarf_reg = DW_FRAME_CFA_COL3;
-    }
-    else {
-        dwarf_reg = reg.getDwarfEnc();
-    }
-    return true;
-}
-
-/*bool DwarfFrameParser::handleExpression(Address pc,
-        Dwarf_Sword registerNum,
-        Dyninst::MachRegister origReg,
-        Dyninst::Architecture arch,
-        DwarfResult &cons,
-        bool &done,
-        FrameErrors_t &err_result)
-{
-    dwarf_printf("HandleExpression\n");
-
-    done = false;
-    dwarf_printf("register num %d\n", registerNum);
-    switch (registerNum) {
-        case DW_FRAME_CFA_COL3:
-            dwarf_printf("\t Getting frame base\n");
-
-            err_result = FE_No_Error;
-            if (!getRegAtFrame(pc, Dyninst::FrameBase,
-                        cons, err_result)) {
-                assert(err_result != FE_No_Error);
-                return false;
-            }
-            break;
-        case DW_FRAME_SAME_VAL:
-            dwarf_printf("\t Getting %s\n", origReg.name().c_str());
-#if defined(arch_aarch64)
-            //if(origReg == Dyninst::ReturnAddr)
-            //    origReg = Dyninst::aarch64::x30;
-            origReg = MachRegister::getArchRegFromAbstractReg(origReg, arch);
-#endif
-            cons.readReg(origReg);
-            done = true;
-            break;
-        case DW_FRAME_UNDEFINED_VAL:
-            dwarf_printf("\t Value not available for %s\n", origReg.name().c_str());
-            err_result = FE_No_Frame_Entry;
-            return false;
-
-        default:
-            {
-                Dyninst::MachRegister dyn_register = MachRegister::DwarfEncToReg(registerNum, arch);
-                dwarf_printf("\t Getting %s\n", dyn_register.name().c_str());
-
-                cons.readReg(dyn_register);
-                break;
-            }
-    }
-    return true;
-}*/
-
 

--- a/dwarf/src/dwarfResult.C
+++ b/dwarf/src/dwarfResult.C
@@ -62,7 +62,7 @@ void SymbolicDwarfResult::readReg(MachRegister reg) {
    var.stClass = storageRegOffset;
    var.refClass = storageNoRef;
    // frameOffset will be set with an add operation
-   var.frameOffset = 0;
+   //var.frameOffset = 0;
    var.mr_reg = reg;
 }
 
@@ -99,9 +99,9 @@ void SymbolicDwarfResult::pushOp(Operator op) {
    }         
 }
 
-void SymbolicDwarfResult::pushOp(Operator op, 
-                                 unsigned u) {
-  dwarf_printf("Push op pair %d,%u\n", op, u);
+void SymbolicDwarfResult::pushOp(Operator op, long long u)
+{
+  dwarf_printf("Push op pair %d,%lld\n", op, u);
   
    switch(op) {
       case Add:
@@ -299,7 +299,7 @@ void ConcreteDwarfResult::pushOp(Operator op) {
    dwarf_printf("\t After queue manipulation, size %d\n", operands.size());
 }
 
-void ConcreteDwarfResult::pushOp(Operator op, unsigned ref) {
+void ConcreteDwarfResult::pushOp(Operator op, long long ref) {
    switch (op) {
       case Add: 
          pushUnsignedVal(ref);
@@ -343,11 +343,13 @@ void ConcreteDwarfResult::pushOp(Operator op, unsigned ref) {
          break;
       }
       case Pick:
-         CHECK_OPER(ref);
+         assert(ref>=0);
+         CHECK_OPER((unsigned long long) ref);
          push(peek(ref));
          break;
       case Drop:
-         CHECK_OPER(ref);
+         assert(ref>=0);
+         CHECK_OPER((unsigned long long) ref);
          pop(ref);
          break;
       default:
@@ -361,7 +363,7 @@ void ConcreteDwarfResult::pushFrameBase() {
 }
 
 void ConcreteDwarfResult::pushCFA() {
-   DwarfFrameParser::Ptr cfaParser = DwarfFrameParser::create(dbg, dwarf_getelf(dbg), arch);
+   DwarfFrameParser::Ptr cfaParser = DwarfFrameParser::create(dbg, dbg_eh_frame, arch);
    if(!cfaParser) return; 
    MachRegisterVal cfa;
    FrameErrors_t err;

--- a/dyninstAPI/src/stackwalk-aarch64.C
+++ b/dyninstAPI/src/stackwalk-aarch64.C
@@ -64,6 +64,14 @@ bool PCProcess::createStackwalkerSteppers()
     }
     startup_printf("Stackwalker stepper %p is a FrameFuncStepper\n", stepper);
 
+  stepper = new DebugStepper(stackwalker_);
+  if (!stackwalker_->addStepper(stepper))
+  {
+    startup_printf("Error adding Stackwalker stepper %p\n", stepper);
+    return false;
+  }
+  startup_printf("Stackwalker stepper %p is a DebugStepper\n", stepper);
+
   stepper = new SigHandlerStepper(stackwalker_);
   if (!stackwalker_->addStepper(stepper))
   {
@@ -79,7 +87,6 @@ bool PCProcess::createStackwalkerSteppers()
     return false;
   }
   startup_printf("Stackwalker stepper %p is a BottomOfStackStepper\n", stepper);
-
 
     return true;
 }

--- a/stackwalk/src/dbginfo-stepper.C
+++ b/stackwalk/src/dbginfo-stepper.C
@@ -83,6 +83,8 @@ static DwarfFrameParser::Ptr getAuxDwarfInfo(std::string s)
 
    DwarfHandle::ptr dwarf = DwarfHandle::createDwarfHandle(s, orig_elf);
    assert(dwarf);
+   sw_printf("[%s:%u] - Separate debug file used: %s\n",
+           FILE__, __LINE__, dwarf->getDebugFilename().c_str());
 
    // MJMTODO - Need to check whether this is supposed to work or not
    // FIXME for ppc, if we ever support debug walking on ppc
@@ -158,7 +160,7 @@ location_t DebugStepperImpl::getLastComputedLocation(unsigned long value)
 
 bool DebugStepperImpl::GetReg(MachRegister reg, MachRegisterVal &val)
 {
-   sw_printf("Attempt to get value for reg %s\n", reg.name().c_str());
+   sw_printf("[%s:%u] Attempt to get value for reg %s\n", FILE__, __LINE__, reg.name().c_str());
    if (reg.isFramePointer()) {
       val = static_cast<MachRegisterVal>(depth_frame->getFP());
       return true;
@@ -521,6 +523,7 @@ gcframe_ret_t DebugStepperImpl::getCallerFrameArch(Address pc, const Frame &in,
 
    depth_frame = cur_frame;
 
+   sw_printf("\nDebugStepperImpl::getCallerFrameArch() calls getRegValueAtFrame()\n");
    result = dinfo->getRegValueAtFrame(pc, Dyninst::ReturnAddr,
    //result = dinfo->getRegValueAtFrame(pc, Dyninst::aarch64::x30,
                                       ret_value, this, frame_error);
@@ -544,6 +547,7 @@ gcframe_ret_t DebugStepperImpl::getCallerFrameArch(Address pc, const Frame &in,
    Dyninst::MachRegister frame_reg;
    frame_reg = Dyninst::aarch64::x29;
 
+   sw_printf("\nDebugStepperImpl::getCallerFrameArch() calls getRegValueAtFrame()\n");
    result = dinfo->getRegValueAtFrame(pc, frame_reg,
                                       frame_value, this, frame_error);
    if (!result) {
@@ -553,6 +557,7 @@ gcframe_ret_t DebugStepperImpl::getCallerFrameArch(Address pc, const Frame &in,
    }
    location_t fp_loc = getLastComputedLocation(frame_value);
 
+   sw_printf("\nDebugStepperImpl::getCallerFrameArch() calls getRegValueAtFrame()\n");
    result = dinfo->getRegValueAtFrame(pc, Dyninst::FrameBase,
                                       stack_value, this, frame_error);
    if (!result) {

--- a/stackwalk/src/linux-aarch64-swk.C
+++ b/stackwalk/src/linux-aarch64-swk.C
@@ -58,30 +58,6 @@ bool Walker::createDefaultSteppers()
     FrameStepper *stepper;
     bool result;
 
-    // ARM: this works on ARM.
-    // Need to adjust a variable that stores the length of _start
-    stepper = new BottomOfStackStepper(this);
-    result = addStepper(stepper);
-    if (!result){
-        sw_printf("[%s:%u] - Error adding stepper %p\n", FILE__, __LINE__,
-                  stepper);
-        return false;
-    }else{
-        sw_printf("[%s:%u] - Stepper %p is BottomOfStackStepper\n",
-                  FILE__, __LINE__, stepper);
-    }
-/*
-    stepper = new DebugStepper(this);
-    result = addStepper(stepper);
-    if (!result){
-        sw_printf("[%s:%u] - Error adding stepper %p\n", FILE__, __LINE__,
-                  stepper);
-        return false;
-    } else{
-        sw_printf("[%s:%u] - Stepper %p is DebugStepper\n",
-                  FILE__, __LINE__, stepper);
-    }
- */
     stepper = new FrameFuncStepper(this);
     result = addStepper(stepper);
     if (!result) {
@@ -92,6 +68,18 @@ bool Walker::createDefaultSteppers()
         sw_printf("[%s:%u] - Stepper %p is FrameFuncStepper\n",
                   FILE__, __LINE__, stepper);
     }
+
+    stepper = new DebugStepper(this);
+    result = addStepper(stepper);
+    if (!result){
+        sw_printf("[%s:%u] - Error adding stepper %p\n", FILE__, __LINE__,
+                  stepper);
+        return false;
+    } else{
+        sw_printf("[%s:%u] - Stepper %p is DebugStepper\n",
+                  FILE__, __LINE__, stepper);
+    }
+
     stepper = new SigHandlerStepper(this);
     result = addStepper(stepper);
     if (!result) {
@@ -100,6 +88,17 @@ bool Walker::createDefaultSteppers()
         return false;
     }else {
         sw_printf("[%s:%u] - Stepper %p is SigHandlerStepper\n",
+                  FILE__, __LINE__, stepper);
+    }
+
+    stepper = new BottomOfStackStepper(this);
+    result = addStepper(stepper);
+    if (!result){
+        sw_printf("[%s:%u] - Error adding stepper %p\n", FILE__, __LINE__,
+                  stepper);
+        return false;
+    }else{
+        sw_printf("[%s:%u] - Stepper %p is BottomOfStackStepper\n",
                   FILE__, __LINE__, stepper);
     }
 


### PR DESCRIPTION
After porting Dyninst to use libdw, DwarfFrameParser missed dealing
with important Dwarf operations that would decode rules for findind
registers values. These rules were not properly decoded by Dyninst
decodeDwarfExpression, neither were being dealt by DwarFrameParser.
This fix properly retrieves libdw Dwarf operations and decodes them,
making it possible to DebugStepper work, which wasn't even before the
port, when lidwarf was being used on Dyninst 9.3.

Basically, Dwarf frame info can be a simple dwarf expression, representing
a value or a memory address, a location description, or a location list.
Libdw gives the consumer an array of dwarf operations that describes how
to find the value they're looking for, as opposed to libdwarf who gives
the consumer many out parameters that lead to different ways to find a
value. This important change made DwarfFrameParser work only partially
after the port. And this fix came to implement the cases that were not
being considered.