### PR TITLE
Bump minimum CMake version to 3.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.0)
+cmake_minimum_required (VERSION 3.4.0)
 project (Dyninst)
 
 set (DYNINST_ROOT ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
This is needed for FindBoost and is already in the Spack recipe