### PR TITLE
Update LibIberty to new build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(Threads)
 include(Boost)
 include(ThreadingBuildingBlocks)
 include(ElfUtils)
-
+include(LibIberty)
 include (${DYNINST_ROOT}/cmake/shared.cmake)
 
 configure_file(cmake/version.h.in common/h/dyninstversion.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,12 @@ set(RT_BINARY_DIR ${PROJECT_BINARY_DIR}/dyninstAPI_RT)
 
 set (CMAKE_MODULE_PATH "${DYNINST_ROOT}/cmake" "${DYNINST_ROOT}/cmake/Modules" ${CMAKE_MODULE_PATH})
 
+find_package(ThreadDB)
 find_package(Threads)
 include(Boost)
 include(ThreadingBuildingBlocks)
 include(ElfUtils)
+
 include (${DYNINST_ROOT}/cmake/shared.cmake)
 
 configure_file(cmake/version.h.in common/h/dyninstversion.h)

--- a/cmake/LibIberty.cmake
+++ b/cmake/LibIberty.cmake
@@ -1,0 +1,117 @@
+#======================================================================================
+# LibIberty.cmake
+#
+# Configure LibIberty for Dyninst
+#
+#   ----------------------------------------
+#
+# Accepts the following CMake variables
+#
+# USE_GNU_DEMANGLER       - Use the GNU C++ name demanger (if yes, this disables using LibIberty)
+#
+# Directly exports the following CMake variables
+#
+# LibIberty_ROOT_DIR       - Computed base directory the of LibIberty installation
+# LibIberty_LIBRARY_DIRS   - Link directories for LibIberty libraries
+# LibIberty_LIBRARIES      - LibIberty library files
+#
+# NOTE:
+# The exported LibIberty_ROOT_DIR can be different from the value provided by the user
+# in the case that it is determined to build LibIberty from source. In such a case,
+# LibIberty_ROOT_DIR will contain the directory of the from-source installation.
+#
+# See Modules/FindLibIberty.cmake for details
+#
+#======================================================================================
+
+if(NOT UNIX)
+  return()
+endif()
+
+# Use the GNU C++ name demangler; if yes, this disables using LibIberty
+set(USE_GNU_DEMANGLER ON CACHE BOOL "Use the GNU C++ name demangler")
+
+# If we don't want to use/build LibIberty, then leave
+if(USE_GNU_DEMANGLER)
+  return()
+endif()
+
+# -------------- PATHS --------------------------------------------------------
+
+# Base directory the of LibIberty installation
+set(LibIberty_ROOT_DIR "/usr"
+    CACHE PATH "Base directory the of LibIberty installation")
+
+# Hint directory that contains the LibIberty library files
+set(LibIberty_LIBRARYDIR "${LibIberty_ROOT_DIR}/lib"
+    CACHE PATH "Hint directory that contains the LibIberty library files")
+
+# -------------- PACKAGES -----------------------------------------------------
+
+find_package(LibIberty)
+
+# -------------- SOURCE BUILD -------------------------------------------------
+if(LibIberty_FOUND)
+  set(_li_root ${LibIberty_ROOT_DIR})
+  set(_li_lib_dirs ${LibIberty_LIBRARY_DIRS})
+  set(_li_libs ${LibIberty_LIBRARIES})
+  add_library(LibIberty STATIC IMPORTED)
+else()
+  message(STATUS "${LibIberty_ERROR_REASON}")
+  message(STATUS "Attempting to build LibIberty as external project")
+
+  include(ExternalProject)
+  ExternalProject_Add(
+    LibIberty
+    PREFIX ${CMAKE_BINARY_DIR}/binutils
+    URL http://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND
+      CFLAGS=-fPIC
+      <SOURCE_DIR>/configure --prefix=${CMAKE_BINARY_DIR}/binutils
+    BUILD_COMMAND make
+    INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/lib/libiberty
+    INSTALL_COMMAND
+      install <SOURCE_DIR>/libiberty/libiberty.a <INSTALL_DIR>
+  )
+
+  set(_li_root ${CMAKE_INSTALL_PREFIX})
+  set(_li_lib_dirs ${_li_root}/lib)
+  set(_li_libs ${_li_lib_dirs}/libiberty/libiberty.a)
+  
+  # For backward compatibility
+  set(IBERTY_FOUND TRUE)
+  set(IBERTY_BUILD TRUE)
+endif()
+
+# Add a dummy target to either the found LibIberty or the one built from source.
+# NB: For backwards compatibility only
+add_custom_target(libiberty_imp)
+add_dependencies(libiberty_imp LibIberty)
+  
+# -------------- EXPORT VARIABLES ---------------------------------------------
+
+set(LibIberty_ROOT_DIR ${_li_root}
+    CACHE PATH "Base directory the of LibIberty installation"
+    FORCE)
+set(LibIberty_LIBRARY_DIRS ${_li_lib_dirs}
+    CACHE PATH "LibIberty library directory"
+    FORCE)
+set(LibIberty_LIBRARIES ${_li_libs}
+    CACHE FILEPATH "LibIberty library files"
+    FORCE)
+
+# This is only here to make ccmake work correctly
+set(USE_GNU_DEMANGLER ${USE_GNU_DEMANGLER}
+    CACHE BOOL "Use the GNU C++ name demangler"
+    FORCE)
+
+# For backward compatibility only
+set(IBERTY_LIBRARIES ${LibIberty_LIBRARIES})
+
+message(STATUS "LibIberty library dirs: ${LibIberty_LIBRARY_DIRS}")
+message(STATUS "LibIberty libraries: ${LibIberty_LIBRARIES}")
+
+if(USE_COTIRE)
+  cotire(LibIberty)
+endif()

--- a/cmake/Modules/FindLibIberty.cmake
+++ b/cmake/Modules/FindLibIberty.cmake
@@ -1,40 +1,71 @@
-# - Find Iberty
-# This module finds libiberty.
+#========================================================================================
+# FindLibIberty.cmake
 #
-# It sets the following variables:
-#  IBERTY_LIBRARIES     - The libiberty library to link against.
+# Find LibIberty include dirs and libraries
+#
+#		----------------------------------------
+#
+# Use this module by invoking find_package with the form::
+#
+#  find_package(LibIberty
+#    [REQUIRED]             # Fail with error if LibIberty is not found
+#  )
+#
+# This module reads hints about search locations from variables::
+#
+#	LibIberty_ROOT_DIR		- Base directory the of LibIberty installation
+#	LibIberty_LIBRARYDIR	- Hint directory that contains the LibIberty library files
+#
+# and saves search results persistently in CMake cache entries::
+#
+#	LibIberty_FOUND			- True if headers and requested libraries were found
+#   IBERTY_FOUND            - Alias for LibIberty_FOUND (backwards compatibility only)
+#	LibIberty_LIBRARY_DIRS  - Link directories for LibIberty libraries
+#	LibIberty_LIBRARIES     - LibIberty library files
+#   IBERTY_LIBRARIES        - Alias for LibIberty_LIBRARIES (backwards compatibility only)
+#
+#========================================================================================
 
-# For Debian <= wheezy, use libiberty_pic.a from binutils-dev
-# For Debian >= jessie, use libiberty.a from libiberty-dev
-# For all RHEL/Fedora, use libiberty.a from binutils-devel
-FIND_LIBRARY( IBERTY_LIBRARIES 
-	      NAMES iberty_pic iberty 
-	      HINTS ${IBERTY_LIBRARIES}
-	      PATHS
-	      /usr/lib
-	      /usr/lib64
-	      /usr/local/lib
-	      /usr/local/lib64
-	      /opt/local/lib
-	      /opt/local/lib64
- 	      /sw/lib
-	      ENV LIBRARY_PATH
-	      ENV LD_LIBRARY_PATH
-	      )
+if(LibIberty_FOUND)
+  return()
+endif()
 
-IF (IBERTY_LIBRARIES)
+# Keep the semantics of IBERTY_LIBRARIES for backward compatibility
+# NB: If both are specified, LibIberty_LIBRARIES is ignored
+if(NOT "${IBERTY_LIBRARIES}" STREQUAL "")
+  set(LibIberty_LIBRARIES ${IBERTY_LIBRARIES})
+endif()
 
-   # show which libiberty was found only if not quiet
-   MESSAGE( STATUS "Found libiberty: ${IBERTY_LIBRARIES}")
+include(DyninstSystemPaths)
 
-   SET(IBERTY_FOUND TRUE)
+# Non-standard subdirectories to search
+set(_path_suffixes libiberty iberty)
 
-ELSE (IBERTY_LIBRARIES)
+# iberty_pic is for Debian <= wheezy
+find_library(LibIberty_LIBRARIES
+             NAMES iberty_pic iberty
+             HINTS ${LibIberty_ROOT_DIR}
+                   ${LibIberty_LIBRARYDIR}
+                   ${IBERTY_LIBRARIES}
+             PATHS ${DYNINST_SYSTEM_LIBRARY_PATHS}
+             PATH_SUFFIXES ${_path_suffixes})
 
-   IF ( IBERTY_FIND_REQUIRED)
-      MESSAGE(FATAL_ERROR "Could not find libiberty. Try to install binutil-devel?")
-   ELSE()
-      MESSAGE(STATUS "Could not find libiberty; downloading binutils and building PIC libiberty.")
-   ENDIF (IBERTY_FIND_REQUIRED)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibIberty
+                                  FOUND_VAR
+                                  LibIberty_FOUND
+                                  REQUIRED_VARS
+                                  LibIberty_LIBRARIES)
 
-ENDIF (IBERTY_LIBRARIES)
+# For backwards compatibility only
+set(IBERTY_FOUND ${LibIberty_FOUND})
+
+if(LibIberty_FOUND)
+  foreach(l in ${LibIberty_LIBRARIES})
+    get_filename_component(_dir ${l} DIRECTORY)
+    list(APPEND LibIberty_LIBRARY_DIRS ${_dir})
+  endforeach()
+  
+  # For backwards compatibility only
+  set(IBERTY_LIBRARIES ${LibIberty_LIBRARIES})
+endif()

--- a/cmake/cap_arch_def.cmake
+++ b/cmake/cap_arch_def.cmake
@@ -7,7 +7,7 @@ set (CAP_DEFINES
      -Dcap_threads
 )
 
-if (${USE_GNU_DEMANGLER} MATCHES 1)
+if(USE_GNU_DEMANGLER)
 set (CAP_DEFINES ${CAP_DEFINES} -Dcap_gnu_demangler)
 endif()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -13,7 +13,6 @@ option (BUILD_RTLIB_32 "Build 32-bit runtime library on mixed 32/64 systems" OFF
 option(BUILD_RTLIB "Building runtime library (can be disabled safely for component-level builds)" ON)
 option(BUILD_DOCS "Build manuals from LaTeX sources" ON)
 option(USE_COTIRE "Enable Cotire precompiled headers")
-option(USE_GNU_DEMANGLER "Use cxa_demangle (ON) or binutils demangle (OFF)" ON)
 
 option (ENABLE_LTO "Enable Link-Time Optimization" OFF)
 

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -1,35 +1,3 @@
-if (UNIX)
-  if (NOT USE_GNU_DEMANGLER)
-    find_package (LibIberty)
-
-    if(NOT IBERTY_FOUND)
-      cmake_minimum_required (VERSION 2.8.11)
-      include(ExternalProject)
-      ExternalProject_Add(LibIberty
-	PREFIX ${CMAKE_BINARY_DIR}/binutils
-	URL http://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz
-	CONFIGURE_COMMAND env CFLAGS=${CMAKE_C_FLAGS}\ -fPIC CPPFLAGS=-fPIC PICFLAG=-fPIC <SOURCE_DIR>/libiberty/configure --prefix=${CMAKE_BINARY_DIR}/libiberty --enable-shared
-	BUILD_COMMAND make all
-	INSTALL_DIR ${CMAKE_BINARY_DIR}/libiberty
-	INSTALL_COMMAND install <BINARY_DIR>/libiberty.a <INSTALL_DIR>
-	)
-      set(IBERTY_LIBRARIES ${CMAKE_BINARY_DIR}/libiberty/libiberty.a)
-      set(IBERTY_FOUND TRUE)
-      set(IBERTY_BUILD TRUE)
-    endif()
-
-    message(STATUS "Using libiberty ${IBERTY_LIBRARIES}")
-    add_library(libiberty_imp STATIC IMPORTED)
-    set_property(TARGET libiberty_imp
-      PROPERTY IMPORTED_LOCATION ${IBERTY_LIBRARIES})
-    if(IBERTY_BUILD)
-      add_dependencies(libiberty_imp LibIberty)
-    endif()
-  endif()
-
-  find_package (ThreadDB)
-endif()
-
 if (PLATFORM MATCHES "bgq")
   # Not a find per se, just a magic include line
   set (PATH_BGQ "/bgsys/drivers/ppcfloor" CACHE STRING "Path to BG/Q include files")

--- a/cmake/shared.cmake
+++ b/cmake/shared.cmake
@@ -81,9 +81,6 @@ function (dyninst_library target)
 endfunction()
 
 
-
-#Change to switch between libiberty/libstdc++ demangler
-
 include (${DYNINST_ROOT}/cmake/platform.cmake)
 if (NOT ${PROJECT_NAME} MATCHES DyninstRT)
 include (${DYNINST_ROOT}/cmake/packages.cmake)


### PR DESCRIPTION
This brings the LibIberty dependency checker up to the new build system.

1. Fix build breakage when not specifying USE_GNU_DEMANGLER or IBERTY_LIBRARIES