### PR TITLE
Resolves emitCall corrupting AMD64 calling registers

### DIFF
--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -2439,7 +2439,6 @@ void EmitterAMD64::emitStackAlign(int offset, codeGen &gen)
    if (gen.rs()->checkVolatileRegisters(gen, registerSlot::live)) {
       saveFlags = true;   // We need to save the flags register
       off += 8;           // Allocate stack space to store the flags
-      scratch = REGNUM_RAX;
    }
 
    emitLEA(REGNUM_RSP, Null_Register, 0, -off, REGNUM_RSP, gen);


### PR DESCRIPTION
When a basic block is instrumented with a callback, the arguments are passed to the callback via the AMD64_ARG_REGS.  These registers are not always correctly marked as live by registerSpace and thus don't get saved during a emitCall or emitBTSaves.  Commonly this will be RDI (arg0) being corrupted by a instrumentation block and causing problems/craches in the original code.

This issues was mentioned in the following issues / external projects:
https://github.com/dyninst/dyninst/issues/461
https://github.com/talos-vulndev/afl-dyninst/blob/master/README.txt#L61

Notes on my patch:
This patch is very aggressive in how often and how much it saves.  For a single function callback it will push/pop the args multiple times depending on the lock/unlock guards.  It also seems to mess with the refcounting / keptvalue system for the register tracking and can cause spurious saves within a single injected trampoline.  Ideally this would be resolved in the registerSpace / AST engine.  Then the emitBTSaves function would correctly identify the AMD64_ARG_REGS which correspond to the number of arguments for a emitCall but I was unable to work back the root cause well enough to make a patch.  I hope this pull request is at least enough to start the process of identifying the root issue / providing a hotpatch for anyone who might need it.