### PR TITLE
Private writable mmap for opening binaries and debug files

### DIFF
--- a/common/src/MappedFile.C
+++ b/common/src/MappedFile.C
@@ -361,19 +361,8 @@ bool MappedFile::map_file()
 
 #else
 
-   int mmap_prot  = PROT_READ;
-   int mmap_flags = MAP_SHARED;
-
-#if defined(os_vxworks)   
-   // VxWorks kernel modules have relocations which need to be
-   // overwritten in memory.
-   //
-   // XXX - We don't overwrite our memory image with relocations from the
-   // target memory space yet due to performance concerns.  If we decide
-   // to go this route, it would simplify a lot of the Dyninst internals.
-   mmap_prot  = PROT_READ | PROT_WRITE;
-   mmap_flags = MAP_PRIVATE;
-#endif
+   int mmap_prot  = PROT_READ | PROT_WRITE;
+   int mmap_flags = MAP_PRIVATE;
 
    map_addr = mmap(0, file_size, mmap_prot, mmap_flags, fd, 0);
    if (MAP_FAILED == map_addr) {

--- a/elf/src/Elf_X.C
+++ b/elf/src/Elf_X.C
@@ -77,7 +77,7 @@ Elf_X *Elf_X::newElf_X(int input, Elf_Cmd cmd, Elf_X *ref, string name)
 #if defined(USES_ELFUTILS)
    //If using libelf via elfutils from RedHat
    if (cmd == ELF_C_READ) {
-      cmd = ELF_C_READ_MMAP;
+      cmd = ELF_C_READ_MMAP_PRIVATE;
    }
 #endif
    if (name.empty()) {

--- a/elf/src/Elf_X.C
+++ b/elf/src/Elf_X.C
@@ -1631,7 +1631,8 @@ static bool loadDebugFileFromDisk(string name, char* &output_buffer, unsigned lo
    if (fd == -1)
       return false;
 
-   char *buffer = (char *) mmap(NULL, fileStat.st_size, PROT_READ, MAP_SHARED, fd, 0);
+   char *buffer = (char *) mmap(NULL, fileStat.st_size,
+                                PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0);
    close(fd);
    if (!buffer)
       return false;

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2879,7 +2879,7 @@ Object::Object(MappedFile *mf_, bool, void (*err_func)(const char *),
 #endif
     is_aout_ = false;
 
-    if (mf->getFD() != -1) {
+    if (mf->base_addr() == NULL) {
         elfHdr = Elf_X::newElf_X(mf->getFD(), ELF_C_READ, NULL, mf_->pathname());
     } else {
         elfHdr = Elf_X::newElf_X((char *) mf->base_addr(), mf->size(), mf_->pathname());


### PR DESCRIPTION
Ran into #436 myself, on a Debian system when opening `libc.so` with `Symtab::openFile`. This patch is essentially a corrected version of #487 (this version still opens the file ro, but also allows the mapped region to be rw).

Also fixes a similar issue that pops up when endianness conversions are needed (done in-place).

Steps to reproduce the issue:

0. Obtain a binary (`.../example.so`, although executables should work too) compiled with debugging info, and a small program (`./symopen`) that calls `Symtab::openFile` on said binary.
1. Generate a debug info file for the library: 
   `objcopy --only-keep-debug --compress-debug-sections .../example.so borked.debug`
2. Add the debug link into (a copy of) the library: 
   `objcopy --add-gnu-debuglink=borked.debug .../example.so borked.so`
3. Try out the little program (`./symopen borked.so`) and look for a segfault in `elf_compress`.

Notes:

- Not compressing sections (removing `--compress-debug-sections` above) runs fine, apparently libelf is read-only when dealing with decompressed sections.
- Running on a library with included compressed debug sections also runs fine, libelf manages its own mmap'd region to account for this.