### PR TITLE
Convert PRIx64 -> std::to_string

### DIFF
--- a/instructionAPI/h/Result.h
+++ b/instructionAPI/h/Result.h
@@ -42,9 +42,9 @@
    typedef unsigned __int64 uint64_t;
    typedef unsigned __int32 uint32_t;
    typedef unsigned __int16 uint16_t;
-#  define  PRIx64  "lx"
 #endif
 #include <assert.h>
+#include <string>
 
 
 
@@ -450,10 +450,9 @@ namespace Dyninst
 	    snprintf(hex, 20, "%x", val.s32val);
 	    break;
 	  case u64:
-	    snprintf(hex, 20, "%" PRIx64, val.u64val);
-	    break;
+	    return std::to_string(val.u64val);
 	  case s64:
-	    snprintf(hex, 20, "%" PRIx64, val.s64val);
+	    return std::to_string(val.s64val);
 	    break;
 	  case sp_float:
 	    snprintf(hex, 20, "%f", val.floatval);
@@ -465,10 +464,10 @@ namespace Dyninst
 	    snprintf(hex, 20, "%x", val.bitval);
 	    break;
 	  case u48:
-	    snprintf(hex, 20, "%" PRIx64, val.s48val);
+	    return std::to_string(val.s48val);
 	    break;
 	  case s48:
-	    snprintf(hex, 20, "%" PRIx64, val.s48val);
+	    return std::to_string(val.s48val);
 	    break;
      case m512:
 	    snprintf(hex, 20, "%p", val.m512val);


### PR DESCRIPTION
This is a fix for #626 as the PRIx64 macros don't work on PPC before Power9.