### PR TITLE
Implements parsing of dwarf variables with abstract origin attribute.

### DIFF
--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -892,6 +892,15 @@ bool DwarfWalker::parseVariable() {
       }
    }
 
+   /* If the DIE has an _abstract_origin, we'll use that for the
+            remainder of our inquiries. */
+   bool hasAbstractOrigin;
+   if (!handleAbstractOrigin(hasAbstractOrigin)) return false;
+   if (hasAbstractOrigin) {
+          // Clone to spec entry too
+          setSpecEntry(abstractEntry());
+   }
+
    Type *type = NULL;
    if (!findType(type, false))
        return false;


### PR DESCRIPTION
New encodings on dwarf sections .debug_info possibly introduced by gcc 8.* emerged.
DW_TAG_variable entries containing DW_AT_abstract_origin attribute were not being considered and therefore wrongly parsed.
