### PR TITLE
Allows same range for different source lines.

### DIFF
--- a/common/src/debug_common.C
+++ b/common/src/debug_common.C
@@ -36,6 +36,7 @@
 
 int common_debug_dwarf = 0;
 int common_debug_addrtranslate = 0;
+int common_debug_lineinfo = 0;
 
 #if defined(_MSC_VER)
 #pragma warning(push)
@@ -55,6 +56,9 @@ bool init_debug_common() {
     if (getenv("DYNINST_DEBUG_ADDRTRANSLATE") ||
         getenv("DYNINST_DEBUG_TRANSLATE")) {
        common_debug_addrtranslate = 1;
+    }
+    if (getenv("DYNINST_DEBUG_LINEINFO")) {
+           common_debug_lineinfo = 1;
     }
 
     return true;
@@ -89,6 +93,19 @@ int translate_printf_int(const char *format, ...)
   return ret;
 }
 
+int lineinfo_printf_int(const char *format, ...)
+{
+   init_debug_common();
+  if (!common_debug_lineinfo) return 0;
+  if (NULL == format) return -1;
+
+  va_list va;
+  va_start(va, format);
+  int ret = vfprintf(stderr, format, va);
+  va_end(va);
+
+  return ret;
+}
 
 #if defined(_MSC_VER)
 #pragma warning(pop)

--- a/common/src/debug_common.h
+++ b/common/src/debug_common.h
@@ -36,6 +36,7 @@
 
 COMMON_EXPORT extern int common_debug_dwarf;
 extern int common_debug_addrtranslate;
+extern int common_debug_lineinfo;
 
 #if defined(__GNUC__)
 #define dwarf_printf(format, ...)                                       \
@@ -58,6 +59,18 @@ COMMON_EXPORT int dwarf_printf_int(const char *format, ...);
 #endif
 
 COMMON_EXPORT int translate_printf_int(const char *format, ...);
+
+
+#if defined(__GNUC__)
+#define lineinfo_printf(format, ...)                                       \
+   do {                                                                 \
+	   lineinfo_printf_int("[%s:%u] " format, __FILE__, __LINE__, ## __VA_ARGS__); \
+   } while (0)
+#else
+#define lineinfo_printf lineinfo_printf_int
+#endif
+
+COMMON_EXPORT int lineinfo_printf_int(const char *format, ...);
 
 // And initialization
 COMMON_EXPORT bool init_debug_common();

--- a/symtabAPI/h/RangeLookup.h
+++ b/symtabAPI/h/RangeLookup.h
@@ -114,7 +114,7 @@ namespace Dyninst {
                     <
                             typename Value::Ptr,
                             boost::multi_index::indexed_by<
-                                    boost::multi_index::ordered_unique< boost::multi_index::tag<typename Value::addr_range>, addr_range_key>,
+                                    boost::multi_index::ordered_non_unique< boost::multi_index::tag<typename Value::addr_range>, addr_range_key>,
                                     boost::multi_index::ordered_non_unique< boost::multi_index::tag<typename Value::upper_bound>, upper_bound_key>,
                                     boost::multi_index::ordered_non_unique< boost::multi_index::tag<typename Value::line_info>, line_info_key >
                             >
@@ -131,3 +131,4 @@ namespace Dyninst {
     }
 }
 #endif
+

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -4135,8 +4135,8 @@ class open_statement {
         };
         friend std::ostream& operator<<(std::ostream& os, const open_statement& st)
         {
-            os << st.start_addr << " " << st.end_addr << " "
-                << st.line_number << " " << st.string_table_index << std::endl;
+            os << hex << st.start_addr << " " << st.end_addr << " line:"
+                << dec << st.line_number << " file:" << st.string_table_index << " col:" << st.column_number << std::endl;
             return os;
         }
     public:
@@ -4152,13 +4152,17 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
 {
     /* Acquire this CU's source lines. */
     Dwarf_Lines *lineBuffer;
+    Dwarf_Attribute attr2;
     size_t lineCount;
+    auto comp_name = dwarf_formstring( dwarf_attr(&cuDIE, DW_AT_name, &attr2) );
     int status = dwarf_getsrclines(&cuDIE, &lineBuffer, &lineCount);
+    lineinfo_printf("Compilation Unit name: %s\n", std::string( comp_name ? comp_name : "" ).c_str());
 
     /* It's OK for a CU not to have line information. */
     if (status != 0) {
         return;
     }
+
     StringTablePtr strings(li_for_module->getStrings());
     Dwarf_Files *files;
     size_t offset = strings->size();
@@ -4215,11 +4219,10 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
         }
     }
     li_for_module->setStrings(strings);
-    //std::cerr << *strings.get();
+
     /* The 'lines' returned are actually interval markers; the code
      generated from lineNo runs from lineAddr up to but not including
      the lineAddr of the next line. */
-
     Offset baseAddr = getBaseAddress();
 
     Dwarf_Addr cu_high_pc = 0;
@@ -4228,13 +4231,14 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
     /* Iterate over this CU's source lines. */
     open_statement current_line;
     open_statement current_statement;
+    int count=0;
     for (size_t i = 0; i < lineCount; i++) {
         auto line = dwarf_onesrcline(lineBuffer, i);
 
         /* Acquire the line number, address, source, and end of sequence flag. */
         status = dwarf_lineno(line, &current_statement.line_number);
         if (status != 0) {
-            cout << "dwarf_lineno failed" << endl;
+        	lineinfo_printf("dwarf_lineno failed\n");
             continue;
         }
 
@@ -4243,7 +4247,7 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
 
         status = dwarf_lineaddr(line, &current_statement.start_addr);
         if (status != 0) {
-            cout << "dwarf_lineaddr failed" << endl;
+        	lineinfo_printf("dwarf_lineaddr failed\n");
             continue;
         }
 
@@ -4259,7 +4263,7 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
         //status = dwarf_line_srcfileno(line, &current_statement.string_table_index);
         const char *file_name = dwarf_linesrc(line, NULL, NULL);
         if (!file_name) {
-            cout << "dwarf_linesrc - empty name" << endl;
+        	lineinfo_printf("dwarf_linesrc - empty name\n");
             continue;
         }
 
@@ -4273,7 +4277,7 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
             }
         }
         if (index == -1) {
-            cout << "dwarf_linesrc didn't find index" << endl;
+        	lineinfo_printf("dwarf_linesrc didn't find index\n");
             continue;
         }
         current_statement.string_table_index = index;
@@ -4281,7 +4285,7 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
         bool isEndOfSequence;
         status = dwarf_lineendsequence(line, &isEndOfSequence);
         if (status != 0) {
-            cout << "dwarf_lineendsequence failed" << endl;
+        	lineinfo_printf("dwarf_lineendsequence failed\n");
             continue;
         }
         if (i == lineCount - 1) {
@@ -4290,29 +4294,35 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
         bool isStatement;
         status = dwarf_linebeginstatement(line, &isStatement);
         if (status != 0) {
-            cout << "dwarf_linebeginstatement failed" << endl;
+        	lineinfo_printf("dwarf_linebeginstatement failed\n");
             continue;
         }
-	if (current_line.uninitialized()) {
-	  current_line = current_statement;
-	} else {
-	      current_line.end_addr = current_statement.start_addr;
-	      if (!current_line.sameFileLineColumn(current_statement) ||
-		  isEndOfSequence) {
-                li_for_module->addLine((unsigned int)(current_line.string_table_index),
-                                       (unsigned int)(current_line.line_number),
-                                       (unsigned int)(current_line.column_number),
-                                       current_line.start_addr, current_line.end_addr);
-		current_line = current_statement;
-	      }
-	}
-	if (isEndOfSequence) {
-	  current_line.reset();
-	}
-    } /* end iteration over source line entries. */
+        if (current_line.uninitialized()) {
+            current_line = current_statement;
+            lineinfo_printf("current_line uninitialized\n");
+        } else {
+            current_line.end_addr = current_statement.start_addr;
+            if(current_line.sameFileLineColumn(current_statement))
+            	lineinfo_printf("sameFileLineColumn\n");
+            if (!current_line.sameFileLineColumn(current_statement) ||
+                    isEndOfSequence) {
+            	auto success = li_for_module->addLine((unsigned int)(current_line.string_table_index),
+                        (unsigned int)(current_line.line_number),
+                        (unsigned int)(current_line.column_number),
+                        current_line.start_addr, current_line.end_addr);
+            	lineinfo_printf("[%d, %d) %s:%d %s\n", current_line.start_addr, current_line.end_addr,
+            			((*strings)[current_line.string_table_index]).str.c_str(), current_line.line_number, (success?" inserted":" not"));
+                current_line = current_statement;
 
-/* Free this CU's source lines. */
-    //dwarf_srclines_dealloc(dbg, lineBuffer, lineCount);
+                if (success) count++;
+            }
+        }
+        if (isEndOfSequence) {
+            current_line.reset();
+            lineinfo_printf("reset current_line\n");
+        }
+    } // end for
+    lineinfo_printf("amount of line info added: %d\n", count);
 }
 
 


### PR DESCRIPTION
Come to fix the other issue in https://github.com/dyninst/dyninst/issues/625

Now the multi_index_container does not have a unique key for ranges, which allows the same range to be added for multiple source lines.
