### PR TITLE
Make ThreadDB required when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(PLATFORM MATCHES "bgq")
   message(WARNING "Support for Bluegene/Q has been deprecated and will be removed in a future release")
 endif()
 
-find_package(ThreadDB)
+find_package(ThreadDB REQUIRED)
 find_package(Threads)
 include(Boost)
 include(ThreadingBuildingBlocks)


### PR DESCRIPTION
In the test suite, proccontrol causes hangs and zombie processes when it is not present.