### PR TITLE
Add explicit ElfUtils dependency for ParseThat and examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,11 +8,11 @@ add_executable(unstrip unstrip.dir/unstrip.C
                        unstrip.dir/fingerprint.C
                        unstrip.dir/callback.C)
 add_dependencies(unstrip parseAPI symtabAPI instructionAPI common)
-target_link_libraries(unstrip parseAPI symtabAPI instructionAPI common dynDwarf dynElf ${Boost_LIBRARIES})
+target_link_libraries(unstrip parseAPI symtabAPI instructionAPI common dynDwarf dynElf ${Boost_LIBRARIES} ${ElfUtils_LIBRARIES})
 
 add_executable(codeCoverage codeCoverage.dir/codeCoverage.C)
 add_dependencies(codeCoverage dyninstAPI patchAPI parseAPI symtabAPI instructionAPI pcontrol common stackwalk dynDwarf dynElf)
-target_link_libraries(codeCoverage dyninstAPI patchAPI parseAPI symtabAPI instructionAPI pcontrol common stackwalk dynDwarf dynElf ${Boost_LIBRARIES})
+target_link_libraries(codeCoverage dyninstAPI patchAPI parseAPI symtabAPI instructionAPI pcontrol common stackwalk dynDwarf dynElf ${Boost_LIBRARIES} ${ElfUtils_LIBRARIES})
 
 add_library(Inst SHARED codeCoverage.dir/libInst.C)
 if(TARGET TBB)
@@ -21,7 +21,7 @@ endif()
 
 add_executable(cfg_to_dot ../parseAPI/doc/example.cc)
 add_dependencies(cfg_to_dot parseAPI symtabAPI instructionAPI common dynDwarf dynElf)
-target_link_libraries(cfg_to_dot parseAPI symtabAPI instructionAPI common dynDwarf dynElf ${Boost_LIBRARIES})
+target_link_libraries(cfg_to_dot parseAPI symtabAPI instructionAPI common dynDwarf dynElf ${Boost_LIBRARIES} ${ElfUtils_LIBRARIES})
 #add_executable(retee)
 
 if (USE_OpenMP MATCHES "ON")

--- a/parseThat/CMakeLists.txt
+++ b/parseThat/CMakeLists.txt
@@ -5,5 +5,5 @@ if (USE_OpenMP MATCHES "ON")
 set_target_properties (parseThat PROPERTIES LINK_FLAGS "-fopenmp")
 endif()
 
-target_link_private_libraries(parseThat dyninstAPI patchAPI parseAPI instructionAPI stackwalk symtabAPI common pcontrol dynDwarf dynElf ${Boost_LIBRARIES})
+target_link_private_libraries(parseThat dyninstAPI patchAPI parseAPI instructionAPI stackwalk symtabAPI common pcontrol dynDwarf dynElf ${Boost_LIBRARIES} ${ElfUtils_LIBRARIES})
 install(TARGETS parseThat RUNTIME DESTINATION bin)


### PR DESCRIPTION
When linking the binaries for ParseThat and the examples, the transitive linkage between libsymtabAPI and libelf was not correctly resolved by the linker. Instead, it used the system libelf which may or may not be correct.