### PR TITLE
Ignore additional Eclipse file and spurious .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ instructionAPI/doc/latex/hierarchy.tex
 instructionAPI/doc/latex/index.tex
 instructionAPI/doc/latex/modules.tex
 instructionAPI/doc/html
+instructionAPI/doc/.gitignore
 patchAPI/doc/patchapi.aux
 patchAPI/doc/patchapi.log
 patchAPI/doc/patchapi.out
@@ -125,3 +126,4 @@ cmake-build-*/
 .project
 .cproject
 .settings
+.pydevproject


### PR DESCRIPTION
The instructionAPI/doc/.gitignore seems to be auto-generated when building the documentation. It tries to ignore instructionAPI/doc/API which is already in the git history, so it's best to just ignore it to
prevent its accidental inclusion.