### PR TITLE
Remove undefined behavior from Symtab::Type

### DIFF
--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -161,8 +161,6 @@ class SYMTAB_EXPORT Type : public Serializable, public  TYPE_ANNOTATABLE_CLASS
     **/
    bool updatingSize;
 
-   static boost::atomic<typeId_t> USER_TYPE_ID;
-
    // INTERNAL DATA MEMBERS
 
 protected:


### PR DESCRIPTION
Calling a member function of a base class before the base class's constructor has completed is undefined behavior.

I tried not to change `Type`'s API, but the member needed to be extracted in order to be handled during base class construction.

@mxz297 @blue42u Could you double-check that I didn't change the semantics?