### PR TITLE
proccontrol: Handle "ghost" threads

### DIFF
--- a/proccontrol/src/handler.C
+++ b/proccontrol/src/handler.C
@@ -983,11 +983,21 @@ int HandleThreadDestroy::getPriority() const
 Handler::handler_ret_t HandleThreadDestroy::handleEvent(Event::ptr ev)
 {
    int_thread *thrd = ev->getThread()->llthrd();
-   int_process *proc = ev->getProcess()->llproc();
 
-	if (!thrd->isUser()) {
-		ev->setSuppressCB(true);
-	}
+   /* The internal thread can be NULL if we receive multiple ThreadDestroy events
+    * for the same thread. This can happen when handling "ghost" threads.
+    */
+   if(!thrd) {
+	   ev->setSuppressCB(true);
+	   pthrd_printf("Encountered an already-destroyed thread\n");
+	   return ret_success;
+   }
+
+   if (!thrd->isUser()) {
+      ev->setSuppressCB(true);
+   }
+
+   int_process *proc = ev->getProcess()->llproc();
 
    if (ev->getEventType().time() == EventType::Pre && proc->plat_supportLWPPostDestroy()) {
       pthrd_printf("Handling pre-thread destroy for %d\n", thrd->getLWP());

--- a/proccontrol/src/handler.C
+++ b/proccontrol/src/handler.C
@@ -1084,6 +1084,10 @@ Handler::handler_ret_t HandleThreadCleanup::handleEvent(Event::ptr ev)
 
 
    int_thread *thrd = ev->getThread()->llthrd();
+   if(!thrd) {
+	   pthrd_printf("Thread for thread cleanup event is NULL. We have no work we can do.\n");
+	   return ret_success;
+   }
    pthrd_printf("Cleaning thread %d/%d from HandleThreadCleanup handler.\n", 
                 proc->getPid(), thrd->getLWP());
    int_thread::cleanFromHandler(thrd, should_delete);

--- a/proccontrol/src/int_process.h
+++ b/proccontrol/src/int_process.h
@@ -997,6 +997,7 @@ public:
    virtual bool plat_setRegisterAsync(Dyninst::MachRegister reg,
                                       Dyninst::MachRegisterVal val,
                                       result_response::ptr result);
+   virtual void plat_handle_ghost_thread();
    virtual void plat_terminate();
 
    void updateRegCache(int_registerPool &pool);

--- a/proccontrol/src/int_thread_db.C
+++ b/proccontrol/src/int_thread_db.C
@@ -1455,8 +1455,11 @@ Handler::handler_ret_t ThreadDBDestroyHandler::handleEvent(Event::ptr ev) {
    }
    thread_db_process *proc = dynamic_cast<thread_db_process *>(ev->getProcess()->llproc());
    thread_db_thread *thrd = dynamic_cast<thread_db_thread *>(ev->getThread()->llthrd());
-   pthrd_printf("Running ThreadDBDestroyHandler on %d/%d\n", proc->getPid(), thrd->getLWP());
-   thrd->markDestroyed();
+
+   if(thrd) {
+      pthrd_printf("Running ThreadDBDestroyHandler on %d/%d\n", proc->getPid(), thrd->getLWP());
+      thrd->markDestroyed();
+   }
 
    return Handler::ret_success;
 }

--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -2837,7 +2837,13 @@ void linux_thread::plat_handle_ghost_thread() {
 
 	pthrd_printf("GHOST_THREAD: exists=%d, loc=%s\n", res, loc.c_str());
 
-	if(res == -1) {
+	// If the thread is still active, do nothing
+	if(res != -1) return;
+
+	auto *initial_thread = llproc()->threadPool()->initialThread();
+
+	// Do not create a destroy event for the thread executed from 'main'
+	if(initial_thread != thread()->llthrd()) {
 		EventLWPDestroy::ptr lwp_ev = EventLWPDestroy::ptr(new EventLWPDestroy(EventType::Post));
 		lwp_ev->setSyncType(Event::async);
 		lwp_ev->setThread(thread());

--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -3445,6 +3445,7 @@ void linux_process::plat_adjustSyncType(Event::ptr ev, bool gen)
       return;
 
    int_thread *thrd = ev->getThread()->llthrd();
+   if(!thrd) return;
    if (thrd->getGeneratorState().getState() != int_thread::running)
       return;
 

--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -2841,6 +2841,7 @@ void linux_thread::plat_handle_ghost_thread() {
 		EventLWPDestroy::ptr lwp_ev = EventLWPDestroy::ptr(new EventLWPDestroy(EventType::Post));
 		lwp_ev->setSyncType(Event::async);
 		lwp_ev->setThread(thread());
+		lwp_ev->setProcess(proc());
 		dynamic_cast<linux_process*>(proc()->llproc())->decodeTdbLWPExit(lwp_ev);
 		mbox()->enqueue(lwp_ev, true);
 	}

--- a/proccontrol/src/linux.h
+++ b/proccontrol/src/linux.h
@@ -222,6 +222,7 @@ class linux_thread : virtual public thread_db_thread
    virtual bool thrdb_getThreadArea(int val, Dyninst::Address &addr);
    virtual bool plat_convertToSystemRegs(const int_registerPool &pool, unsigned char *regs, bool gprs_only = false);
 
+   virtual void plat_handle_ghost_thread();
    void setOptions();
    bool unsetOptions();
    bool getSegmentBase(Dyninst::MachRegister reg, Dyninst::MachRegisterVal &val);

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -2524,9 +2524,9 @@ bool indep_lwp_control_process::plat_syncRunState()
          result = thr->intStop();
       }
       if (!result && getLastError() == err_exited) {
-         pthrd_printf("Suppressing error of continue on exited process\n");
-	 pthrd_printf("TESTING: setting handler to running anyway\n");
-	 thr->getHandlerState().setState(int_thread::running);
+    	  pthrd_printf("Suppressing error of continue/stop on exited process\n");
+    	  thr->plat_handle_ghost_thread();
+    	  thr->getHandlerState().setState(int_thread::running);
       }
       else if (!result) {
          pthrd_printf("Error changing process state from plat_syncRunState\n");
@@ -3988,6 +3988,8 @@ bool int_thread::plat_setRegisterAsync(Dyninst::MachRegister,
    assert(0);
    return false;
 }
+
+void int_thread::plat_handle_ghost_thread() {}
 
 void int_thread::addPostedRPC(int_iRPC::ptr rpc_)
 {


### PR DESCRIPTION
Fixes #741

A "ghost" thread is one which has encountered an error when continuing
from a SIGSTOP. This can come about from the process being exited before
the SIGSTOP is handled.

@sashanicolas @mplegendre 