### PR TITLE
Don't abort for instruction semantic errors.

### DIFF
--- a/dataflowAPI/rose/x86_64InstructionSemantics.h
+++ b/dataflowAPI/rose/x86_64InstructionSemantics.h
@@ -16,12 +16,13 @@
 #include "SgAsmExpression.h"
 #include "conversions.h"
 
-#ifndef ROSE_X86INSTRUCTIONSEMANTICS_H
-
+#undef ROSE_ASSERT
 #define ROSE_ASSERT(x) \
     if (!(x)) {\
         throw rose::BinaryAnalysis::InstructionSemantics2::BaseSemantics::Exception("", NULL); \
     }\
+
+#ifndef ROSE_X86INSTRUCTIONSEMANTICS_H
 
 /* Returns the segment register corresponding to the specified register reference address expression. */
 static inline X86SegmentRegister getSegregFromMemoryReference(SgAsmMemoryReferenceExpression* mr) {


### PR DESCRIPTION
Define ROSE_ASSERT so that a signal is thrown for instruction
semantic errors instead of doing an assertion abort.  SymbolicExpansion.C  includes x86InstructionSemantics.h which includes rose.h which defines ROSE_ASSERT but a subsequent redefinition of ROSE_ASSERT by x86_64InstructionSemantics.h has no effect since it is bracketed by ROSE_X86INSTRUCTIONSEMANTICS_H
