### PR TITLE
remove unnecessary assertion for unknown phdr_type

### DIFF
--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -211,7 +211,6 @@ std::string phdrTypeStr(Elf64_Word phdr_type) {
         case PT_PAX_FLAGS:
             return "PAX";
         default:
-            assert(0);
             return "<UNKNOWN>";
             break;
 


### PR DESCRIPTION
This should fix the problem of failed assertion in EmitELF.C when an unknown phdr_type is seen.

Fixes #743 