### PR TITLE
Retrieve dyninstAPI examples from May 2019 manual

### DIFF
--- a/dyninstAPI/doc/examples/InterestingProgram.cpp
+++ b/dyninstAPI/doc/examples/InterestingProgram.cpp
@@ -1,0 +1,23 @@
+#include <cstdlib>
+#include <iostream>
+using namespace std;
+class Test{
+public:
+    int a;
+    char b;
+    Test(){
+
+    }
+
+};
+
+void InterestingProcedure(){
+    cout << " Calling function " << __func__ << endl; 
+    Test * test = new Test();
+    delete (test);
+}
+
+int main(int argc, char * argv[]){
+    InterestingProcedure();
+    return 0;
+}

--- a/dyninstAPI/doc/examples/binary_analysis.cpp
+++ b/dyninstAPI/doc/examples/binary_analysis.cpp
@@ -1,0 +1,111 @@
+#include <stdio.h>
+
+#include "BPatch.h"
+#include "BPatch_addressSpace.h"
+#include "BPatch_process.h"
+#include "BPatch_binaryEdit.h"
+#include "BPatch_function.h"
+#include "BPatch_flowGraph.h"
+
+using namespace std;
+using namespace Dyninst;
+
+// Create an instance of class BPatch
+BPatch bpatch;
+
+// Different ways to perform instrumentation
+typedef enum {
+    create,
+    attach,
+    open
+} accessType_t; 
+
+BPatch_addressSpace* startInstrumenting(accessType_t accessType,
+        const char* name,
+        int pid,
+        const char* argv[]) {
+    BPatch_addressSpace* handle = NULL;
+
+    switch(accessType) {
+        case create:
+            handle = bpatch.processCreate(name, argv);
+            if (!handle) { fprintf(stderr, "processCreate failed\n"); }
+            break;
+        case attach:
+            handle = bpatch.processAttach(name, pid);
+            if (!handle) { fprintf(stderr, "processAttach failed\n"); }
+            break;
+        case open:
+            // Open the binary file and all dependencies
+            handle = bpatch.openBinary(name, true);
+            if (!handle) { fprintf(stderr, "openBinary failed\n"); }
+            break;
+    }
+
+    return handle;
+}
+
+int binaryAnalysis(BPatch_addressSpace* app) {
+    BPatch_image* appImage = app->getImage();
+
+    int insns_access_memory = 0;
+
+    std::vector<BPatch_function*> functions;
+    appImage->findFunction("InterestingProcedure", functions);
+
+    if (functions.size() == 0) {
+        fprintf(stderr, "No function InterestingProcedure\n");
+        return insns_access_memory;
+    } else if (functions.size() > 1) {
+        fprintf(stderr, "More than one InterestingProcedure; using the first one\n");
+    }
+
+    BPatch_flowGraph* fg = functions[0]->getCFG();
+
+    std::set<BPatch_basicBlock*> blocks;
+    fg->getAllBasicBlocks(blocks);
+
+    for (auto block_iter = blocks.begin(); 
+            block_iter != blocks.end(); 
+            ++block_iter) {
+        BPatch_basicBlock* block = *block_iter;
+        std::vector<InstructionAPI::Instruction> insns;
+        block->getInstructions(insns);
+
+        for (auto insn_iter = insns.begin(); 
+                insn_iter != insns.end(); 
+                ++insn_iter) {
+            if (insn_iter->readsMemory() || insn_iter->writesMemory()) {
+                insns_access_memory++;
+            }
+        }
+    }
+
+    return insns_access_memory;
+}
+
+
+
+
+
+
+int main() {
+    // Set up information about the program to be instrumented
+    const char* progName = "InterestingProgram";
+    int progPID = 42;
+    const char* progArgv[] = {"InterestingProgram", "-h", NULL};
+    accessType_t mode = create;
+
+    // Create/attach/open a binary
+    BPatch_addressSpace* app = 
+        startInstrumenting(mode, progName, progPID, progArgv);
+    if (!app) {
+        fprintf(stderr, "startInstrumenting failed\n");
+        exit(1);
+    }
+    
+    int memAccesses = binaryAnalysis(app);
+    
+    fprintf(stderr, "Found %d memory accesses\n", memAccesses);
+}
+

--- a/dyninstAPI/doc/examples/instrumenting_a_function.cpp
+++ b/dyninstAPI/doc/examples/instrumenting_a_function.cpp
@@ -1,0 +1,195 @@
+#include <stdio.h>
+
+#include "BPatch.h"
+#include "BPatch_addressSpace.h"
+#include "BPatch_process.h"
+#include "BPatch_binaryEdit.h"
+#include "BPatch_point.h"
+#include "BPatch_function.h"
+
+using namespace std;
+using namespace Dyninst;
+
+// Create an instance of class BPatch
+BPatch bpatch;
+
+// Different ways to perform instrumentation
+typedef enum {
+    create,
+    attach,
+    open
+} accessType_t; 
+
+// Attach, create, or open a file for rewriting
+BPatch_addressSpace* startInstrumenting(accessType_t accessType,
+        const char* name,
+        int pid,
+        const char* argv[]) {
+    BPatch_addressSpace* handle = NULL;
+
+    switch(accessType) {
+        case create:
+            handle = bpatch.processCreate(name, argv);
+            if (!handle) { fprintf(stderr, "processCreate failed\n"); }
+            break;
+        case attach:
+            handle = bpatch.processAttach(name, pid);
+            if (!handle) { fprintf(stderr, "processAttach failed\n"); }
+            break;
+        case open:
+            // Open the binary file and all dependencies
+            handle = bpatch.openBinary(name, true);
+            if (!handle) { fprintf(stderr, "openBinary failed\n"); }
+            break;
+    }
+
+    return handle;
+}
+// Find a point at which to insert instrumentation
+std::vector<BPatch_point*>* findPoint(BPatch_addressSpace* app, 
+		const char* name, 
+		BPatch_procedureLocation loc) {
+    std::vector<BPatch_function*> functions;
+    std::vector<BPatch_point*>* points;
+
+    // Scan for functions named "name"
+    BPatch_image* appImage = app->getImage();
+    appImage->findFunction(name, functions);
+    if (functions.size() == 0) {
+        fprintf(stderr, "No function %s\n", name);
+        return points;
+    } else if (functions.size() > 1) {
+        fprintf(stderr, "More than one %s; using the first one\n", name);
+    }
+
+    // Locate the relevant points
+    points = functions[0]->findPoint(loc);
+    return points;
+}
+
+// Create and insert an increment snippet
+bool createAndInsertSnippet(BPatch_addressSpace* app,
+        std::vector<BPatch_point*>* points) {
+    BPatch_image* appImage = app->getImage();
+
+    // Create an increment snippet
+    BPatch_variableExpr* intCounter = 
+        app->malloc(*(appImage->findType("int")), "myCounter");
+    BPatch_arithExpr addOne(BPatch_assign,
+                            *intCounter,
+                            BPatch_arithExpr(BPatch_plus, 
+                                *intCounter, 
+                                BPatch_constExpr(1)));
+
+    // Insert the snippet
+    if (!app->insertSnippet(addOne, *points)) {
+        fprintf(stderr, "insertSnippet failed\n");
+        return false;
+    }
+    return true;
+}
+
+// Create and insert a printf snippet
+bool createAndInsertSnippet2(BPatch_addressSpace* app,
+        std::vector<BPatch_point*>* points) {
+    BPatch_image* appImage = app->getImage();
+    
+    // Create the printf function call snippet
+    std::vector<BPatch_snippet*> printfArgs;
+    BPatch_snippet* fmt = 
+        new BPatch_constExpr("InterestingProcedure called %d times\n");
+    printfArgs.push_back(fmt);
+
+    BPatch_variableExpr* var = appImage->findVariable("myCounter");
+if (!var) {
+        fprintf(stderr, "Could not find 'myCounter' variable\n");
+        return false;
+    } else {
+        printfArgs.push_back(var);
+    }
+    
+    // Find the printf function
+    std::vector<BPatch_function*> printfFuncs;
+    appImage->findFunction("printf", printfFuncs);
+    if (printfFuncs.size() == 0) {
+        fprintf(stderr, "Could not find printf\n");
+        return false;
+    }
+
+    // Construct a function call snippet
+    BPatch_funcCallExpr printfCall(*(printfFuncs[0]), printfArgs);
+
+    //  Insert the snippet
+    if (!app->insertSnippet(printfCall, *points)) {
+        fprintf(stderr, "insertSnippet failed\n");
+        return false;
+    }
+    return true;
+}
+
+void finishInstrumenting(BPatch_addressSpace* app, const char* newName)
+{
+    BPatch_process* appProc = dynamic_cast<BPatch_process*>(app);
+    BPatch_binaryEdit* appBin = dynamic_cast<BPatch_binaryEdit*>(app);
+
+    if (appProc) {
+        if (!appProc->continueExecution()) {
+            fprintf(stderr, "continueExecution failed\n");
+        }
+        while (!appProc->isTerminated()) {
+            bpatch.waitForStatusChange();
+        }
+    } else if (appBin) {
+        if (!appBin->writeFile(newName)) {
+            fprintf(stderr, "writeFile failed\n");
+        }
+    }
+}
+
+int main() {
+    // Set up information about the program to be instrumented
+    const char* progName = "InterestingProgram";
+    int progPID = 42;
+    const char* progArgv[] = {"InterestingProgram", "-h", NULL};
+    accessType_t mode = create;
+
+    // Create/attach/open a binary
+    BPatch_addressSpace* app = 
+        startInstrumenting(mode, progName, progPID, progArgv);
+    if (!app) {
+        fprintf(stderr, "startInstrumenting failed\n");
+        exit(1);
+    }
+
+    // Find the entry point for function InterestingProcedure
+    const char* interestingFuncName = "InterestingProcedure";
+    std::vector<BPatch_point*>* entryPoint = 
+        findPoint(app, interestingFuncName, BPatch_entry);
+    if (!entryPoint || entryPoint->size() == 0) {
+        fprintf(stderr, "No entry points for %s\n", interestingFuncName);
+        exit(1);
+    }
+
+    // Create and insert instrumentation snippet
+    if (!createAndInsertSnippet(app, entryPoint)) {
+        fprintf(stderr, "createAndInsertSnippet failed\n");
+        exit(1);
+    }
+
+    // Find the exit point of main
+    std::vector<BPatch_point*>* exitPoint = 
+        findPoint(app, "main", BPatch_exit);
+    if (!exitPoint || exitPoint->size() == 0) {
+        fprintf(stderr, "No exit points for main\n");
+        exit(1);
+    }
+
+    // Create and insert instrumentation snippet 2
+    if (!createAndInsertSnippet2(app, exitPoint)) {
+        fprintf(stderr, "createAndInsertSnippet2 failed\n");
+        exit(1);
+    }
+    // Finish instrumentation
+    const char* progName2 = "InterestingProgram-rewritten";
+    finishInstrumenting(app, progName2);
+}

--- a/dyninstAPI/doc/examples/instrumenting_memory_access.cpp
+++ b/dyninstAPI/doc/examples/instrumenting_memory_access.cpp
@@ -1,0 +1,138 @@
+#include <stdio.h>
+
+#include "BPatch.h"
+#include "BPatch_addressSpace.h"
+#include "BPatch_process.h"
+#include "BPatch_binaryEdit.h"
+#include "BPatch_point.h"
+#include "BPatch_function.h"
+
+using namespace std;
+using namespace Dyninst;
+
+// Create an instance of class BPatch
+BPatch bpatch;
+
+// Different ways to perform instrumentation
+typedef enum {
+    create,
+    attach,
+    open
+} accessType_t; 
+
+// Attach, create, or open a file for rewriting
+BPatch_addressSpace* startInstrumenting(accessType_t accessType,
+        const char* name,
+        int pid,
+        const char* argv[]) {
+    BPatch_addressSpace* handle = NULL;
+
+    switch(accessType) {
+        case create:
+            handle = bpatch.processCreate(name, argv);
+            if (!handle) { fprintf(stderr, "processCreate failed\n"); }
+            break;
+        case attach:
+            handle = bpatch.processAttach(name, pid);
+            if (!handle) { fprintf(stderr, "processAttach failed\n"); }
+            break;
+        
+case open:
+            // Open the binary file; do not open dependencies
+            handle = bpatch.openBinary(name, false);
+            if (!handle) { fprintf(stderr, "openBinary failed\n"); }
+            break;
+    }
+
+    return handle;
+}
+
+bool instrumentMemoryAccesses(BPatch_addressSpace* app) {
+    BPatch_image* appImage = app->getImage();
+
+    // We're interested in loads and stores
+    BPatch_Set<BPatch_opCode> axs;
+    axs.insert(BPatch_opLoad);
+    axs.insert(BPatch_opStore);
+
+    // Scan the function InterestingProcedure 
+    // and create instrumentation points
+    std::vector<BPatch_function*> functions;
+    appImage->findFunction("InterestingProcedure", functions);
+    std::vector<BPatch_point*>* points = 
+        functions[0]->findPoint(axs);
+    if (!points) {
+        fprintf(stderr, "No load/store points found\n");
+        return false;
+    }
+
+    // Create the printf function call snippet
+    std::vector<BPatch_snippet*> printfArgs;
+    BPatch_snippet* fmt = new BPatch_constExpr("Access at: 0x%lx\n");
+    printfArgs.push_back(fmt);
+    BPatch_snippet* eae = new BPatch_effectiveAddressExpr();
+    printfArgs.push_back(eae);
+    
+    // Find the printf function
+    std::vector<BPatch_function*> printfFuncs;
+    appImage->findFunction("printf", printfFuncs);
+    if (printfFuncs.size() == 0) {
+        fprintf(stderr, "Could not find printf\n");
+        return false;
+    }
+
+    // Construct a function call snippet 
+    BPatch_funcCallExpr printfCall(*(printfFuncs[0]), printfArgs);
+
+    // Insert the snippet at the instrumentation points
+    if (!app->insertSnippet(printfCall, *points)) {
+        fprintf(stderr, "insertSnippet failed\n");
+        return false;
+    }
+    return true;
+}
+
+void finishInstrumenting(BPatch_addressSpace* app, const char* newName) {
+    BPatch_process* appProc = dynamic_cast<BPatch_process*>(app);
+    BPatch_binaryEdit* appBin = dynamic_cast<BPatch_binaryEdit*>(app);
+
+    if (appProc) {
+        if (!appProc->continueExecution()) {
+            fprintf(stderr, "continueExecution failed\n");
+        }
+        while (!appProc->isTerminated()) {
+            bpatch.waitForStatusChange();
+        }
+    } else if (appBin) {
+        if (!appBin->writeFile(newName)) {
+            fprintf(stderr, "writeFile failed\n");
+        }
+    }
+}
+
+int main() {
+    // Set up information about the program to be instrumented
+    const char* progName = "InterestingProgram";
+    int progPID = 42;
+    const char* progArgv[] = {"InterestingProgram", "-h", NULL};
+    accessType_t mode = create;
+
+    // Create/attach/open a binary
+    BPatch_addressSpace* app = 
+        startInstrumenting(mode, progName, progPID, progArgv);
+    if (!app) {
+        fprintf(stderr, "startInstrumenting failed\n");
+        exit(1);
+    }
+
+    // Instrument memory accesses
+    if (!instrumentMemoryAccesses(app)) {
+        fprintf(stderr, "instrumentMemoryAccesses failed\n");
+        exit(1);
+    }
+    
+    // Finish instrumentation 
+    const char* progName2 = "InterestingProgram-rewritten";
+    finishInstrumenting(app, progName2);
+}
+

--- a/dyninstAPI/doc/examples/retee.cpp
+++ b/dyninstAPI/doc/examples/retee.cpp
@@ -1,0 +1,297 @@
+#include <stdio.h> 
+#include <fcntl.h> 
+#include <vector> 
+#include "BPatch.h" 
+#include "BPatch_point.h"
+#include "BPatch_process.h"
+#include "BPatch_function.h"
+#include "BPatch_thread.h" 
+
+/* 
+ * retee.C
+ *
+ * This program (mutator) provides an example of several facets of
+ * Dyninst's behavior, and is a good basis for many Dyninst
+ * mutators. We want to intercept all output from a target application
+ * (the mutatee), duplicating output to a file as well as the
+ * original destination (e.g., stdout).
+ *
+ * This mutator operates in several phases. In brief:
+ * 1) Attach to the running process and get a handle (BPatch_process
+ *    object)
+ * 2) Get a handle for the parsed image of the mutatee for function
+ *    lookup (BPatch_image object)
+ * 3) Open a file for output
+ *    3a) Look up the "open" function
+ *    3b) Build a code snippet to call open with the file name.
+ *    3c) Run that code snippet via a oneTimeCode, saving the returned
+ *        file descriptor
+ * 4) Write the returned file descriptor into a memory variable for
+ *    mutatee-side use
+ * 5) Build a snippet that copies output to the file
+ *    5a) Locate the "write" library call
+ *    5b) Access its parameters
+ *    5c) Build a snippet calling write(fd, parameters)
+ *    5d) Insert the snippet at write
+ * 6) Add a hook to exit to ensure that we close the file (using
+ *    a callback at exit and another oneTimeCode)
+ */
+
+void usage() {
+    fprintf(stderr, "Usage: retee <process pid> <filename>\n");
+    fprintf(stderr, "   note: <filename> is relative to the application pro-cess.\n");
+}
+
+// We need to use a callback, and so the things that callback requires
+// are made global - this includes the file descriptor snippet (see below)
+BPatch_variableExpr *fdVar = NULL;
+
+// Before we add instrumentation, we need to open the file for
+// writing. We can do this with a oneTimeCode - a piece of code run at
+// a particular time, rather than at a particular location.
+
+int openFileForWrite(BPatch_process *app, BPatch_image *appImage, char *fileName) {
+    // The code to be generated is: 
+    // fd = open(argv[2], O_WRONLY|O_CREAT, 0666); 
+    
+    // (1) Find the open function 
+    std::vector<BPatch_function *>openFuncs; 
+    appImage->findFunction("open", openFuncs); 
+    if (openFuncs.size() == 0) {
+        fprintf(stderr, "ERROR: Unable to find function for open()\n");
+        return -1;
+    }
+    
+    // (2) Allocate a vector of snippets for the parameters to open 
+    std::vector<BPatch_snippet *> openArgs; 
+    
+    // (3) Create a string constant expression from argv[3] 
+    BPatch_constExpr fileNameExpr(fileName); 
+    
+    // (4) Create two more constant expressions _WRONLY|O_CREAT and 0666 
+    BPatch_constExpr fileFlagsExpr(O_WRONLY|O_CREAT); 
+    BPatch_constExpr fileModeExpr(0666); 
+    
+    // (5) Push 3 & 4 onto the list from step 2, push first to last parameter.
+    openArgs.push_back(&fileNameExpr); 
+    openArgs.push_back(&fileFlagsExpr); 
+    openArgs.push_back(&fileModeExpr); 
+    
+    // (6) create a procedure call using function found at 1 and 
+    // parameters from step 5. 
+    BPatch_funcCallExpr openCall(*openFuncs[0], openArgs); 
+    
+    // (7) The oneTimeCode returns whatever the return result from
+    // the BPatch_snippet is. In this case, the return result of
+    // open -> the file descriptor.
+    void *openFD = app->oneTimeCode( openCall );
+    
+    // oneTimeCode returns a void *, and we want an int file handle
+    return (int) (long) openFD;
+}
+
+// We have used a oneTimeCode to open the file descriptor. However,
+// this returns the file descriptor to the mutator - the mutatee has
+// no idea what the descriptor is. We need to allocate a variable in
+// the mutatee to hold this value for future use and copy the
+// (mutator-side) value into the mutatee variable.
+
+// Note: there are alternatives to this technique. We could have
+// allocated the variable before the oneTimeCode and augmented the
+// snippet to do the assignment. We could also write the file
+// descriptor as a constant into any inserted instrumentation.
+
+BPatch_variableExpr *writeFileDescIntoMutatee(BPatch_process *app, 
+                                              BPatch_image *appImage, 
+                                              int fileDescriptor) {
+    // (1) Allocate a variable in the mutatee of size (and type) int
+    BPatch_variableExpr *fdVar = app->malloc(*appImage->findType("int")); 
+    if (fdVar == NULL) return NULL;
+
+    // (2) Write the value into the variable
+    // Like memcpy, writeValue takes a pointer
+    // The third parameter is for functionality called "saveTheWorld", 
+    // which we don't worry about here (and so is false)
+    bool ret = fdVar->writeValue((void *) &fileDescriptor, sizeof(int),
+  					   false);    
+    if (ret == false) return NULL;
+
+    return fdVar;
+}
+
+// We now have an open file descriptor in the mutatee. We want to
+// instrument write to intercept and copy the output. That happens
+// here. 
+
+bool interceptAndCloneWrite(BPatch_process *app, 
+                            BPatch_image *appImage, 
+                            BPatch_variableExpr *fdVar) {
+    // (1) Locate the write call
+    std::vector<BPatch_function *> writeFuncs;
+
+    appImage->findFunction("write", 
+                           writeFuncs);
+    if(writeFuncs.size() == 0) {
+        fprintf(stderr, "ERROR: Unable to find function for write()\n");
+        return false;
+    }
+    
+    // (2) Build the call to (our) write. Arguments are:
+    //   ours: fdVar (file descriptor)
+    //   parameter: buffer
+    //   parameter: buffer size
+
+    // Declare a vector to hold these.
+    std::vector<BPatch_snippet *> writeArgs;
+    // Push on the file descriptor
+    writeArgs.push_back(fdVar);
+    // Well, we need the buffer... but that's a parameter to the
+    // function we're implementing. That's not a problem - we can grab
+    // it out with a BPatch_paramExpr.
+    BPatch_paramExpr buffer(1); // Second (0, 1, 2) argument
+    BPatch_paramExpr bufferSize(2);
+    writeArgs.push_back(&buffer);
+    writeArgs.push_back(&bufferSize);
+
+    // And build the write call
+    BPatch_funcCallExpr writeCall(*writeFuncs[0], writeArgs);
+
+    // (3) Identify the BPatch_point for the entry of write. We're
+    // instrumenting the function with itself; normally the findPoint
+    // call would operate off a different function than the snippet.
+
+    std::vector<BPatch_point *> *points;
+    points = writeFuncs[0]->findPoint(BPatch_entry);
+    if ((*points).size() == 0) { 
+        return false;
+    } 
+
+    // (4) Insert the snippet at the start of write
+
+    return app->insertSnippet(writeCall, *points);
+
+    // Note: we have just instrumented write() with a call to
+    // write(). This would ordinarily be a _bad thing_, as there is
+    // nothing to stop infinite recursion - write -> instrumentation
+    // -> write -> instrumentation....
+    // However, Dyninst uses a feature called a "tramp guard" to
+    // prevent this, and it's on by default. 
+}
+
+// This function is called as an exit callback (that is, called
+// immediately before the process exits when we can still affect it)
+// and thus must match the exit callback signature:
+// 
+// typedef void (*BPatchExitCallback) (BPatch_thread *, BPatch_exitType)
+// 
+// Note that the callback gives us a thread, and we want a process - but
+// each thread has an up pointer.
+
+void closeFile(BPatch_thread *thread, BPatch_exitType) {
+    fprintf(stderr, "Exit callback called for process...\n");
+
+    // (1) Get the BPatch_process and BPatch_images
+    BPatch_process *app = thread->getProcess();
+    BPatch_image *appImage = app->getImage();
+
+    // The code to be generated is:
+    // close(fd);
+    
+    // (2) Find close
+    std::vector<BPatch_function *> closeFuncs; 
+    appImage->findFunction("close", closeFuncs); 
+    if (closeFuncs.size() == 0) {
+        fprintf(stderr, "ERROR: Unable to find function for close()\n");
+        return;
+    }
+    
+    // (3) Allocate a vector of snippets for the parameters to open 
+    std::vector<BPatch_snippet *> closeArgs; 
+    
+    // (4) Add the fd snippet - fdVar is global since we can't
+    // get it via the callback
+    closeArgs.push_back(fdVar);
+    
+    // (5) create a procedure call using function found at 1 and 
+    // parameters from step 3. 
+    BPatch_funcCallExpr closeCall(*closeFuncs[0], closeArgs); 
+    
+    // (6) Use a oneTimeCode to close the file
+    app->oneTimeCode( closeCall );
+
+    // (7) Tell the app to continue to finish it off.
+    app->continueExecution();
+    
+    return;
+}
+
+BPatch bpatch; 
+
+// In main we perform the following operations.
+// 1) Attach to the process and get BPatch_process and BPatch_image
+//    handles
+// 2) Open a file descriptor
+// 3) Instrument write
+// 4) Continue the process and wait for it to terminate
+
+int main(int argc, char *argv[]) { 
+    int pid; 
+    if (argc != 3) { 
+        usage();
+        exit(1); 
+    } 
+    pid = atoi(argv[1]); 
+
+    // Attach to the program - we can attach with just a pid; the
+    // program name is no longer necessary
+    fprintf(stderr, "Attaching to process %d...\n", pid);
+    BPatch_process *app = bpatch.processAttach(NULL, pid); 
+
+    if (!app) return -1;
+	
+    // Read the program's image and get an associated image object 
+    BPatch_image *appImage = app->getImage(); 
+    std::vector<BPatch_function*> writeFuncs; 
+
+    fprintf(stderr, "Opening file %s for write...\n", argv[2]);
+    int fileDescriptor = openFileForWrite(app, appImage, argv[2]);
+
+    if (fileDescriptor == -1) {
+        fprintf(stderr, "ERROR: opening file %s for write failed\n",
+                argv[2]);
+        exit(1);
+    }
+
+    fprintf(stderr, "Writing returned file descriptor %d into"
+                    "mutatee...\n", fileDescriptor);
+
+    // This was defined globally as the exit callback needs it.
+    fdVar = writeFileDescIntoMutatee(app, appImage, fileDescriptor);
+    if (fdVar == NULL) {
+        fprintf(stderr, "ERROR: failed to write mutatee-side variable\n");
+        exit(1);
+    }
+
+    fprintf(stderr, "Instrumenting write...\n");
+    bool ret = interceptAndCloneWrite(app, appImage, fdVar);
+    if (!ret) {
+        fprintf(stderr, "ERROR: failed to instrument mutatee\n");
+        exit(1);
+    }
+
+    fprintf(stderr, "Adding exit callback...\n");
+    bpatch.registerExitCallback(closeFile);
+      
+    // Continue the execution...
+    fprintf(stderr, "Continuing execution and waiting for termination\n");
+    app->continueExecution();
+
+    while (!app->isTerminated()) 
+        bpatch.waitForStatusChange();
+        
+    printf("Done.\n");
+
+    return 0;
+}
+
+

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,20 @@
+add_executable(instrumenting_a_function ../dyninstAPI/doc/examples/instrumenting_a_function.cpp)
+add_dependencies(instrumenting_a_function dyninstAPI parseAPI symtabAPI instructionAPI common)
+target_link_libraries(instrumenting_a_function dyninstAPI symtabAPI instructionAPI common dynDwarf dynElf ${Boost_LIBRARIES} ${ElfUtils_LIBRARIES} boost_filesystem boost_system tbbmalloc )
+
+add_executable(binary_analysis ../dyninstAPI/doc/examples/binary_analysis.cpp)
+add_dependencies(binary_analysis dyninstAPI parseAPI symtabAPI instructionAPI common)
+target_link_libraries(binary_analysis dyninstAPI symtabAPI instructionAPI common dynDwarf dynElf ${Boost_LIBRARIES} ${ElfUtils_LIBRARIES} boost_filesystem boost_system tbbmalloc )
+
+add_executable(instrumenting_memory_access ../dyninstAPI/doc/examples/instrumenting_memory_access.cpp)
+add_dependencies(instrumenting_memory_access dyninstAPI parseAPI symtabAPI instructionAPI common)
+target_link_libraries(instrumenting_memory_access dyninstAPI symtabAPI instructionAPI common dynDwarf dynElf ${Boost_LIBRARIES} ${ElfUtils_LIBRARIES} boost_filesystem boost_system tbbmalloc )
+
+add_executable(retee ../dyninstAPI/doc/examples/retee.cpp)
+add_dependencies(retee dyninstAPI parseAPI symtabAPI instructionAPI common)
+target_link_libraries(retee dyninstAPI symtabAPI instructionAPI common dynDwarf dynElf ${Boost_LIBRARIES} ${ElfUtils_LIBRARIES} boost_filesystem boost_system tbbmalloc )
+
+add_executable(InterestingProgram ../dyninstAPI/doc/examples/InterestingProgram.cpp)
 
 
 add_executable(unstrip unstrip.dir/unstrip.C
@@ -31,7 +48,7 @@ set_target_properties (cfg_to_dot PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS} L
 endif()
 
 
-install (TARGETS cfg_to_dot unstrip codeCoverage Inst
+install (TARGETS cfg_to_dot unstrip codeCoverage Inst instrumenting_a_function binary_analysis instrumenting_memory_access retee InterestingProgram
         RUNTIME DESTINATION ${INSTALL_BIN_DIR}
         LIBRARY DESTINATION ${INSTALL_LIB_DIR}
         ARCHIVE DESTINATION ${INSTALL_LIB_DIR}

--- a/examples/InterestingProgram.cpp
+++ b/examples/InterestingProgram.cpp
@@ -1,0 +1,1 @@
+../dyninstAPI/doc/examples/InterestingProgram.cpp

--- a/examples/binary_analysis.cpp
+++ b/examples/binary_analysis.cpp
@@ -1,0 +1,1 @@
+../dyninstAPI/doc/examples/binary_analysis.cpp

--- a/examples/instrumenting_a_function.cpp
+++ b/examples/instrumenting_a_function.cpp
@@ -1,0 +1,1 @@
+../dyninstAPI/doc/examples/instrumenting_a_function.cpp

--- a/examples/instrumenting_memory_access.cpp
+++ b/examples/instrumenting_memory_access.cpp
@@ -1,0 +1,1 @@
+../dyninstAPI/doc/examples/instrumenting_memory_access.cpp

--- a/examples/retee.cpp
+++ b/examples/retee.cpp
@@ -1,0 +1,1 @@
+../dyninstAPI/doc/examples/retee.cpp

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -211,7 +211,6 @@ std::string phdrTypeStr(Elf64_Word phdr_type) {
         case PT_PAX_FLAGS:
             return "PAX";
         default:
-            assert(0);
             return "<UNKNOWN>";
             break;
 


### PR DESCRIPTION
The examples in the May 2019 dyninstAPI manual appendix are now standalone c++ source code placed under the path dyninstAPI/doc/examples