### PR TITLE
Retain hint function from external source

### DIFF
--- a/parseAPI/src/CodeObject.C
+++ b/parseAPI/src/CodeObject.C
@@ -78,6 +78,12 @@ CodeObject::CodeObject(CodeSource *cs,
     process_hints(); // if any
     if (!ignoreParse)
       parse();
+    else {
+      // For cases where the user does not want to parse the CodeObject,
+      // the user may still provides hints from external source,
+      // we should report hints functions back.
+      parser->record_hint_functions();
+    }
 }
 
 void

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -171,8 +171,10 @@ Parser::parse()
     parsing_printf("[%s:%d] parse() called on Parser %p with state %d\n",
                    FILE__,__LINE__,this, _parse_state);
 
-    if(_parse_state == UNPARSEABLE)
+    if(_parse_state == UNPARSEABLE) {
+        record_hint_functions();
         return;
+    }
 
     // For modification: once we've full-parsed once, don't do it again
     if (_parse_state >= COMPLETE) return;
@@ -2704,4 +2706,11 @@ Parser::update_function_ret_status(ParseFrame &frame, Function * other_func, Par
         parsing_printf("\t other_func is NORETURN, this path does not impact the return status of this function\n");
     }
 
+}
+
+void
+Parser::record_hint_functions() {
+    for (auto f : hint_funcs) {
+        sorted_funcs.insert(f);
+    }
 }

--- a/parseAPI/src/Parser.h
+++ b/parseAPI/src/Parser.h
@@ -262,6 +262,7 @@ namespace Dyninst {
             void delete_bogus_blocks(Edge*);
             bool set_edge_parsing_status(ParseFrame&, Address addr, Block *b);
             void update_function_ret_status(ParseFrame &, Function*, ParseWorkElem* );
+            void record_hint_functions();
 
 
 


### PR DESCRIPTION
In earlier PR for parallel parsing, I changed the parser to only populate the function list during parsing finalization, which makes it convenient to delete bogus functions created during parsing. However, for external code source such as CUDA, we will not invoke parsing or finalization. This causes hpcstruct to generate empty CFG.

This PR fixes the empty CUDA CFG problem by retaining functions from external source when the code object is told to not parse or cannot perform parsing.