### PR TITLE
Fix proccontrol hangs in test_thread_X

### DIFF
--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -531,9 +531,11 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
 							FILE__, __LINE__, event_ptr->name().c_str());
 		assert(false);
 	}
+	procCount[evProc]--;
+	assert(procCount[evProc] >= 0);
+    proccontrol_printf("%s[%d]: Returning event %s from mailbox for process %p\n",
+    				   FILE__, __LINE__, event_ptr->name().c_str(), evProc);
 
-    proccontrol_printf("%s[%d]: Returning event %s for process %p from mailbox\n",
-    				   FILE__, __LINE__, ret->name().c_str(), evProc);
     return ret;
 }
 

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -520,8 +520,10 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
         queueCond.wait();
     }
 
-    Event::const_ptr ret = eventQueue.front();
-    eventQueue.pop();
+    // Dequeue an event
+    Event::const_ptr event_ptr = eventQueue.front();
+	eventQueue.pop();
+	
     PCProcess *evProc = static_cast<PCProcess *>(ret->getProcess()->getData());
     if(evProc) procCount[evProc]--;
     assert(procCount[evProc] >= 0);

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -119,7 +119,7 @@ PCEventMuxer::WaitResult PCEventMuxer::wait_internal(bool block) {
      return EventsReceived;
 }
 
-bool PCEventMuxer::handle_internal(PCProcess *proc) {
+bool PCEventMuxer::handle_internal(PCProcess *) {
    bool ret = true;
    while (mailbox_.size()) {
       EventPtr ev = dequeue(false);

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -43,6 +43,7 @@
 
 #include <queue>
 #include <vector>
+#include <mutex>
 
 using namespace Dyninst;
 using namespace ProcControlAPI;
@@ -482,7 +483,7 @@ PCEventMailbox::~PCEventMailbox()
 }
 
 void PCEventMailbox::enqueue(Event::const_ptr ev) {
-    queueCond.lock();
+	std::lock_guard<CondVar<>> l{queueCond};
     eventQueue.push(ev);
     PCProcess *evProc = static_cast<PCProcess *>(ev->getProcess()->getData());
     if(evProc) procCount[evProc]++;
@@ -491,7 +492,6 @@ void PCEventMailbox::enqueue(Event::const_ptr ev) {
     proccontrol_printf("%s[%d]: Added event %s from process %p to mailbox, size now %d\n",
     				   FILE__, __LINE__, ev->name().c_str(), evProc, eventQueue.size());
     
-    queueCond.unlock();
 }
 
 Event::const_ptr PCEventMailbox::dequeue(bool block) {

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -560,6 +560,7 @@ unsigned int PCEventMailbox::size() {
 }
 
 bool PCEventMailbox::find(PCProcess *proc) {
+   proccontrol_printf("Calling find for process %p\n", proc);
    auto it = procCount.find(proc);
    if(it != procCount.end()) {
 	   return it->second > 0;

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -535,7 +535,16 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
 	if(!evProc) {
 		proccontrol_printf("%s[%d]: Found event %s, but process is invalid\n",
 							FILE__, __LINE__, event_ptr->name().c_str());
-		assert(false);
+		namespace pc = Dyninst::ProcControlAPI;
+		auto const& et = event_ptr->getEventType();
+		bool const is_exit = et.code() == pc::EventType::Exit;
+		bool const is_post = et.time() == pc::EventType::Time::Post;
+		if(is_exit && is_post) {
+			// post-exit events handled after process destruction are irrelevant
+			return Event::const_ptr{};
+		} else {
+			assert(false);
+		}
 	}
 	procCount[evProc]--;
 	assert(procCount[evProc] >= 0);

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -523,10 +523,14 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
     // Dequeue an event
     Event::const_ptr event_ptr = eventQueue.front();
 	eventQueue.pop();
-	
-    PCProcess *evProc = static_cast<PCProcess *>(ret->getProcess()->getData());
-    if(evProc) procCount[evProc]--;
-    assert(procCount[evProc] >= 0);
+
+	// Update the process-count table
+	auto* evProc = static_cast<PCProcess *>(event_ptr->getProcess()->getData());
+	if(!evProc) {
+		proccontrol_printf("%s[%d]: Found event %s, but process is invalid\n",
+							FILE__, __LINE__, event_ptr->name().c_str());
+		assert(false);
+	}
 
     proccontrol_printf("%s[%d]: Returning event %s for process %p from mailbox\n",
     				   FILE__, __LINE__, ret->name().c_str(), evProc);

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -498,6 +498,12 @@ void PCEventMailbox::enqueue(Event::const_ptr ev) {
 		assert(false);
 	}
 
+	proccontrol_printf("--------- Enqueue for Process ID [%d] -------------\n", evProc->getPid());
+	for(auto const& p : procCount) {
+		proccontrol_printf("\t%p -> %d\n", p.first, p.second);
+	}
+	proccontrol_printf("---------------------------------------------------\n");
+
     queueCond.broadcast();
 }
 
@@ -536,7 +542,13 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
     proccontrol_printf("%s[%d]: Returning event %s from mailbox for process %p\n",
     				   FILE__, __LINE__, event_ptr->name().c_str(), evProc);
 
-    return ret;
+	proccontrol_printf("--------- Dequeue for Process ID [%d] -------------\n", evProc->getPid());
+	for(auto const& p : procCount) {
+		proccontrol_printf("\t%p -> %d\n", p.first, p.second);
+	}
+	proccontrol_printf("---------------------------------------------------\n");
+
+	return event_ptr;
 }
 
 unsigned int PCEventMailbox::size() {

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -560,5 +560,9 @@ unsigned int PCEventMailbox::size() {
 }
 
 bool PCEventMailbox::find(PCProcess *proc) {
-   return (procCount[proc] > 0);
+   auto it = procCount.find(proc);
+   if(it != procCount.end()) {
+	   return it->second > 0;
+   }
+   return false;
 }

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -511,7 +511,7 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
 	std::lock_guard<CondVar<>> l{queueCond};
 
     if(!block && eventQueue.empty()) {
-        return Event::const_ptr();
+        return Event::const_ptr{};
     }
 
     while( eventQueue.empty() ) {

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -81,8 +81,12 @@ PCEventMuxer::WaitResult PCEventMuxer::wait_internal(bool block) {
    proccontrol_printf("[%s/%d]: PCEventMuxer waiting for events, %s\n",
                       FILE__, __LINE__, (block ? "blocking" : "non-blocking"));
    if (!block) {
-      Process::handleEvents(false);
-      proccontrol_printf("[%s:%d] after PC event handling, %d events in mailbox\n", FILE__, __LINE__, mailbox_.size());
+	  const bool err = !Process::handleEvents(false);
+	  const bool no_events = ProcControlAPI::getLastError() == err_noevents;
+      if(err && !no_events) {
+    	  proccontrol_printf("[%s:%d] PC event handling failed\n", FILE__, __LINE__);
+    	  return Error;
+      }
       if (mailbox_.size() == 0) return NoEvents;
       if (!handle(NULL)) {
          proccontrol_printf("[%s:%d] Failed to handle event, returning error\n", FILE__, __LINE__);

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -116,6 +116,7 @@ PCEventMuxer::WaitResult PCEventMuxer::wait_internal(bool block) {
     	 proccontrol_printf("[%s:%d] PC event handling failed\n", FILE__, __LINE__);
     	 return Error;
      }
+     proccontrol_printf("[%s:%d] PC event handling completed\n", FILE__, __LINE__);
      return EventsReceived;
    }
    proccontrol_printf("[%s:%u] - PCEventMuxer::wait is returning\n", FILE__, __LINE__);

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -112,7 +112,10 @@ PCEventMuxer::WaitResult PCEventMuxer::wait_internal(bool block) {
        }
      }
      proccontrol_printf("[%s:%d] after PC event handling, %d events in mailbox\n", FILE__, __LINE__, mailbox_.size());
-     if (!handle(NULL)) return Error;
+     if (!handle(NULL)) {
+    	 proccontrol_printf("[%s:%d] PC event handling failed\n", FILE__, __LINE__);
+    	 return Error;
+     }
      return EventsReceived;
    }
    proccontrol_printf("[%s:%u] - PCEventMuxer::wait is returning\n", FILE__, __LINE__);

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -489,9 +489,9 @@ void PCEventMailbox::enqueue(Event::const_ptr ev) {
 	if(evProc) {
 	    // Only add the event to the queue if the underlying process is still valid
 	    eventQueue.push(ev);
-	    procCount[evProc]++;
-		proccontrol_printf("%s[%d]: Added event %s from process %p to mailbox, size now %d\n",
-						   FILE__, __LINE__, ev->name().c_str(), evProc, eventQueue.size());
+	    procCount[evProc->getPid()]++;
+		proccontrol_printf("%s[%d]: Added event %s from process %d to mailbox, size now %d\n",
+						   FILE__, __LINE__, ev->name().c_str(), evProc->getPid(), eventQueue.size());
 	} else {
 		proccontrol_printf("%s[%d]: Got bad process: event %s not added\n",
 						   FILE__, __LINE__, ev->name().c_str());
@@ -546,10 +546,10 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
 			assert(false);
 		}
 	}
-	procCount[evProc]--;
-	assert(procCount[evProc] >= 0);
-    proccontrol_printf("%s[%d]: Returning event %s from mailbox for process %p\n",
-    				   FILE__, __LINE__, event_ptr->name().c_str(), evProc);
+	procCount[evProc->getPid()]--;
+	assert(procCount[evProc->getPid()] >= 0);
+    proccontrol_printf("%s[%d]: Returning event %s from mailbox for process %d\n",
+    				   FILE__, __LINE__, event_ptr->name().c_str(), evProc->getPid());
 
 	proccontrol_printf("--------- Dequeue for Process ID [%d] -------------\n", evProc->getPid());
 	for(auto const& p : procCount) {
@@ -569,9 +569,9 @@ unsigned int PCEventMailbox::size() {
 }
 
 bool PCEventMailbox::find(PCProcess *proc) {
-   proccontrol_printf("Calling find for process %p\n", proc);
+   proccontrol_printf("Calling find for process %p (%d)\n", proc, proc->getPid());
    assert(proc != nullptr);
-   auto it = procCount.find(proc);
+   auto it = procCount.find(proc->getPid());
    if(it != procCount.end()) {
 	   return it->second > 0;
    }

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -87,7 +87,10 @@ PCEventMuxer::WaitResult PCEventMuxer::wait_internal(bool block) {
     	  proccontrol_printf("[%s:%d] PC event handling failed\n", FILE__, __LINE__);
     	  return Error;
       }
-      if (mailbox_.size() == 0) return NoEvents;
+      if (mailbox_.size() == 0) {
+    	  proccontrol_printf("[%s:%d] The mailbox is empty\n", FILE__, __LINE__);
+    	  return NoEvents;
+      }
       if (!handle(NULL)) {
          proccontrol_printf("[%s:%d] Failed to handle event, returning error\n", FILE__, __LINE__);
          return Error;

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -487,11 +487,11 @@ void PCEventMailbox::enqueue(Event::const_ptr ev) {
     eventQueue.push(ev);
     PCProcess *evProc = static_cast<PCProcess *>(ev->getProcess()->getData());
     if(evProc) procCount[evProc]++;
-    queueCond.broadcast();
 
     proccontrol_printf("%s[%d]: Added event %s from process %p to mailbox, size now %d\n",
     				   FILE__, __LINE__, ev->name().c_str(), evProc, eventQueue.size());
-    
+
+    queueCond.broadcast();
 }
 
 Event::const_ptr PCEventMailbox::dequeue(bool block) {

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -561,6 +561,7 @@ unsigned int PCEventMailbox::size() {
 
 bool PCEventMailbox::find(PCProcess *proc) {
    proccontrol_printf("Calling find for process %p\n", proc);
+   assert(proc != nullptr);
    auto it = procCount.find(proc);
    if(it != procCount.end()) {
 	   return it->second > 0;

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -99,7 +99,6 @@ PCEventMuxer::WaitResult PCEventMuxer::wait_internal(bool block) {
     		  	  FILE__, __LINE__, mailbox_.size());
       return EventsReceived;
    }
-   else {
       // It's really annoying from a user design POV that ProcControl methods can
       // trigger callbacks; it means that we can't just block here, because we may
       // have _already_ gotten a callback and just not finished processing...
@@ -118,9 +117,6 @@ PCEventMuxer::WaitResult PCEventMuxer::wait_internal(bool block) {
      }
      proccontrol_printf("[%s:%d] PC event handling completed\n", FILE__, __LINE__);
      return EventsReceived;
-   }
-   proccontrol_printf("[%s:%u] - PCEventMuxer::wait is returning\n", FILE__, __LINE__);
-   return NoEvents;
 }
 
 bool PCEventMuxer::handle_internal(PCProcess *proc) {

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -477,7 +477,7 @@ void PCEventMailbox::enqueue(Event::const_ptr ev) {
     queueCond.lock();
     eventQueue.push(ev);
     PCProcess *evProc = static_cast<PCProcess *>(ev->getProcess()->getData());
-    procCount[evProc]++;
+    if(evProc) procCount[evProc]++;
     queueCond.broadcast();
 
     proccontrol_printf("%s[%d]: Added event %s to mailbox, size now %d\n", FILE__, __LINE__,

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -41,7 +41,6 @@
 #include "Mailbox.h"
 #include "PCErrors.h"
 
-#include <set>
 #include <queue>
 #include <vector>
 

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -92,9 +92,11 @@ PCEventMuxer::WaitResult PCEventMuxer::wait_internal(bool block) {
     	  return NoEvents;
       }
       if (!handle(NULL)) {
-         proccontrol_printf("[%s:%d] Failed to handle event, returning error\n", FILE__, __LINE__);
+         proccontrol_printf("[%s:%d] Failed to handle event\n", FILE__, __LINE__);
          return Error;
       }
+      proccontrol_printf("[%s:%d] PC event handling completed; mailbox size is %d\n",
+    		  	  FILE__, __LINE__, mailbox_.size());
       return EventsReceived;
    }
    else {

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -510,7 +510,7 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
 	 */
 	std::lock_guard<CondVar<>> l{queueCond};
 
-    if( eventQueue.empty() && !block ) {
+    if(!block && eventQueue.empty()) {
         return Event::const_ptr();
     }
 

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -511,7 +511,8 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
 	std::lock_guard<CondVar<>> l{queueCond};
 
     if(!block && eventQueue.empty()) {
-        return Event::const_ptr{};
+		proccontrol_printf("%s[%d]: Event queue is empty, but not blocking\n", FILE__, __LINE__);
+		return Event::const_ptr{};
     }
 
     while( eventQueue.empty() ) {

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -480,8 +480,8 @@ void PCEventMailbox::enqueue(Event::const_ptr ev) {
     if(evProc) procCount[evProc]++;
     queueCond.broadcast();
 
-    proccontrol_printf("%s[%d]: Added event %s to mailbox, size now %d\n", FILE__, __LINE__,
-                       ev->name().c_str(), eventQueue.size());
+    proccontrol_printf("%s[%d]: Added event %s from process %p to mailbox, size now %d\n",
+    				   FILE__, __LINE__, ev->name().c_str(), evProc, eventQueue.size());
     
     queueCond.unlock();
 }
@@ -506,7 +506,8 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
     assert(procCount[evProc] >= 0);
     queueCond.unlock();
 
-    proccontrol_printf("%s[%d]: Returning event %s from mailbox\n", FILE__, __LINE__, ret->name().c_str());
+    proccontrol_printf("%s[%d]: Returning event %s for process %p from mailbox\n",
+    				   FILE__, __LINE__, ret->name().c_str(), evProc);
     return ret;
 }
 

--- a/dyninstAPI/src/pcEventMuxer.h
+++ b/dyninstAPI/src/pcEventMuxer.h
@@ -39,7 +39,6 @@
 #include "dyninstAPI/src/syscallNotification.h"
 
 #include <queue>
-#include <set>
 /*
  * Overall design comment
  * 

--- a/dyninstAPI/src/pcEventMuxer.h
+++ b/dyninstAPI/src/pcEventMuxer.h
@@ -82,7 +82,7 @@ public:
     bool find(PCProcess *proc);
 
 protected:
-    std::map<PCProcess *, int> procCount;
+    std::map<int, int> procCount;
     std::queue<ProcControlAPI::Event::const_ptr> eventQueue;
     CondVar<> queueCond;
 };


### PR DESCRIPTION
This cleans up handling of events from the mailbox (event queue) used to communicate between Dyninst and proccontrol.

This is rebased on #742
Closes #741