### PR TITLE
Fix Variable location parsing

### DIFF
--- a/dwarf/src/dwarfHandle.C
+++ b/dwarf/src/dwarfHandle.C
@@ -29,6 +29,7 @@
  */
 
 #include "elfutils/libdw.h"
+#include "elfutils/libdwfl.h"
 #include "Elf_X.h"
 #include "dwarfHandle.h"
 #include "dwarfFrameParser.h"
@@ -49,6 +50,13 @@ using namespace std;
 #if !defined(EM_AARCH64)
 #define EM_AARCH64 183
 #endif
+
+static const Dwfl_Callbacks dwfl_callbacks =
+{
+    .find_elf = dwfl_build_id_find_elf,
+    .find_debuginfo = dwfl_standard_find_debuginfo,
+    .section_address = dwfl_offline_section_address,
+};
 
 /*void DwarfHandle::defaultDwarfError(Dwarf_Error err, Dwarf_Ptr p) {
   dwarf_dealloc(*(Dwarf*)(p), err, DW_DLA_ERROR);
@@ -80,6 +88,7 @@ void DwarfHandle::locate_dbg_file()
     bool result = file->findDebugFile(filename, debug_filename, buffer, buffer_size);
     if (!result)
         return;
+
     dbg_file = Elf_X::newElf_X(buffer, buffer_size, debug_filename);
     if (!dbg_file->isValid()) {
         dwarf_printf("Invalid ELF file for debug info: %s\n", debug_filename.c_str());
@@ -100,7 +109,15 @@ bool DwarfHandle::init_dbg()
         return false;
     }
 
-    file_data = dwarf_begin_elf(file->e_elfp(), DWARF_C_READ, NULL);
+    /* Create a one elf module file Dwfl. */
+    const char *base = basename (filename.c_str());
+    Dwfl *dwfl = dwfl_begin (&dwfl_callbacks);
+    dwfl_report_begin (dwfl);
+    Dwfl_Module *mod = dwfl_report_elf (dwfl, base, filename.c_str(), -1, 0, true);
+    dwfl_report_end (dwfl, NULL, NULL);
+
+    Dwarf_Addr bias;
+    file_data = dwfl_module_getdwarf(mod, &bias);
 
     //if (!file_data /*&& errno==0*/ )  {
     //    init_dwarf_status = dwarf_status_error;
@@ -108,9 +125,18 @@ bool DwarfHandle::init_dbg()
 
 
     if (dbg_file) {
-        dbg_file_data = dwarf_begin_elf(dbg_file->e_elfp(), DWARF_C_READ, NULL); 
         //status = dwarf_elf_init(dbg_file->e_elfp(), DW_DLC_READ,
         //        err_func, &dbg_file_data, &dbg_file_data, &err);
+
+        /* Create a one elf module file Dwfl. */
+        const char *base = basename (debug_filename.c_str());
+        Dwfl *dwfl = dwfl_begin (&dwfl_callbacks);
+        dwfl_report_begin (dwfl);
+        Dwfl_Module *mod = dwfl_report_elf (dwfl, base, debug_filename.c_str(), -1, 0, true);
+        dwfl_report_end (dwfl, NULL, NULL);
+
+        Dwarf_Addr bias;
+        dbg_file_data = dwfl_module_getdwarf(mod, &bias);
 
         if (!dbg_file_data) {
             init_dwarf_status = dwarf_status_error;

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -1785,10 +1785,16 @@ bool DwarfWalker::decodeLocationList(Dwarf_Half attr,
         std::vector<LocDesc> locDescs;
         ptrdiff_t offset = 0;
         Dwarf_Addr basep, start, end;
+
         do {
             offset = dwarf_getlocations(&locationAttribute, offset, &basep,
                     &start, &end, &exprs, &exprlen);
-            if(offset==-1) return false;
+            if(offset==-1){
+                cerr << "err message: " << dwarf_errmsg(dwarf_errno()) << endl;
+                return false;
+            }
+            if(offset==0) break;
+
             LocDesc ld;
             ld.ld_lopc = start;
             ld.ld_hipc = end;


### PR DESCRIPTION
Start using elfutils' libdwfl to open binaries with dwarf data.
This fixes dwarf variable location parsing for relocatable objects.