### PR TITLE
Improve detection of ghost threads

### DIFF
--- a/proccontrol/src/int_process.h
+++ b/proccontrol/src/int_process.h
@@ -997,7 +997,7 @@ public:
    virtual bool plat_setRegisterAsync(Dyninst::MachRegister reg,
                                       Dyninst::MachRegisterVal val,
                                       result_response::ptr result);
-   virtual void plat_handle_ghost_thread();
+   virtual bool plat_handle_ghost_thread();
    virtual void plat_terminate();
 
    void updateRegCache(int_registerPool &pool);

--- a/proccontrol/src/linux.h
+++ b/proccontrol/src/linux.h
@@ -222,7 +222,7 @@ class linux_thread : virtual public thread_db_thread
    virtual bool thrdb_getThreadArea(int val, Dyninst::Address &addr);
    virtual bool plat_convertToSystemRegs(const int_registerPool &pool, unsigned char *regs, bool gprs_only = false);
 
-   virtual void plat_handle_ghost_thread();
+   virtual bool plat_handle_ghost_thread();
    void setOptions();
    bool unsetOptions();
    bool getSegmentBase(Dyninst::MachRegister reg, Dyninst::MachRegisterVal &val);

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -2525,8 +2525,9 @@ bool indep_lwp_control_process::plat_syncRunState()
       }
       if (!result && getLastError() == err_exited) {
     	  pthrd_printf("Suppressing error of continue/stop on exited process\n");
-    	  thr->plat_handle_ghost_thread();
-    	  thr->getHandlerState().setState(int_thread::running);
+    	  if(thr->plat_handle_ghost_thread()) {
+    		  thr->getHandlerState().setState(int_thread::running);
+    	  }
       }
       else if (!result) {
          pthrd_printf("Error changing process state from plat_syncRunState\n");
@@ -3989,7 +3990,7 @@ bool int_thread::plat_setRegisterAsync(Dyninst::MachRegister,
    return false;
 }
 
-void int_thread::plat_handle_ghost_thread() {}
+bool int_thread::plat_handle_ghost_thread() { return true; }
 
 void int_thread::addPostedRPC(int_iRPC::ptr rpc_)
 {


### PR DESCRIPTION
Change plat_handle_ghost_thread to return 'bool' (see #742).

This indicates if the thread is actually a ghost or not. This can happen
because ptrace returned ESRCH (no such process) in
LinuxPtrace::ptrace_int, yet the process is alive. This is a valid state
for ptrace, but ptrace_int doesn't check for this. The ptrace man-page
indicates that this can happen when a process received a STOP signal,
but it hasn't transitioned to the new state yet.