### PR TITLE
Add include for Elf_X in emitElf.h

### DIFF
--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -33,6 +33,7 @@
 
 #include "Object.h"
 #include "debug.h"
+#include "Elf_X.h"
 #include <iostream>
 
 #include <unordered_map>


### PR DESCRIPTION
This is transitively included (somehow), but it's best to include it
directly both for completeness and for IDEs.