### PR TITLE
Fix memory leak of AddressSpace::patcher_

### DIFF
--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -88,8 +88,7 @@ AddressSpace::AddressSpace () :
     memEmulator_(NULL),
     emulateMem_(false),
     emulatePC_(false),
-    delayRelocation_(false),
-    patcher_(NULL)
+    delayRelocation_(false)
 {
 #if 0
    // Disabled for now; used by defensive mode

--- a/dyninstAPI/src/addressSpace.h
+++ b/dyninstAPI/src/addressSpace.h
@@ -565,14 +565,14 @@ class AddressSpace : public InstructionSource {
   public:
     Dyninst::PatchAPI::PatchMgrPtr mgr() const { assert(mgr_); return mgr_; }
     void setMgr(Dyninst::PatchAPI::PatchMgrPtr m) { mgr_ = m; }
-    void setPatcher(Dyninst::PatchAPI::Patcher* p) { patcher_ = p; }
+    void setPatcher(Dyninst::PatchAPI::Patcher::Ptr p) { patcher_ = p; }
     void initPatchAPI();
     void addMappedObject(mapped_object* obj);
-    Dyninst::PatchAPI::Patcher* patcher() { return patcher_; }
+    Dyninst::PatchAPI::Patcher::Ptr patcher() { return patcher_; }
     static bool patch(AddressSpace*);
   protected:
     Dyninst::PatchAPI::PatchMgrPtr mgr_;
-    Dyninst::PatchAPI::Patcher* patcher_;
+    Dyninst::PatchAPI::Patcher::Ptr patcher_;
 };
 
 

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -309,7 +309,7 @@ void BinaryEdit::deleteBinaryEdit() {
 
 BinaryEdit *BinaryEdit::openFile(const std::string &file, 
                                  PatchMgrPtr mgr, 
-                                 Dyninst::PatchAPI::Patcher *patch,
+                                 Dyninst::PatchAPI::Patcher::Ptr patch,
                                  const std::string &member) {
     if (!OS::executableExists(file)) {
         startup_printf("%s[%d]:  failed to read file %s\n", FILE__, __LINE__, file.c_str());

--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -144,7 +144,7 @@ class BinaryEdit : public AddressSpace {
     // And the "open" factory method.
     static BinaryEdit *openFile(const std::string &file,
                                 Dyninst::PatchAPI::PatchMgrPtr mgr = Dyninst::PatchAPI::PatchMgrPtr(),
-                                Dyninst::PatchAPI::Patcher *patch = NULL,
+                                Dyninst::PatchAPI::Patcher::Ptr patch = Dyninst::PatchAPI::Patcher::Ptr(),
                                 const std::string &member = "");
 
     bool writeFile(const std::string &newFileName);

--- a/patchAPI/h/Command.h
+++ b/patchAPI/h/Command.h
@@ -81,8 +81,9 @@ class PATCHAPI_EXPORT BatchCommand : public Command {
 
 class PATCHAPI_EXPORT Patcher : public BatchCommand {
   public:
-   static Patcher* create(Dyninst::PatchAPI::PatchMgrPtr mgr) {
-      return new Patcher(mgr);
+   using Ptr = boost::shared_ptr<Patcher>;
+   static Ptr create(Dyninst::PatchAPI::PatchMgrPtr mgr) {
+      return boost::make_shared<Patcher>(mgr);
     }
     Patcher(Dyninst::PatchAPI::PatchMgrPtr mgr) : mgr_(mgr) {}
     virtual ~Patcher() {}


### PR DESCRIPTION
This was originally part of https://github.com/dyninst/dyninst/pull/317.
This is an API-breaking change since AddressSpace is exported through the BPatch interface.