### PR TITLE
Remove AddressSpace::getAddressWidth from public API

### DIFF
--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -2325,3 +2325,12 @@ bool uninstrument(Dyninst::PatchAPI::Instance::Ptr inst) {
    return true;
 
 }
+
+
+unsigned AddressSpace::getAddressWidth() const {
+    if( mapped_objects.size() > 0 ) {
+        return mapped_objects[0]->parse_img()->codeObject()->cs()->getAddressWidth();
+    }
+    // We can call this before we've attached...best effort guess
+    return sizeof(Address);
+}

--- a/dyninstAPI/src/addressSpace.h
+++ b/dyninstAPI/src/addressSpace.h
@@ -192,7 +192,7 @@ class AddressSpace : public InstructionSource {
     virtual bool isValidAddress(const Address) const;
     virtual void *getPtrToInstruction(const Address) const;
     virtual void *getPtrToData(const Address a) const { return getPtrToInstruction(a); }
-    virtual unsigned getAddressWidth() const = 0;
+
     bool usesDataLoadAddress() const; // OS-specific
     virtual bool isCode(const Address) const;
     virtual bool isData(const Address) const;
@@ -367,6 +367,8 @@ class AddressSpace : public InstructionSource {
     bool needsPIC(int_variable *v); 
     bool needsPIC(func_instance *f);
     bool needsPIC(AddressSpace *s);
+    
+    unsigned getAddressWidth() const;
     
     //////////////////////////////////////////////////////
     // BPatch-level stuff

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -255,10 +255,6 @@ Architecture BinaryEdit::getArch() const {
   return mapped_objects[0]->parse_img()->codeObject()->cs()->getArch();
 }
 
-unsigned BinaryEdit::getAddressWidth() const {
-  assert(!mapped_objects.empty());
-  return mapped_objects[0]->parse_img()->codeObject()->cs()->getAddressWidth();
-}
 Address BinaryEdit::offset() const {
     fprintf(stderr,"error BinaryEdit::offset() unimpl\n");
     return 0;

--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -100,8 +100,6 @@ class BinaryEdit : public AddressSpace {
     virtual void inferiorFree(Address item);
     virtual bool inferiorRealloc(Address item, unsigned newSize);
 
-    /* AddressSpace pure virtual implementation */
-    unsigned getAddressWidth() const;
     Address offset() const;
     Address length() const;
     Architecture getArch() const;

--- a/dyninstAPI/src/dynProcess.C
+++ b/dyninstAPI/src/dynProcess.C
@@ -1522,15 +1522,6 @@ int PCProcess::incrementThreadIndex() {
     return ret;
 }
 
-unsigned PCProcess::getAddressWidth() const {
-    if( mapped_objects.size() > 0 ) {
-        return mapped_objects[0]->parse_img()->codeObject()->cs()->getAddressWidth();
-    }
-
-    // We can call this before we've attached...best effort guess
-    return sizeof(Address);
-}
-
 PCEventHandler * PCProcess::getPCEventHandler() const {
     return eventHandler_;
 }

--- a/dyninstAPI/src/dynProcess.h
+++ b/dyninstAPI/src/dynProcess.h
@@ -154,7 +154,7 @@ public:
     bool removeThread(dynthread_t tid);
 
     int getPid() const;
-    unsigned getAddressWidth() const;
+
     bool wasRunningWhenAttached() const;
     bool wasCreatedViaAttach() const;
     bool wasCreatedViaFork() const;


### PR DESCRIPTION
This was originally part of https://github.com/dyninst/dyninst/pull/317.

@wrwilliams Could you provide some rationale why this was done? It's a fairly blunt change since both `PCProcess` and `BinaryEdit` are part of the public API. Also, there are other examples where this kind of transformation could be applied: `common/SymReader` and `ParseAPI/InstructionSource`, for example. Should this kind of refactoring be propagated elsewhere?