### PR TITLE
Make ~DynObject virtual

### DIFF
--- a/dyninstAPI/src/Relocation/DynObject.h
+++ b/dyninstAPI/src/Relocation/DynObject.h
@@ -49,7 +49,7 @@ class DynObject : public PatchObject {
     }
     DynObject(ParseAPI::CodeObject* co, AddressSpace* as, Address base);
     DynObject(const DynObject *par_obj, AddressSpace* child, Address base);
-    ~DynObject();
+    virtual ~DynObject();
 
     // Getters
     AddressSpace* as() const { return as_; }


### PR DESCRIPTION
This is base class for dyninstAPI/mapped_object, so it should have a
virtual destructor.

Fixes #802 