### PR TITLE
Fix cmake configuration with -pie

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,6 @@ foreach (dir ${HEADER_DIRS})
   include_directories ( ${DYNINST_ROOT}/${dir}/h )
 endforeach()
 
-set(DYNINST_RT_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-set(DYNINST_RT_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-
 set(ADD_VALGRIND_ANNOTATIONS OFF CACHE BOOL "Enable annotations for Valgrind analysis")
 if(ADD_VALGRIND_ANNOTATIONS)
   find_package(Valgrind REQUIRED)

--- a/dyninstAPI_RT/CMakeLists.txt
+++ b/dyninstAPI_RT/CMakeLists.txt
@@ -3,8 +3,6 @@ cmake_minimum_required (VERSION 2.6.4)
 project (DyninstRT C)
 
 set (DYNINST_ROOT ${PROJECT_SOURCE_DIR}/..)
-set(CMAKE_C_FLAGS "${DYNINST_RT_CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "${DYNINST_RT_CMAKE_CXX_FLAGS}")
 
 include (${DYNINST_ROOT}/cmake/shared.cmake)
 


### PR DESCRIPTION
Remove DYNINST_RT_CMAKE_C_FLAGS which causes a mismatch when configuring dyninstAPI_RT with -pie

This is just the minimum patch.  It builds and links with the standard *_FLAGS.  I wonder about the if(BUILD_RTLIB)
loop step to allow building with a separate compiler.  I cannot foresee a situation on Linux where doing that is advantageous.