### PR TITLE
Undeprecate mapped_object::getBaseAddress

### DIFF
--- a/dyninstAPI/src/mapped_object.h
+++ b/dyninstAPI/src/mapped_object.h
@@ -183,7 +183,6 @@ class mapped_object : public codeRange, public Dyninst::PatchAPI::DynObject {
     bool isCode(Address addr) const;
     bool isData(Address addr) const;
 
-    // Deprecated...
     Address getBaseAddress() const { return codeBase(); }
 
     Address dataAbs() const;


### PR DESCRIPTION
This was deprecated in 8442d36 in 2005. No reason was given, and it's being used in dyninstAPI/src/dynProcess.C:669.

closes #823 