### PR TITLE
Remove deprecated members of BPatch_flowGraph

### DIFF
--- a/dyninstAPI/h/BPatch_flowGraph.h
+++ b/dyninstAPI/h/BPatch_flowGraph.h
@@ -93,7 +93,6 @@ public:
   BPatch_basicBlock *findBlock(block_instance *b);
   BPatch_edge *findEdge(edge_instance *e);
   void invalidate(); // invoked when additional parsing takes place
-  //  End of deprecated function
 
   //  Functions for use by Dyninst users
 
@@ -144,16 +143,8 @@ public:
 
   BPatch_basicBlockLoop * findLoop(const char *name);
 
-  // Deprecated - this should not be an API method
-  //void, initLivenessInfo();
-
   bool isValid(); 
 
-  /*
-  BPatch_point * createInstPointAtEdge(BPatch_edge *edge);
-  */
-  // Deprecated... use BPatch_edge->point() instead
-  
   /** find instrumentation points specified by loc, add to points*/
   BPatch_Vector<BPatch_point*> * 
       findLoopInstPoints(const BPatch_procedureLocation loc, 


### PR DESCRIPTION
This was deprecated in 71c302f in 2005. The code was commented out instead of being removed.