### PR TITLE
Remove deprecated BPatch_process::enableDumpPatchedImage

### DIFF
--- a/dyninstAPI/h/BPatch_process.h
+++ b/dyninstAPI/h/BPatch_process.h
@@ -459,10 +459,6 @@ class BPATCH_DLL_EXPORT BPatch_process : public BPatch_addressSpace {
 #if 0
   void  printDefensiveStats();
 #endif
-  //  BPatch_process::enableDumpPatchedImage
-  //  
-  //  
-  void enableDumpPatchedImage();
 
 #ifdef IBM_BPATCH_COMPAT
   bool addSharedObject(const char *name, const unsigned long loadaddr);

--- a/dyninstAPI/src/BPatch_process.C
+++ b/dyninstAPI/src/BPatch_process.C
@@ -1077,11 +1077,6 @@ BPatch_object *BPatch_process::loadLibrary(const char *libname, bool)
    return object;
 }
 
-
-void BPatch_process::enableDumpPatchedImage(){
-    // deprecated; saveTheWorld is dead. Do nothing for now; kill later.
-}
-
 void BPatch_process::setExitedViaSignal(int signalnumber)
 {
    exitedViaSignal = true;


### PR DESCRIPTION
This was deprecated by 4d83371 in 2011.

closes #825 