### PR TITLE
Remove deprecated BPatch_snippet::getCost*

### DIFF
--- a/dyninstAPI/h/BPatch_snippet.h
+++ b/dyninstAPI/h/BPatch_snippet.h
@@ -173,16 +173,6 @@ class BPATCH_DLL_EXPORT BPatch_snippet {
     
     virtual ~BPatch_snippet();
 
-    //  BPatch_snippet::getCost
-    //  Returns an estimated cost of executing the snippet, in seconds.
-
-    float getCost();
-
-    //  BPatch_snippet::getCostAtPoint
-    //  Returns an estimated cost of executing the snippet at a specified point, in seconds.
-
-    float getCostAtPoint(BPatch_point *pt);
-
     //  BPatch_snippet::is_trivial
     //  allows users to check to see if
     //  a snippet operation failed (leaving ast NULL)

--- a/dyninstAPI/src/BPatch_snippet.C
+++ b/dyninstAPI/src/BPatch_snippet.C
@@ -133,25 +133,6 @@ BPatch_type *BPatch_snippet::getType(){
    return ast_wrapper->getType();
 }
 
-/*
- * BPatch_snippet:getCost
- *
- * Deprecated.
- */
-float BPatch_snippet::getCost()
-{
-    return 0.0;
-}
-/*
- * BPatch_snippet:getCostAtPoint
- *
- * Deprecated.
- */
-float BPatch_snippet::getCostAtPoint(BPatch_point *)
-{
-    return 0.0;
-}
-
 bool BPatch_snippet::is_trivial()
 {
   return (ast_wrapper == NULL);


### PR DESCRIPTION
These were deprecated by 52f3437 in 2010.

closes #824 