### PR TITLE
Fix memory leak in singleton_object_pool

### DIFF
--- a/common/src/singleton_object_pool.h
+++ b/common/src/singleton_object_pool.h
@@ -57,6 +57,7 @@ public:
     static void destroy(typename Alloc::pointer p)
     {
         Alloc().destroy(p);
+        deallocate(p);
     };
 
 };

--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -97,7 +97,7 @@ namespace Dyninst {
         InstructionDecoder_aarch64::InstructionDecoder_aarch64(Architecture a)
                 : InstructionDecoderImpl(a), isPstateRead(false), isPstateWritten(false), isFPInsn(false),
                   isSIMDInsn(false), skipRn(false), skipRm(false),
-                  is64Bit(true), isValid(true), insn(0), insn_in_progress(NULL),
+                  is64Bit(true), isValid(true), insn(0),
                   hasHw(false), hasShift(false), hasOption(false), hasN(false),
                   immr(0), immrLen(0), sField(0), nField(0), nLen(0),
                   immlo(0), immloLen(0), _szField(-1), size(-1),
@@ -163,7 +163,7 @@ namespace Dyninst {
             mainDecode();
             b.start += 4;
 
-            return *insn_in_progress;
+            return *(insn_in_progress.get());
         }
 
         /* replace this function with a more generic function, which is setRegWidth
@@ -2941,7 +2941,6 @@ Expression::Ptr InstructionDecoder_aarch64::makeMemRefExPair2(){
                 : aarch64_insn_entry::main_insn_table[0];
 
             insn = insn_to_complete->m_RawInsn.small_insn;
-            insn_in_progress = const_cast<Instruction *>(insn_to_complete);
 
             if (IS_INSN_LDST_REG(insn) ||
                 IS_INSN_ADDSUB_EXT(insn) ||
@@ -3032,7 +3031,7 @@ Expression::Ptr InstructionDecoder_aarch64::makeMemRefExPair2(){
             modify_mnemonic_simd_upperhalf_insns();
 
             if (IS_INSN_BRANCHING(insn)) {
-                decodeOperands(insn_in_progress);
+                decodeOperands(insn_in_progress.get());
             }
 
             insn_in_progress->arch_decoded_from = Arch_aarch64;

--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -2898,7 +2898,10 @@ Expression::Ptr InstructionDecoder_aarch64::makeMemRefExPair2(){
             InstructionDecoder::buffer b(insn_to_complete->ptr(), insn_to_complete->size());
             //insn_to_complete->m_Operands.reserve(4);
             decode(b);
-            decodeOperands(insn_to_complete);
+            decodeOperands(insn_in_progress.get());
+
+            Instruction* iptr = const_cast<Instruction*>(insn_to_complete);
+            *iptr = *(insn_in_progress.get());
         }
 
         bool InstructionDecoder_aarch64::pre_process_checks(const aarch64_insn_entry &entry) {

--- a/instructionAPI/src/InstructionDecoder-aarch64.h
+++ b/instructionAPI/src/InstructionDecoder-aarch64.h
@@ -168,7 +168,7 @@ namespace Dyninst {
             void reorderOperands();
 
             unsigned int insn;
-            Instruction *insn_in_progress;
+            boost::shared_ptr<Instruction> insn_in_progress;
 
             template<int start, int end>
             int field(unsigned int raw) {

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -98,7 +98,7 @@ namespace Dyninst
 
     InstructionDecoder_power::InstructionDecoder_power(Architecture a)
       : InstructionDecoderImpl(a),
-        insn(0), insn_in_progress(NULL),
+        insn(0),
 	isRAWritten(false), invertBranchCondition(false),
         isFPInsn(false), bcIsConditional(false)
     {
@@ -272,7 +272,7 @@ namespace Dyninst
 #endif
         mainDecode();
         b.start += 4;
-        return *insn_in_progress;
+        return *(insn_in_progress.get());
     }
 
     bool InstructionDecoder_power::decodeOperands(const Instruction*)
@@ -843,7 +843,6 @@ namespace Dyninst
 	if (findRAAndRS(current)) {
 	    isRAWritten = true;
 	}
-        insn_in_progress = const_cast<Instruction*>(insn_to_complete);
         if(current->op == power_op_b ||
            current->op == power_op_bc ||
            current->op == power_op_bclr ||
@@ -1433,7 +1432,7 @@ using namespace boost::assign;
           current->op == power_op_bcctr)
         {
             // decode control-flow operands immediately; we're all but guaranteed to need them
-            doDelayedDecode(insn_in_progress);
+            doDelayedDecode(insn_in_progress.get());
         }
 	// FIXME in parsing
         insn_in_progress->arch_decoded_from = m_Arch;

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -275,10 +275,78 @@ namespace Dyninst
         return *(insn_in_progress.get());
     }
 
-    bool InstructionDecoder_power::decodeOperands(const Instruction*)
+    bool InstructionDecoder_power::decodeOperands(const Instruction* insn_to_complete)
     {
-      assert(!"not implemented");
-      return false;
+				/* Yuhan's notes for implementation
+					 For all instructions in opcode 60, the extended opcode is 21-29th bit.
+					 special case for opcode 60: (Opcode table on Page 1190)
+			  I. Decision Tree:
+				  (1) For XX4 format, the 26&27 bits are 1. (only for opcde "xxsel" P773)
+			    (2) Two special XX3 cases: 0..00 010.. & 0..01 010.., started from 21th bit. (manual 1208)
+				  (3) Other instruction are all implemented normally, 
+				    the "." bits are treated as 0 and 1 respectively in the opcode table
+				II. The Rc bit for opcode 60 is the 21st bit
+
+			   **	There are 2 XX1 instructions, the last bit of the extended opcodes are ignored (30th bit, which are both 0).
+				*/
+
+        isRAWritten = false;
+        isFPInsn = false;
+        bcIsConditional = false;
+        insn = insn_to_complete->m_RawInsn.small_insn;
+        const power_entry* current = &power_entry::main_opcode_table[field<0,5>(insn)];
+        while(current->next_table)
+        {
+            current = &(std::mem_fun(current->next_table)(this));
+        }
+	if (findRAAndRS(current)) {
+	    isRAWritten = true;
+	}
+        if(current->op == power_op_b ||
+           current->op == power_op_bc ||
+           current->op == power_op_bclr ||
+           current->op == power_op_bcctr)
+        {
+            insn_in_progress->appendOperand(makeRegisterExpression(ppc32::pc), false, true);
+        }
+        
+        for(operandSpec::const_iterator curFn = current->operands.begin();
+            curFn != current->operands.end();
+            ++curFn)
+        {
+            std::mem_fun(*curFn)(this);
+        }
+        if(current->op == power_op_bclr)
+        {
+	  // blrl is in practice a return-and-link, not a call-through-LR
+	  // so we'll treat it as such
+            insn_in_progress->addSuccessor(makeRegisterExpression(ppc32::lr),
+                                           /*field<31,31>(insn) == 1*/ false, true, 
+					   bcIsConditional, false);
+            if(bcIsConditional)
+            {
+                insn_in_progress->addSuccessor(makeFallThroughExpr(), false, false, false, true);
+            }
+        }
+        if(current->op == power_op_bcctr)
+        {
+            insn_in_progress->addSuccessor(makeRegisterExpression(ppc32::ctr),
+                                           field<31,31>(insn) == 1, true, bcIsConditional, false);
+            if(bcIsConditional)
+            {
+                insn_in_progress->addSuccessor(makeFallThroughExpr(), false, false, false, true);
+            }
+        }
+        if(current->op == power_op_addic_rc ||
+           current->op == power_op_andi_rc ||
+           current->op == power_op_andis_rc ||
+           current->op == power_op_stwcx_rc ||
+           current->op == power_op_stdcx_rc)
+        {
+            insn_in_progress->appendOperand(makeCR0Expr(), false, true);
+        }
+
+        return true;
     }
     void InstructionDecoder_power::OE()
     {
@@ -819,75 +887,11 @@ namespace Dyninst
     void InstructionDecoder_power::doDelayedDecode(const Instruction* insn_to_complete)
     {
 
-				/* Yuhan's notes for implementation
-					 For all instructions in opcode 60, the extended opcode is 21-29th bit.
-					 special case for opcode 60: (Opcode table on Page 1190)
-			  I. Decision Tree:
-				  (1) For XX4 format, the 26&27 bits are 1. (only for opcde "xxsel" P773)
-			    (2) Two special XX3 cases: 0..00 010.. & 0..01 010.., started from 21th bit. (manual 1208)
-				  (3) Other instruction are all implemented normally, 
-				    the "." bits are treated as 0 and 1 respectively in the opcode table
-				II. The Rc bit for opcode 60 is the 21st bit
+        insn_in_progress = boost::shared_ptr<Instruction>(new Instruction(*insn_to_complete));
+        decodeOperands(insn_in_progress.get());
+        Instruction* iptr = const_cast<Instruction*>(insn_to_complete);
+        *iptr = *(insn_in_progress.get());
 
-			   **	There are 2 XX1 instructions, the last bit of the extended opcodes are ignored (30th bit, which are both 0).
-				*/
-        isRAWritten = false;
-        isFPInsn = false;
-        bcIsConditional = false;
-        insn = insn_to_complete->m_RawInsn.small_insn;
-        const power_entry* current = &power_entry::main_opcode_table[field<0,5>(insn)];
-        while(current->next_table)
-        {
-            current = &(std::mem_fun(current->next_table)(this));
-        }
-	if (findRAAndRS(current)) {
-	    isRAWritten = true;
-	}
-        if(current->op == power_op_b ||
-           current->op == power_op_bc ||
-           current->op == power_op_bclr ||
-           current->op == power_op_bcctr)
-        {
-            insn_in_progress->appendOperand(makeRegisterExpression(ppc32::pc), false, true);
-        }
-        
-        for(operandSpec::const_iterator curFn = current->operands.begin();
-            curFn != current->operands.end();
-            ++curFn)
-        {
-            std::mem_fun(*curFn)(this);
-        }
-        if(current->op == power_op_bclr)
-        {
-	  // blrl is in practice a return-and-link, not a call-through-LR
-	  // so we'll treat it as such
-            insn_in_progress->addSuccessor(makeRegisterExpression(ppc32::lr),
-                                           /*field<31,31>(insn) == 1*/ false, true, 
-					   bcIsConditional, false);
-            if(bcIsConditional)
-            {
-                insn_in_progress->addSuccessor(makeFallThroughExpr(), false, false, false, true);
-            }
-        }
-        if(current->op == power_op_bcctr)
-        {
-            insn_in_progress->addSuccessor(makeRegisterExpression(ppc32::ctr),
-                                           field<31,31>(insn) == 1, true, bcIsConditional, false);
-            if(bcIsConditional)
-            {
-                insn_in_progress->addSuccessor(makeFallThroughExpr(), false, false, false, true);
-            }
-        }
-        if(current->op == power_op_addic_rc ||
-           current->op == power_op_andi_rc ||
-           current->op == power_op_andis_rc ||
-           current->op == power_op_stwcx_rc ||
-           current->op == power_op_stdcx_rc)
-        {
-            insn_in_progress->appendOperand(makeCR0Expr(), false, true);
-        }
-
-        return;
     }
     MachRegister InstructionDecoder_power::makePowerRegID(MachRegister base, unsigned int encoding, int field)
     {
@@ -1432,7 +1436,7 @@ using namespace boost::assign;
           current->op == power_op_bcctr)
         {
             // decode control-flow operands immediately; we're all but guaranteed to need them
-            doDelayedDecode(insn_in_progress.get());
+            decodeOperands(insn_in_progress.get());
         }
 	// FIXME in parsing
         insn_in_progress->arch_decoded_from = m_Arch;

--- a/instructionAPI/src/InstructionDecoder-power.h
+++ b/instructionAPI/src/InstructionDecoder-power.h
@@ -321,7 +321,7 @@ namespace Dyninst {
                 Expression::Ptr makeFallThroughExpr();
 
                 unsigned int insn;
-                Instruction* insn_in_progress;
+                boost::shared_ptr<Instruction> insn_in_progress;
                 bool isRAWritten;
                 bool invertBranchCondition;
                 bool isFPInsn;

--- a/instructionAPI/src/InstructionDecoderImpl.C
+++ b/instructionAPI/src/InstructionDecoderImpl.C
@@ -41,11 +41,11 @@ namespace Dyninst
 {
     namespace InstructionAPI
     {
-        Instruction* InstructionDecoderImpl::makeInstruction(entryID opcode, const char* mnem,
+        boost::shared_ptr<Instruction> InstructionDecoderImpl::makeInstruction(entryID opcode, const char* mnem,
             unsigned int decodedSize, const unsigned char* raw)
         {
             Operation tmp(opcode, mnem, m_Arch);
-            return singleton_object_pool<Instruction>::construct(tmp, decodedSize, raw, m_Arch);
+            return make_shared(singleton_object_pool<Instruction>::construct(tmp, decodedSize, raw, m_Arch));
         }
 
 

--- a/instructionAPI/src/InstructionDecoderImpl.h
+++ b/instructionAPI/src/InstructionDecoderImpl.h
@@ -71,7 +71,7 @@ class InstructionDecoderImpl
         virtual Expression::Ptr makeMaskRegisterExpression(MachRegister reg);
         virtual Expression::Ptr makeRegisterExpression(MachRegister reg, Result_Type extendFrom);
         virtual Result_Type makeSizeType(unsigned int opType) = 0;
-        Instruction* makeInstruction(entryID opcode, const char* mnem, unsigned int decodedSize,
+        boost::shared_ptr<Instruction> makeInstruction(entryID opcode, const char* mnem, unsigned int decodedSize,
                                      const unsigned char* raw);
       
     protected:


### PR DESCRIPTION
Two memory leak fixes related singleton_object_pool.

1. The singleon_object_pool currently only destructs objects but does not deallocate memory space. This leak applies to all architectures.

2. On ppc and arm, instruction decoder does not use smart pointers to manage InstructionAPI::Instruction constructed by a singleon_object_pool, and thus cause memory leaks.