### PR TITLE
Remove BPatch_addressSpace::findFunctionByAddr

### DIFF
--- a/dyninstAPI/h/BPatch_addressSpace.h
+++ b/dyninstAPI/h/BPatch_addressSpace.h
@@ -324,13 +324,6 @@ class BPATCH_DLL_EXPORT BPatch_addressSpace {
   statement_iter getAddressRanges_begin(const char* file, unsigned long line);
   statement_iter getAddressRanges_end(const char* file, unsigned long line);
 
-  //  DEPRECATED:
-  //  BPatch_addressSpace::findFunctionByAddr
-  //  
-  //  Returns the function containing an address
-
-  BPatch_function * findFunctionByAddr(void *addr);
-
   //  BPatch_addressSpace::findFunctionByEntry
   //  
   //  Returns the function starting at the given address

--- a/dyninstAPI/src/BPatch_addressSpace.C
+++ b/dyninstAPI/src/BPatch_addressSpace.C
@@ -682,44 +682,6 @@ BPatch_variableExpr *BPatch_addressSpace::createVariable(std::string name,
 }
 
 /*
- * BPatch_addressSpace::findFunctionByAddr
- *
- * Returns the function that contains the specified address, or NULL if the
- * address is not within a function.
- *
- * addr         The address to use for the lookup.
- */
-BPatch_function *BPatch_addressSpace::findFunctionByAddr(void *addr)
-{
-   std::vector<AddressSpace *> as;
-
-   getAS(as);
-   assert(as.size());
-   std::set<func_instance *> funcs;
-   if (!as[0]->findFuncsByAddr((Address) addr, funcs)) {
-      // if it's a mapped_object that has yet to be analyzed,
-      // trigger analysis and re-invoke this function
-       mapped_object *obj = as[0]->findObject((Address) addr);
-       if (obj &&
-           !obj->isAnalyzed()) {
-         obj->analyze();
-         return findFunctionByAddr(addr);
-      }
-      return NULL;
-   }
-   if (funcs.empty()) return NULL;
-
-   if (funcs.size() > 1) {
-       bpwarn("Warning: deprecated function findFunctionByAddr found "
-              "multiple functions sharing address 0x%lx, picking one at "
-              "random.  Use findFunctionByEntry or findFunctionsByAddr\n",
-              addr);
-   }
-
-   return findOrCreateBPFunc((*(funcs.begin())), NULL);
-}
-
-/*
  *  BPatch_addressSpace::findFunctionByEntry
  *
  *  Returns the function starting at the given address, or NULL if the

--- a/dyninstAPI/src/BPatch_frame.C
+++ b/dyninstAPI/src/BPatch_frame.C
@@ -89,10 +89,10 @@ BPatch_function *BPatch_frame::findFunction()
   /* 
    * When we generate a BPatch_frame, we store the return address for the call
    * as the PC. When we try to get the function associated with the frame, we
-   * use the PC to identify the function (via findFunctionByAddr). However, if
+   * use the PC to identify the function (via findFunctionByEntry). However, if
    * the function made a non-returning call, the corresponding return address
    * is never parsed, since it is unreachable code. This means that
-   * findFunctionByAddr will return NULL. 
+   * findFunctionByEntry will return NULL.
    *
    * To compensate, we'll instead look up the function by the address of the
    * callsite itself, which is the instruction prior to the return address.
@@ -100,8 +100,8 @@ BPatch_function *BPatch_frame::findFunction()
    * use PC-1, which is within the call instruction.
    */
 
-  void * callSite = (void*)((Address)(getPC()) - 1);
-  return thread->getProcess()->findFunctionByAddr(callSite);
+  Address callSite = reinterpret_cast<Address>(getPC()) - 1;
+  return thread->getProcess()->findFunctionByEntry(callSite);
 }
 
 BPatch_frame::BPatch_frame() : 


### PR DESCRIPTION
This was deprecated by 7f20129 in 2010. Users should instead use either BPatch_addressSpace::findFunctionByEntry or BPatch_addressSpace::findFunctionsByAddr.

Closes #820 