### PR TITLE
Remove exception specifications

### DIFF
--- a/common/h/dyntypes.h
+++ b/common/h/dyntypes.h
@@ -59,10 +59,8 @@
   #include <unordered_map>  
   #define dyn_hash_map std::unordered_map
   #define dyn_hash_set std::unordered_set
-  #define DECLTHROW(x)
 #elif defined(__GNUC__)
   #include <functional>
-  #define DECLTHROW(x) throw(x)
   //*****************libcxx**********************
   #if defined(_LIBCPP_VERSION)
       #include <unordered_set>
@@ -116,7 +114,6 @@
   #include <unordered_map>
   #define dyn_hash_set std::tr1::unordered_set
   #define dyn_hash_map std::tr1::unordered_map
-  #define DECLTHROW(x)
 #else
    #error Unknown compiler
 #endif

--- a/common/h/util.h
+++ b/common/h/util.h
@@ -198,16 +198,6 @@
 #endif
 #endif
 
-#if !defined(THROW) && !defined(THROW_SPEC)
-#if defined(_MSC_VER)
-#define THROW_SPEC(x)
-#define THROW
-#else
-#define THROW_SPEC(x) throw (x)
-#define THROW throw ()
-#endif
-#endif
-
 #ifndef TLS_VAR
 #if defined(_MSC_VER)
 #define TLS_VAR __declspec(thread)

--- a/dataflowAPI/rose/semantics/MemoryMap.h
+++ b/dataflowAPI/rose/semantics/MemoryMap.h
@@ -131,7 +131,7 @@ public:
     class Exception: public std::runtime_error {
     public:
         Exception(const std::string &mesg, const MemoryMap *map): std::runtime_error(mesg), map(map) {}
-        virtual ~Exception() throw() {}
+        virtual ~Exception() {}
         virtual std::string leader(std::string dflt="memory map problem") const;   /**< Leading part of the error message. */
         virtual std::string details(bool) const; /**< Details emitted on following lines, indented two spaces. */
         virtual void print(std::ostream&, bool verbose=true) const;
@@ -151,7 +151,7 @@ public:
             : Exception(mesg, map),
               new_range(new_range), old_range(old_range),
               new_segment(new_segment), old_segment(old_segment) {}
-        virtual ~Inconsistent() throw() {}
+        virtual ~Inconsistent() {}
         virtual void print(std::ostream&, bool verbose=true) const;
         friend std::ostream& operator<<(std::ostream&, const Inconsistent&);
         AddressInterval new_range, old_range;
@@ -162,7 +162,7 @@ public:
     struct NotMapped : public Exception {
         NotMapped(const std::string &mesg, const MemoryMap *map, rose_addr_t va)
             : Exception(mesg, map), va(va) {}
-        virtual ~NotMapped() throw() {}
+        virtual ~NotMapped() {}
         virtual void print(std::ostream&, bool verbose=true) const;
         friend std::ostream& operator<<(std::ostream&, const NotMapped&);
         rose_addr_t va;
@@ -172,7 +172,7 @@ public:
     struct NoFreeSpace : public Exception {
         NoFreeSpace(const std::string &mesg, const MemoryMap *map, size_t size)
             : Exception(mesg, map), size(size) {}
-        virtual ~NoFreeSpace() throw() {}
+        virtual ~NoFreeSpace() {}
         virtual void print(std::ostream&, bool verbose=true) const;
         friend std::ostream& operator<<(std::ostream&, const NoFreeSpace&);
         size_t size;
@@ -182,7 +182,7 @@ public:
     struct SyntaxError: public Exception {
         SyntaxError(const std::string &mesg, const MemoryMap *map, const std::string &filename, unsigned linenum, int colnum=-1)
             : Exception(mesg, map), filename(filename), linenum(linenum), colnum(colnum) {}
-        virtual ~SyntaxError() throw() {}
+        virtual ~SyntaxError() {}
         virtual void print(std::ostream&, bool verbose=true) const;
         friend std::ostream& operator<<(std::ostream&, const SyntaxError&);
         std::string filename;                   /**< Name of index file where error occurred. */

--- a/dataflowAPI/rose/util/Exception.h
+++ b/dataflowAPI/rose/util/Exception.h
@@ -16,7 +16,7 @@ namespace Exception {
 /** Base class for %Sawyer runtime errors. */
 class SAWYER_EXPORT RuntimeError: public std::runtime_error {
 public:
-    ~RuntimeError() throw() {}
+    ~RuntimeError() {}
 
     /** Constructor taking a description of the error. */
     explicit RuntimeError(const std::string &mesg)
@@ -26,7 +26,7 @@ public:
 /** Base class for %Sawyer domain errors. */
 class SAWYER_EXPORT DomainError: public RuntimeError {
 public:
-    ~DomainError() throw() {}
+    ~DomainError() {}
 
     /** Constructor taking a description of the error. */
     explicit DomainError(const std::string &mesg)
@@ -38,7 +38,7 @@ public:
  *  This error is thrown when querying a container and no value is stored for the specified key. */
 class SAWYER_EXPORT NotFound: public DomainError {
 public:
-    ~NotFound() throw () {}
+    ~NotFound() {}
 
     /** Constructor taking a description of the error. */
     explicit NotFound(const std::string &mesg)
@@ -50,7 +50,7 @@ public:
  *  This error is thrown when attempting to modify a container by inserting a value that already exists. */
 class SAWYER_EXPORT AlreadyExists: public DomainError {
 public:
-    ~AlreadyExists() throw () {}
+    ~AlreadyExists() {}
 
     /** Constructor taking a description of the error. */
     AlreadyExists(const std::string &mesg)


### PR DESCRIPTION
They were deprecated in c++11 and removed in c++17.

closes #708 