### PR TITLE
Cleanup dyn_hash_{set,map}

### DIFF
--- a/common/h/dyntypes.h
+++ b/common/h/dyntypes.h
@@ -53,70 +53,22 @@
 #define XLC
 #endif
 
-#if defined (_MSC_VER)
-  //**************** Windows ********************
-  #include <unordered_set>
-  #include <unordered_map>  
-  #define dyn_hash_map std::unordered_map
-  #define dyn_hash_set std::unordered_set
-#elif defined(__GNUC__)
-  #include <functional>
-  //*****************libcxx**********************
-  #if defined(_LIBCPP_VERSION)
-      #include <unordered_set>
-      #include <unordered_map>
-      #define dyn_hash_set std::unordered_set
-      #define dyn_hash_map std::unordered_map
-  //***************** GCC ***********************
-   #elif defined (__GLIBCXX__) && (__GLIBCXX__ >= 20080306)
-      //**************** GCC >= 4.3.0 ***********
-      #include <tr1/unordered_set>
-      #include <tr1/unordered_map>
-      #define cap_tr1
-      #define dyn_hash_set std::tr1::unordered_set
-      #define dyn_hash_map std::tr1::unordered_map
-   #else
-      //**************** GCC < 4.3.0 ************
-      #include <ext/hash_map>
-      #include <ext/hash_set>
-      #include <string>
-      #define dyn_hash_set __gnu_cxx::hash_set
-      #define dyn_hash_map __gnu_cxx::hash_map    
-      namespace Dyninst {
-	     unsigned ptrHash(void * addr);
-      }
-      using namespace __gnu_cxx;
-      namespace __gnu_cxx {
+#include <unordered_set>
+#include <unordered_map>
 
-		  template<> struct hash<std::string> {
-			  hash<char*> h;
-			  unsigned operator()(const std::string &s) const 
-			  {
-				  const char *cstr = s.c_str();
-				  return h(cstr);
-			  };
-		  };
+// NB: std::hash has overloads for [un]scoped enums
+template <typename Key,
+		  typename Value,
+		  typename Hash = std::hash<Key>,
+		  typename Comp = std::equal_to<Key>,
+		  typename Alloc = std::allocator<std::pair<const Key, Value>>>
+using dyn_hash_map = std::unordered_map<Key, Value, Hash, Comp, Alloc>;
 
-		  template<> struct hash<void *> {
-			  unsigned operator()(void *v) const 
-			  {
-				  return Dyninst::ptrHash(v);
-			  };
-		  };
-
-	  }
-   #endif
-#elif defined(XLC)
-  #define __IBMCPP_TR1__ 1
-
-  #include <functional>
-  #include <unordered_set>
-  #include <unordered_map>
-  #define dyn_hash_set std::tr1::unordered_set
-  #define dyn_hash_map std::tr1::unordered_map
-#else
-   #error Unknown compiler
-#endif
+template <typename Key,
+		  typename Hash = std::hash<Key>,
+		  typename Comp = std::equal_to<Key>,
+		  typename Alloc = std::allocator<Key>>
+using dyn_hash_set = std::unordered_set<Key, Hash, Comp, Alloc>;
 
 // TODO: when should we use thread_local?
 #if defined(_MSC_VER)

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -33,7 +33,7 @@
 
 #include "dyntypes.h"
 
-enum entryID {
+enum entryID : unsigned int {
   e_jb = 0,
   e_ja,
   e_jb_jnaej_j,
@@ -3004,7 +3004,7 @@ power_op_dxex,
   aarch64_op_zip2_advsimd,
   _entry_ids_max_
 };
-enum prefixEntryID {
+enum prefixEntryID : unsigned int {
   prefix_none,
   prefix_rep,
   prefix_repnz

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -3009,54 +3009,7 @@ enum prefixEntryID {
   prefix_rep,
   prefix_repnz
 };
- #if defined(__GNUC__)
-  #if defined(_LIBCPP_VERSION)
-//***************** GCC ***********************
-  #elif !defined(cap_tr1)
-  //**************** GCC < 4.3.0 ************
-  namespace __gnu_cxx {
-     template<> struct hash<entryID> {
-      hash<unsigned int> h;
-      unsigned operator()(const entryID &e) const
-      {
-         return h(static_cast<unsigned int>(e));
-      };
-    };
-    template<> struct hash<prefixEntryID> {
-      hash<unsigned int> h;
-      unsigned operator()(const prefixEntryID &e) const
-      {
-         return h(static_cast<unsigned int>(e));
-      };
-    };
-  }
-	#else
-  namespace std
-  {
-    namespace tr1
-    {
-      template <>
-      struct hash<entryID>
-      {
-        hash<size_t> h;
-        size_t operator()(const entryID &eid) const
-        {
-           return h(static_cast<size_t>(eid));
-        }
-      };
-      template <>
-         struct hash<prefixEntryID>
-      {
-        hash<size_t> h;
-	size_t operator()(const prefixEntryID &eid) const
-	{
-	  return h(static_cast<size_t>(eid));
-	}
-      };
-    }
-  }
-	#endif
-#endif
+
 namespace NS_x86 {
 COMMON_EXPORT extern dyn_hash_map<entryID, std::string> entryNames_IAPI;
 COMMON_EXPORT extern dyn_hash_map<prefixEntryID, std::string> prefixEntryNames_IAPI;

--- a/instructionAPI/h/RegisterIDs.h
+++ b/instructionAPI/h/RegisterIDs.h
@@ -99,36 +99,6 @@ namespace Dyninst
   };
 };
 	  
-#if defined(__GNUC__)
-#if !defined(cap_tr1)
-namespace __gnu_cxx 
-{
-  template<> struct hash<Dyninst::InstructionAPI::IA32Regs> {
-    hash<unsigned int> h;
-    unsigned operator()(const Dyninst::InstructionAPI::IA32Regs &e) const 
-    {
-      return h(static_cast<unsigned int>(e));
-    };
-  };
-}
-#else
-namespace std 
-{
-  namespace tr1
-  {
-    template <>
-    struct hash<Dyninst::InstructionAPI::IA32Regs>
-    {
-      size_t operator()(const Dyninst::InstructionAPI::IA32Regs &e) const
-      {
-	return static_cast<size_t>(e);
-      };
-    };
-  }   
-}
-#endif
-#endif
-	  
 	  
 namespace Dyninst
 {

--- a/instructionAPI/h/RegisterIDs.h
+++ b/instructionAPI/h/RegisterIDs.h
@@ -46,7 +46,7 @@ namespace Dyninst
     // We REALLY REALLY NEED these definitions to stay aligned as given,
     // so (e.g.) (r_EAX - r_AH) == (r_EDX - r_DH). We use that later
     // for upconverting overlapping/aliased registers.
-    enum IA32Regs { r_AH=0, r_BH, r_CH, r_DH, 
+    enum IA32Regs : unsigned int { r_AH=0, r_BH, r_CH, r_DH,
 		    r_AL=10, r_BL, r_CL, r_DL,
 		    r_AX=20, r_BX, r_CX, r_DX, r_SI, r_DI,
 		    r_eAX=30, r_eBX, r_eCX, r_eDX, r_eSI, r_eDI,


### PR DESCRIPTION
Require std::unordered_{map,set} for dyn_hash_{map,set}, and convert the dyn_hash_* macros to alias templates for better type safety and error messages. Remove the custom hashers, and use typed enums for IA32Regs, entryID, and prefixEntryID.