### PR TITLE
Fix undefined behavior in usage of std::transform

### DIFF
--- a/dyninstAPI/src/mapped_object.C
+++ b/dyninstAPI/src/mapped_object.C
@@ -1898,8 +1898,7 @@ void mapped_object::removeEmptyPages()
 bool mapped_object::isSystemLib(const std::string &objname)
 {
    std::string lowname = objname;
-   std::transform(lowname.begin(),lowname.end(),lowname.begin(),
-                  (int(*)(int))std::tolower);
+   for(char &c : lowname) c = std::tolower(c);
 
    if (std::string::npos != lowname.find("libdyninstapi_rt"))
       return true;

--- a/instructionAPI/src/ArchSpecificFormatters.C
+++ b/instructionAPI/src/ArchSpecificFormatters.C
@@ -106,7 +106,8 @@ std::string ArmFormatter::formatRegister(std::string regName) {
     if (substr != std::string::npos) {
         ret = ret.substr(substr + 1, ret.length());
     }
-    std::transform(ret.begin(), ret.end(), ret.begin(), ::toupper);
+    for(char &c : ret) c = std::toupper(c);
+
     return ret;
 }
 
@@ -162,7 +163,7 @@ std::string x86Formatter::formatImmediate(std::string evalString)
 
 std::string x86Formatter::formatRegister(std::string regName) 
 {
-    std::transform(regName.begin(), regName.end(), regName.begin(), ::tolower);
+    for(char &c : regName) c = std::tolower(c);
 
     char* orig = strdup(regName.c_str());
 

--- a/instructionAPI/src/Register.C
+++ b/instructionAPI/src/Register.C
@@ -104,7 +104,8 @@ namespace Dyninst
         }
 
         /* we have moved to AT&T syntax (lowercase registers) */
-        std::transform(name.begin(), name.end(), name.begin(), ::toupper);
+        for(char &c : name) c = std::toupper(c);
+
         return name;
     }
       std::string MaskRegisterAST::format(Architecture, formatStyle f) const


### PR DESCRIPTION
Starting in C++11, it is undefined behavior to have the destination
iterator be contained within the input range.