### PR TITLE
Remove binaryEdit::deleteBinaryEdit

### DIFF
--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -288,20 +288,14 @@ BinaryEdit::BinaryEdit() :
    trapMapping.shouldBlockFlushes(true);
 }
 
-BinaryEdit::~BinaryEdit() 
+BinaryEdit::~BinaryEdit()
 {
-}
-
-void BinaryEdit::deleteBinaryEdit() {
-    deleteAddressSpace();
-    highWaterMark_ = 0;
-    lowWaterMark_ = 0;
-
-    // TODO: is this cleanup necessary?
-    depRelocation *rel;
-    while (dependentRelocations.size() > 0) {
-        rel = dependentRelocations[0];
-        dependentRelocations.erase(dependentRelocations.begin());
+	/*
+	 * NB: We do not own the objects contained in
+	 * 	   newDyninstSyms_, rtlib, or siblings, so
+	 * 	   do not ::delete them
+	*/
+    for(auto *rel : dependentRelocations) {
         delete rel;
     }
     delete memoryTracker_;

--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -138,9 +138,6 @@ class BinaryEdit : public AddressSpace {
     BinaryEdit();
     ~BinaryEdit();
 
-    // Same usage pattern as process
-    void deleteBinaryEdit();
-
     // And the "open" factory method.
     static BinaryEdit *openFile(const std::string &file,
                                 Dyninst::PatchAPI::PatchMgrPtr mgr = Dyninst::PatchAPI::PatchMgrPtr(),
@@ -226,6 +223,8 @@ class BinaryEdit : public AddressSpace {
     void buildDyninstSymbols(std::vector<SymtabAPI::Symbol *> &newSyms, 
                              SymtabAPI::Region *newSec,
                              SymtabAPI::Module *newMod);
+
+    // `mobj` is only a view. The actual object is owned by AddressSpace::mapped_objects
     mapped_object *mobj;
     std::vector<BinaryEdit *> rtlib;
     std::vector<BinaryEdit *> siblings;


### PR DESCRIPTION
This moves the same functionality into the destructor and prevents possible memory corruption when its usage would promote in-place object reuse. Originally part of #317.