### PR TITLE
Remove include cycle in dyntypes.h

### DIFF
--- a/common/h/Buffer.h
+++ b/common/h/Buffer.h
@@ -32,6 +32,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include "util.h"
 #include "dyntypes.h"
 
 namespace Dyninst {

--- a/common/h/DynAST.h
+++ b/common/h/DynAST.h
@@ -35,6 +35,7 @@
 #include <string>
 #include <sstream>
 #include <iostream>
+#include <map>
 #include "util.h"
 #include "boost/enable_shared_from_this.hpp"
 

--- a/common/h/SymReader.h
+++ b/common/h/SymReader.h
@@ -31,6 +31,8 @@
 #define SYM_READER_H_
 
 #include "dyntypes.h"
+#include "util.h"
+#include "dyn_regs.h"
 #include <string>
 
 namespace Dyninst

--- a/common/h/dyntypes.h
+++ b/common/h/dyntypes.h
@@ -121,5 +121,4 @@ namespace Dyninst
    } OSType;
 }
 
-#include "dyn_regs.h"
 #endif

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -32,6 +32,7 @@
 #define ENTRYIDS_IA32_H
 
 #include "dyntypes.h"
+#include "util.h"
 
 enum entryID : unsigned int {
   e_jb = 0,

--- a/common/src/arch-power.C
+++ b/common/src/arch-power.C
@@ -30,6 +30,7 @@
 
 #include "common/src/Types.h"
 #include "common/src/arch-power.h"
+#include <cassert>
 using namespace NS_power;
 
 unsigned int NS_power::swapBytesIfNeeded(unsigned int i)

--- a/common/src/arch-power.h
+++ b/common/src/arch-power.h
@@ -36,6 +36,7 @@
 // Code generation
 
 #include "common/src/Types.h"
+#include "dyn_regs.h"
 #include <vector>
 class AddressSpace;
 

--- a/common/src/util.C
+++ b/common/src/util.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include "util.h"
 #if defined(os_windows)
 #include "common/src/ntHeaders.h"
 #endif

--- a/dyninstAPI/src/codegen.h
+++ b/dyninstAPI/src/codegen.h
@@ -31,6 +31,8 @@
 #define _codegen_h_
 
 #include <vector>
+#include <string>
+#include <map>
 
 #include "common/src/arch.h"
 #include "dyninstAPI/src/patch.h"

--- a/symtabAPI/h/symutil.h
+++ b/symtabAPI/h/symutil.h
@@ -34,6 +34,7 @@
 #define _symtab_util_h_
 
 #include "dyntypes.h"
+#include "util.h"
 #include <string>
 
 #if defined(_MSC_VER)	


### PR DESCRIPTION
This prevented using concurrent data structures in dyntypes.