### PR TITLE
Correctly destruct AddressSpace objects

### DIFF
--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -154,7 +154,6 @@ void AddressSpace::copyAddressSpace(AddressSpace *parent) {
     // This is only defined for process->process copy
     // until someone can give a good reason for copying
     // anything else...
-
     assert(proc());
 
     mapped_object *par_aout = parent->getAOut();
@@ -170,10 +169,7 @@ void AddressSpace::copyAddressSpace(AddressSpace *parent) {
           assert(child_obj);
           addMappedObject(child_obj);
         }
-        // This clones funcs, which then clone instPoints, which then 
-        // clone baseTramps, which then clones miniTramps.
     }
-
 
     // Clone the tramp guard base
     if (parent->trampGuardBase_) 
@@ -184,7 +180,6 @@ void AddressSpace::copyAddressSpace(AddressSpace *parent) {
     /////////////////////////
     // Inferior heap
     /////////////////////////
-
     heap_ = inferiorHeap(parent->heap_);
     heapInitialized_ = parent->heapInitialized_;
 
@@ -194,31 +189,15 @@ void AddressSpace::copyAddressSpace(AddressSpace *parent) {
     trapMapping.copyTrapMappings(& (parent->trapMapping));
 
     /////////////////////////
-    // Overly complex code tracking system
+    // Code tracking system
     /////////////////////////
-    for (CodeTrackers::iterator iter = parent->relocatedCode_.begin();
-         iter != parent->relocatedCode_.end(); ++iter) {
-       // Efficiency; this avoids a spurious copy of the entire
-       // CodeTracker. 
-
-       relocatedCode_.push_back(Relocation::CodeTracker::fork(*iter, this));
+    for (auto *ct : parent->relocatedCode_) {
+       // Efficiency; this avoids a spurious copy of the entire CodeTracker.
+       relocatedCode_.push_back(Relocation::CodeTracker::fork(ct, this));
     }
     
-    // Let's assume we're not forking _in the middle of instrumentation_
-    // (good Lord), and so leave modifiedFunctions_ alone.
-    /*
-    for (CallModMap::iterator iter = parent->callModifications_.begin(); 
-         iter != parent->callModifications_.end(); ++iter) {
-       // Need to forward map the lot
-       block_instance *newB = findBlock(iter->first->llb());
-       for (std::map<func_instance *, func_instance *>::iterator iter2 = iter->second.begin();
-            iter2 != iter->second.end(); ++iter2) {
-          func_instance *context = (iter2->first == NULL) ? NULL : findFunction(iter2->first->ifunc());
-          func_instance *target = (iter2->second == NULL) ? NULL : findFunction(iter2->second->ifunc());
-          callModifications_[newB][context] = target;
-       }
-    }
-    */
+    // Let's assume we're not forking in the middle of instrumentation, so
+    // leave modifiedFunctions_ alone.
 
     assert(parent->mgr());
     PatchAPI::CallModMap& cmm = parent->mgr()->instrumenter()->callModMap();
@@ -253,19 +232,28 @@ void AddressSpace::copyAddressSpace(AddressSpace *parent) {
 }
 
 void AddressSpace::deleteAddressSpace() {
-   // Methodically clear everything we have - it all went away
-   // We have the following member variables:
-
-   // bool heapInitialized_
-   // inferiorHeap heap_
-
    heapInitialized_ = false;
    heap_.clear();
-   for (unsigned i = 0; i < mapped_objects.size(); i++) 
-      delete mapped_objects[i];
 
+   for (auto *mo : mapped_objects) {
+      delete mo;
+   }
    mapped_objects.clear();
 
+   for (auto *rc : relocatedCode_) {
+      delete rc;
+   }
+   relocatedCode_.clear();
+
+   /*
+   * NB: We do not own the contents of forwardDefensiveMap_, reverseDefensiveMap_,
+   *     instrumentationInstances_, modifiedFunctions_, reverseDefensiveMap_,
+   *     or runtime_lib
+   */
+   forwardDefensiveMap_.clear();
+   reverseDefensiveMap_.clear();
+   instrumentationInstances_.clear();
+   modifiedFunctions_.clear();
    runtime_lib.clear();
 
    trampGuardBase_ = NULL;
@@ -273,15 +261,6 @@ void AddressSpace::deleteAddressSpace() {
 
    // up_ptr_ is untouched
    costAddr_ = 0;
-   for (CodeTrackers::iterator iter = relocatedCode_.begin(); 
-        iter != relocatedCode_.end(); ++iter) {
-      delete *iter;
-   }
-   relocatedCode_.clear();
-   modifiedFunctions_.clear();
-   forwardDefensiveMap_.clear();
-   reverseDefensiveMap_.clear();
-   instrumentationInstances_.clear();
 
    if (memEmulator_) delete memEmulator_;
    memEmulator_ = NULL;

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -110,6 +110,8 @@ AddressSpace::~AddressSpace() {
       delete memEmulator_;
     if (mgr_)
        static_cast<DynAddrSpace*>(mgr_->as())->removeAddrSpace(this);
+
+    deleteAddressSpace();
 }
 
 PCProcess *AddressSpace::proc() {


### PR DESCRIPTION
`deleteAddressSpace` is still highly suspect because its only use is `copyAddressSpace` which doesn't fully copy the object. However, this fix at least makes `deleteAddressSpace` and `~AddressSpace` correct and perform the same actions.

This was originally part of #317.