### PR TITLE
Add lookup by name in block_instance::callee

### DIFF
--- a/dyninstAPI/src/block.h
+++ b/dyninstAPI/src/block.h
@@ -128,7 +128,7 @@ class block_instance : public Dyninst::PatchAPI::PatchBlock {
  private:
     void updateCallTarget(func_instance *func);
     func_instance *findFunction(ParseAPI::Function *);
-
+    func_instance* callee(std::string const&);
     // edges srcs_;
     // edges trgs_;
 

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -750,8 +750,7 @@ func_instance *block_instance::callee() {
    // get the relocation information for this image
    Symtab *sym = obj()->parse_img()->getObject();
    std::vector<relocationEntry> fbt;
-   vector <relocationEntry> fbtvector;
-   if (!sym->getFuncBindingTable(fbtvector)) {
+   if (!sym->getFuncBindingTable(fbt)) {
       return NULL;
    }
 
@@ -761,14 +760,11 @@ func_instance *block_instance::callee() {
     * because the function binding table holds relocations used by the dynamic
     * linker
     */
-   if (!fbtvector.size() && !sym->isStaticBinary() && 
+   if (!fbt.size() && !sym->isStaticBinary() &&
            sym->getObjectType() != obj_RelocatableFile ) 
    {
       fprintf(stderr, "%s[%d]:  WARN:  zero func bindings\n", FILE__, __LINE__);
    }
-
-   for (unsigned index=0; index< fbtvector.size();index++)
-      fbt.push_back(fbtvector[index]);
    
    std::map<Address, std::string> pltFuncs;
    obj()->parse_img()->getPltFuncs(pltFuncs);

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -703,10 +703,7 @@ func_instance* block_instance::callee(std::string const& target_name) {
    return nullptr;
 }
 
-// The following functions were factored from linux.C to be used
-// on both Linux and FreeBSD
-
-// findCallee: finds the function called by the instruction corresponding
+// callee: finds the function called by the instruction corresponding
 // to the instPoint "instr". If the function call has been bound to an
 // address, then the callee function is returned in "target" and the 
 // instPoint "callee" data member is set to pt to callee's func_instance.  
@@ -714,11 +711,9 @@ func_instance* block_instance::callee(std::string const& target_name) {
 // func_instance associated with the name of the target function (this is 
 // obtained by the PLT and relocation entries in the image), and the instPoint
 // callee is not set.  If the callee function cannot be found, (ex. function
-// pointers, or other indirect calls), it returns false.
-// Returns false on error (ex. process doesn't contain this instPoint).
-//
-// HACK: made an func_instance method to remove from instPoint class...
-// FURTHER HACK: made a block_instance method so we can share blocks
+// pointers, or other indirect calls), it returns NULL.
+// Returns NULL on error (ex. process doesn't contain this instPoint).
+
 func_instance *block_instance::callee() {
    // pre-computed callee via PLT
    func_instance *ret = obj()->getCallee(this);

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -797,6 +797,14 @@ func_instance *block_instance::callee() {
          }
       }
       return callee(pltFuncs[target_addr]);
+   } else {
+	   /*
+	    * Sometimes, the PLT address and the CFG target aren't the same
+	    * (e.g., Intel's CET causes this), so we just look up by name.
+	    */
+	   func_instance *f = obj()->findFuncByEntry(tEdge->trg());
+	   if(!f) return nullptr;
+	   return callee(f->get_name());
    }
    
    //fprintf(stderr, "%s[%d]:  returning NULL: target addr = %p\n", FILE__, __LINE__, (void *)target_addr);

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -720,7 +720,7 @@ func_instance* block_instance::callee(std::string const& target_name) {
 // HACK: made an func_instance method to remove from instPoint class...
 // FURTHER HACK: made a block_instance method so we can share blocks
 func_instance *block_instance::callee() {
-   // Check 1: pre-computed callee via PLT
+   // pre-computed callee via PLT
    func_instance *ret = obj()->getCallee(this);
    if (ret) return ret;
 
@@ -737,8 +737,6 @@ func_instance *block_instance::callee() {
       }
    }
 
-   
-
    // Do this the hard way - an inter-module jump
    // get the target address of this function
    Address target_addr; bool success;
@@ -746,7 +744,6 @@ func_instance *block_instance::callee() {
    if(!success) {
       // this is either not a call instruction or an indirect call instr
       // that we can't get the target address
-      //fprintf(stderr, "%s[%d]:  returning NULL\n", FILE__, __LINE__);
       return NULL;
    }
    
@@ -755,7 +752,6 @@ func_instance *block_instance::callee() {
    std::vector<relocationEntry> fbt;
    vector <relocationEntry> fbtvector;
    if (!sym->getFuncBindingTable(fbtvector)) {
-      //fprintf(stderr, "%s[%d]:  returning NULL\n", FILE__, __LINE__);
       return NULL;
    }
 
@@ -774,13 +770,12 @@ func_instance *block_instance::callee() {
    for (unsigned index=0; index< fbtvector.size();index++)
       fbt.push_back(fbtvector[index]);
    
-   Address base_addr = obj()->codeBase();
-   
    std::map<Address, std::string> pltFuncs;
    obj()->parse_img()->getPltFuncs(pltFuncs);
 
    // find the target address in the list of relocationEntries
    if (pltFuncs.find(target_addr) != pltFuncs.end()) {
+	  Address base_addr = obj()->codeBase();
       for (u_int i=0; i < fbt.size(); i++) {
          if (fbt[i].target_addr() == target_addr) 
          {
@@ -807,7 +802,6 @@ func_instance *block_instance::callee() {
 	   return callee(f->get_name());
    }
    
-   //fprintf(stderr, "%s[%d]:  returning NULL: target addr = %p\n", FILE__, __LINE__, (void *)target_addr);
    return NULL;
 }
 


### PR DESCRIPTION
Sometimes, the PLT address and the CFG target aren't the same (e.g., Intel's CET causes this), so we just look up by name.

Fixes #852