### PR TITLE
cleanup memoryTracker memory handling

### DIFF
--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -251,8 +251,8 @@ public:
   memoryTracker(Address a, unsigned s) : memoryTracker(a, s, nullptr) {}
 
   memoryTracker(Address a, unsigned s, void *b)
-      : a_(a), s_(s), b_{nullptr, &::free} {
-    b_.reset(calloc(1, s_));
+      : a_(a), s_(s) {
+    b_.reset(new char[s_]);
     if (b) {
       memcpy(b_.get(), b, s_);
     }
@@ -269,9 +269,10 @@ public:
 
   Address get_address() const { return a_; }
   unsigned get_size() const { return s_; }
-  void *get_local_ptr() const { return b_.get(); }
+  void *get_local_ptr() const { return static_cast<void*>(b_.get()); }
   void realloc(unsigned newsize) {
-    b_.reset(::realloc(b_.get(), newsize));
+	if(newsize == s_) return;
+    b_.reset(new char[newsize]);
     s_ = newsize;
     if (!b_ && newsize) {
       cerr << "Odd: failed to realloc " << newsize << endl;
@@ -285,7 +286,7 @@ public:
 private:
   Address a_;
   unsigned s_;
-  std::unique_ptr<void, decltype(&::free)> b_;
+  std::unique_ptr<char[]> b_;
 };
 
 #endif // BINARY_H

--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -271,7 +271,7 @@ public:
   unsigned get_size() const { return s_; }
   void *get_local_ptr() const { return static_cast<void*>(b_.get()); }
   void realloc(unsigned newsize) {
-	if(newsize == s_) return;
+    if(newsize == s_) return;
     b_.reset(new char[newsize]);
     s_ = newsize;
     if (!b_ && newsize) {

--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -247,47 +247,45 @@ class depRelocation {
 };
 
 class memoryTracker : public codeRange {
- public:
-    memoryTracker(Address a, unsigned s) : memoryTracker(a, s, nullptr) {}
+public:
+  memoryTracker(Address a, unsigned s) : memoryTracker(a, s, nullptr) {}
 
-    memoryTracker(Address a, unsigned s, void *b) :
-    a_(a), s_(s), b_{nullptr, &::free}
-        {
-            b_.reset(calloc(1, s_));
-            if(b) {
-                memcpy(b_.get(), b, s_);
-            }
-        }
-    ~memoryTracker() = default;
-
-    // Not copyable
-    memoryTracker(memoryTracker const&) = delete;
-    memoryTracker& operator=(memoryTracker const&) = delete;
-
-    // move-only
-    memoryTracker(memoryTracker&&) = default;
-    memoryTracker& operator=(memoryTracker&&) = default;
-
-    Address get_address() const { return a_; }
-    unsigned get_size() const { return s_; }
-    void *get_local_ptr() const { return b_.get(); }
-    void realloc(unsigned newsize) {
-      b_.reset(::realloc(b_.get(), newsize));
-      s_ = newsize;
-      if (!b_ && newsize) {
-	cerr << "Odd: failed to realloc " << newsize << endl;
-	assert(b_);
-      }
+  memoryTracker(Address a, unsigned s, void *b)
+      : a_(a), s_(s), b_{nullptr, &::free} {
+    b_.reset(calloc(1, s_));
+    if (b) {
+      memcpy(b_.get(), b, s_);
     }
+  }
+  ~memoryTracker() = default;
 
-    bool alloced{false};
-    bool dirty{false};
+  // Not copyable
+  memoryTracker(memoryTracker const &) = delete;
+  memoryTracker &operator=(memoryTracker const &) = delete;
 
- private:
-    Address a_;
-    unsigned s_;
-    std::unique_ptr<void, decltype(&::free)> b_;
-    
+  // move-only
+  memoryTracker(memoryTracker &&) = default;
+  memoryTracker &operator=(memoryTracker &&) = default;
+
+  Address get_address() const { return a_; }
+  unsigned get_size() const { return s_; }
+  void *get_local_ptr() const { return b_.get(); }
+  void realloc(unsigned newsize) {
+    b_.reset(::realloc(b_.get(), newsize));
+    s_ = newsize;
+    if (!b_ && newsize) {
+      cerr << "Odd: failed to realloc " << newsize << endl;
+      assert(b_);
+    }
+  }
+
+  bool alloced{false};
+  bool dirty{false};
+
+private:
+  Address a_;
+  unsigned s_;
+  std::unique_ptr<void, decltype(&::free)> b_;
 };
 
 #endif // BINARY_H

--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -251,7 +251,7 @@ class memoryTracker : public codeRange {
     memoryTracker(Address a, unsigned s) : memoryTracker(a, s, nullptr) {}
 
     memoryTracker(Address a, unsigned s, void *b) :
-    alloced(false), dirty(false), a_(a), s_(s), b_{nullptr, &::free}
+    a_(a), s_(s), b_{nullptr, &::free}
         {
             b_.reset(calloc(1, s_));
             if(b) {
@@ -280,8 +280,8 @@ class memoryTracker : public codeRange {
       }
     }
 
-    bool alloced;
-    bool dirty;
+    bool alloced{false};
+    bool dirty{false};
 
  private:
     Address a_;


### PR DESCRIPTION
This gives explicit copy and move semantics to the class and uses a std::unique_ptr to manage the contained buffer. Construction is also simplified by always using calloc.