### PR TITLE
Fix memory leaks in BinaryEdit::openResolvedLibraryName

### DIFF
--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -614,6 +614,9 @@ mapped_object *BinaryEdit::openResolvedLibraryName(std::string filename,
           if (auto temp = is_compatible(path, member->memberName())) {
             std::string mapName = path + ":" + member->memberName();
             retMap.emplace(std::move(mapName), temp.release());
+          } else {
+              retMap.clear();
+              break;
           }
         }
 

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -561,98 +561,100 @@ using namespace Dyninst::SymtabAPI;
 mapped_object *BinaryEdit::openResolvedLibraryName(std::string filename,
                                                    std::map<std::string, BinaryEdit*> &retMap) {
     std::vector<std::string> paths;
-    // First, find the specified library file
-    bool resolved = getResolvedLibraryPath(filename, paths);
-
-    // Second, create a set of BinaryEdits for the found library
-    if ( resolved ) {
-        startup_printf("[%s:%u] - Opening dependent file %s\n",
+    if (!getResolvedLibraryPath(filename, paths)) {
+        startup_printf("[%s:%u] - Unable to resolve library path for '%s'\n",
                        FILE__, __LINE__, filename.c_str());
-
-        Symtab *origSymtab = getMappedObject()->parse_img()->getObject();
-
-        // A little helper to fix some clunky checks
-        auto is_compatible =
-            [this](std::string const& path, std::string const& member={}) {
-                auto temp = std::unique_ptr<BinaryEdit>{
-                	BinaryEdit::openFile(path, mgr(), patcher(), member)
-                };
-                if(temp && temp->getAddressWidth() == getAddressWidth()) {
-                    return temp;
-                }
-                temp.reset(nullptr);
-                return temp;
-            };
-
-	assert(mgr());
-        // Dynamic case
-        if ( !origSymtab->isStaticBinary() ) {
-            for(auto const& path : paths) {
-                if (auto temp = is_compatible(path)) {
-                	auto ret = retMap.emplace(path, temp.release());
-                    return (*ret.first).second->getMappedObject();
-                }
-            }
-        } else {
-            // Static executable case
-
-            /* 
-             * Alright, this is a kludge, but even though the Archive is opened
-             * twice (once here and once by the image class later on), it is
-             * only parsed once because the Archive class keeps track of all
-             * open Archives.
-             *
-             * This is partly due to the fact that Archives are collections of
-             * Symtab objects and their is one Symtab for each BinaryEdit. In
-             * some sense, an Archive is a collection of BinaryEdits.
-             */
-            for(auto const& path : paths) {
-                Archive *library;
-                Symtab *singleObject;
-                if (Archive::openArchive(library, path)) {
-                    std::vector<Symtab *> members;
-                    if (library->getAllMembers(members)) {
-                        for(auto *member : members) {
-                            if (auto temp = is_compatible(path, member->memberName())) {
-                                std::string mapName = path + ":" + member->memberName();
-                                retMap.emplace(std::move(mapName), temp.release());
-                            }
-                        }
-
-                        if (retMap.size() > 0) {
-                            origSymtab->addLinkingResource(library);
-                            // So we tried loading "libc.a", and got back a swarm of individual members. 
-                            // Lovely. 
-                            // Just return the first thing...
-                            return retMap.begin()->second->getMappedObject();
-                        }
-                        //if( library ) delete library;
-                    }
-                } else if (Symtab::openFile(singleObject, path)) {
-                    if (auto temp = is_compatible(path)) {
-                        if( singleObject->getObjectType() == obj_SharedLib ||
-                            singleObject->getObjectType() == obj_Executable ) 
-                        {
-                          startup_printf("%s[%d]: cannot load dynamic object(%s) when rewriting a static binary\n", 
-                                  FILE__, __LINE__, path.c_str());
-                          std::string msg{"Cannot load a dynamic object when rewriting a static binary"};
-                          showErrorCallback(71, std::move(msg));
-
-                          delete singleObject;
-                        }else{
-                            auto ret = retMap.emplace(path, temp.release());
-                            return (*ret.first).second->getMappedObject();
-                        }
-                    }
-                }
-            }
-        }
+        return nullptr;
     }
+
+	// A little helper to fix some clunky checks
+	auto is_compatible =
+		[this](std::string const& path, std::string const& member={}) {
+			auto temp = std::unique_ptr<BinaryEdit>{
+				BinaryEdit::openFile(path, mgr(), patcher(), member)
+			};
+			if(temp && temp->getAddressWidth() == getAddressWidth()) {
+				return temp;
+			}
+			temp.reset(nullptr);
+			return temp;
+		};
+
+    assert(mgr());
+
+	// Dynamic case
+    Symtab *origSymtab = getMappedObject()->parse_img()->getObject();
+	if ( !origSymtab->isStaticBinary() ) {
+		for(auto const& path : paths) {
+			if (auto temp = is_compatible(path)) {
+				auto ret = retMap.emplace(path, temp.release());
+				return (*ret.first).second->getMappedObject();
+			}
+		}
+        startup_printf("[%s:%u] - Unable to find compatible BinaryEdit for '%s'\n",
+                       FILE__, __LINE__, filename.c_str());
+        return nullptr;
+	}
+
+	// Static executable case
+
+	/*
+	 * Alright, this is a kludge, but even though the Archive is opened
+	 * twice (once here and once by the image class later on), it is
+	 * only parsed once because the Archive class keeps track of all
+	 * open Archives.
+	 *
+	 * This is partly due to the fact that Archives are collections of
+	 * Symtab objects and their is one Symtab for each BinaryEdit. In
+	 * some sense, an Archive is a collection of BinaryEdits.
+	 */
+	for(auto const& path : paths) {
+		Archive *library;
+		if (Archive::openArchive(library, path)) {
+			std::vector<Symtab *> members;
+			if (library->getAllMembers(members)) {
+				for(auto *member : members) {
+					if (auto temp = is_compatible(path, member->memberName())) {
+						std::string mapName = path + ":" + member->memberName();
+						retMap.emplace(std::move(mapName), temp.release());
+					}
+				}
+
+				if (retMap.size() > 0) {
+					origSymtab->addLinkingResource(library);
+					// So we tried loading "libc.a", and got back a swarm of individual members.
+					// Just return the first thing...
+					return retMap.begin()->second->getMappedObject();
+				}
+				//if( library ) delete library;
+			}
+	        startup_printf("[%s:%u] - Failed to find archive members in '%s' for static executable '%s'\n",
+	                       FILE__, __LINE__, path.c_str(), filename.c_str());
+		} else {
+			Symtab *singleObject;
+			if (Symtab::openFile(singleObject, path)) {
+				if (auto temp = is_compatible(path)) {
+					if( singleObject->getObjectType() == obj_SharedLib ||
+						singleObject->getObjectType() == obj_Executable )
+					{
+					  startup_printf("%s[%d]: cannot load dynamic object(%s) when rewriting a static binary\n",
+							  FILE__, __LINE__, path.c_str());
+					  std::string msg{"Cannot load a dynamic object when rewriting a static binary"};
+					  showErrorCallback(71, std::move(msg));
+
+					  delete singleObject;
+					}else{
+						auto ret = retMap.emplace(path, temp.release());
+						return (*ret.first).second->getMappedObject();
+					}
+				}
+			}
+		}
+	}
 
     startup_printf("[%s:%u] - Creation error opening %s\n",
                    FILE__, __LINE__, filename.c_str());
-    // If the only thing we could find was a dynamic lib for a static executable, we can reach here; caller should handle this.
-    return NULL;
+    return nullptr;
 }
 
 #endif

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -614,8 +614,8 @@ mapped_object *BinaryEdit::openResolvedLibraryName(std::string filename,
                     if (library->getAllMembers(members)) {
                         for(auto *member : members) {
                             if (auto temp = is_compatible(path, member->memberName())) {
-                                std::string mapName = path + string(":") + member->memberName();
-                                retMap.emplace(mapName, temp.release());
+                                std::string mapName = path + ":" + member->memberName();
+                                retMap.emplace(std::move(mapName), temp.release());
                             }
                         }
 
@@ -635,8 +635,8 @@ mapped_object *BinaryEdit::openResolvedLibraryName(std::string filename,
                         {
                           startup_printf("%s[%d]: cannot load dynamic object(%s) when rewriting a static binary\n", 
                                   FILE__, __LINE__, path.c_str());
-                          std::string msg = std::string("Cannot load a dynamic object when rewriting a static binary");
-                          showErrorCallback(71, msg.c_str());
+                          std::string msg{"Cannot load a dynamic object when rewriting a static binary"};
+                          showErrorCallback(71, std::move(msg));
 
                           delete singleObject;
                         }else{

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -589,7 +589,7 @@ mapped_object *BinaryEdit::openResolvedLibraryName(std::string filename,
         if ( !origSymtab->isStaticBinary() ) {
             for(auto const& path : paths) {
                 if (auto temp = is_compatible(path)) {
-                	auto ret = retMap.insert(std::make_pair(path, temp.release()));
+                	auto ret = retMap.emplace(path, temp.release());
                     return (*ret.first).second->getMappedObject();
                 }
             }
@@ -615,7 +615,7 @@ mapped_object *BinaryEdit::openResolvedLibraryName(std::string filename,
                         for(auto *member : members) {
                             if (auto temp = is_compatible(path, member->memberName())) {
                                 std::string mapName = path + string(":") + member->memberName();
-                                retMap.insert(std::make_pair(mapName, temp.release()));
+                                retMap.emplace(mapName, temp.release());
                             }
                         }
 
@@ -640,7 +640,7 @@ mapped_object *BinaryEdit::openResolvedLibraryName(std::string filename,
 
                           delete singleObject;
                         }else{
-                            auto ret = retMap.insert(std::make_pair(path, temp.release()));
+                            auto ret = retMap.emplace(path, temp.release());
                             return (*ret.first).second->getMappedObject();
                         }
                     }


### PR DESCRIPTION
This was originally part of #317

@wrwilliams 
1. I didn't use SymElfFactor::openSymbolReader from the original fixes in #317 because it adds a link dependency to unix.o. Instead, I used a lambda with admittedly funky semantics.

2. For the static executable case, previously only the first archive member was checked. If it was not a compatible binary, the retMap was cleared (approx. line 605 in c0acebbe7). Now, all members are checked, and the retMap is never cleared. Is this a significant algorithmic change?

@mxz297 

Could you take a close look at dca0e46f3 to make sure I didn't inadvertently change the overall behavior?