### PR TITLE
Remove CFGFactor::destroy_all

### DIFF
--- a/parseAPI/h/CFGFactory.h
+++ b/parseAPI/h/CFGFactory.h
@@ -98,8 +98,6 @@ class PARSER_EXPORT CFGFactory  {
     void destroy_block(Block *b);
     void destroy_edge(Edge *e, EdgeState reason);
 
-    void destroy_all();
-
  protected:
     virtual Function * mkfunc(Address addr, FuncSource src, 
             std::string name, CodeObject * obj, CodeRegion * region, 

--- a/parseAPI/src/CFGFactory.C
+++ b/parseAPI/src/CFGFactory.C
@@ -85,7 +85,15 @@ Edge::Edge(Block *source, Block *target, EdgeTypeEnum type)
 
 CFGFactory::~CFGFactory()
 {
-   destroy_all();
+  for(Edge *e : edges_) {
+    destroy_edge(e, destroyed_all);
+  }
+  for(Block *b : blocks_) {
+    destroy_block(b);
+  }
+  for(Function *f : funcs_) {
+    destroy_func(f);
+  }
 }
 
 // ParseAPI call...
@@ -202,26 +210,3 @@ void
 CFGFactory::free_edge(Edge *e) {
    delete e;
 }
-
-void
-CFGFactory::destroy_all() {
-    // XXX carefully calling free_* routines; could be faster and just
-    // call delete
-
-    fact_list<Edge *>::iterator eit = edges_.begin();
-    while(eit != edges_.end()) {
-        fact_list<Edge *>::iterator cur = eit++;
-        destroy_edge(*cur, destroyed_all);
-    }
-    fact_list<Block *>::iterator bit = blocks_.begin();
-    while(bit != blocks_.end()) {
-        fact_list<Block *>::iterator cur = bit++;
-        destroy_block(*cur);
-    }
-    fact_list<Function *>::iterator fit = funcs_.begin();
-    while(fit != funcs_.end()) {
-        fact_list<Function *>::iterator cur = fit++;
-        destroy_func(*cur);
-    }
-}
-


### PR DESCRIPTION
This removes the possiblity of object reuse and its associated undefined
behavior. This was originally part of #317.