### PR TITLE
CodeSource destructor cleanup

### DIFF
--- a/parseAPI/h/CodeSource.h
+++ b/parseAPI/h/CodeSource.h
@@ -205,11 +205,14 @@ class PARSER_EXPORT CodeSource : public Dyninst::InstructionSource {
     virtual void startTimer(const std::string& /*name*/) const { return; } 
     virtual void stopTimer(const std::string& /*name*/) const { return; }
     virtual bool findCatchBlockByTryRange(Address /*given try address*/, std::set<Address> & /* catch start */)  const { return false; }
-   
+
+    virtual ~CodeSource() {
+        for(auto *r : _regions)
+            delete r;
+    }
  protected:
     CodeSource() : _regions_overlap(false),
                    _table_of_contents(0) {}
-    virtual ~CodeSource() {}
 
     void addRegion(CodeRegion *);
    

--- a/parseAPI/h/CodeSource.h
+++ b/parseAPI/h/CodeSource.h
@@ -334,7 +334,7 @@ class PARSER_EXPORT SymtabCodeSource : public CodeSource, public boost::lockable
     void init_try_blocks();
 
     CodeRegion * lookup_region(const Address addr) const;
-    void removeRegion(CodeRegion &); // removes from region tree
+    void removeRegion(CodeRegion *); // removes from region tree
 
     void overlapping_warn(const char * file, unsigned line) const;
     

--- a/parseAPI/h/CodeSource.h
+++ b/parseAPI/h/CodeSource.h
@@ -206,10 +206,7 @@ class PARSER_EXPORT CodeSource : public Dyninst::InstructionSource {
     virtual void stopTimer(const std::string& /*name*/) const { return; }
     virtual bool findCatchBlockByTryRange(Address /*given try address*/, std::set<Address> & /* catch start */)  const { return false; }
 
-    virtual ~CodeSource() {
-        for(auto *r : _regions)
-            delete r;
-    }
+    virtual ~CodeSource();
  protected:
     CodeSource() : _regions_overlap(false),
                    _table_of_contents(0) {}

--- a/parseAPI/h/CodeSource.h
+++ b/parseAPI/h/CodeSource.h
@@ -215,6 +215,7 @@ class PARSER_EXPORT CodeSource : public Dyninst::InstructionSource {
                    _table_of_contents(0) {}
 
     void addRegion(CodeRegion *);
+    void removeRegion(CodeRegion *);
    
  private: 
     // statistics

--- a/parseAPI/h/SymLiteCodeSource.h
+++ b/parseAPI/h/SymLiteCodeSource.h
@@ -129,7 +129,7 @@ class SymReaderCodeSource : public CodeSource {
  private:
 
     CodeRegion * lookup_region(const Address addr) const;
-    void removeRegion(CodeRegion &); // removes from region tree
+    void removeRegion(CodeRegion *); // removes from region tree
 
     void overlapping_warn(const char * file, unsigned line) const;
     

--- a/parseAPI/src/CodeSource.C
+++ b/parseAPI/src/CodeSource.C
@@ -62,16 +62,17 @@ CodeSource::addRegion(CodeRegion * cr)
 }
 
 void CodeSource::removeRegion(CodeRegion *cr) {
-	auto pos = std::remove(_regions.begin(), _regions.end(), cr);
-	if(pos != _regions.end()) {
-		// NB: Assume no duplicates
-		delete *pos;
-		_regions.erase(pos);
+  auto pos = std::remove(_regions.begin(), _regions.end(), cr);
+  if (pos != _regions.end()) {
+    // NB: Assume no duplicates
+    delete *pos;
+    _regions.erase(pos);
 
-		// Also remove from the tree
-		_region_tree.remove(*pos);
-	}
+    // Also remove from the tree
+    _region_tree.remove(*pos);
+  }
 }
+
 
 int
 CodeSource::findRegions(Address addr, set<CodeRegion *> & ret) const

--- a/parseAPI/src/CodeSource.C
+++ b/parseAPI/src/CodeSource.C
@@ -67,6 +67,18 @@ CodeSource::addRegion(CodeRegion * cr)
     _region_tree.insert(cr);
 }
 
+void CodeSource::removeRegion(CodeRegion *cr) {
+	auto pos = std::remove(_regions.begin(), _regions.end(), cr);
+	if(pos != _regions.end()) {
+		// NB: Assume no duplicates
+		delete *pos;
+		_regions.erase(pos);
+
+		// Also remove from the tree
+		_region_tree.remove(*pos);
+	}
+}
+
 int
 CodeSource::findRegions(Address addr, set<CodeRegion *> & ret) const
 {

--- a/parseAPI/src/CodeSource.C
+++ b/parseAPI/src/CodeSource.C
@@ -54,14 +54,8 @@ CodeSource::addRegion(CodeRegion * cr)
         set<CodeRegion *> exist;
         _region_tree.find(cr,exist);
         if(!exist.empty()) {
-	    // for(auto i = exist.begin();
-	    // 	i != exist.end();
-	    // 	++i)
-	    // {
-	    // 	std::cerr << "Region " << **i << " overlaps " << *cr << std::endl;
-	    // }
             _regions_overlap = true;
-	}
+        }
     }
 
     _region_tree.insert(cr);

--- a/parseAPI/src/CodeSource.C
+++ b/parseAPI/src/CodeSource.C
@@ -43,6 +43,11 @@ using namespace std;
 using namespace Dyninst;
 using namespace Dyninst::ParseAPI;
 
+CodeSource::~CodeSource() {
+  for(auto *r : _regions)
+    delete r;
+}
+
 /** CodeSource **/
 void
 CodeSource::addRegion(CodeRegion * cr)

--- a/parseAPI/src/SymLiteCodeSource.C
+++ b/parseAPI/src/SymLiteCodeSource.C
@@ -194,8 +194,6 @@ SymReaderCodeSource::~SymReaderCodeSource()
     free(stats_parse);
     if(owns_symtab && _symtab)
       getSymReaderFactory()->closeSymbolReader(_symtab);
-    for(unsigned i=0;i<_regions.size();++i)
-        delete _regions[i];
 }
 
 SymReaderCodeSource::SymReaderCodeSource(SymReader * st) : 

--- a/parseAPI/src/SymLiteCodeSource.C
+++ b/parseAPI/src/SymLiteCodeSource.C
@@ -500,16 +500,7 @@ SymReaderCodeSource::length() const
 void 
 SymReaderCodeSource::removeRegion(CodeRegion *cr)
 {
-    _region_tree.remove( &cr );
-
-    for (vector<CodeRegion*>::iterator rit = _regions.begin(); 
-         rit != _regions.end(); rit++) 
-    {
-        if ( &cr == *rit ) {
-            _regions.erase( rit );
-            break;
-        }
-    }
+	CodeSource::removeRegion(cr);
 }
 
 // fails and returns false if it can't find a CodeRegion

--- a/parseAPI/src/SymLiteCodeSource.C
+++ b/parseAPI/src/SymLiteCodeSource.C
@@ -500,7 +500,7 @@ SymReaderCodeSource::length() const
 
 
 void 
-SymReaderCodeSource::removeRegion(CodeRegion &cr)
+SymReaderCodeSource::removeRegion(CodeRegion *cr)
 {
     _region_tree.remove( &cr );
 
@@ -538,7 +538,7 @@ SymReaderCodeSource::resizeRegion(SymSegment *sr, Address newDiskSize)
     }
 
     // remove, resize, reinsert
-    removeRegion( **rit );
+    removeRegion( *rit );
     sr->file_size = newDiskSize;
     addRegion( *rit );
     return true;

--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -847,7 +847,7 @@ SymtabCodeSource::length() const
 
 
 void 
-SymtabCodeSource::removeRegion(CodeRegion &cr)
+SymtabCodeSource::removeRegion(CodeRegion *cr)
 {
     _region_tree.remove( &cr );
 
@@ -885,7 +885,7 @@ SymtabCodeSource::resizeRegion(SymtabAPI::Region *sr, Address newDiskSize)
     }
 
     // remove, resize, reinsert
-    removeRegion( **rit );
+    removeRegion( *rit );
     sr->setDiskSize( newDiskSize );
     addRegion( *rit );
     return true;

--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -235,8 +235,6 @@ SymtabCodeSource::~SymtabCodeSource()
     delete stats_parse;
     if(owns_symtab && _symtab)
         SymtabAPI::Symtab::closeSymtab(_symtab);
-    for(unsigned i=0;i<_regions.size();++i)
-        delete _regions[i];
 }
 
 SymtabCodeSource::SymtabCodeSource(SymtabAPI::Symtab * st, 

--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -847,16 +847,7 @@ SymtabCodeSource::length() const
 void 
 SymtabCodeSource::removeRegion(CodeRegion *cr)
 {
-    _region_tree.remove( &cr );
-
-    for (vector<CodeRegion*>::iterator rit = _regions.begin(); 
-         rit != _regions.end(); rit++) 
-    {
-        if ( &cr == *rit ) {
-            _regions.erase( rit );
-            break;
-        }
-    }
+	CodeSource::removeRegion(cr);
 }
 
 // fails and returns false if it can't find a CodeRegion


### PR DESCRIPTION
This ensures that CodeSource is responsible for cleanup up its own objects rather than relying on the derived class to do it. This is particularly important since this class is part of the pubic API.

This was originally part of #317