### PR TITLE
Improve single thread's backward slicing speed by 40%

### DIFF
--- a/dataflowAPI/h/Absloc.h
+++ b/dataflowAPI/h/Absloc.h
@@ -288,7 +288,8 @@ class Assignment {
   DATAFLOW_EXPORT const std::vector<AbsRegion> &inputs() const { return inputs_; }
   DATAFLOW_EXPORT std::vector<AbsRegion> &inputs() { return inputs_; }
 
-  DATAFLOW_EXPORT InstructionAPI::Instruction insn() const { return insn_; }
+  DATAFLOW_EXPORT const InstructionAPI::Instruction &insn() const { return insn_; }
+  DATAFLOW_EXPORT InstructionAPI::Instruction &insn() { return insn_; }
   DATAFLOW_EXPORT Address addr() const { return addr_; }
 
   DATAFLOW_EXPORT const AbsRegion &out() const { return out_; }

--- a/dataflowAPI/h/AbslocInterface.h
+++ b/dataflowAPI/h/AbslocInterface.h
@@ -64,7 +64,7 @@ class AbsRegionConverter {
                                   ParseAPI::Block *block,
 				  std::vector<AbsRegion> &regions);
   
-  DATAFLOW_EXPORT void convertAll(InstructionAPI::Instruction insn,
+  DATAFLOW_EXPORT void convertAll(const InstructionAPI::Instruction &insn,
 				  Address addr,
 				  ParseAPI::Function *func,
                                   ParseAPI::Block *block,
@@ -128,7 +128,7 @@ class AssignmentConverter {
  public:  
  DATAFLOW_EXPORT AssignmentConverter(bool cache, bool stack) : cacheEnabled_(cache), aConverter(false, stack) {};
 
-  DATAFLOW_EXPORT void convert(const InstructionAPI::Instruction insn,
+  DATAFLOW_EXPORT void convert(const InstructionAPI::Instruction &insn,
                                const Address &addr,
                                ParseAPI::Function *func,
                                ParseAPI::Block *block,

--- a/dataflowAPI/h/slicing.h
+++ b/dataflowAPI/h/slicing.h
@@ -511,8 +511,8 @@ class Slicer {
             SliceFrame &cand,
             bool skip,
             std::map<CacheEdge, std::set<AbsRegion> > & visited,
-            std::map<Address,DefCache> & single,
-            std::map<Address, DefCache>& cache);
+            std::unordered_map<Address,DefCache> & single,
+            std::unordered_map<Address, DefCache>& cache);
 
     bool updateAndLink(
             GraphPtr g,
@@ -669,7 +669,7 @@ class Slicer {
 		  SliceNode::Ptr& target,
           AbsRegion const& data);
 
-  void convertInstruction(InstructionAPI::Instruction,
+  void convertInstruction(const InstructionAPI::Instruction &,
                           Address,
                           ParseAPI::Function *,
                           ParseAPI::Block *,
@@ -708,7 +708,7 @@ private:
 
   void insertInitialNode(GraphPtr ret, Direction dir, SliceNode::Ptr aP);
 
-  void mergeRecursiveCaches(std::map<Address, DefCache>& sc, std::map<Address, DefCache>& c, Address a);
+  void mergeRecursiveCaches(std::unordered_map<Address, DefCache>& sc, std::unordered_map<Address, DefCache>& c, Address a);
 
   InsnCache* insnCache_;
   bool own_insnCache;

--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -78,7 +78,7 @@ void AbsRegionConverter::convertAll(InstructionAPI::Expression::Ptr expr,
   }
 }
 
-void AbsRegionConverter::convertAll(InstructionAPI::Instruction insn,
+void AbsRegionConverter::convertAll(const InstructionAPI::Instruction &insn,
 				    Address addr,
 				    ParseAPI::Function *func,
                                     ParseAPI::Block *block,
@@ -491,7 +491,7 @@ bool AbsRegionConverter::definedCache(Address addr,
 // Instruction.
 ///////////////////////////////////////////////////////
 
-void AssignmentConverter::convert(const Instruction I, 
+void AssignmentConverter::convert(const Instruction &I, 
                                   const Address &addr,
 				  ParseAPI::Function *func,
                                   ParseAPI::Block *block,


### PR DESCRIPTION
1. Change pass-by-value arguments to pass-by-reference.
2. Pre-allocate vector/map entries to avoid redundant copies.
3. Use hash map for slicing cache.