### PR TITLE
Make libiberty detection more flexible

### DIFF
--- a/cmake/Modules/FindLibIberty.cmake
+++ b/cmake/Modules/FindLibIberty.cmake
@@ -45,7 +45,7 @@ include(DyninstSystemPaths)
 set(_path_suffixes libiberty iberty)
 
 find_path(LibIberty_INCLUDE_DIRS
-          NAMES libiberty/libiberty.h
+          NAMES libiberty.h
           HINTS ${LibIberty_ROOT_DIR} ${LibIberty_ROOT_DIR}/include ${LibIberty_INCLUDEDIR}
           PATHS ${DYNINST_SYSTEM_INCLUDE_PATHS}
           PATH_SUFFIXES ${_path_suffixes}

--- a/common/src/symbolDemangle.c
+++ b/common/src/symbolDemangle.c
@@ -31,7 +31,7 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <libiberty/demangle.h>
+#include <demangle.h> // from libiberty
 #include "symbolDemangle.h"
 
 


### PR DESCRIPTION
Some platforms don't install libiberty in a subdirectory (e.g., /usr/include/libiberty), so account for that.