### PR TITLE
CMake: Don't use C-language for assembly files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ set(RT_BINARY_DIR ${PROJECT_BINARY_DIR}/dyninstAPI_RT)
 
 set (CMAKE_MODULE_PATH "${DYNINST_ROOT}/cmake" "${DYNINST_ROOT}/cmake/Modules" ${CMAKE_MODULE_PATH})
 
+# Set the compiler to use for ASM
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+
 # Set the C and C++ language standards
 include(LanguageStandards)
 

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -193,6 +193,7 @@ add_definitions(-DBPATCH_DLL_BUILD)
 if (PLATFORM MATCHES i386 AND UNIX)
 set (SRC_LIST ${SRC_LIST} src/cpuid-x86.S)
 set_source_files_properties(src/cpuid-x86.S PROPERTIES LANGUAGE ASM)
+set_source_files_properties(src/cpuid-x86.S PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif ()
 
 dyninst_library(dyninstAPI common instructionAPI stackwalk pcontrol patchAPI parseAPI symtabAPI)

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -192,7 +192,7 @@ set_source_files_properties(${SRC_LIST} PROPERTIES LANGUAGE CXX)
 add_definitions(-DBPATCH_DLL_BUILD)
 if (PLATFORM MATCHES i386 AND UNIX)
 set (SRC_LIST ${SRC_LIST} src/cpuid-x86.S)
-set_source_files_properties(src/cpuid-x86.S PROPERTIES LANGUAGE C)
+set_source_files_properties(src/cpuid-x86.S PROPERTIES LANGUAGE ASM)
 endif ()
 
 dyninst_library(dyninstAPI common instructionAPI stackwalk pcontrol patchAPI parseAPI symtabAPI)

--- a/dyninstAPI_RT/CMakeLists.txt
+++ b/dyninstAPI_RT/CMakeLists.txt
@@ -76,6 +76,7 @@ set (SRC_LIST_aarch64
 
 file(GLOB SRC_ASSEMBLY "src/*.S")
 set_source_files_properties(${SRC_ASSEMBLY} PROPERTIES LANGUAGE ASM)
+set_source_files_properties(${SRC_ASSEMBLY} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # The arch-specific files other than RTthread-x86 are Unix-only.
 if(UNIX)

--- a/dyninstAPI_RT/CMakeLists.txt
+++ b/dyninstAPI_RT/CMakeLists.txt
@@ -1,6 +1,5 @@
 # CMake configuration for dyninstAPI_RT directory
-cmake_minimum_required (VERSION 2.6.4)
-project (DyninstRT C)
+project (DyninstRT C ASM)
 
 set (DYNINST_ROOT ${PROJECT_SOURCE_DIR}/..)
 
@@ -75,21 +74,8 @@ set (SRC_LIST_aarch64
     src/RTstatic_ctors_dtors-aarch64.c                                                                                         
 )
 
-
-# We use gcc to compile the various assembly files, but
-# cmake doesn't default to knowing that gcc can
-# handle .S. 
-ENABLE_LANGUAGE(ASM)
-file (GLOB SRC_ASSEMBLY "src/*.S")
-if(NEED_NATIVE_ASSEMBER MATCHES YES)
-set_source_files_properties(${SRC_ASSEMBLY}
-        PROPERTIES
-        LANGUAGE ASM)
-else()
-set_source_files_properties(${SRC_ASSEMBLY}
-        PROPERTIES
-        LANGUAGE C)
-endif()
+file(GLOB SRC_ASSEMBLY "src/*.S")
+set_source_files_properties(${SRC_ASSEMBLY} PROPERTIES LANGUAGE ASM)
 
 # The arch-specific files other than RTthread-x86 are Unix-only.
 if(UNIX)


### PR DESCRIPTION
CMake 3.19 now passes the language flag to the compiler based on the source's language property.

Fixes #923 