### PR TITLE
Clang fixes

### DIFF
--- a/common/h/concurrent.h
+++ b/common/h/concurrent.h
@@ -145,8 +145,8 @@ public:
 
     using base::clear;
 
-    using base::iterator;
-    using base::const_iterator;
+    using typename base::iterator;
+    using typename base::const_iterator;
     using base::begin;
     using base::end;
 };

--- a/dyninstAPI/src/codegen.C
+++ b/dyninstAPI/src/codegen.C
@@ -321,7 +321,7 @@ void codeGen::insert(const void *b, const unsigned size, const codeBufIndex_t in
     assert(buffer_);
 
     realloc(used() + size);
-    auto * temp = get_ptr(index);
+    char * temp = static_cast<char*>(get_ptr(index));
     memmove(temp + size, temp, used()-index);
     memcpy(temp, b, size);
 


### PR DESCRIPTION
Here are a few fixes to get dyninst building with clang.  The concurrent.h fix is especially important, because this is a public header and the error is preventing other projects that interface with dyninst from building with clang.