### PR TITLE
Add direct tail call case for getCallee

### DIFF
--- a/patchAPI/src/Point.C
+++ b/patchAPI/src/Point.C
@@ -80,8 +80,9 @@ Point::getCallee() {
   PatchBlock* b = the_block_;
   PatchBlock::edgelist::const_iterator it = b->targets().begin();
   for (; it != b->targets().end(); ++it) {
-    if ((*it)->type() == ParseAPI::CALL) {
-       PatchBlock* trg = (*it)->trg();
+    if ((*it)->type() == ParseAPI::CALL ||
+        ((((*it)->type() == ParseAPI::DIRECT || (*it)->type() == ParseAPI::COND_TAKEN)) && (*it)->interproc())) {
+      PatchBlock* trg = (*it)->trg();
       return obj()->getFunc(obj()->co()->findFuncByEntry(trg->block()->region(),
                                                          trg->block()->start()));
     }


### PR DESCRIPTION
When an edge is direct branch or conditional taken branch, and it is inter-procedural, we consider it as a direct tail call and return the target of this edge as the callee.