### PR TITLE
Require gcc >= 6.0

### DIFF
--- a/cmake/LanguageStandards.cmake
+++ b/cmake/LanguageStandards.cmake
@@ -18,10 +18,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Require the standards-compliant C++11 ABI for gcc
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.1")
-    message(FATAL_ERROR "Dyninst requires gcc >= 5.1")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0")
+    message(FATAL_ERROR "Dyninst requires gcc >= 6.0")
   endif()
-  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
 endif()
 
 


### PR DESCRIPTION
We've quietly required the ABI and API changes in libstdc++ for some time, but we make them explicit now.