### PR TITLE
Aggregate variable symbols based on offset and size

### DIFF
--- a/common/h/concurrent.h
+++ b/common/h/concurrent.h
@@ -59,7 +59,9 @@ class dyn_c_hash_map : protected tbb::concurrent_hash_map<K, V,
     typedef tbb::concurrent_hash_map<K, V,
         tbb::tbb_hash_compare<K>, std::allocator<std::pair<K,V>>> base;
 public:
-    using value_type = typename base::value_type;
+    using typename base::value_type;
+    using typename base::mapped_type;
+    using typename base::key_type;
 
     class const_accessor : public base::const_accessor {
         friend class dyn_c_hash_map<K,V>;

--- a/symtabAPI/doc/API/Symtab/Module.tex
+++ b/symtabAPI/doc/API/Symtab/Module.tex
@@ -76,12 +76,14 @@ and \code{false} if there are no modules. The error value is set to \code{No\_Su
 }
 
 \begin{apient}
-bool findVariableByOffset(Variable *&ret,
-                          const Offset offset)
+bool findVariablesByOffset(std::vector<Variable *> &ret,
+                           const Offset offset)
 \end{apient}
 \apidesc{
-This method returns the \code{Variable} object at \code{offset}. Returns \code{true} on success and
-\code{false} if there is no matching variable. The error value is set to \code{No\_Such\_Variable}.
+This method returns a vector of \code{Variable}s with the specified offset. 
+There may be more than one variable at an offset if they have different sizes.
+Returns \code{true} on success and \code{false} if there is no matching variable.
+The error value is set to \code{No\_Such\_Variable}.
 }
 
 \begin{apient}

--- a/symtabAPI/doc/API/Symtab/Symtab.tex
+++ b/symtabAPI/doc/API/Symtab/Symtab.tex
@@ -143,12 +143,14 @@ and \code{false} if there are no modules. The error value is set to \code{No\_Su
 }
 
 \begin{apient}
-bool findVariableByOffset(Variable *&ret,
-                          const Offset offset)
+bool findVariablesByOffset(std::vector<Variable *> &ret,
+                           const Offset offset)
 \end{apient}
 \apidesc{
-This method returns the \code{Variable} object at offset. Returns \code{true} on success and
-\code{false} if there is no matching variable. The error value is set to \code{No\_Such\_Variable}.
+This method returns a vector of \code{Variable}s with the specified offset.
+There may be more than one variable at an offset if they have different sizes.
+Returns \code{true} on success and \code{false} if there is no matching variable.
+The error value is set to \code{No\_Such\_Variable}.
 }
 
 \begin{apient}

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -184,7 +184,7 @@ namespace Dyninst{
 									 bool checkCase = true);
 
 			// Variable based methods
-			bool findVariableByOffset(Variable *&ret, const Offset offset);
+			bool findVariablesByOffset(std::vector<Variable *> &ret, const Offset offset);
 			bool findVariablesByName(std::vector<Variable *> &ret, const std::string& name,
 									 NameType nameType = anyName,
 									 bool isRegex = false,

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -183,7 +183,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool getContainingInlinedFunction(Offset offset, FunctionBase* &func);
 
    // Variable
-   bool findVariableByOffset(Variable *&ret, const Offset offset);
+   bool findVariablesByOffset(std::vector<Variable *> &ret, const Offset offset);
    bool findVariablesByName(std::vector<Variable *> &ret, const std::string name,
                                           NameType nameType = anyName, 
                                           bool isRegex = false, 
@@ -589,7 +589,8 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
    // Similar for Variables
    std::vector<Variable *> everyVariable;
-   dyn_c_hash_map <Offset, Variable *> varsByOffset;
+   using VarsByOffsetMap = dyn_c_hash_map<Offset, std::vector<Variable *> >;
+   VarsByOffsetMap varsByOffset;
 
     dyn_mutex im_lock;
     boost::multi_index_container<Module*,

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -475,6 +475,24 @@ bool Module::setDefaultNamespacePrefix(string str)
     return exec_->setDefaultNamespacePrefix(str);
 }
 
+bool Module::findVariablesByOffset(std::vector<Variable *> &ret, const Offset offset)
+{
+    std::vector<Variable *> tmp;
+    if (!exec()->findVariablesByOffset(tmp, offset))  {
+        return false;
+    }
+
+    bool succ = false;
+    for (auto v: tmp)  {
+        if (v->getModule() == this)  {
+            ret.push_back(v);
+            succ = true;
+        }
+    }
+
+    return succ;
+}
+
 bool Module::findVariablesByName(std::vector<Variable *> &ret, const std::string& name,
 				 NameType nameType,
 				 bool isRegex,

--- a/symtabAPI/src/Object-nt.C
+++ b/symtabAPI/src/Object-nt.C
@@ -2096,10 +2096,12 @@ BOOL CALLBACK add_type_info(PSYMBOL_INFO pSymInfo, ULONG SymbolSize, void *info)
    
    if (type)
    {
-      Variable *var = NULL;
-      bool result = obj->findVariableByOffset(var, addr);
+      std::vector<Variable *> vars;
+      bool result = obj->findVariablesByOffset(vars, addr);
       if (result) {
-         var->setType(type);
+         for (auto v: vars)  {
+            v->setType(type);
+         }
       }
       if (name) {
          std::string vName = name;

--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -75,10 +75,14 @@ bool Symtab::changeType(Symbol *sym, Symbol::SymbolType oldType)
     }
     case Symbol::ST_TLS:
     case Symbol::ST_OBJECT: {
-        Variable *var = NULL;
-        if (findVariableByOffset(var, sym->getOffset())) {
-            var->removeSymbol(sym);
-            // See above
+        std::vector<Variable *> vars;
+        if (findVariablesByOffset(vars, sym->getOffset())) {
+            for (auto v: vars)  {
+                if (v->getSize() == sym->getSize())  {
+                    v->removeSymbol(sym);
+                    // See above
+                }
+            }
         }
         break;
     }
@@ -113,10 +117,22 @@ bool Symtab::deleteFunction(Function *func) {
 }
 
 bool Symtab::deleteVariable(Variable *var) {
-    // First, remove the function
+    // remove variable from everyVariable
     everyVariable.erase(std::remove(everyVariable.begin(), everyVariable.end(), var), everyVariable.end());
 
-    varsByOffset.erase(var->getOffset());
+    // remove variable from varsByOffset
+    {
+        VarsByOffsetMap::accessor a;
+        bool found = !varsByOffset.find(a, var->getOffset());
+        if (found)  {
+            VarsByOffsetMap::mapped_type &vars = a->second;
+            vars.erase(std::remove(vars.begin(), vars.end(), var), vars.end());
+            if (vars.empty())  {
+                varsByOffset.erase(a);
+            }
+        }
+    }
+
     return deleteAggregate(var);
 }
 
@@ -188,8 +204,30 @@ bool Symtab::changeAggregateOffset(Aggregate *agg, Offset oldOffset, Offset newO
         }
     }
     if (var) {
-        varsByOffset.erase(oldOffset);
-        if (!varsByOffset.insert({newOffset, var})) {
+        VarsByOffsetMap::accessor a;
+        bool found = !varsByOffset.find(a, oldOffset);
+        VarsByOffsetMap::mapped_type &vars = a->second;
+        if (found)  {
+            remove(vars.begin(), vars.end(), var);
+            if (vars.empty())  {
+                varsByOffset.erase(a);
+            }
+        }  else  {
+            assert(0);
+        }
+
+        found = !varsByOffset.insert(a, newOffset);
+        if (found)  {
+            found = false;
+            for (auto v: vars)  {
+                if (v->getSize() == var->getSize())  {
+                    found = true;
+                }
+            }
+        }
+        if (!found)  {
+            vars.push_back(var);
+        }  else  {
             // Already someone there... odd, so don't do anything.
         }
     }

--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -181,7 +181,8 @@ bool Symtab::changeSymbolOffset(Symbol *sym, Offset newOffset) {
     if (!everyDefinedSymbol.by_offset.find(oa, sym->offset_))  {
         assert(!"everyDefinedSymbol.by_offset.find(oa, sym->offset_)");
     }
-    std::remove(oa->second.begin(), oa->second.end(), sym);
+    auto &syms = oa->second;
+    syms.erase(std::remove(syms.begin(), syms.end(), sym), syms.end());
     everyDefinedSymbol.by_offset.insert(oa, newOffset);
     oa->second.push_back(sym);
 
@@ -208,7 +209,7 @@ bool Symtab::changeAggregateOffset(Aggregate *agg, Offset oldOffset, Offset newO
         bool found = !varsByOffset.find(a, oldOffset);
         VarsByOffsetMap::mapped_type &vars = a->second;
         if (found)  {
-            remove(vars.begin(), vars.end(), var);
+            vars.erase(std::remove(vars.begin(), vars.end(), var), vars.end());
             if (vars.empty())  {
                 varsByOffset.erase(a);
             }

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -296,7 +296,7 @@ bool Symtab::getAllFunctions(std::vector<Function *> &ret) {
     return (ret.size() > 0);
 }
 
-bool Symtab::findVariableByOffset(Variable *&ret, const Offset offset) {
+bool Symtab::findVariablesByOffset(std::vector<Variable *> &ret, const Offset offset) {
 
     /* XXX
      *
@@ -304,12 +304,13 @@ bool Symtab::findVariableByOffset(Variable *&ret, const Offset offset) {
      * relocatable files -- this discrepancy applies here as well.
      */
     {
-        dyn_c_hash_map<Offset, Variable*>::const_accessor ca;
+        VarsByOffsetMap::const_accessor ca;
         if (varsByOffset.find(ca, offset)) {
             ret = ca->second;
-        return true;
+            return true;
+        }
     }
-    }
+    ret.clear();
     setSymtabError(No_Such_Symbol);
     return false;
 }

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -761,15 +761,24 @@ bool Symtab::addSymbolToAggregates(const Symbol *sym_tmp)
         Variable *var = NULL;
         bool found = false;
         {
-            dyn_c_hash_map<Offset,Variable*>::accessor a;
+            VarsByOffsetMap::accessor a;
             found = !varsByOffset.insert(a, sym->getOffset());
-            if(found) var = a->second;
-            else {
-            // Create a new function
-            // Also, update the symbol to point to this function.
-            var = new Variable(sym);
-                a->second = var;
-        }
+            VarsByOffsetMap::mapped_type &vars = a->second;
+            if (found)  {
+                found = false;
+                for (auto v: vars)  {
+                    if (v->getSize() == sym->getSize())  {
+                        found = true;
+                        var = v;
+                    }
+                }
+            }
+            if (!found)  {
+                // Create a new variable
+                // Also, update the symbol to point to this variable.
+                var = new Variable(sym);
+                vars.push_back(var);
+            }
         }
         if(found) {
             /* XXX

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -916,11 +916,13 @@ void DwarfWalker::createGlobalVariable(const vector<VariableLocation> &locs, boo
    Offset addr = 0;
    if (locs.size() && locs[0].stClass == storageAddr)
          addr = locs[0].frameOffset;
-   Variable *var;
-   bool result = symtab()->findVariableByOffset(var, addr);
-   if (result) {
-         var->setType(type);
-      }
+   std::vector<Variable *> vars;
+   bool result = symtab()->findVariablesByOffset(vars, addr);
+   if (result)  {
+	for (auto v: vars)  {
+	    v->setType(type);
+	}
+   }
    tc()->addGlobalVariable(curName(), type);
 }
 


### PR DESCRIPTION
- changed findVariableByOffset that returned a Variable
  to      findVariablesByOffset that returns a vector of Variables

- changed Symtab::varsByOffset to map an offset to a vector of
  variables each with a unique size.

- added undefined method Module::findVariablesByOffset

Fixes #933