### PR TITLE
make Symbol methods const

### DIFF
--- a/symtabAPI/h/Symbol.h
+++ b/symtabAPI/h/Symbol.h
@@ -211,7 +211,7 @@ class SYMTAB_EXPORT Symbol : public AnnotatableSparse
    int getStrIndex() const { return strindex_; }
    bool setStrIndex(int strindex) { strindex_ = strindex; return true; }
    void setReferringSymbol (Symbol *referringSymbol);
-   Symbol* getReferringSymbol ();
+   Symbol* getReferringSymbol () const;
 
    //////////////// Modification
    bool setOffset (Offset newOffset);
@@ -236,17 +236,17 @@ class SYMTAB_EXPORT Symbol : public AnnotatableSparse
    bool  setVersionNum(unsigned verNum);
    void setVersionHidden() { versionHidden_ = true; }
 
-   bool  getVersionFileName(std::string &fileName);
-   bool  getVersions(std::vector<std::string> *&vers);
-   bool  getVersionNum(unsigned &verNum);
-   bool  getVersionHidden() { return versionHidden_; }
+   bool  getVersionFileName(std::string &fileName) const;
+   bool  getVersions(std::vector<std::string> *&vers) const;
+   bool  getVersionNum(unsigned &verNum) const;
+   bool  getVersionHidden() const { return versionHidden_; }
 
    friend
       std::ostream& operator<< (std::ostream &os, const Symbol &s);
 
    public:
    static std::string emptyString;
-   int getInternalType() { return internal_type_; }
+   int getInternalType() const { return internal_type_; }
    void setInternalType(int i) { internal_type_ = i; }
 
    private:

--- a/symtabAPI/src/Symbol.C
+++ b/symtabAPI/src/Symbol.C
@@ -209,7 +209,7 @@ SYMTAB_EXPORT bool Symbol::setVersions(std::vector<std::string> &vers)
    return true;
 }
 
-SYMTAB_EXPORT bool Symbol::getVersionFileName(std::string &fileName)
+SYMTAB_EXPORT bool Symbol::getVersionFileName(std::string &fileName) const
 {
    std::string *fn_p = NULL;
 
@@ -224,7 +224,7 @@ SYMTAB_EXPORT bool Symbol::getVersionFileName(std::string &fileName)
    return false;
 }
 
-SYMTAB_EXPORT bool Symbol::getVersions(std::vector<std::string> *&vers)
+SYMTAB_EXPORT bool Symbol::getVersions(std::vector<std::string> *&vers) const
 {
    std::vector<std::string> *vn_p = NULL;
 
@@ -409,7 +409,8 @@ void Symbol::setReferringSymbol(Symbol* referringSymbol)
 	referring_= referringSymbol;
 }
 
-Symbol* Symbol::getReferringSymbol() {
+Symbol* Symbol::getReferringSymbol() const
+{
 	return referring_;
 }
 


### PR DESCRIPTION
The following methods should be const methods of the class Symbol:

- getVersions
- getVersionFileName
- getVersionNum
- getVersionHidden
- getReferringSymbol

Fixes: #935