### PR TITLE
Fix a bug in DwarfHandle::init_dbg where incorrect value is returned

### DIFF
--- a/dwarf/src/dwarfHandle.C
+++ b/dwarf/src/dwarfHandle.C
@@ -200,10 +200,9 @@ bool DwarfHandle::init_dbg()
             unsigned int ef_amdgpu_mach = 0x000000ff & file->e_flags();
 			switch(ef_amdgpu_mach){
 				case 0x33: case 0x34: case 0x35: case 0x36: case 0x37: case 0x38:
-					return Dyninst::Arch_amdgpu_rdna;
-					assert( 0 && "rdna not supported yet " );
+					arch =  Dyninst::Arch_amdgpu_rdna;
 				case 0x28: case 0x29: case 0x2a: case 0x2b: case 0x2c: case 0x2d: case 0x2e: case 0x2f: case 0x30: case 0x31:
-					return Dyninst::Arch_amdgpu_vega;
+					arch = Dyninst::Arch_amdgpu_vega;
 				case 0x11: case 0x12: case 0x13: case 0x14: case 0x15: case 0x16: case 0x17: case 0x18:
 				case 0x19: case 0x1a: case 0x1b: case 0x1c: case 0x1d: case 0x1e: case 0x1f:
 					assert(0 && "reserved for r600 architecture");


### PR DESCRIPTION
Fix a bug for AMDGPU where we erroneously returned the arch enum instead of boolean value, and didn't set the arch variable correctly in the function DwarfHandle::init_dbg 