### PR TITLE
add missing libiberty include dir

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -112,6 +112,10 @@ dyninst_library(common)
 if(TARGET LibIberty)
   add_dependencies(common LibIberty)
   target_link_libraries(common PRIVATE LibIberty)
+
+  if(${ENABLE_STATIC_LIBS})
+	  target_link_libraries(common_static PRIVATE LibIberty)
+  endif()
 endif()
 
 if(TARGET TBB)


### PR DESCRIPTION
On some platforms, the libiberty headers are not in the usual place. The user can override the location in CMake, but this path is ignored by the CMakeLists.txt