### PR TITLE
Fix compile warnings for AMDGPU for Release 11.0

### DIFF
--- a/instructionAPI/src/InstructionDecoder-amdgpu-vega.C
+++ b/instructionAPI/src/InstructionDecoder-amdgpu-vega.C
@@ -173,7 +173,6 @@ namespace Dyninst {
 
 		void InstructionDecoder_amdgpu_vega::finalizeFLATOperands(){
 			layout_flat & layout = insn_layout.flat;
-			//const amdgpu_insn_entry & insn_entry = amdgpu_vega::flat_insn_table[layout.op];
 
 			Expression::Ptr addr_ast = 
 				makeTernaryExpression(
@@ -198,7 +197,6 @@ namespace Dyninst {
 		}
 		void InstructionDecoder_amdgpu_vega::finalizeMUBUFOperands(){
 			layout_mubuf & layout = insn_layout.mubuf;
-			//const amdgpu_insn_entry  &insn_entry = amdgpu_insn_entry::mubuf_insn_table[layout.op];
 
 			MachRegister vsharp = makeAmdgpuRegID(amdgpu_vega::sgpr0,layout.srsrc<<2,4);
 			Expression::Ptr const_base_ast   = makeRegisterExpression(vsharp,0,47); 
@@ -309,7 +307,6 @@ namespace Dyninst {
 
 		void InstructionDecoder_amdgpu_vega::finalizeMTBUFOperands(){
 			layout_mtbuf & layout = insn_layout.mtbuf;
-			//const amdgpu_insn_entry  &insn_entry = amdgpu_insn_entry::mtbuf_insn_table[layout.op];
 
 			MachRegister vsharp = makeAmdgpuRegID(amdgpu_vega::sgpr0,layout.srsrc<<2,4);
 			Expression::Ptr const_base_ast   = makeRegisterExpression(vsharp,0,47); 
@@ -393,7 +390,6 @@ namespace Dyninst {
 		void InstructionDecoder_amdgpu_vega::finalizeVOP1Operands(){
 
 			layout_vop1 & layout = insn_layout.vop1;
-			//const amdgpu_insn_entry  &insn_entry = amdgpu_insn_entry::vop1_insn_table[layout.op];
 			//cout << " finalizing vop1 operands , vdst = " << std::dec << layout.vdst << " src0 = " << layout.src0 <<endl;
 
 			insn_in_progress->appendOperand(decodeVDST(layout.vdst),false,true);
@@ -405,7 +401,6 @@ namespace Dyninst {
 		void InstructionDecoder_amdgpu_vega::finalizeSOP1Operands(){
 
 			layout_sop1 & layout = insn_layout.sop1;
-			//const amdgpu_insn_entry  &insn_entry = amdgpu_insn_entry::sop1_insn_table[layout.op];
 
 			if(isBranch){
 				if(isModifyPC){
@@ -455,7 +450,6 @@ namespace Dyninst {
 		void InstructionDecoder_amdgpu_vega::finalizeSOPPOperands(){
 
 			layout_sopp & layout = insn_layout.sopp;
-			//const amdgpu_insn_entry  &insn_entry = amdgpu_insn_entry::sopp_insn_table[layout.op];
 
 			if(isBranch){
 				if(!isModifyPC){	
@@ -470,7 +464,6 @@ namespace Dyninst {
 		void InstructionDecoder_amdgpu_vega::finalizeSOPKOperands(){
 
 			layout_sopp & layout = insn_layout.sopp;
-			//const amdgpu_insn_entry  &insn_entry = amdgpu_insn_entry::sopp_insn_table[layout.op];
 
 			if(isBranch){
 				if(!isModifyPC){	
@@ -489,7 +482,6 @@ namespace Dyninst {
 		void InstructionDecoder_amdgpu_vega::finalizeSOP2Operands(){
 
 			layout_sop2 & layout = insn_layout.sop2;
-			//const amdgpu_insn_entry  &insn_entry = amdgpu_insn_entry::sop2_insn_table[layout.op];
 		    auto opID = insn_in_progress->getOperation().operationID ;	
 
             switch(opID){
@@ -513,7 +505,6 @@ namespace Dyninst {
 		void InstructionDecoder_amdgpu_vega::finalizeSMEMOperands(){
 			layout_smem & layout = insn_layout.smem;
 
-			//const amdgpu_insn_entry  &insn_entry = amdgpu_insn_entry::smem_insn_table[layout.op];
 			if(IS_LD_ST()){
 				Expression::Ptr offset_expr ;
 				Expression::Ptr inst_offset_expr ;

--- a/instructionAPI/src/InstructionDecoder-amdgpu-vega.C
+++ b/instructionAPI/src/InstructionDecoder-amdgpu-vega.C
@@ -156,9 +156,9 @@ namespace Dyninst {
 		}
 
 
-		bool InstructionDecoder_amdgpu_vega::decodeOperands(const Instruction *insn_to_complete) {
+		bool InstructionDecoder_amdgpu_vega::decodeOperands(const Instruction *) {
 			assert(0 && "decodeOperands deprecated for amdgpu");
-			return insn_to_complete != NULL;
+			return true;
 		}
 
 		Expression::Ptr InstructionDecoder_amdgpu_vega::decodeSGPRorM0(unsigned int offset){

--- a/instructionAPI/src/InstructionDecoder-amdgpu-vega.h
+++ b/instructionAPI/src/InstructionDecoder-amdgpu-vega.h
@@ -65,7 +65,8 @@ namespace Dyninst {
             virtual void setMode(bool) { }
 
             virtual bool decodeOperands(const Instruction *insn_to_complete);
-            virtual bool decodeOperands(const Instruction *insn_to_complete, const amdgpu_insn_entry & insn_entry);
+            
+            bool decodeOperands(const amdgpu_insn_entry & insn_entry);
 
             virtual void doDelayedDecode(const Instruction *insn_to_complete);
 
@@ -195,7 +196,6 @@ namespace Dyninst {
             bool fix_bitfieldinsn_alias(int, int);
 	        void fix_condinsn_alias_and_cond(int &);
 	        void modify_mnemonic_simd_upperhalf_insns();
-            bool pre_process_checks(const amdgpu_insn_entry &);
 
             MachRegister makeAmdgpuRegID(MachRegister, unsigned int, unsigned int len = 1);
 

--- a/instructionAPI/src/amdgpu_decoder_impl_vega.C
+++ b/instructionAPI/src/amdgpu_decoder_impl_vega.C
@@ -6,7 +6,7 @@ void InstructionDecoder_amdgpu_vega::decodeSOP2(){
 	layout.sdst      = longfield<16,22>(insn_long);
 	layout.op        = longfield<23,29>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::sop2_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeSOP2Operands();
 }
@@ -17,7 +17,7 @@ void InstructionDecoder_amdgpu_vega::decodeSOP1(){
 	layout.op        = longfield<8,15>(insn_long);
 	layout.sdst      = longfield<16,22>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::sop1_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeSOP1Operands();
 }
@@ -28,7 +28,7 @@ void InstructionDecoder_amdgpu_vega::decodeSOPK(){
 	layout.sdst      = longfield<16,22>(insn_long);
 	layout.op        = longfield<23,27>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::sopk_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeSOPKOperands();
 }
@@ -39,7 +39,7 @@ void InstructionDecoder_amdgpu_vega::decodeSOPC(){
 	layout.ssrc1     = longfield<8,15>(insn_long);
 	layout.op        = longfield<16,22>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::sopc_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeSOPCOperands();
 }
@@ -49,7 +49,7 @@ void InstructionDecoder_amdgpu_vega::decodeSOPP(){
 	layout.simm16    = longfield<0,15>(insn_long);
 	layout.op        = longfield<16,22>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::sopp_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeSOPPOperands();
 }
@@ -66,7 +66,7 @@ void InstructionDecoder_amdgpu_vega::decodeSMEM(){
 	layout.offset    = longfield<32,52>(insn_long);
 	layout.soffset   = longfield<57,63>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::smem_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeSMEMOperands();
 }
@@ -107,7 +107,7 @@ void InstructionDecoder_amdgpu_vega::decodeVOP2(){
 		vop_literal.row_mask  = longfield<60,63>(insn_long);
 	}
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::vop2_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeVOP2Operands();
 }
@@ -147,7 +147,7 @@ void InstructionDecoder_amdgpu_vega::decodeVOP1(){
 		vop_literal.row_mask  = longfield<60,63>(insn_long);
 	}
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::vop1_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeVOP1Operands();
 }
@@ -185,7 +185,7 @@ void InstructionDecoder_amdgpu_vega::decodeVOPC(){
 		vop_literal.row_mask  = longfield<60,63>(insn_long);
 	}
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::vopc_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeVOPCOperands();
 }
@@ -198,7 +198,7 @@ void InstructionDecoder_amdgpu_vega::decodeVINTRP(){
 	layout.op        = longfield<16,17>(insn_long);
 	layout.vdst      = longfield<18,25>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::vintrp_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeVINTRPOperands();
 }
@@ -214,7 +214,7 @@ void InstructionDecoder_amdgpu_vega::decodeDS(){
 	layout.data1     = longfield<48,55>(insn_long);
 	layout.vdst      = longfield<56,63>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::ds_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeDSOperands();
 }
@@ -235,7 +235,7 @@ void InstructionDecoder_amdgpu_vega::decodeMTBUF(){
 	layout.tfe       = longfield<55,55>(insn_long);
 	layout.soffset   = longfield<56,63>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::mtbuf_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeMTBUFOperands();
 }
@@ -255,7 +255,7 @@ void InstructionDecoder_amdgpu_vega::decodeMUBUF(){
 	layout.tfe       = longfield<55,55>(insn_long);
 	layout.soffset   = longfield<56,63>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::mubuf_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeMUBUFOperands();
 }
@@ -264,7 +264,7 @@ void InstructionDecoder_amdgpu_vega::decodeVOP3AB(){
 	layout_vop3ab & layout = insn_layout.vop3ab;
 	layout.op        = longfield<16,25>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::vop3ab_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeVOP3ABOperands();
 }
@@ -283,7 +283,7 @@ void InstructionDecoder_amdgpu_vega::decodeVOP3P(){
 	layout.opsel_hi  = longfield<59,60>(insn_long);
 	layout.neg       = longfield<61,63>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::vop3p_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeVOP3POperands();
 }
@@ -302,7 +302,7 @@ void InstructionDecoder_amdgpu_vega::decodeFLAT(){
 	layout.nv        = longfield<55,55>(insn_long);
 	layout.vdst      = longfield<56,63>(insn_long);
 	const amdgpu_insn_entry &insn_entry = amdgpu_insn_entry::flat_insn_table[layout.op];
-	decodeOperands(this->insn_in_progress.get(),insn_entry);
+	decodeOperands(insn_entry);
 	this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
 	finalizeFLATOperands();
 }

--- a/parseAPI/src/IA_amdgpu.C
+++ b/parseAPI/src/IA_amdgpu.C
@@ -64,7 +64,7 @@ IA_amdgpu* IA_amdgpu::clone() const {
     return new IA_amdgpu(*this);
 }
 
-bool IA_amdgpu::isFrameSetupInsn(Instruction i) const
+bool IA_amdgpu::isFrameSetupInsn(Instruction ) const
 {
     return false;
 }
@@ -83,8 +83,8 @@ bool IA_amdgpu::isThunk() const
     return false;
 }
 
-bool IA_amdgpu::isTailCall(const Function* context, EdgeTypeEnum type, unsigned int,
-        const std::set<Address>& knownTargets ) const
+bool IA_amdgpu::isTailCall(const Function*, EdgeTypeEnum , unsigned int,
+        const std::set<Address>&  ) const
 {
    return false;
 }
@@ -104,17 +104,17 @@ bool IA_amdgpu::cleansStack() const
    return false;
 }
 
-bool IA_amdgpu::sliceReturn(ParseAPI::Block* bit, Address ret_addr, ParseAPI::Function * func) const
+bool IA_amdgpu::sliceReturn(ParseAPI::Block* , Address , ParseAPI::Function * ) const
 {
     return true;
 }
 
-bool IA_amdgpu::isReturnAddrSave(Address& retAddr) const
+bool IA_amdgpu::isReturnAddrSave(Address& ) const
 {
   return false;
 }
 
-bool IA_amdgpu::isReturn(Dyninst::ParseAPI::Function * context, Dyninst::ParseAPI::Block* currBlk) const
+bool IA_amdgpu::isReturn(Dyninst::ParseAPI::Function * , Dyninst::ParseAPI::Block*) const
 {
     return curInsn().getCategory() == c_ReturnInsn;
 }

--- a/parseAPI/src/SymbolicExpression.C
+++ b/parseAPI/src/SymbolicExpression.C
@@ -372,6 +372,7 @@ Address SymbolicExpression::PCValue(Address cur, size_t insnSize, Architecture a
     case Arch_amdgpu_vega:
 	    return cur + insnSize;
 	case Arch_aarch64:
+    case Arch_amdgpu_rdna:
         case Arch_ppc32:
         case Arch_ppc64:
 	    return cur;


### PR DESCRIPTION
This commit should fix most of the compile warnings mentioned in #952  except -Wunused-parameter


The fix involves:
Reorder the C++ initializer list to get rid off reorder warnings
Removing unused functions copied from InstructionDecoer-aarch64.C
Unused variable commented out in amdgpu_vega_impl.C
Add cases to handle the yet-to-be-supported Arch_amdgpu_rdna in dyn_regs.C

Fixes #952 