### PR TITLE
Remove unused 'name' parameter from Collections::addGlobalVariable

### DIFF
--- a/symtabAPI/h/Collections.h
+++ b/symtabAPI/h/Collections.h
@@ -123,9 +123,9 @@ public:
     void addType(Type* t, dyn_mutex::unique_lock& g) {
       addType(t->reshare(), g);
     }
-    void addGlobalVariable(std::string &name, boost::shared_ptr<Type> type);
-    void addGlobalVariable(std::string &name, Type* t) {
-      addGlobalVariable(name, t->reshare());
+    void addGlobalVariable(boost::shared_ptr<Type> type);
+    void addGlobalVariable(Type* t) {
+      addGlobalVariable(t->reshare());
     }
 
     /* Some debug formats allow forward references.  Rather than

--- a/symtabAPI/src/Collections.C
+++ b/symtabAPI/src/Collections.C
@@ -368,7 +368,7 @@ void typeCollection::addType(boost::shared_ptr<Type> type)
     }
 }
 
-void typeCollection::addGlobalVariable(std::string &name, boost::shared_ptr<Type> type)
+void typeCollection::addGlobalVariable(boost::shared_ptr<Type> type)
 {
     globalVarsByName.insert({type->getName(), type});
 }

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -4719,7 +4719,7 @@ void Object::parseStabTypes() {
                         if (!commonBlock->isCommonType()) {
                             // its still the null type, create a new one for it
                             commonBlock = Type::make_shared<typeCommon>(*commonBlockName);
-                            tc->addGlobalVariable(*commonBlockName, commonBlock);
+                            tc->addGlobalVariable(commonBlock);
                         }
                         // reset field list
                         commonBlock->asCommonType().beginCommonBlock();

--- a/symtabAPI/src/Object-nt.C
+++ b/symtabAPI/src/Object-nt.C
@@ -2104,10 +2104,9 @@ BOOL CALLBACK add_type_info(PSYMBOL_INFO pSymInfo, ULONG SymbolSize, void *info)
          }
       }
       if (name) {
-         std::string vName = name;
 		 typeCollection *tc = typeCollection::getModTypeCollection(mod);
 		 assert(tc);
-         tc->addGlobalVariable(vName, type);
+         tc->addGlobalVariable(type);
       }
    }
    return TRUE;

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -808,7 +808,7 @@ boost::shared_ptr<Type> DwarfWalker::getCommonBlockType(string &commonBlockName)
    auto commonBlockType = tc()->findVariableType(commonBlockName, Type::share);
    if(!commonBlockType || !commonBlockType->isCommonType()) {
      commonBlockType = Type::make_shared<typeCommon>( type_id(), commonBlockName );
-     tc()->addGlobalVariable(commonBlockName, commonBlockType);
+     tc()->addGlobalVariable(commonBlockType);
    }
    return commonBlockType;
 }
@@ -932,7 +932,7 @@ void DwarfWalker::createGlobalVariable(const vector<VariableLocation> &locs, boo
 	    v->setType(type);
 	}
    }
-   tc()->addGlobalVariable(curName(), type);
+   tc()->addGlobalVariable(type);
 }
 
 void DwarfWalker::createLocalVariable(const vector<VariableLocation> &locs, boost::shared_ptr<Type> type,

--- a/symtabAPI/src/parseStab.C
+++ b/symtabAPI/src/parseStab.C
@@ -459,7 +459,7 @@ std::string Dyninst::SymtabAPI::parseStabString(Module *mod, int linenum, char *
 	       }
 
 		   typeCollection *tc_to_use = typeCollection::getModTypeCollection(toUse);
-               tc_to_use->addGlobalVariable(name, BPtype);
+               tc_to_use->addGlobalVariable(BPtype);
             }
             else 
             break;
@@ -587,7 +587,7 @@ std::string Dyninst::SymtabAPI::parseStabString(Module *mod, int linenum, char *
                                             true)) 
                   {
 		     
-                     tc->addGlobalVariable(nameTrailer, BPtype);
+                     tc->addGlobalVariable(BPtype);
                   }
                }
 


### PR DESCRIPTION
This was removed by a8def5c64b5 in 2017

@wrwilliams Why does `Collections::addGlobalVariable` use the name from the `Type`'s constructor, but [`BPatch_typeCollection`](https://github.com/dyninst/dyninst/blob/master/dyninstAPI/src/BPatch_collections.h#L101) uses the user-provided one?