### PR TITLE
Allow usage of SIGILL for signal trampolines

### DIFF
--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -84,6 +84,7 @@ AddressSpace::AddressSpace () :
     new_instp_cb(NULL),
     heapInitialized_(false),
     useTraps_(true),
+    sigILLTrampoline_(false),
     trampGuardBase_(NULL),
     up_ptr_(NULL),
     costAddr_(0),
@@ -102,6 +103,16 @@ AddressSpace::AddressSpace () :
        emulatePC_ = true;
    }
 #endif
+   // Historically, we only use SIGTRAP as the signal for tramopline.
+   // However, SIGTRAP is always intercepted by GDB, causing it is 
+   // almost impossible to debug through signal trampolines.
+   // Here, we add a new environment variable DYNINST_SIGNAL_TRAMPOLINE_SIGILL
+   // to control whether we use SIGILL as the signal for trampolines.
+   // In the case of binary rewriting, DYNINST_SIGNAL_TRAMPOLINE_SIGILL should be 
+   // consistently set or unset for rewriting the binary and running the rewritten binaries. 
+   if (getenv("DYNINST_SIGNAL_TRAMPOLINE_SIGILL")) {
+      sigILLTrampoline_ = true;
+   }
 }
 
 AddressSpace::~AddressSpace() {

--- a/dyninstAPI/src/addressSpace.h
+++ b/dyninstAPI/src/addressSpace.h
@@ -506,6 +506,7 @@ class AddressSpace : public InstructionSource {
 
     bool heapInitialized_;
     bool useTraps_;
+    bool sigILLTrampoline_;
     inferiorHeap heap_;
 
     // Loaded mapped objects (may be just 1)

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -1026,7 +1026,11 @@ void BinaryEdit::addTrap(Address from, Address to, codeGen &gen) {
    gen.allocate(4);
    gen.setAddrSpace(this);
    gen.setAddr(from);
-   insnCodeGen::generateTrap(gen);
+   if (sigILLTrampoline_) {
+      insnCodeGen::generateIllegal(gen);
+   } else {
+      insnCodeGen::generateTrap(gen);
+   }
    trapMapping.addTrapMapping(from, to, true);
    springboard_cerr << "Generated springboard trap " << hex << from << "->" << to << dec << endl;
 }

--- a/dyninstAPI/src/dynProcess.C
+++ b/dyninstAPI/src/dynProcess.C
@@ -3240,7 +3240,11 @@ void PCProcess::addTrap(Address from, Address to, codeGen &gen) {
    gen.allocate(4);
    gen.setAddrSpace(this);
    gen.setAddr(from);
-   insnCodeGen::generateTrap(gen);
+   if (sigILLTrampoline_) {
+      insnCodeGen::generateIllegal(gen);
+   } else {
+      insnCodeGen::generateTrap(gen);
+   }   
    trapMapping.addTrapMapping(from, to, true);
    springboard_cerr << "Generated springboard trap " << hex << from << "->" << to << dec << endl;
 }

--- a/dyninstAPI_RT/src/RTposix.c
+++ b/dyninstAPI_RT/src/RTposix.c
@@ -268,13 +268,22 @@ int DYNINSTinitializeTrapHandler()
 {
    int result;
    struct sigaction new_handler;
+   int signo = SIGTRAP;
+
+   // If environment variable DYNINST_SIGNAL_TRAMPOLINE_SIGILL is set,
+   // we use SIGILL as the signal for signal trampoline.
+   // The mutatee has to be generated with DYNINST_SIGNAL_TRAMPOLINE_SIGILL set
+   // so that the mutator will generates illegal instructions as trampolines.
+   if (getenv("DYNINST_SIGNAL_TRAMPOLINE_SIGILL")) {
+      signo = SIGILL;
+   }
 
    new_handler.sa_sigaction = dyninstTrapHandler;
    //new_handler.sa_restorer = NULL; obsolete
    sigemptyset(&new_handler.sa_mask);
    new_handler.sa_flags = SA_SIGINFO | SA_NODEFER;
    
-   result = sigaction(SIGTRAP, &new_handler, NULL);
+   result = sigaction(signo, &new_handler, NULL);
    return (result == 0) ? 1 /*Success*/ : 0 /*Fail*/ ;
 }
 


### PR DESCRIPTION
Add a new environment variable `DYNINST_SIGNAL_TRAMPOLINE_SIGILL` to control whether we use SIGILL as the signal for trampolines.

If `DYNINST_SIGNAL_TRAMPOLINE_SIGILL` is set, we use SIGILL as signal trampolines and the mutator will generate illegal instructions in the mutatee.

In the case of binary rewriting, `DYNINST_SIGNAL_TRAMPOLINE_SIGILL` should be consistently set or unset when rewriting the binary and running the rewritten binaries.