### PR TITLE
Remove usage of designated initializer in dwarfHandle.C

### DIFF
--- a/dwarf/src/dwarfHandle.C
+++ b/dwarf/src/dwarfHandle.C
@@ -53,9 +53,10 @@ using namespace std;
 
 static const Dwfl_Callbacks dwfl_callbacks =
 {
-    .find_elf = dwfl_build_id_find_elf,
-    .find_debuginfo = dwfl_standard_find_debuginfo,
-    .section_address = dwfl_offline_section_address,
+    dwfl_build_id_find_elf,
+    dwfl_standard_find_debuginfo,
+    dwfl_offline_section_address,
+	nullptr
 };
 
 /*void DwarfHandle::defaultDwarfError(Dwarf_Error err, Dwarf_Ptr p) {


### PR DESCRIPTION
Designated initializers aren't part of C++ until C++20; use aggregate initialization, instead. This also fixes the missing initializer for Dwfl_Callbacks::debuginfo_path.