### PR TITLE
Fix C-string truncations in parseThat/config.C

### DIFF
--- a/parseThat/src/config.C
+++ b/parseThat/src/config.C
@@ -295,7 +295,7 @@ bool getNext_BatchFile()
         cmdline = char2strlist(buf);
 
         strncpy(config.target, strlist_get(&cmdline, 0),
-                sizeof(config.target));
+                sizeof(config.target) - 1U);
 
         if (maxArgc < (cmdline.count + 1)) {
             char **newargv =(char **)realloc(config.argv, (cmdline.count + 1) * sizeof(char *));

--- a/parseThat/src/parseThat.C
+++ b/parseThat/src/parseThat.C
@@ -832,7 +832,7 @@ void parseArgs(int argc, char **argv)
 
     // Prepare child arguments
     if (i < argc) {
-        strncpy(config.target, argv[i], sizeof(config.target));
+        strncpy(config.target, argv[i], sizeof(config.target) - 1U);
         config.argv = argv + i - 1;
         config.argc = argc - i;
 
@@ -952,7 +952,7 @@ void parseArgs(int argc, char **argv)
                     userError();
 
                 }
-                strncpy(config.pipe_filename, tmp_pipename, sizeof(config.pipe_filename));
+                strncpy(config.pipe_filename, tmp_pipename, sizeof(config.pipe_filename) - 1U);
             }
         }
     }


### PR DESCRIPTION
For some reason, these didn't show up when fixing those in #967.