### PR TITLE
Correctly declare Aggregate::operator<<

### DIFF
--- a/symtabAPI/h/Aggregate.h
+++ b/symtabAPI/h/Aggregate.h
@@ -44,7 +44,6 @@
 #include <boost/iterator/transform_iterator.hpp>
 #include <functional>
 #include "concurrent.h"
-SYMTAB_EXPORT std::ostream &operator<<(std::ostream &os, const Dyninst::SymtabAPI::Aggregate &);
 
 namespace Dyninst{
 namespace SymtabAPI{
@@ -62,7 +61,7 @@ class SYMTAB_EXPORT Aggregate
 {
    friend class Symtab;
    friend struct SymbolCompareByAddr;
-	friend std::ostream &::operator<<(std::ostream &os, const Dyninst::SymtabAPI::Aggregate &);
+	friend std::ostream& operator<<(std::ostream &os, const Aggregate &);
    friend class DwarfWalker;
   protected:
       Aggregate();

--- a/symtabAPI/src/Aggregate.C
+++ b/symtabAPI/src/Aggregate.C
@@ -259,7 +259,9 @@ bool Aggregate::changeSymbolOffset(Symbol *sym)
     return true;
 }
 
-std::ostream &operator<<(std::ostream &os, const Dyninst::SymtabAPI::Aggregate &a)
+namespace Dyninst {
+namespace SymtabAPI {
+std::ostream& operator<<(std::ostream &os, const Aggregate &a)
 {
   std::string modname = a.module_ ? a.module_->fullName() : std::string("no_mod");
   os   << "Aggregate{"
@@ -280,6 +282,7 @@ std::ostream &operator<<(std::ostream &os, const Dyninst::SymtabAPI::Aggregate &
   
   return os;
 }
+}}
 
 bool Aggregate::operator==(const Aggregate &a)
 {


### PR DESCRIPTION
The previous declaration relied on header inclusion ordering to be correct. The following example program failed to build:

    #include "Function.h"
     int main(){}