### PR TITLE
Bump minimum Boost version to 1.67

### DIFF
--- a/cmake/Boost.cmake
+++ b/cmake/Boost.cmake
@@ -50,8 +50,8 @@ if(Boost_FOUND)
   return()
 endif()
 
-# Need at least Boost-1.61 for filesytem components
-set(_boost_min_version 1.61.0)
+# Need at least Boost-1.67 because of deprecated headers
+set(_boost_min_version 1.67.0)
 
 # Provide a default, if the user didn't specify
 set(Boost_MIN_VERSION ${_boost_min_version} CACHE STRING "Minimum Boost version")


### PR DESCRIPTION
This is needed because we no longer support the headers deprecated in that version. See also #974