### PR TITLE
Add the default case in adhocMovementTransformer::isPCRelData to suppress compiler warning

### DIFF
--- a/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
@@ -294,6 +294,8 @@ bool adhocMovementTransformer::isPCRelData(Widget::Ptr ptr,
       case c_BranchInsn:
       case c_ReturnInsn:
           return false;
+      default:
+	  break;
   }
   if (insn.getControlFlowTarget()) return false;
 


### PR DESCRIPTION
Fix #985 