### PR TITLE
Remove assert in block_instance::callee(std::string const&)

### DIFF
--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -694,7 +694,6 @@ func_instance* block_instance::callee(std::string const& target_name) {
 		 }
 	  }
    }
-   assert(0 && "Unable to find callee by name");
    return nullptr;
 }
 


### PR DESCRIPTION
This was introduce by 14b6941fc in 2020 (PR #875). This fix allows both types of lookup by name, but preserves the "return NULL if not found" semantics of block_instance::callee().