### PR TITLE
Fix PLT function call lookup

### DIFF
--- a/dyninstAPI/src/Parsing.C
+++ b/dyninstAPI/src/Parsing.C
@@ -164,6 +164,13 @@ DynCFGFactory::mkfunc(
         if(stf && stf->getFirstSymbol()) {
             ret = new parse_func(stf, pdmod,_img,obj,reg,isrc,src);
             ret->isPLTFunction_ = true;
+            // PLT stubs are typically are undefined symbols in the binary,
+            // so there is no corresponding SymtabAPI::Function at Symtab level.
+            // PLTFunction is a subclass of SymtabAPI::Function to represent PLT stubs.
+            // However, since there is no easy way to add a PLTFunction back to the
+            // Symtab object, we need to add PLTFunction to a data structure for
+            // future lookup.
+            _img->insertPLTParseFuncMap(stf->getName(), ret);
             _mtx.unlock();
             return ret;
         }

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -1936,8 +1936,16 @@ const std::vector <parse_func *> *image::findFuncVectorByMangled(const std::stri
         if (imf) {
             res->push_back(imf);
         }
+    }
 
-    }	    
+    if (res->empty()) {
+        // Lookup PLT stubs
+        auto it = plt_parse_funcs.find(name);
+        if (it != plt_parse_funcs.end()) {
+            res->push_back(it->second);
+        }
+    }
+
     if(res->size()) 
 	return res;	    
     else {
@@ -2181,3 +2189,7 @@ void image::setImageLength(Address newlen)
 void image::destroy(ParseAPI::Block *) {}
 void image::destroy(ParseAPI::Edge *) {}
 void image::destroy(ParseAPI::Function *) {}
+
+void image::insertPLTParseFuncMap(const std::string & name, parse_func* f) {
+    plt_parse_funcs[name] = f;
+}

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -447,6 +447,8 @@ class image : public codeRange {
    bool buildFunctionLists(std::vector<parse_func *> &raw_funcs);
    void analyzeImage();
 
+   void insertPLTParseFuncMap(const std::string&, parse_func*);
+
    //
    //  **** GAP PARSING SUPPORT  ****
    bool parseGaps() { return parseGaps_; }
@@ -530,6 +532,8 @@ class image : public codeRange {
    bool parseGaps_;
    BPatch_hybridMode mode_;
    Dyninst::Architecture arch;
+
+   dyn_hash_map<string, parse_func*> plt_parse_funcs;
 
 };
 

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -686,6 +686,11 @@ func_instance* block_instance::callee(std::string const& target_name) {
    }
    if (auto *bedit = dynamic_cast<BinaryEdit *>(proc())) {
 	  std::vector<func_instance *> pdfv;
+	  if (bedit->findFuncsByMangled(target_name, pdfv)) {
+         obj()->setCallee(this, pdfv[0]);
+		 updateCallTarget(pdfv[0]);
+		 return pdfv[0];
+	  }
 	  for (auto *sib : bedit->getSiblings()) {
 		 if (sib->findFuncsByMangled(target_name, pdfv)) {
 			obj()->setCallee(this, pdfv[0]);


### PR DESCRIPTION
BPatch creates additional SymtabAPI::Function objects for PLT stubs but does not put these SymtabAPI::Function objects back to Symtab objects. Later BPatch look up function callees through the Symtab object and cannot find PLT stubs.

This PR records functions created for PLT and fix the lookup.