### PR TITLE
Remove visibility compilation flags

### DIFF
--- a/cmake/shared.cmake
+++ b/cmake/shared.cmake
@@ -83,7 +83,6 @@ endfunction()
 
 include (${DYNINST_ROOT}/cmake/platform.cmake)
 include (${DYNINST_ROOT}/cmake/cap_arch_def.cmake)
-include (${DYNINST_ROOT}/cmake/visibility.cmake)
 include (${DYNINST_ROOT}/cmake/warnings.cmake)
 include (${DYNINST_ROOT}/cmake/options.cmake)
 include (${DYNINST_ROOT}/cmake/optimization.cmake)

--- a/cmake/visibility.cmake
+++ b/cmake/visibility.cmake
@@ -1,5 +1,0 @@
-if(CMAKE_COMPILER_IS_GNUCXX  OR  ${CMAKE_C_COMPILER_ID} MATCHES Clang)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
-    message(STATUS "Found g++, enabling -fvisibility=hidden")
-endif()


### PR DESCRIPTION
This was added by 98da2f2d52 in 2013. The original commit notes that "There's a substantial reduction in the size of the libraries." However, removing this flag resulted in a maximum size change of <2%. Using a default hidden visibility was preventing many member functions in symtabAPI.so from being visible (specifically `operator<<` in the global namespace).