### PR TITLE
Set -B and -S when configuring dyninstAPI_RT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,8 @@ if(BUILD_RTLIB)
     -DBUILD_RTLIB_32=${BUILD_RTLIB_32}
     -DPLATFORM=${PLATFORM}
     -G ${CMAKE_GENERATOR}
-    ${RT_SOURCE_DIR})
+    -B ${RT_BINARY_DIR}
+    -S ${RT_SOURCE_DIR})
   find_file(${RT_MAKEFILE} Makefile PATHS ${RT_BINARY_DIR} NO_DEFAULT_PATH)
   message(STATUS "RTlib Makefile: ${RT_MAKEFILE}")
   if(MSVC)


### PR DESCRIPTION
Set the build directory (-B) and source directory (-S) when
configuring dyninstAPI_RT

This simple change configures out of source tree correctly for dyninstAPI_RT on
 (Fedora release 33)
 cmake version 3.19.7

(without the change: Build files have been written to: /work/scox/dyninst/src/dyninstAPI_RT)