### PR TITLE
Do not treat symbols in any text sections as data

### DIFF
--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -83,7 +83,7 @@ SymtabCodeRegion::SymtabCodeRegion(
     st->getAllSymbols(symbols);
     for (auto sit = symbols.begin(); sit != symbols.end(); ++sit)
         if ( (*sit)->getRegion() == reg && (*sit)->getType() != SymtabAPI::Symbol::ST_FUNCTION && (*sit)->getType() != SymtabAPI::Symbol::ST_INDIRECT) {
-            if ((*sit)->getRegion()->getRegionName() == ".text") continue;
+	    if ((*sit)->getRegion()->isText()) continue;
             knownData[(*sit)->getOffset()] = (*sit)->getOffset() + (*sit)->getSize();
             parsing_printf("Add known data range [%lx, %lx) from symbol %s\n", (*sit)->getOffset(), (*sit)->getOffset() + (*sit)->getSize(), (*sit)->getMangledName().c_str());
         }
@@ -99,7 +99,7 @@ SymtabCodeRegion::SymtabCodeRegion(
 {
     for (auto sit = symbols.begin(); sit != symbols.end(); ++sit)
         if ( (*sit)->getRegion() == reg && (*sit)->getType() != SymtabAPI::Symbol::ST_FUNCTION && (*sit)->getType() != SymtabAPI::Symbol::ST_INDIRECT) {
-            if ((*sit)->getRegion()->getRegionName() == ".text") continue;
+	    if ((*sit)->getRegion()->isText()) continue;
             knownData[(*sit)->getOffset()] = (*sit)->getOffset() + (*sit)->getSize();
             parsing_printf("Add known data range [%lx, %lx) from symbol %s\n", (*sit)->getOffset(), (*sit)->getOffset() + (*sit)->getSize(), (*sit)->getMangledName().c_str());
         }


### PR DESCRIPTION
This PR aims to fix a hpcstruct segfault reported by a user (https://github.com/HPCToolkit/hpctoolkit/issues/403).

ParseAPI will assert when parsing a binary compiled on Lassen. The root cause of the problem is that PLT stubs in the binary are marked as NOTYPE and they are inside .fini section rather than .plt section. This causes ParseAPI to treat these symbols as data rather than code. 