### PR TITLE
Remove Debug Cout that causes large output

### DIFF
--- a/common/src/debug_common.C
+++ b/common/src/debug_common.C
@@ -62,7 +62,7 @@ bool init_debug_common() {
            common_debug_lineinfo = 1;
     }
     
-    if(getenv("DYNINST_DEBUG_PARSING") || getenv("COMMON_DEBUG_PARSING")){
+    if(getenv("COMMON_DEBUG_PARSING")){
         common_debug_parsing = 1;  
     }
 

--- a/common/src/debug_common.C
+++ b/common/src/debug_common.C
@@ -37,6 +37,7 @@
 int common_debug_dwarf = 0;
 int common_debug_addrtranslate = 0;
 int common_debug_lineinfo = 0;
+int common_debug_parsing = 0;
 
 #if defined(_MSC_VER)
 #pragma warning(push)
@@ -59,6 +60,10 @@ bool init_debug_common() {
     }
     if (getenv("DYNINST_DEBUG_LINEINFO")) {
            common_debug_lineinfo = 1;
+    }
+    
+    if(getenv("DYNINST_DEBUG_PARSING") || getenv("COMMON_DEBUG_PARSING")){
+        common_debug_parsing = 1;  
     }
 
     return true;
@@ -97,6 +102,20 @@ int lineinfo_printf_int(const char *format, ...)
 {
    init_debug_common();
   if (!common_debug_lineinfo) return 0;
+  if (NULL == format) return -1;
+
+  va_list va;
+  va_start(va, format);
+  int ret = vfprintf(stderr, format, va);
+  va_end(va);
+
+  return ret;
+}
+
+int common_parsing_printf_int(const char *format, ...)
+{
+   init_debug_common();
+  if (!common_debug_parsing) return 0;
   if (NULL == format) return -1;
 
   va_list va;

--- a/common/src/debug_common.h
+++ b/common/src/debug_common.h
@@ -37,6 +37,7 @@
 COMMON_EXPORT extern int common_debug_dwarf;
 extern int common_debug_addrtranslate;
 extern int common_debug_lineinfo;
+extern int common_debug_parsing;
 
 #if defined(__GNUC__)
 #define dwarf_printf(format, ...)                                       \
@@ -71,6 +72,17 @@ COMMON_EXPORT int translate_printf_int(const char *format, ...);
 #endif
 
 COMMON_EXPORT int lineinfo_printf_int(const char *format, ...);
+
+#if defined(__GNUC__)
+#define common_parsing_printf(format, ...)                                       \
+   do {                                                                 \
+	   common_parsing_printf_int("[%s:%u] " format, __FILE__, __LINE__, ## __VA_ARGS__); \
+   } while (0)
+#else
+#define common_parsing_printf common_parsing_printf_int
+#endif
+
+COMMON_EXPORT int common_parsing_printf_int(const char *format, ...);
 
 // And initialization
 COMMON_EXPORT bool init_debug_common();

--- a/common/src/dyn_regs.C
+++ b/common/src/dyn_regs.C
@@ -30,6 +30,7 @@
 
 #define DYN_DEFINE_REGS
 #include "common/h/dyn_regs.h"
+#include "common/src/debug_common.h"
 
 #include "external/rose/rose-compat.h"
 #include "external/rose/powerpcInstructionEnum.h"
@@ -198,7 +199,7 @@ std::string MachRegister::name() const {
             return iter->second;
         }
     }
-    std::cout << " can't find " <<  std::hex << "0x" << reg << std::endl;
+    common_parsing_printf(" can't find register with index %x\n",reg);
     return std::string("<INVALID_REG>");
 
 }
@@ -313,8 +314,7 @@ unsigned int MachRegister::size() const {
                      case amdgpu_vega::BITS_512:
                          return 64;
                  }
-                 std::cerr << "unknown reg size " << std::hex << reg << std::endl;
-
+                 common_parsing_printf(" unknown reg size %x\n",reg);
                  assert(0);
              }
          }

--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -498,7 +498,6 @@ void AssignmentConverter::convert(const Instruction &I,
 				  std::vector<Assignment::Ptr> &assignments) {
   assignments.clear();
   if (cache(func, addr, assignments)){ 
-      std::cout << "returning cached for " << I.format() << std::endl;
       return;
   }
 

--- a/parseAPI/src/JumpTableFormatPred.C
+++ b/parseAPI/src/JumpTableFormatPred.C
@@ -516,7 +516,4 @@ bool JumpTableFormatPred::ignoreEdge(ParseAPI::Edge *e) {
     if (e->type() == INDIRECT) return true;
     return false;
 }
-/*bool JumpTableFormatPred::endAtPoint(AssignmentPtr ptr){
-    cout << "calling end at Point GG? " << endl;
-    return true;
-}*/
+


### PR DESCRIPTION
As title, there is one lingering debug cout that causes large output as mentioned in the issue #1028 

closes #1028 