### PR TITLE
fix Position Independent Executable (PIE) handling

### DIFF
--- a/dyninstAPI/src/dynProcess.C
+++ b/dyninstAPI/src/dynProcess.C
@@ -200,7 +200,7 @@ PCProcess *PCProcess::setupForkedProcess(PCProcess *parent, Process::ptr pcProc)
         for(unsigned i = 0; i < ret->mapped_objects.size(); ++i) {
             const fileDescriptor &desc = ret->mapped_objects[i]->getFileDesc();
             fileDescriptor tmpDesc(ret->dyninstRT_name,
-                    desc.code(), desc.data(), true);
+                    desc.code(), desc.data());
             if( desc == tmpDesc ) {
                 ret->runtime_lib.insert(ret->mapped_objects[i]);
                 break;
@@ -620,7 +620,7 @@ bool PCProcess::createInitialMappedObjects() {
        }
 
        const fileDescriptor &desc = newObj->getFileDesc();
-       fileDescriptor tmpDesc(dyninstRT_name, desc.code(), desc.data(), true);
+       fileDescriptor tmpDesc(dyninstRT_name, desc.code(), desc.data());
        if( desc == tmpDesc ) {
           startup_printf("%s[%d]: RT library already loaded, manual loading not necessary\n",
                          FILE__, __LINE__);

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -129,7 +129,7 @@ class fileDescriptor {
     // Some platforms have split code and data. If yours is not one of them,
     // hand in the same address for code and data.
     fileDescriptor(string file, Address code, Address data, 
-                   bool isShared=false, Address dynamic=0) :
+			Address dynamic=0) :
 #if defined(os_windows)
 		procHandle_(INVALID_HANDLE_VALUE),
 		fileHandle_(INVALID_HANDLE_VALUE),
@@ -139,7 +139,6 @@ class fileDescriptor {
         code_(code),
         data_(data),
 		dynamic_(dynamic),
-        shared_(isShared),
         pid_(0),
         length_(0),
         rawPtr_(NULL) {}
@@ -147,7 +146,7 @@ class fileDescriptor {
     // ctor for non-files
     fileDescriptor(string file, Address code, Address data, 
                    Address length, void* rawPtr,
-                   bool isShared=false, Address dynamic=0) :
+		    Address dynamic=0) :
 #if defined(os_windows)
 		procHandle_(INVALID_HANDLE_VALUE),
 		fileHandle_(INVALID_HANDLE_VALUE),
@@ -157,7 +156,6 @@ class fileDescriptor {
         code_(code),
         data_(data),
 		dynamic_(dynamic),
-        shared_(isShared),
         pid_(0),
         length_(length),
         rawPtr_(rawPtr) {}
@@ -184,7 +182,6 @@ class fileDescriptor {
      const string &member() const { return member_; }
      Address code() const { return code_; }
      Address data() const { return data_; }
-     bool isSharedObject() const { return shared_; }
      int pid() const { return pid_; }
 //     Address loadAddr() const { return loadAddr_; }
      Address dynamic() const { return dynamic_; }
@@ -196,7 +193,6 @@ class fileDescriptor {
      void setData(Address d) { data_ = d; }
      void setMember(string member) { member_ = member; }
      void setPid(int pid) { pid_ = pid; }
-     void setIsShared(bool shared) { shared_ = shared; }
      Address length() const { return length_; } //only for non-files
      void* rawPtr();                            //only for non-files
 
@@ -221,7 +217,6 @@ private:
      Address code_;
      Address data_;
      Address dynamic_; //Used on Linux, address of dynamic section.
-     bool shared_;      // TODO: Why is this here? We should probably use the image version instead...
      int pid_;
      Address length_;        // set only if this is not really a file
      void* rawPtr_; // set only if this is not really a file
@@ -361,8 +356,9 @@ class image : public codeRange {
    ParseAPI::CodeObject *codeObject() const { return obj_; }
 
    bool isDyninstRTLib() const { return is_libdyninstRT; }
-   bool isAOut() const { return is_a_out; }
-   bool isSharedObj() const { 
+   bool isExecutable() const { return getObject()->isExec(); }
+   bool isSharedLibrary() const { return getObject()->isSharedLibrary(); }
+   bool isSharedObject() const { 
     return (getObject()->getObjectType() == SymtabAPI::obj_SharedLib); 
    }
    bool isRelocatableObj() const { 
@@ -474,7 +470,6 @@ class image : public codeRange {
    //Address dataValidEnd_;
 
    bool is_libdyninstRT;
-   bool is_a_out;
    Address main_call_addr_; // address of call to main()
 
    // data from the symbol table 

--- a/dyninstAPI/src/mapped_object.C
+++ b/dyninstAPI/src/mapped_object.C
@@ -132,8 +132,7 @@ mapped_object *mapped_object::createMappedObject(Library::const_ptr lib,
                                                  bool parseGaps) {
    fileDescriptor desc(lib->getAbsoluteName(),
                        lib->getLoadAddress(),
-                       p->usesDataLoadAddress() ? lib->getDataLoadAddress() : lib->getLoadAddress(),
-                       lib->isSharedLib());
+                       p->usesDataLoadAddress() ? lib->getDataLoadAddress() : lib->getLoadAddress());
    return createMappedObject(desc, p, analysisMode, parseGaps);
 }
    
@@ -851,9 +850,7 @@ bool mapped_object::isSharedLib() const
 {
     if (isMemoryImg()) return false;
 
-    return parse_img()->isSharedObj();
-    // HELL NO
-    //return desc_.isSharedObject();
+    return parse_img()->isSharedLibrary();
 }
 
 bool mapped_object::isStaticExec() const

--- a/dyninstAPI/src/pcEventHandler.C
+++ b/dyninstAPI/src/pcEventHandler.C
@@ -854,7 +854,7 @@ bool PCEventHandler::handleLibrary(EventLibrary::const_ptr ev, PCProcess *evProc
         if( evProc->usesDataLoadAddress() ) dataAddress = (*i)->getDataLoadAddress();
 
         fileDescriptor tmpDesc((*i)->getAbsoluteName(), (*i)->getLoadAddress(),
-                    dataAddress, true);
+                    dataAddress);
 		if( execFd == tmpDesc ) {
             proccontrol_printf("%s[%d]: ignoring Library event for executable %s\n",
                     FILE__, __LINE__, (*i)->getAbsoluteName().c_str());
@@ -878,7 +878,7 @@ bool PCEventHandler::handleLibrary(EventLibrary::const_ptr ev, PCProcess *evProc
         dataAddress = (*i)->getLoadAddress();
         if( evProc->usesDataLoadAddress() ) dataAddress = (*i)->getDataLoadAddress();
         fileDescriptor rtLibDesc(evProc->dyninstRT_name, (*i)->getLoadAddress(),
-            dataAddress, true);
+            dataAddress);
         if( rtLibDesc == tmpDesc ) {
            proccontrol_printf("%s[%d]: library event contains RT library load\n", FILE__, __LINE__);
 
@@ -902,7 +902,7 @@ bool PCEventHandler::handleLibrary(EventLibrary::const_ptr ev, PCProcess *evProc
         Address dataAddress = (*i)->getLoadAddress();
         if( evProc->usesDataLoadAddress() ) dataAddress = (*i)->getDataLoadAddress();
         deletedDescriptors.push_back(fileDescriptor((*i)->getAbsoluteName(), (*i)->getLoadAddress(),
-                    dataAddress, true));
+                    dataAddress));
     }
 
     const std::vector<mapped_object *> &currList = evProc->mappedObjects();

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -437,9 +437,8 @@ bool PCProcess::getExecFileDescriptor(string filename,
    Address base = 0;
 
     desc = fileDescriptor(filename.c_str(),
-                          base, // code
-                          base, // data
-                          false); // a.out
+                          base,  // code
+                          base); // data
     return true;
 }
 

--- a/proccontrol/src/sysv.C
+++ b/proccontrol/src/sysv.C
@@ -313,7 +313,9 @@ bool sysv_process::refresh_libraries(set<int_library *> &added_libs,
    if (!aout) {
       LoadedLib *ll_aout = translator()->getExecutable();
       aout = (int_library *) (ll_aout ? ll_aout->getUpPtr() : NULL);
-      aout->markAOut();
+      if (aout)  {
+         aout->markAOut();
+      }
    }
 
    return true;

--- a/symtabAPI/doc/API/Symtab/Module.tex
+++ b/symtabAPI/doc/API/Symtab/Module.tex
@@ -1,5 +1,5 @@
 \subsection{Class Module}\label{Module}
-This class represents the concept of a single source file. Currently,Modules are only identified for the executable file; each shared library is made up of a single Module, ignoring any source file information that may be present. We also create a single module, called \code{DEFAULT\_MODULE}, for each Symtab that contains any symbols for which module information was unavailable. This may be compiler template code, or files produced without module information. 
+This class represents the concept of a single source file. Currently, Modules are only identified for the executable file; each shared library is made up of a single Module, ignoring any source file information that may be present. We also create a single module, called \code{DEFAULT\_MODULE}, for each Symtab that contains any symbols for which module information was unavailable. This may be compiler template code, or files produced without module information.
 
 \begin{center}
 \begin{tabular}{ll}

--- a/symtabAPI/doc/API/Symtab/Symtab.tex
+++ b/symtabAPI/doc/API/Symtab/Symtab.tex
@@ -17,8 +17,10 @@ Method name & Return type & Method description \\
 \code{dataOffset} & Offset & Offset of the first data segment from the start of the binary. \\
 \code{imageLength} & Offset & Size of the primary code-containing region, typically .text. \\
 \code{dataLength} & Offset & Size of the primary data-containing region, typically .data. \\
-\code{isStaticBinary} & Offset & True if the binary was compiled statically. \\
-\code{isExec} & bool & True if the file is an executable, false if it is a shared library or object file. \\
+\code{isStaticBinary} & bool & True if the binary was compiled statically. \\
+\code{isExecutable} & bool & True if the file is an executable. \\
+\code{isSharedLibrary} & bool & True if the file is a shared library. \\
+\code{isExec} & bool & True if the file is can only be an executable, false otherwise including files that are both exeutables and shared libraries.  Typically files that are both executables and shared libraries are primarily used as libraries, if you need to determine specifics use the methods \code{isExecutable} and \code{isSharedLibrary}. \\
 \code{isStripped} & bool & True if the file was stripped of symbol table information. \\
 \code{getAddressWidth} & unsigned & Size (in bytes) of a pointer value in the Symtab; 4 for 32-bit binaries and 8 for 64-bit binaries. \\
 \code{getArchitecture} & Architecture & Representation of the system architecture for the binary. \\
@@ -33,6 +35,83 @@ ObjectType getObjectType() const
 \end{apient}
 \apidesc{
 This method queries information on the type of the object file.
+}
+
+\begin{apient}
+bool isExecutable()
+bool isSharedLibrary()
+bool isExec()
+\end{apient}
+\apidesc{
+These methods respectively return true if the Symtab's object is an executable, a shared
+library, and an executable is that is not a shared library.
+An object may be both an executable and a shared library.
+
+An Elf Object that can be loaded into memory to form an executable's image has
+one of two types:  ET\_EXEC and ET\_DYN.
+ET\_EXEC type objects are executables that are loaded at a fixed address
+determined at link time.
+ET\_DYN type objects historically were shared libraries that are loaded at an
+arbitrary location in memory and are position independent code (PIC).
+The ET\_DYN object type was reused for position independent executables (PIE)
+that allows the executable to be loaded at an arbitrary location in memory.
+Although generally not the case an object can be both a PIE executable and a
+shared library.
+Examples of these include libc.so and the dynamic linker library (ld.so).
+These objects are generally used as a shared library so \code{isExec()} will
+classify these based on their typical usage.
+The methods below use heuristics to classify ET\_DYN object types correctly
+based on the properties of the Elf Object, and will correctly classify most
+objects.
+Due to the inherent ambiguity of ET\_DYN object types, the heuristics may fail
+to classify some libraries that are also executables as an executable.
+This can happen in object is a shared library and an executable, and its entry
+point happens to be at the start of the .text section.
+
+\code{isExecutable()} is equivalent to elfutils' \code{elfclassify -{}-program}
+test with the refinement of the soname value and entry point tests.
+Pseudocode for the algorithm is shown below:
+
+\newcommand{\ifthenstmt}[2]{\textbf{if} (#1) \textbf{return} \textit{#2}}
+\newcommand{\otherwisestmt}[1]{\textbf{otherwise return} \textit{#1}}
+
+\begin{itemize}[leftmargin=+7em]
+\item \ifthenstmt{\textbf{not} loadable()}{false}
+\item \ifthenstmt{object type is ET\_EXEC}{true}
+\item \ifthenstmt{has an interpreter (PT\_INTERP segment exists)}{true}
+\item \ifthenstmt{PIE flag is set in FLAGS\_1 of the PT\_DYNAMIC segment}{true}
+\item \ifthenstmt{DT\_DEBUG tag exists in PT\_DYNAMIC segment}{true}
+\item \ifthenstmt{has a soname and its value is ``linux-gate.so.1''}{false}
+\item \ifthenstmt{entry point is in range .text section offset plus 1 to the end of the .text section}{true}
+\item \ifthenstmt{has a soname and its value starts with ``ld-linux''}{true}
+\item \otherwisestmt{false}
+\end{itemize}
+
+\code{isSharedLibrary()} is equivalent to elfutils' \code{elfclassify -{}-library}.
+Pseudocode for the algorithm is shown below:
+
+\begin{itemize}[leftmargin=7em]
+\item \ifthenstmt{\textbf{not} loadable()}{false}
+\item \ifthenstmt{object type is ET\_EXEC}{false}
+\item \ifthenstmt{there is no PT\_DYNAMIC segment}{false}
+\item \ifthenstmt{PIE flag is set in FLAGS\_1 of the PT\_DYNAMIC segment}{false}
+\item \ifthenstmt{DT\_DEBUG tag exists in PT\_DYNAMIC segment}{false}
+\item \otherwisestmt{true}
+\end{itemize}
+
+Elf files can also store data that is neither an executable nor a shared
+library including object files, core files and debug symbol files.
+To distinguish these cases the \code{loadable()} function is defined using the
+pseudocode shown below and returns true is the file can loaded into a process's
+address space:
+
+\begin{itemize}[leftmargin=7em]
+\item \ifthenstmt{object type is neither ET\_EXEC nor ET\_DYN}{false}
+\item \ifthenstmt{there is are no program segments with the PT\_LOAD flag set}{false}
+\item \ifthenstmt{contains no sections}{true}
+\item \ifthenstmt{contains a section with the SHF\_ALLOC flag set and a section type of neither SHT\_NOTE nor SHT\_NOBITS}{true}
+\item \otherwisestmt{false}
+\end{itemize}
 }
 
 \subsubsection{File opening/parsing}
@@ -534,7 +613,7 @@ Returns all the standard types that normally occur in a program.
 static std::vector<Type *> * getAllbuiltInTypes()
 \end{apient}
 \apidesc{
-Returns all the bulit-in types defined in the binary.
+Returns all the built-in types defined in the binary.
 }
 
 \begin{apient}

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -235,6 +235,8 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
    /*****Query Functions*****/
    bool isExec() const;
+   bool isExecutable() const;
+   bool isSharedLibrary() const;
    bool isStripped();
    ObjectType getObjectType() const;
    Dyninst::Architecture getArchitecture() const;

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -342,7 +342,6 @@ public:
 	// returns an offset from the base address of the object
 	// so the entry can easily be located in memory
 	Offset getPltSlot(std::string funcName) const ;
-	Offset textAddress(){ return text_addr_;}
 	bool isText( Offset addr ) const
 	{
 	    if( addr >= text_addr_ && addr <= text_addr_ + text_size_ )
@@ -388,6 +387,21 @@ public:
     Offset getRelPLTSize() const { return rel_plt_size_; }
     Offset getRelDynAddr() const { return rel_addr_; }
     Offset getRelDynSize() const { return rel_size_; }
+    const char* getSoname() const { return soname_; }
+    bool hasPieFlag() const { return hasPieFlag_; }
+    bool hasProgramLoad() const { return hasProgramLoad_; }
+    bool hasDtDebug() const { return hasDtDebug_; }
+    bool hasBitsAlloc() const { return hasBitsAlloc_; }
+    bool hasDebugSections() const { return hasDebugSections_; }
+    bool hasModinfo() const { return hasModinfo_; }
+    bool hasGnuLinkonceThisModule() const { return hasGnuLinkonceThisModule_; }
+    bool isLoadable() const;
+    SYMTAB_EXPORT bool isOnlyExecutable() const;
+    SYMTAB_EXPORT bool isExecutable() const;
+    SYMTAB_EXPORT bool isSharedLibrary() const;
+    SYMTAB_EXPORT bool isOnlySharedLibrary() const;
+    SYMTAB_EXPORT bool isDebugOnly() const;
+    SYMTAB_EXPORT bool isLinuxKernelModule() const;
 
     std::vector<relocationEntry> &getPLTRelocs() { return fbt_; }
     std::vector<relocationEntry> &getDynRelocs() { return relocation_table_; }
@@ -466,6 +480,13 @@ public:
                                //   Set to 0 if it may load anywhere
   Offset entryAddress_;
   char *interpreter_name_;
+  bool  hasPieFlag_;
+  bool  hasDtDebug_;
+  bool  hasProgramLoad_;
+  bool  hasBitsAlloc_;
+  bool  hasDebugSections_;
+  bool  hasModinfo_;
+  bool  hasGnuLinkonceThisModule_;
   bool  isStripped;
 
   std::map<Offset, Offset> TOC_table_;

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -373,7 +373,6 @@ SYMTAB_EXPORT Symtab::Symtab() :
 
 SYMTAB_EXPORT bool Symtab::isExec() const 
 {
-    assert( is_a_out == obj_private->isOnlyExecutable() );
     return is_a_out; 
 }
 

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -373,7 +373,18 @@ SYMTAB_EXPORT Symtab::Symtab() :
 
 SYMTAB_EXPORT bool Symtab::isExec() const 
 {
+    assert( is_a_out == obj_private->isOnlyExecutable() );
     return is_a_out; 
+}
+
+SYMTAB_EXPORT bool Symtab::isExecutable() const
+{
+    return obj_private->isExecutable();
+}
+
+SYMTAB_EXPORT bool Symtab::isSharedLibrary() const
+{
+    return obj_private->isSharedLibrary();
 }
 
 SYMTAB_EXPORT bool Symtab::isStripped() 


### PR DESCRIPTION
All functions that determine if an object is a shared library and/or an
executable are now based on a single set of functions in Object-elf.
This make all the functions in the various Dyninst libraries and classes
consistent and also makes Dyninst correctly handle PIE executables.
These functions in Object-elf are based on functions found in elfutils's
elfclassify program (with small improvements to better determine if a
shared library is also an executable).   The new functions in Object-elf
include:

    * isOnlyExecutable()
    * isExecutable()
    * isSharedLibrary()
    * isOnlySharedLibrary()
    * isLoadable()
    * isDebugOnly()
    * isLinuxKernelModule()

Symtab exposes some of these functions through its public API.  isExec()
now correctly handles PIE executables, and two new functions were added
to determine if the underlying file is a shared library, an executable,
or both.  These function are:

    * isExec()            (isExecutable() and not isSharedLibrary())
    * isExecutable()
    * isSharedLibrary()

Fixes #605