### PR TITLE
Remove Module::getAllVariables

### DIFF
--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -189,8 +189,6 @@ namespace Dyninst{
 									 NameType nameType = anyName,
 									 bool isRegex = false,
 									 bool checkCase = true);
-			bool getAllVariables(std::vector<Variable *> &ret);
-
 
 			// Type output methods
 			virtual bool findType(boost::shared_ptr<Type>& type, std::string name);


### PR DESCRIPTION
It was declared by c848409ec9 in 2009, but never defined.

closes #635