### PR TITLE
remove executable flag from .dyninst_heap section

### DIFF
--- a/dyninstAPI_RT/src/RTspace.S
+++ b/dyninstAPI_RT/src/RTspace.S
@@ -8,7 +8,7 @@
 .type DYNINSTstaticHeap_16M_anyHeap_1, @object
 .size DYNINSTstaticHeap_16M_anyHeap_1, 16777216
 
-.section .dyninst_heap,"awx",@nobits
+.section .dyninst_heap,"aw",@nobits
 .align 16
 DYNINSTstaticHeap_512K_lowmemHeap_1:
         .skip 524288


### PR DESCRIPTION
This prevents the library/object with this code from having a segment violates
the W^X security property for segments as the current setting resulted in
segment with both the WRITE and EXECUTE flags set.  The function
mark_heaps_exec() restores execute protection to just the heap arrays.

Tested and no regressions on X86_64, ARM and POWER
.
Fixes #1094