### PR TITLE
Fixed issues found during static library builds

### DIFF
--- a/dataflowAPI/rose/semantics/DispatcherARM64.C
+++ b/dataflowAPI/rose/semantics/DispatcherARM64.C
@@ -5291,7 +5291,7 @@ namespace rose {
             DispatcherARM64::getBitfieldMask(int immr, int imms,
                                              int N, bool iswmask, int datasize) {
                 int hsbarg = (N << 6) | (~imms);
-                int len;
+                int len = 0;
                 for (int idx = 0; idx < 7; idx++) {
                     if ((hsbarg & 0x1) == 1)
                         len = idx;
@@ -5684,4 +5684,3 @@ namespace rose {
 } // namespace
 
 //using namespace rose::Diagnostics;
-

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -1,28 +1,28 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
@@ -60,6 +60,8 @@ const StackAnalysis::Height StackAnalysis::Height::bottom(
 const StackAnalysis::Height StackAnalysis::Height::top(
    StackAnalysis::Height::uninitialized, StackAnalysis::Height::TOP);
 
+namespace
+{
 AnnotationClass<StackAnalysis::Intervals>
         Stack_Anno_Intervals(std::string("Stack_Anno_Intervals"), NULL);
 AnnotationClass<StackAnalysis::BlockEffects>
@@ -68,6 +70,7 @@ AnnotationClass<StackAnalysis::InstructionEffects>
         Stack_Anno_Insn_Effects(std::string("Stack_Anno_Insn_Effects"), NULL);
 AnnotationClass<StackAnalysis::CallEffects>
         Stack_Anno_Call_Effects(std::string("Stack_Anno_Call_Effects"), NULL);
+}
 
 template class std::list<Dyninst::StackAnalysis::TransferFunc*>;
 template class std::map<Dyninst::Absloc, Dyninst::StackAnalysis::Height>;
@@ -86,7 +89,7 @@ if(!(X)) { \
 // Concepts:
 //
 // There are three terms we throw around:
-// 
+//
 // Stack height: the size of the stack; (cur_stack_ptr - func_start_stack_ptr)
 // Stack delta: the difference in the size of the stack over the execution of
 //   a region of code (basic block here). (block_end_stack_ptr -
@@ -782,7 +785,7 @@ StackAnalysis::Height StackAnalysis::getStackCleanAmount(Function *func) {
 
 StackAnalysis::StackAnalysis() : func(NULL), blockEffects(NULL),
    insnEffects(NULL), callEffects(NULL), intervals_(NULL), word_size(0) {}
-   
+
 StackAnalysis::StackAnalysis(Function *f) : func(f), blockEffects(NULL),
    insnEffects(NULL), callEffects(NULL), intervals_(NULL) {
    word_size = func->isrc()->getAddressWidth();
@@ -1924,7 +1927,7 @@ void StackAnalysis::handlePowerAddSub(Instruction insn, Block *block,
    if (!insn.isRead(theStackPtr) || !insn.isWritten(theStackPtr)) {
       return handleDefault(insn, block, off, xferFuncs);
    }
-   
+
    Operand arg = insn.getOperand(2);
    Result res = arg.getValue()->eval();
    Absloc sploc(sp());
@@ -1943,7 +1946,7 @@ void StackAnalysis::handlePowerStoreUpdate(Instruction insn, Block *block,
    if (!insn.isWritten(theStackPtr)) {
       return handleDefault(insn, block, off, xferFuncs);
    }
-   
+
    std::set<Expression::Ptr> memWriteAddrs;
    insn.getMemoryWriteOperands(memWriteAddrs);
    Expression::Ptr stackWrite = *(memWriteAddrs.begin());
@@ -1969,7 +1972,7 @@ void StackAnalysis::handleMov(Instruction insn, Block *block,
    //   3. mov mem, reg
    //   4. mov reg, mem
    //   5. mov imm, mem
-   // 
+   //
    // #1 Causes register copying.
    // #2 Causes an absolute value in the register.
    // #3 Depends on whether the memory address we're loading from can be
@@ -2599,15 +2602,15 @@ bool StackAnalysis::handleNormalCall(Instruction insn, Block *block,
          copyBaseSubReg(sp(), xferFuncs);
          return true;
       }
-      
+
       if (cur_edge->type() != CALL) continue;
-      
+
       Block *target_bbl = cur_edge->trg();
       Function *target_func = target_bbl->obj()->findFuncByEntry(
          target_bbl->region(), target_bbl->start());
-      
+
       if (!target_func) continue;
-      
+
       Height h = getStackCleanAmount(target_func);
       if (h == Height::bottom) {
          xferFuncs.push_back(TransferFunc::bottomFunc(sploc));
@@ -3566,7 +3569,7 @@ StackAnalysis::TransferFunc StackAnalysis::TransferFunc::summaryAccumulate(
 
    if (isCopy()) {
       // We need to record that we want to take the inflow height
-      // of a different register. 
+      // of a different register.
       // Don't do an inputs[from] as that creates
       auto iter = inputs.find(from);
       if (iter == inputs.end()) {
@@ -3724,7 +3727,7 @@ void StackAnalysis::SummaryFunc::addSummary(const TransferSet &summary) {
 }
 
 void StackAnalysis::SummaryFunc::validate() const {
-   for (TransferSet::const_iterator iter = accumFuncs.begin(); 
+   for (TransferSet::const_iterator iter = accumFuncs.begin();
       iter != accumFuncs.end(); ++iter) {
       const TransferFunc &func = iter->second;
       STACKANALYSIS_ASSERT(func.target.isValid());
@@ -3734,11 +3737,11 @@ void StackAnalysis::SummaryFunc::validate() const {
    }
 }
 
-MachRegister StackAnalysis::sp() { 
+MachRegister StackAnalysis::sp() {
    return MachRegister::getStackPointer(func->isrc()->getArch());
 }
 
-MachRegister StackAnalysis::fp() { 
+MachRegister StackAnalysis::fp() {
    return MachRegister::getFramePointer(func->isrc()->getArch());
 }
 

--- a/dyninstAPI/src/BPatch.C
+++ b/dyninstAPI/src/BPatch.C
@@ -1,28 +1,28 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
@@ -142,10 +142,10 @@ BPatch::BPatch()
     if (bpatch == NULL){
        bpatch = this;
     }
-    
+
     BPatch::bpatch->registerErrorCallback(defaultErrorFunc);
     bpinfo("installed default error reporting function");
-    
+
     /*
      * Create the list of processes.
      */
@@ -156,7 +156,7 @@ BPatch::BPatch()
      */
     type_Error   = BPatch_type::createFake("<error>");
     type_Untyped = BPatch_type::createFake("<no type>");
-    
+
     /*
      * Initialize hash table of API types.
      */
@@ -194,7 +194,7 @@ BPatch::BPatch()
 BPatch::~BPatch()
 {
    inDestructor = true;
-    for(auto i = info->procsByPid.begin(); 
+    for(auto i = info->procsByPid.begin();
         i != info->procsByPid.end();
         ++i)
     {
@@ -212,7 +212,7 @@ BPatch::~BPatch()
         BPatch_typeCollection::freeTypeCollection(APITypes);
     if(builtInTypes)
       delete builtInTypes;
-    
+
     if(systemPrelinkCommand){
         delete [] systemPrelinkCommand;
     }
@@ -362,7 +362,7 @@ BPatchErrorCallback BPatch::registerErrorCallback(BPatchErrorCallback function)
  */
 BPatchForkCallback BPatch::registerPostForkCallback(BPatchForkCallback func)
 {
-#if defined(i386_unknown_nt4_0) 
+#if defined(i386_unknown_nt4_0)
   reportError(BPatchWarning, 0,
 	      "postfork callbacks not implemented on this platform\n");
   return NULL;
@@ -397,7 +397,7 @@ BPatchForkCallback BPatch::registerPreForkCallback(BPatchForkCallback func)
 /*
  * BPatch::registerExecCallback
  *
- * Registers a function that is to be called by the library when a 
+ * Registers a function that is to be called by the library when a
  * process has just completed an exec* call
  *
  * func	The function to be called.
@@ -405,7 +405,7 @@ BPatchForkCallback BPatch::registerPreForkCallback(BPatchForkCallback func)
 BPatchExecCallback BPatch::registerExecCallback(BPatchExecCallback func)
 {
 
-#if defined(i386_unknown_nt4_0) 
+#if defined(i386_unknown_nt4_0)
     reportError(BPatchWarning, 0,
 	"exec callbacks not implemented on this platform\n");
     return NULL;
@@ -419,7 +419,7 @@ BPatchExecCallback BPatch::registerExecCallback(BPatchExecCallback func)
 /*
  * BPatch::registerExitCallback
  *
- * Registers a function that is to be called by the library when a 
+ * Registers a function that is to be called by the library when a
  * process has just called the exit system call
  *
  * func	The function to be called.
@@ -434,7 +434,7 @@ BPatchExitCallback BPatch::registerExitCallback(BPatchExitCallback func)
 /*
  * BPatch::registerOneTimeCodeCallback
  *
- * Registers a function that is to be called by the library when a 
+ * Registers a function that is to be called by the library when a
  * oneTimeCode (inferior RPC) is completed.
  *
  * func	The function to be called.
@@ -497,14 +497,14 @@ void BPatch::reportError(BPatchErrorLevel severity, int number, const char *str)
     if ((severity == BPatchFatal) || (severity == BPatchSerious))
         bpatch->lastError = number;
 
-    if( !BPatch::bpatch->errorCallback ) { 
+    if( !BPatch::bpatch->errorCallback ) {
         fprintf(stdout, "%s[%d]:  DYNINST ERROR:\n %s\n", FILE__, __LINE__, str);
         fflush(stdout);
-        return; 
+        return;
     }
 
     BPatch::bpatch->errorCallback(severity, number, &str);
-    
+
 }
 
 
@@ -640,7 +640,7 @@ BPatch_Vector<BPatch_process *> *BPatch::getProcesses()
    for (auto iter = info->procsByPid.begin(); iter != info->procsByPid.end(); ++iter) {
       result->push_back(iter->second);
    }
-   
+
    return result;
 }
 
@@ -679,7 +679,7 @@ void BPatch::registerForkedProcess(PCProcess *parentProc, PCProcess *childProc)
     proccontrol_printf("BPatch: registering fork, parent %d, child %d\n",
                     parentPid, childPid);
     assert(getProcessByPid(childPid) == NULL);
-    
+
     BPatch_process *parent = getProcessByPid(parentPid);
     assert(parent);
 
@@ -689,7 +689,7 @@ void BPatch::registerForkedProcess(PCProcess *parentProc, PCProcess *childProc)
     if( postForkCallback ) {
         postForkCallback(parent->threads[0], child->threads[0]);
     }
-    
+
     proccontrol_printf("BPatch: finished registering fork, parent %d, child %d\n",
                     parentPid, childPid);
 }
@@ -723,7 +723,7 @@ void BPatch::registerForkingProcess(int forkingPid, PCProcess * /*proc*/)
  * Gives us some cleanup time
  */
 
-void BPatch::registerExecCleanup(PCProcess *p, char *) 
+void BPatch::registerExecCleanup(PCProcess *p, char *)
 {
     BPatch_process *execing = getProcessByPid(p->getPid());
     assert(execing);
@@ -731,7 +731,7 @@ void BPatch::registerExecCleanup(PCProcess *p, char *)
     for (unsigned i=0; i<execing->threads.size(); i++)
        registerThreadExit(p, execing->threads[i]->llthread);
 
-}    
+}
 
 /*
  * BPatch::registerExecExit
@@ -753,7 +753,7 @@ void BPatch::registerExecExit(PCProcess *proc) {
 
     // Create a new initial thread or update it
     BPatch_thread *initialThread;
-    if( process->threads.size() == 0 ) { 
+    if( process->threads.size() == 0 ) {
         initialThread = new BPatch_thread(process, thr);
         process->threads.push_back(initialThread);
     }else{
@@ -848,7 +848,7 @@ void BPatch::registerSignalExit(PCProcess *proc, int signalnum)
           exitCallback(bpprocess->threads[0], ExitedViaSignal);
       }
    }
-   
+
    // We now run the process out; set its state to terminated. Really, the user shouldn't
    // try to do anything else with this, but we can get that happening.
    BPatch_process *stillAround = getProcessByPid(pid);
@@ -875,9 +875,9 @@ bool BPatch::registerThreadCreate(BPatch_process *proc, BPatch_thread *newthr)
 void BPatch::registerThreadExit(PCProcess *llproc, PCThread *llthread)
 {
     assert( llproc && llthread );
-    
+
     BPatch_process *bpprocess = getProcessByPid(llproc->getPid());
-    
+
     if (!bpprocess) {
         // Error during startup can cause this -- we have a partially
         // constructed process object, but it was never registered with
@@ -888,7 +888,7 @@ void BPatch::registerThreadExit(PCProcess *llproc, PCThread *llthread)
     BPatch_thread *thrd = bpprocess->getThread(llthread->getTid());
     if (!thrd) {
         //If we don't have an BPatch thread, then it might have been an internal
-        // thread that we decided not to report to the user (happens during 
+        // thread that we decided not to report to the user (happens during
         //  windows attach).  Just trigger the lower level clean up in this case.
         llproc->removeThread(llthread->getTid());
         return;
@@ -962,7 +962,7 @@ void BPatch::registerLoadedModule(PCProcess *process, mapped_object *obj) {
 
     BPatch_image *bImage = bProc->getImage();
     assert(bImage); // This we can assert to be true
-    
+
     BPatch_object *bpobj = bImage->findOrCreateObject(obj);
 
     if( dynLibraryCallback ) {
@@ -988,11 +988,11 @@ void BPatch::registerUnloadedModule(PCProcess *process, mapped_object *obj) {
     if (!bImage) { // we got an event during process startup
         return;
     }
-    
+
     BPatch_object *bpobj = bImage->findObject(obj);
     if (bpobj == NULL) return;
 
-    
+
     // For now we use the same callback for load and unload of library....
     if( dynLibraryCallback ) {
         dynLibraryCallback(bProc->threads[0], bpobj, false);
@@ -1009,7 +1009,7 @@ void BPatch::registerUnloadedModule(PCProcess *process, mapped_object *obj) {
  * is called only by the constructor for BPatch_process).
  *
  * process	A pointer to the process to register.
- */ 
+ */
 void BPatch::registerProcess(BPatch_process *process, int pid)
 {
    if (!pid)
@@ -1135,8 +1135,8 @@ static void buildPath(const char *path, const char **argv,
  * stderr_fd	file descriptor to use for stderr for the application
 
  */
-BPatch_process *BPatch::processCreate(const char *path, const char *argv[], 
-                                         const char **envp, int stdin_fd, 
+BPatch_process *BPatch::processCreate(const char *path, const char *argv[],
+                                         const char **envp, int stdin_fd,
                                          int stdout_fd, int stderr_fd,
                                          BPatch_hybridMode mode)
 {
@@ -1157,7 +1157,7 @@ BPatch_process *BPatch::processCreate(const char *path, const char *argv[],
    struct stat statbuf;
    if (-1 == stat(path, &statbuf)) {
       char ebuf[2048];
-      sprintf(ebuf, "createProcess(%s,...):  file does not exist\n", path);
+      snprintf(ebuf, 2048, "createProcess(%s,...):  file does not exist\n", path);
       reportError(BPatchFatal, 68, ebuf);
       return NULL;
    }
@@ -1165,7 +1165,7 @@ BPatch_process *BPatch::processCreate(const char *path, const char *argv[],
    //  and ensure its a regular file:
    if (!S_ISREG(statbuf.st_mode)) {
       char ebuf[2048];
-      sprintf(ebuf, "createProcess(%s,...):  not a regular file \n", path);
+      snprintf(ebuf, 2048, "createProcess(%s,...):  not a regular file\n", path);
       reportError(BPatchFatal, 68, ebuf);
       return NULL;
    }
@@ -1175,7 +1175,7 @@ BPatch_process *BPatch::processCreate(const char *path, const char *argv[],
             || (statbuf.st_mode & S_IXGRP)
             || (statbuf.st_mode & S_IXOTH) )) {
       char ebuf[2048];
-      sprintf(ebuf, "createProcess(%s,...):  not an executable  \n", path);
+      snprintf(ebuf, 2048, "createProcess(%s,...):  not an executable\n", path);
       reportError(BPatchFatal, 68, ebuf);
       return NULL;
    }
@@ -1188,11 +1188,11 @@ BPatch_process *BPatch::processCreate(const char *path, const char *argv[],
 
    buildPath(path, argv, pathToUse, argvToUse);
 
-   BPatch_process *ret = 
-      new BPatch_process((pathToUse ? pathToUse : path), 
-                         (argvToUse ? (const_cast<const char **>(argvToUse)) : argv), 
+   BPatch_process *ret =
+      new BPatch_process((pathToUse ? pathToUse : path),
+                         (argvToUse ? (const_cast<const char **>(argvToUse)) : argv),
                          mode, envp, stdin_fd,stdout_fd,stderr_fd);
-   
+
    if (pathToUse) free(pathToUse);
    if (argvToUse) {
 
@@ -1204,7 +1204,7 @@ BPatch_process *BPatch::processCreate(const char *path, const char *argv[],
       free(argvToUse);
    }
 
-   if (!ret->llproc 
+   if (!ret->llproc
          ||  !ret->llproc->isStopped()
          ||  !ret->llproc->isBootstrapped()) {
       delete ret;
@@ -1249,7 +1249,7 @@ BPatch_process *BPatch::processAttach
       char msg[256];
       sprintf(msg, "attachProcess failed.  Dyninst is already attached to %d.",
               pid);
-      reportError(BPatchWarning, 26, msg);      
+      reportError(BPatchWarning, 26, msg);
       return NULL;
    }
 
@@ -1261,7 +1261,7 @@ BPatch_process *BPatch::processAttach
        char msg[256];
        sprintf(msg,"attachProcess failed: process %d may now be killed!",pid);
        reportError(BPatchWarning, 26, msg);
-	   
+
 	   delete ret;
        return NULL;
    }
@@ -1304,7 +1304,7 @@ bool BPatch::pollForStatusChange()
     if( result == PCEventMuxer::Error ) {
         proccontrol_printf("[%s:%d] Failed to poll for events\n",
                 FILE__, __LINE__);
-        BPatch_reportError(BPatchWarning, 0, 
+        BPatch_reportError(BPatchWarning, 0,
                 "Failed to handle events and deliver callbacks");
         return false;
     }
@@ -1314,7 +1314,7 @@ bool BPatch::pollForStatusChange()
         proccontrol_printf("[%s:%d] Events received\n", FILE__, __LINE__);
         return true;
     }
-  
+
     proccontrol_printf("[%s:%d] No events available\n", FILE__, __LINE__);
     return false;
 }
@@ -1336,7 +1336,7 @@ bool BPatch::waitForStatusChange() {
     // Sanity check: make sure there are processes running that could
     // cause events to occur, otherwise the user will be waiting indefinitely
     bool processRunning = false;
-    for(auto i = info->procsByPid.begin(); i != info->procsByPid.end(); ++i) 
+    for(auto i = info->procsByPid.begin(); i != info->procsByPid.end(); ++i)
     {
        if( !i->second->isStopped() &&
 	   !i->second->isTerminated()) {
@@ -1388,7 +1388,7 @@ bool BPatch::waitForStatusChange() {
  * It returns a pointer to a BPatch_type that was added to the APITypes
  * collection.
  */
-BPatch_type * BPatch::createEnum( const char * name, 
+BPatch_type * BPatch::createEnum( const char * name,
 				     BPatch_Vector<char *> &elementNames,
 				     BPatch_Vector<int> &elementIds)
 {
@@ -1397,15 +1397,15 @@ BPatch_type * BPatch::createEnum( const char * name,
     }
     string typeName = name;
     dyn_c_vector<pair<string, int> *>elements;
-    for (unsigned int i=0; i < elementNames.size(); i++) 
+    for (unsigned int i=0; i < elementNames.size(); i++)
         elements.push_back(new pair<string, int>(elementNames[i], elementIds[i]));
-    
+
     boost::shared_ptr<Type> typ(typeEnum::create( typeName, elements));
     if (!typ) return NULL;
-    
+
     BPatch_type *newType = new BPatch_type(typ);
     if (!newType) return NULL;
-    
+
     APITypes->addType(newType);
 
     return(newType);
@@ -1421,20 +1421,20 @@ BPatch_type * BPatch::createEnum( const char * name,
  * It returns a pointer to a BPatch_type that was added to the APITypes
  * collection.
  */
-BPatch_type * BPatch::createEnum( const char * name, 
+BPatch_type * BPatch::createEnum( const char * name,
 				        BPatch_Vector<char *> &elementNames)
 {
     string typeName = name;
     dyn_c_vector<pair<string, int> *>elements;
-    for (unsigned int i=0; i < elementNames.size(); i++) 
+    for (unsigned int i=0; i < elementNames.size(); i++)
         elements.push_back(new pair<string, int>(elementNames[i], i));
-    
+
     boost::shared_ptr<Type> typ(typeEnum::create( typeName, elements));
     if (!typ) return NULL;
-    
+
     BPatch_type *newType = new BPatch_type(typ);
     if (!newType) return NULL;
-    
+
     APITypes->addType(newType);
 
     return(newType);
@@ -1455,11 +1455,11 @@ BPatch_type * BPatch::createStruct( const char * name,
 				       BPatch_Vector<BPatch_type *> &fieldTypes)
 {
    unsigned int i;
-   
+
    if (fieldNames.size() != fieldTypes.size()) {
       return NULL;
    }
-   
+
    string typeName = name;
    dyn_c_vector<pair<string, boost::shared_ptr<Type> > *> fields;
    for(i=0; i<fieldNames.size(); i++)
@@ -1467,16 +1467,16 @@ BPatch_type * BPatch::createStruct( const char * name,
       if(!fieldTypes[i])
          return NULL;
       fields.push_back(new pair<string, boost::shared_ptr<Type>>(fieldNames[i], fieldTypes[i]->getSymtabType(Type::share)));
-   }	
-   
+   }
+
    boost::shared_ptr<Type> typ(typeStruct::create(typeName, fields));
    if (!typ) return NULL;
-   
+
    BPatch_type *newType = new BPatch_type(typ);
    if (!newType) return NULL;
-   
+
    APITypes->addType(newType);
-   
+
    return(newType);
 }
 
@@ -1490,12 +1490,12 @@ BPatch_type * BPatch::createStruct( const char * name,
  * collection.
  */
 
-BPatch_type * BPatch::createUnion( const char * name, 
+BPatch_type * BPatch::createUnion( const char * name,
 				      BPatch_Vector<char *> &fieldNames,
 				      BPatch_Vector<BPatch_type *> &fieldTypes)
 {
     unsigned int i;
-    
+
     if (fieldNames.size() != fieldTypes.size()) {
       return NULL;
     }
@@ -1507,18 +1507,18 @@ BPatch_type * BPatch::createUnion( const char * name,
         if(!fieldTypes[i])
 	    return NULL;
         fields.push_back(new pair<string, boost::shared_ptr<Type> > (fieldNames[i], fieldTypes[i]->getSymtabType(Type::share)));
-    }	
-    
+    }
+
     boost::shared_ptr<Type> typ(typeUnion::create(typeName, fields));
     if (!typ) return NULL;
-    
+
     BPatch_type *newType = new BPatch_type(typ);
     if (!newType) return NULL;
 
     APITypes->addType(newType);
 
     return(newType);
-}    
+}
 
 /*
  * createArray for Arrays and SymTypeRanges
@@ -1534,13 +1534,13 @@ BPatch_type * BPatch::createArray( const char * name, BPatch_type * ptr,
 {
 
     BPatch_type * newType;
-    if (!ptr) 
+    if (!ptr)
         return NULL;
-        
+
     string typeName = name;
     boost::shared_ptr<Type> typ(typeArray::create(typeName, ptr->getSymtabType(Type::share), low, hi));
     if (!typ) return NULL;
-    
+
     newType = new BPatch_type(typ);
     if (!newType) return NULL;
 
@@ -1563,11 +1563,11 @@ BPatch_type * BPatch::createPointer(const char * name, BPatch_type * ptr,
     BPatch_type * newType;
     if(!ptr)
         return NULL;
-    
+
     string typeName = name;
     boost::shared_ptr<Type> typ(typePointer::create(typeName, ptr->getSymtabType(Type::share)));
     if (!typ) return NULL;
-    
+
     newType = new BPatch_type(typ);
     if (!newType) return NULL;
 
@@ -1588,11 +1588,11 @@ BPatch_type * BPatch::createPointer(const char * name, BPatch_type * ptr,
 BPatch_type * BPatch::createScalar( const char * name, int size)
 {
     BPatch_type * newType;
-    
+
     string typeName = name;
     boost::shared_ptr<Type> typ(typeScalar::create(typeName, size));
     if (!typ) return NULL;
-    
+
     newType = new BPatch_type(typ);
     if (!newType) return NULL;
 
@@ -1614,11 +1614,11 @@ BPatch_type * BPatch::createTypedef( const char * name, BPatch_type * ptr)
     BPatch_type * newType;
     if(!ptr)
         return NULL;
-    
+
     string typeName = name;
     boost::shared_ptr<Type> typ(typeTypedef::create(typeName, ptr->getSymtabType(Type::share)));
     if (!typ) return NULL;
-    
+
     newType = new BPatch_type(typ);
     if (!newType) return NULL;
 
@@ -1647,7 +1647,7 @@ bool BPatch::waitUntilStopped(BPatch_thread *appThread){
  		goto done;
 	}
 #if defined(os_windows)
-	else if((appThread->getProcess()->stopSignal() != EXCEPTION_BREAKPOINT) && 
+	else if((appThread->getProcess()->stopSignal() != EXCEPTION_BREAKPOINT) &&
 		(appThread->getProcess()->stopSignal() != -1))
 	{
 		cerr << "ERROR : process stopped on signal different"
@@ -1676,9 +1676,9 @@ BPatch_stats &BPatch::getBPatchStatistics()
 }
 //  updateStats() -- an internal function called before returning
 //  statistics buffer to caller of BPatch_getStatistics(),
-//  -- just copies global variable statistics counters into 
+//  -- just copies global variable statistics counters into
 //  the buffer which is returned to the user.
-void BPatch::updateStats() 
+void BPatch::updateStats()
 {
   stats.pointsUsed = pointsUsed.value();
   stats.totalMiniTramps = totalMiniTramps.value();
@@ -1793,7 +1793,7 @@ bool BPatch::removeCodeDiscoveryCallback(BPatchCodeDiscoveryCallback)
     return true;
 }
 
-bool BPatch::registerSignalHandlerCallback(BPatchSignalHandlerCallback bpatchCB, 
+bool BPatch::registerSignalHandlerCallback(BPatchSignalHandlerCallback bpatchCB,
                                            std::set<long> &signums)
 {
     signalHandlerCallback = HybridAnalysis::getSignalHandlerCB();
@@ -1807,17 +1807,17 @@ bool BPatch::registerSignalHandlerCallback(BPatchSignalHandlerCallback bpatchCB,
     return true;
 }
 
-bool BPatch::registerSignalHandlerCallback(BPatchSignalHandlerCallback bpatchCB, 
+bool BPatch::registerSignalHandlerCallback(BPatchSignalHandlerCallback bpatchCB,
                                            BPatch_Set<long> *signums) {
    // This is unfortunate, but our method above takes a std::set<long>,
    // not a std::set<long, comparison<long>>
-   
+
    std::set<long> tmp;
    if (NULL == signums || signums->empty())
 	   tmp = std::set<long>();
    else
        std::copy(signums->begin(), signums->end(), std::inserter(tmp, tmp.end()));
-   
+
    return registerSignalHandlerCallback(bpatchCB, tmp);
 }
 
@@ -1848,7 +1848,7 @@ bool BPatch::registerCodeOverwriteCallbacks
     return true;
 }
 
-void BPatch::continueIfExists(int pid) 
+void BPatch::continueIfExists(int pid)
 {
     BPatch_process *proc = getProcessByPid(pid);
     if (!proc) return;
@@ -1859,7 +1859,7 @@ void BPatch::continueIfExists(int pid)
 
 int BPatch::getNotificationFD() {
 #if !defined(os_windows)
-   return Dyninst::ProcControlAPI::evNotify()->getFD(); 
+   return Dyninst::ProcControlAPI::evNotify()->getFD();
 #else
     return -1;
 #endif
@@ -1871,7 +1871,7 @@ void BPatch::truncateLineInfoFilenames(bool newval) {
    mapped_module::truncateLineFilenames = newval;
 }
 
-void BPatch::getBPatchVersion(int &major, int &minor, int &subminor) 
+void BPatch::getBPatchVersion(int &major, int &minor, int &subminor)
 {
    major = DYNINST_MAJOR;
    minor = DYNINST_MINOR;

--- a/dyninstAPI/src/function.C
+++ b/dyninstAPI/src/function.C
@@ -1,28 +1,28 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
@@ -148,11 +148,11 @@ func_instance::func_instance(const func_instance *parFunc,
 #endif
 }
 
-func_instance::~func_instance() { 
+func_instance::~func_instance() {
    // We don't delete blocks, since they're shared between functions
    // We _do_ delete context instPoints, though
    // Except that should get taken care of normally since the
-   // structures are static. 
+   // structures are static.
    for (unsigned i = 0; i < parallelRegions_.size(); i++)
       delete parallelRegions_[i];
    if (wrapperSym_ != NULL) {
@@ -161,7 +161,7 @@ func_instance::~func_instance() {
 }
 
 // the original entry block is gone, we choose a new entry block from the
-// function, whichever non-dead block we can find that has no intraprocedural 
+// function, whichever non-dead block we can find that has no intraprocedural
 // incoming edges.  If there's no obvious block to choose, we stick with the
 // default block
 block_instance * func_instance::setNewEntry(block_instance *def,
@@ -172,16 +172,16 @@ block_instance * func_instance::setNewEntry(block_instance *def,
 
     // choose block with no intraprocedural incoming edges
     PatchFunction::Blockset::iterator bIter;
-    for (bIter = all_blocks_.begin(); 
-         bIter != all_blocks_.end(); 
-         bIter++) 
+    for (bIter = all_blocks_.begin();
+         bIter != all_blocks_.end();
+         bIter++)
     {
         block_instance *block = static_cast<block_instance*>(*bIter);
         if (deadBlocks.find(block) == deadBlocks.end()) {
             ParseAPI::Intraproc epred;
             const Block::edgelist & ib_ins = block->llb()->sources();
-	    
-	    if(std::distance(boost::make_filter_iterator(epred, ib_ins.begin(), ib_ins.end()), 
+
+	    if(std::distance(boost::make_filter_iterator(epred, ib_ins.begin(), ib_ins.end()),
 			     boost::make_filter_iterator(epred, ib_ins.end(), ib_ins.end())) == 0)
             {
                 if (NULL != newEntry) {
@@ -204,7 +204,7 @@ block_instance * func_instance::setNewEntry(block_instance *def,
         newEntry = def;
         mal_printf("Setting new entry block for func at 0x%lx to "
                 "actively executing block [%lx %lx), as none of the function "
-                "blocks lacks intraprocedural edges %s[%d]\n", addr_, 
+                "blocks lacks intraprocedural edges %s[%d]\n", addr_,
                 def->start(), def->end(), FILE__,__LINE__);
     }
 
@@ -311,8 +311,8 @@ const func_instance::BlockSet &func_instance::unresolvedCF() {
        // A block has unresolved control flow if it has an indirect
        // out-edge.
        blocks(); // force initialization of all_blocks_
-       for (PatchFunction::Blockset::const_iterator iter = all_blocks_.begin(); 
-            iter != all_blocks_.end(); ++iter) 
+       for (PatchFunction::Blockset::const_iterator iter = all_blocks_.begin();
+            iter != all_blocks_.end(); ++iter)
        {
           block_instance* iblk = SCAST_BI(*iter);
           if (iblk->llb()->unresolvedCF()) {
@@ -326,8 +326,8 @@ const func_instance::BlockSet &func_instance::unresolvedCF() {
 const func_instance::BlockSet &func_instance::abruptEnds() {
     if (prevBlocksAbruptEnds_ != ifunc()->num_blocks()) {
        prevBlocksAbruptEnds_ = blocks().size();
-        for (PatchFunction::Blockset::const_iterator iter = all_blocks_.begin(); 
-             iter != all_blocks_.end(); ++iter) 
+        for (PatchFunction::Blockset::const_iterator iter = all_blocks_.begin();
+             iter != all_blocks_.end(); ++iter)
         {
             block_instance* iblk = SCAST_BI(*iter);
             if (iblk->llb()->abruptEnd()) {
@@ -358,8 +358,8 @@ block_instance *func_instance::entryBlock() {
 unsigned func_instance::getNumDynamicCalls()
 {
    unsigned count=0;
-   for (PatchFunction::Blockset::const_iterator iter = callBlocks().begin(); 
-        iter != callBlocks().end(); ++iter) 
+   for (PatchFunction::Blockset::const_iterator iter = callBlocks().begin();
+        iter != callBlocks().end(); ++iter)
    {
       block_instance* iblk = SCAST_BI(*iter);
       if (iblk->containsDynamicCall()) {
@@ -370,22 +370,22 @@ unsigned func_instance::getNumDynamicCalls()
 }
 
 
-// warning: doesn't (and can't) force initialization of lazily-built 
+// warning: doesn't (and can't) force initialization of lazily-built
 // data structures because this function is declared to be constant
 void func_instance::debugPrint() const {
     fprintf(stderr, "Function debug dump (%p):\n", (const void*)this);
     fprintf(stderr, "  Symbol table names:\n");
-    for (auto i = symtab_names_begin(); 
+    for (auto i = symtab_names_begin();
 	 i != symtab_names_end(); ++i) {
       fprintf(stderr, "    %s\n", i->c_str());
     }
     fprintf(stderr, "  Demangled names:\n");
-    for (auto j = pretty_names_begin(); 
+    for (auto j = pretty_names_begin();
 	 j != pretty_names_end(); ++j) {
       fprintf(stderr, "    %s\n", j->c_str());
     }
     fprintf(stderr, "  Typed names:\n");
-    for (auto k = typed_names_begin(); 
+    for (auto k = typed_names_begin();
 	 k != typed_names_end(); ++k) {
       fprintf(stderr, "    %s\n", k->c_str());
     }
@@ -546,7 +546,7 @@ bool func_instance::consistency() const {
 }
 
 void func_instance::triggerModified() {
-    // KEVINTODO: is there anything to do here? 
+    // KEVINTODO: is there anything to do here?
 }
 
 Address func_instance::get_address() const { assert(0); return 0; }
@@ -557,10 +557,10 @@ bool func_instance::isInstrumentable() {
 #if defined(os_freebsd)
   // FreeBSD system call wrappers are using an indirect jump to an error
   // handling function; this confuses our parsing and we conclude they
-  // are uninstrumentable. They're not. It's fine. 
-  
+  // are uninstrumentable. They're not. It's fine.
+
   std::string wrapper_prefix = "__sys_";
-  for(auto i = symtab_names_begin(); i != symtab_names_end(); ++i) 
+  for(auto i = symtab_names_begin(); i != symtab_names_end(); ++i)
   {
     if (i->compare(0, 6, wrapper_prefix) == 0) {
       return true;
@@ -586,13 +586,13 @@ block_instance *func_instance::getBlockByEntry(const Address addr) {
 }
 
 
-// get all blocks that have an instruction starting at addr, or if 
+// get all blocks that have an instruction starting at addr, or if
 // there are none, return all blocks containing addr
 bool func_instance::getBlocks(const Address addr, set<block_instance*> &blks) {
    set<block_instance*> objblks;
    obj()->findBlocksByAddr(addr, objblks);
-   blocks(); // ensure that all_blocks_ is filled in 
-   std::vector<std::set<block_instance *>::iterator> to_erase; 
+   blocks(); // ensure that all_blocks_ is filled in
+   std::vector<std::set<block_instance *>::iterator> to_erase;
    for (set<block_instance*>::iterator bit = objblks.begin(); bit != objblks.end(); bit++) {
       // Make sure it's one of ours
       if (all_blocks_.find(*bit) == all_blocks_.end()) {
@@ -603,7 +603,7 @@ bool func_instance::getBlocks(const Address addr, set<block_instance*> &blks) {
       objblks.erase(to_erase[i]);
    }
 
-   if (objblks.size() > 1) { 
+   if (objblks.size() > 1) {
       // only add blocks that have an instruction at "addr"
       for (set<block_instance*>::iterator bit = objblks.begin(); bit != objblks.end(); bit++) {
          if ((*bit)->getInsn(addr).isValid()) {
@@ -611,7 +611,7 @@ bool func_instance::getBlocks(const Address addr, set<block_instance*> &blks) {
          }
       }
    }
-   // if there are no blocks containing an instruction that starts at addr, 
+   // if there are no blocks containing an instruction that starts at addr,
    // but there are blocks that contain addr, add those to blks
    if (blks.empty() && !objblks.empty()) {
       std::copy(objblks.begin(), objblks.end(), std::inserter(blks, blks.end()));
@@ -857,8 +857,8 @@ void func_instance::split_block_cb(block_instance *b1, block_instance *b2)
 
 void func_instance::add_block_cb(block_instance * /*block*/)
 {
-#if 0 // KEVINTODO: eliminate this?  as presently constituted, 
-      // these if cases will never execute anyway, at least not 
+#if 0 // KEVINTODO: eliminate this?  as presently constituted,
+      // these if cases will never execute anyway, at least not
       // when we intend them to
     if (block->llb()->unresolvedCF()) {
        size_t prev = ifunc()->getPrevBlocksUnresolvedCF();
@@ -867,7 +867,7 @@ void func_instance::add_block_cb(block_instance * /*block*/)
           ifunc()->setPrevBlocksUnresolvedCF(prev+1);
        }
     }
-    if (block->llb()->abruptEnd() && 
+    if (block->llb()->abruptEnd() &&
         prevBlocksAbruptEnds_ == ifunc()->blocks().size())
     {
         abruptEnds_.insert(block);
@@ -882,8 +882,8 @@ void func_instance::markModified() {
 
 // get caller blocks that aren't in deadBlocks
 bool func_instance::getLiveCallerBlocks
-(const std::set<block_instance*> &deadBlocks, 
- const std::list<func_instance*> &deadFuncs, 
+(const std::set<block_instance*> &deadBlocks,
+ const std::list<func_instance*> &deadFuncs,
  std::map<Address,vector<block_instance*> > & stubs)  // output: block + target addr
 {
    using namespace ParseAPI;
@@ -894,16 +894,16 @@ bool func_instance::getLiveCallerBlocks
       if (CALL == (*eit)->type()) {// includes tail calls
           block_instance *cbbi = static_cast<block_instance*>((*eit)->src());
           if (deadBlocks.end() != deadBlocks.find(cbbi)) {
-             continue; 
+             continue;
           }
 
-          // don't use stub if it only appears in dead functions 
+          // don't use stub if it only appears in dead functions
           std::set<func_instance*> bfuncs;
           cbbi->getFuncs(std::inserter(bfuncs,bfuncs.end()));
           bool allSrcFuncsDead = true;
           for (std::set<func_instance*>::iterator bfit = bfuncs.begin();
-               bfit != bfuncs.end(); 
-               bfit++) 
+               bfit != bfuncs.end();
+               bfit++)
           {
              bool isSrcFuncDead = false;
              for (std::list<func_instance*>::const_iterator dfit = deadFuncs.begin();
@@ -921,7 +921,7 @@ bool func_instance::getLiveCallerBlocks
              }
           }
           if (allSrcFuncsDead) {
-             continue; 
+             continue;
           }
           // add stub
           stubs[addr()].push_back(cbbi);
@@ -1703,6 +1703,8 @@ void func_instance::createTMap_internal(StackMod* mod, TMap* tMap)
     }
 }
 
+namespace
+{
 AnnotationClass<StackAnalysis::Intervals>
         Stack_Anno_Intervals(std::string("Stack_Anno_Intervals"), NULL);
 AnnotationClass<StackAnalysis::BlockEffects>
@@ -1711,6 +1713,7 @@ AnnotationClass<StackAnalysis::InstructionEffects>
         Stack_Anno_Insn_Effects(std::string("Stack_Anno_Insn_Effects"), NULL);
 AnnotationClass<StackAnalysis::CallEffects>
         Stack_Anno_Call_Effects(std::string("Stack_Anno_Call_Effects"), NULL);
+}
 void func_instance::freeStackMod() {
     // Free stack analysis intervals
     StackAnalysis::Intervals *i = NULL;

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -1,28 +1,28 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
@@ -86,7 +86,7 @@ bool Object::truncateLineFilenames = false;
 
 string symt_current_func_name;
 string symt_current_mangled_func_name;
-Symbol *symt_current_func = NULL;
+Function *symt_current_func = NULL;
 
 std::vector<Symbol *> opdsymbols_;
 
@@ -2771,7 +2771,7 @@ Object::Object(MappedFile *mf_, bool, void (*err_func)(const char *),
         DbgSectionMapSorted(false),
         soname_(NULL)
 {
-    li_for_object = NULL; 
+    li_for_object = NULL;
 
 #if defined(TIMED_PARSE)
     struct timeval starttime;
@@ -3166,30 +3166,30 @@ int read_except_table_gcc3(
     int res = 0;
     Elf_Data * eh_frame_data = eh_frame->get_data().elf_data();
 
-    //For each CFI entry 
+    //For each CFI entry
     do {
         Dwarf_CFI_Entry entry;
         res = dwarf_next_cfi(e_ident, eh_frame_data, true, offset, &next_offset, &entry);
-        saved_cur_offset = offset; //saved in case needed later 
+        saved_cur_offset = offset; //saved in case needed later
         offset = next_offset;
 
-        // If no more CFI entries left in the section 
+        // If no more CFI entries left in the section
         if(res==1 && next_offset==(Dwarf_Off)-1) break;
-        
+
         // CFI error
         if(res == -1) {
 	  if (offset != saved_cur_offset) {
             continue; // Soft error, skip to the next CFI entry
           }
           // Since offset didn't advance, we can't skip this CFI entry and need to quit
-          return false; 
+          return false;
         }
 
         if(dwarf_cfi_cie_p(&entry))
         {
             continue;
         }
-        
+
         unsigned int j;
         unsigned char lsda_encoding = DW_EH_PE_absptr;
         unsigned char personality_encoding = DW_EH_PE_absptr;
@@ -3283,13 +3283,13 @@ int read_except_table_gcc3(
         // pointer encodings, the FDE contains the actual pointers.
 
         // Calculate size in bytes of PC Begin
-        const unsigned char* pc_begin_start = fde_bytes + 4 /* CIE Pointer size is 4 bytes */ + 
+        const unsigned char* pc_begin_start = fde_bytes + 4 /* CIE Pointer size is 4 bytes */ +
             (*(uint32_t*)fde_bytes == 0xffffffff ? LONG_FDE_HLEN : SHORT_FDE_HLEN);
         unsigned long pc_begin_val;
         mi.pc = fde_addr + (unsigned long) (pc_begin_start - fde_bytes);
         int pc_begin_size = read_val_of_type(range_encoding, &pc_begin_val, pc_begin_start, mi);
 
-        // Calculate size in bytes of PC Range 
+        // Calculate size in bytes of PC Range
         const unsigned char* pc_range_start = pc_begin_start + pc_begin_size;
         unsigned long pc_range_val;
         mi.pc = fde_addr + (unsigned long) (pc_range_start - fde_bytes);
@@ -3302,7 +3302,7 @@ int read_except_table_gcc3(
         auto aug_length_size = read_val_of_type(DW_EH_PE_uleb128, &aug_length_value, aug_length_start, mi);
 
         // Confirm low_pc
-        auto pc_begin = reinterpret_cast<const unsigned char*>(entry.fde.start); 
+        auto pc_begin = reinterpret_cast<const unsigned char*>(entry.fde.start);
         unsigned long low_pc_val;
         mi.pc = fde_addr + (unsigned long) (pc_begin - fde_bytes);
         read_val_of_type(range_encoding, &low_pc_val, pc_begin, mi);
@@ -3310,9 +3310,9 @@ int read_except_table_gcc3(
         low_pc = pc_begin_val;
 
         // Get the augmentation data for the FDE
-        cur_augdata = fde_bytes + 4 /* CIE Pointer size is 4 bytes */ + 
+        cur_augdata = fde_bytes + 4 /* CIE Pointer size is 4 bytes */ +
             (*(uint32_t*)fde_bytes == 0xffffffff ? LONG_FDE_HLEN : SHORT_FDE_HLEN) +
-            pc_begin_size + pc_range_size + aug_length_size; 
+            pc_begin_size + pc_range_size + aug_length_size;
 
         for (j=0; j<augmentor_len; j++)
         {
@@ -4203,7 +4203,7 @@ LineInformation* Object::parseLineInfoForObject(StringTablePtr strings_)
         // The line information for this object has been parsed.
         return li_for_object;
     }
-    li_for_object = new LineInformation(); 
+    li_for_object = new LineInformation();
     li_for_object->setStrings(strings_);
     /* Initialize libdwarf. */
     Dwarf **dbg_ptr = dwarf->type_dbg();
@@ -4264,7 +4264,7 @@ LineInformation* Object::parseLineInfoForObject(StringTablePtr strings_)
     open_statement current_statement;
     for(size_t i = 0; i < lineCount; i++ )
     {
-        auto line = dwarf_onesrcline(lineBuffer, i); 
+        auto line = dwarf_onesrcline(lineBuffer, i);
 
         /* Acquire the line number, address, source, and end of sequence flag. */
         status = dwarf_lineno(line, &current_statement.line_number);
@@ -4291,7 +4291,7 @@ LineInformation* Object::parseLineInfoForObject(StringTablePtr strings_)
             if (result)
                 current_statement.start_addr = new_lineAddr;
         }
-        
+
         //status = dwarf_line_srcfileno(line, &current_statement.string_table_index);
         const char * file_name = dwarf_linesrc(line, NULL, NULL);
         if ( !file_name ) {
@@ -4304,9 +4304,9 @@ LineInformation* Object::parseLineInfoForObject(StringTablePtr strings_)
         int index = -1;
         for(size_t idx = offset; idx < strings->size(); ++idx)
         {
-            if((*strings)[idx].str==file_name_str) 
-            {  
-                index = idx; 
+            if((*strings)[idx].str==file_name_str)
+            {
+                index = idx;
                 break;
             }
         }
@@ -4347,7 +4347,7 @@ LineInformation* Object::parseLineInfoForObject(StringTablePtr strings_)
 	if (isEndOfSequence) {
 	  current_line.reset();
 	}
-    } 
+    }
     }
     return li_for_object;
 }
@@ -4743,7 +4743,7 @@ bool Object::convertDebugOffset(Offset off, Offset &new_off)
     int hi = DebugSectionMap.size();
 
     if (hi == 0) {
-      // DebugSectionMap is empty; handle this case separately 
+      // DebugSectionMap is empty; handle this case separately
       DbgSectionMapSorted = true;
       return true;
     }


### PR DESCRIPTION
- Fixed uninitialized variable in DispatcherARM64::getBitfieldMask
- anonymous namespace for StackAnalysis variables in stackanalysis.C and function.C
- fix potential buffer overflow in BPatch::processCreate
- fix Symbol* symt_current_func (Object-elf.C) + extern Function* symt_current_func (parseStab.C)

Part of CMake Overhaul (#1101)