### PR TITLE
Only consider register number when calculating used aarch64 float reg…

### DIFF
--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -551,8 +551,13 @@ bool EmitterAARCH64::clobberAllFuncCall(registerSpace *rs,
             rs->GPRs()[*itr]->beenUsed = true;
 
         std::set<Register> *fpRegs = callee->ifunc()->usedFPRs();
-        for(std::set<Register>::iterator itr = fpRegs->begin(); itr != fpRegs->end(); itr++)
-            rs->FPRs()[*itr]->beenUsed = true;
+        for(std::set<Register>::iterator itr = fpRegs->begin(); itr != fpRegs->end(); itr++) {
+            if (*itr <= rs->FPRs().size())
+              rs->FPRs()[*itr]->beenUsed = true;
+            else
+              // parse_func::calcUsedRegs includes the subtype; we only want the regno
+              rs->FPRs()[*itr & 0xff]->beenUsed = true;
+        }
     } else {
         for(int idx = 0; idx < rs->numGPRs(); idx++)
             rs->GPRs()[idx]->beenUsed = true;


### PR DESCRIPTION
…isters.

Do not include the subtype when adding a float register to the used registers set otherwise the registerSlot vector may be exceeded for a value like 0x400 (Q_REG/register 0).

Noticed this problem adding a snippet on aarch64 that generates a call to printf.

Floating point used registers are set at:
#0  parse_func::calcUsedRegs (this=0x2730770) at /home/scox/dyninst/src/dyninstAPI/src/parse-aarch64.C:142
142	                usedRegisters->floatingPointRegisters.insert(r & 0xFFFF);
0xFFFF is going to grab both the subtype, e.g. Q_REG 0x400, as well as the register number.  This can result in, e.g. 0x400, 1024.   Later at
EmitterAARCH64::clobberAllFuncCall (this=0xfffff7fbc270 <AddressSpace::getEmitter()::emitter64Stat>, rs=0x410f810, callee=0x40e8160)
    at /home/scox/dyninst/src/dyninstAPI/src/inst-aarch64.C:555
555	            rs->FPRs()[*itr]->beenUsed = true;
itr will be that value, e.g. 1024, but FPRs, which is a vector of registerSlot* only has 32 elements.  The same is potentially true for general registers but calcUsedRegs ands with 0xFF for those.  This patch does similarly for float registers.