### PR TITLE
Remove usage of arch_ppc and arch_ppc64

### DIFF
--- a/dyninstAPI/src/BPatch_memoryAccessAdapter.C
+++ b/dyninstAPI/src/BPatch_memoryAccessAdapter.C
@@ -179,7 +179,7 @@ BPatch_memoryAccess* BPatch_memoryAccessAdapter::convert(Instruction insn,
   }
   assert(nac < 3);
   return bmap;
-#elif defined(arch_ppc)||defined(arch_ppc64)
+#elif defined arch_power
     std::vector<Operand> operands;
     insn.getOperands(operands);
     for(std::vector<Operand>::iterator op = operands.begin();
@@ -268,7 +268,7 @@ void BPatch_memoryAccessAdapter::visit(RegisterAST* r)
     //fprintf(stderr, "base: %d\n", base.val());
 	    
 	unsigned int converted = base.val() & 0xFFFF;
-	#if defined(arch_ppc)||defined(arch_ppc64)
+	#if defined arch_power
     if((ra == -1) && !setImm) {
         ra = converted;
         return;


### PR DESCRIPTION
These were removed by f33ba7b in 2013 and should have been converted to
arch_power at that time.