### PR TITLE
Unify meaning of 'cap_32_64' macro

### DIFF
--- a/cmake/cap_arch_def.cmake
+++ b/cmake/cap_arch_def.cmake
@@ -1,5 +1,8 @@
-# The test suite needs this as a list rather than a bunch
-# of definitions so that we can append _test to it. 
+#
+# -- Define the capabilities for each supported architecture/platform
+#
+#  cap_32_64 - This host 64-bit platform supports modifying 32-bit binaries
+#
 
 set (CAP_DEFINES
      -Dcap_dynamic_heap 

--- a/cmake/cap_arch_def.cmake
+++ b/cmake/cap_arch_def.cmake
@@ -53,7 +53,7 @@ elseif (PLATFORM MATCHES ppc64)
 elseif (PLATFORM MATCHES aarch64)
   #set (ARCH_DEFINES -Daarch_64 -Darch_64bit)
   set (ARCH_DEFINES -Darch_aarch64 -Darch_64bit)
-  set (CAP_DEFINES ${CAP_DEFINES} -Dcap_32_64 -Dcap_registers)
+  set (CAP_DEFINES ${CAP_DEFINES} -Dcap_registers)
 endif (PLATFORM MATCHES i386)
 
 if (PLATFORM MATCHES linux)

--- a/dataflowAPI/src/ABI.C
+++ b/dataflowAPI/src/ABI.C
@@ -91,8 +91,12 @@ ABI* ABI::getABI(int addr_width){
 	globalABI64_->index = &machRegIndex_aarch64();
 #endif
 
+// We _only_ support instrumenting 32-bit binaries on 64-bit systems
+#if !defined arch_64bit || defined cap_32_64
 	initialize32();
-#if defined(cap_32_64)
+#endif
+
+#ifdef arch_64bit
 	initialize64();
 #endif
     }
@@ -553,10 +557,6 @@ void ABI::initialize64(){
 
 //#warning "This is not verified!"
 #if defined(arch_aarch64)
-void ABI::initialize32(){
-	return;
-}
-
 void ABI::initialize64(){
     RegisterMap aarch64Map = machRegIndex_aarch64();
 	int sz = aarch64Map.size();

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -1151,8 +1151,6 @@ void trampTrapMappings::writeToBuffer(unsigned char *buffer, unsigned long val,
 #if defined(cap_32_64)
       *((uint32_t *) buffer) = (uint32_t) val;
       return;
-#elif
-      static_assert("This platform does not support modifying 32-bit binaries");
 #endif
    }
    *((unsigned long *) buffer) = val;

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -1140,7 +1140,6 @@ bool mapping_sort(const trampTrapMappings::tramp_mapping_t *lhs,
    return lhs->from_addr < rhs->from_addr;
 }
 
-#if defined(cap_32_64)
 void trampTrapMappings::writeToBuffer(unsigned char *buffer, unsigned long val,
                                       unsigned addr_width)
 {
@@ -1149,19 +1148,15 @@ void trampTrapMappings::writeToBuffer(unsigned char *buffer, unsigned long val,
       //Currently only support 64-bit mutators with 32-bit mutatees
       assert(addr_width == 4);
       assert(sizeof(Address) == 8);
+#if defined(cap_32_64)
       *((uint32_t *) buffer) = (uint32_t) val;
       return;
+#elif
+      static_assert("This platform does not support modifying 32-bit binaries");
+#endif
    }
    *((unsigned long *) buffer) = val;
 }
-#else
-void trampTrapMappings::writeToBuffer(unsigned char *buffer, unsigned long val,
-                                      unsigned)
-{
-   *((unsigned long *)(void*) buffer) = val;
-}
-#endif
-
 
 void trampTrapMappings::writeTrampVariable(const int_variable *var, 
                                            unsigned long val)

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -197,7 +197,7 @@ void registerSpace::initialize32() {
 
 }
 
-#if defined(cap_32_64)
+#if defined arch_x86_64
 void registerSpace::initialize64() {
     static bool done = false;
     if (done) return;
@@ -538,7 +538,7 @@ void registerSpace::initialize()
     
 
     initialize32();
-#if defined(cap_32_64)
+#if defined arch_x86_64
     initialize64();
 #endif
 }


### PR DESCRIPTION
Currently, this is used in several different ways due to the historical
original meaning drifting over the years. It's meaning is now "this host
64-bit platform supports modifying 32-bit binaries". Currently, this is
only x86 and PPC32. Although the latter is going away soon due to
obsolescence.

Requires https://github.com/dyninst/testsuite/pull/202