### PR TITLE
Remove support for Cray CNL

### DIFF
--- a/cmake/cap_arch_def.cmake
+++ b/cmake/cap_arch_def.cmake
@@ -67,17 +67,6 @@ set (CAP_DEFINES ${CAP_DEFINES}
     )
 set (BUG_DEFINES -Dbug_syscall_changepc_rewind -Dbug_force_terminate_failure)
 
-elseif (PLATFORM MATCHES cnl)
-set (OS_DEFINES -Dos_linux -Dos_cnl)
-set (CAP_DEFINES ${CAP_DEFINES} 
-             -Dcap_async_events
-             -Dcap_binary_rewriter
-             -Dcap_dwarf
-             -Dcap_mutatee_traps
-             -Dcap_ptrace
-    )
-set (BUG_DEFINES -Dbug_syscall_changepc_rewind)
-
 elseif (PLATFORM MATCHES freebsd)
 set (OS_DEFINES -Dos_freebsd)
 set (CAP_DEFINES ${CAP_DEFINES} 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -70,16 +70,6 @@ if (PLATFORM MATCHES linux)
   )
 endif()
 
-if (PLATFORM MATCHES cnl)
-  set (SRC_LIST ${SRC_LIST}
-    src/linuxKludges.C
-    src/parseauxv.C
-    src/addrtranslate-sysv.C
-    src/addrtranslate-auxv.C
-    src/addrtranslate-linux.C
-  )
-endif()  
-
 if (PLATFORM MATCHES nt OR PLATFORM MATCHES windows)
   set (SRC_LIST ${SRC_LIST}
     src/ntKludges.C

--- a/proccontrol/CMakeLists.txt
+++ b/proccontrol/CMakeLists.txt
@@ -66,15 +66,6 @@ set (SRC_LIST ${SRC_LIST}
 	 ../common/src/dthread.C
      src/loadLibrary/codegen-linux.C
   )
-elseif (PLATFORM MATCHES cnl)
-set (SRC_LIST ${SRC_LIST}
-     src/linux.C
-     src/unix.C
-     src/notify_pipe.C
-     ../common/src/dthread-unix.C
-	 ../common/src/dthread.C
-     src/loadLibrary/codegen-stub.C
-  )
 endif()
 
 SET_SOURCE_FILES_PROPERTIES(${SRC_LIST} PROPERTIES LANGUAGE CXX)

--- a/symtabAPI/CMakeLists.txt
+++ b/symtabAPI/CMakeLists.txt
@@ -34,8 +34,7 @@ set (SRC_LIST
   )
 
 if (PLATFORM MATCHES freebsd OR 
-    PLATFORM MATCHES linux OR 
-    PLATFORM MATCHES cnl)
+    PLATFORM MATCHES linux)
 
 set (SRC_LIST ${SRC_LIST}
     src/Object-elf.C 


### PR DESCRIPTION
The Compute Node Linux (CNL) was for the old Cray XT/XE platforms that
are obsolete now. This should have been removed by e5484368f in
2021. Support for this platform was removed from the test suite by
7e4ab7c12 in 2012.

Closes #1133 