### PR TITLE
fix statement-like macros

### DIFF
--- a/dwarf/src/dwarfResult.C
+++ b/dwarf/src/dwarfResult.C
@@ -43,7 +43,7 @@ using namespace Dyninst;
 using namespace DwarfDyninst;
 using namespace std;
 
-#define CHECK_OPER(n) if (operands.size() < n) { error = true; break; }
+#define CHECK_OPER(n) do { if (operands.size() < (n)) { error = true; return; } } while (0)
 
 void SymbolicDwarfResult::pushReg(MachRegister reg) {
   dwarf_printf("\t\tPush %s\n", reg.name().c_str());

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -777,9 +777,9 @@ bool AstNode::previousComputationValid(Register &reg,
 }
 
 // We're going to use this fragment over and over and over...
-#define RETURN_KEPT_REG(r) { if (previousComputationValid(r, gen)) { decUseCount(gen); gen.rs()->incRefCount(r); return true;} }
-#define ERROR_RETURN { fprintf(stderr, "[%s:%d] ERROR: failure to generate operand\n", __FILE__, __LINE__); return false; }
-#define REGISTER_CHECK(r) if (r == REG_NULL) { fprintf(stderr, "[%s: %d] ERROR: returned register invalid\n", __FILE__, __LINE__); return false; }
+#define RETURN_KEPT_REG(r) do { if (previousComputationValid(r, gen)) { decUseCount(gen); gen.rs()->incRefCount(r); return true;} } while (0)
+#define ERROR_RETURN do { fprintf(stderr, "[%s:%d] ERROR: failure to generate operand\n", __FILE__, __LINE__); return false; } while (0)
+#define REGISTER_CHECK(r) do { if ((r) == REG_NULL) { fprintf(stderr, "[%s: %d] ERROR: returned register invalid\n", __FILE__, __LINE__); return false; } } while (0)
 
 
 bool AstNode::initRegisters(codeGen &g) {

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -51,33 +51,33 @@ using namespace SymtabAPI;
 using namespace DwarfDyninst;
 using namespace std;
 
-#define DWARF_FAIL_RET_VAL(x, v) {                                      \
+#define DWARF_FAIL_RET_VAL(x, v) do  {                                  \
       int dwarf_fail_ret_val_status = (x);                              \
       if (dwarf_fail_ret_val_status != 0) {                             \
          types_printf("[%s:%d]: libdwarf returned %d, ret false\n",     \
                  FILE__, __LINE__, dwarf_fail_ret_val_status);          \
          return (v);                                                    \
       }                                                                 \
-   }
+   } while (0)
 #define DWARF_FAIL_RET(x) DWARF_FAIL_RET_VAL(x, false)
 
-#define DWARF_ERROR_RET_VAL(x, v) {                                     \
+#define DWARF_ERROR_RET_VAL(x, v) do  {                                 \
       int dwarf_error_ret_val_status = (x);                             \
       if (dwarf_error_ret_val_status == 1 /*DW_DLV_ERROR*/) {           \
          types_printf("[%s:%d]: parsing failure, ret false\n",          \
                  FILE__, __LINE__);                                     \
          return (v);                                                    \
       }                                                                 \
-   }
+   } while (0)
 #define DWARF_ERROR_RET(x) DWARF_ERROR_RET_VAL(x, false)
 
-#define DWARF_CHECK_RET_VAL(x, v) {                                     \
+#define DWARF_CHECK_RET_VAL(x, v) do  {                                 \
       if (x) {                                                          \
          types_printf("[%s:%d]: parsing failure, ret false\n",          \
                  FILE__, __LINE__);                                     \
          return (v);                                                    \
       }                                                                 \
-   }
+   } while (0)
 #define DWARF_CHECK_RET(x) DWARF_CHECK_RET_VAL(x, false)
 
 DwarfWalker::DwarfWalker(Symtab *symtab, ::Dwarf * dbg) :


### PR DESCRIPTION
wrap macro body in 'do {...} while (0)' so they can be used as if they were a
statement with a terminating semicolon.