### PR TITLE
Improve docs for lookup functions in CodeObject

### DIFF
--- a/parseAPI/doc/API/CodeObject.tex
+++ b/parseAPI/doc/API/CodeObject.tex
@@ -92,6 +92,15 @@ void parseGaps(CodeRegion *cr,
 \end{apient}
 \apidesc{Speculatively parse the indicated region of the binary using the specified technique to find likely function entry points, enabled on the x86 and x86-64 platforms.}
 
+\fbox{\begin{minipage}[t]{1\columnwidth}%
+\begin{center}{\textbf{A note on using the lookup functions}}\end{center}\\
+When parsing binary objects such as .o files and static libraries which may have multiple
+\texttt{CodeRegion} objects that overlap in the address space, the \texttt{CodeRegion} argument
+\textit{must} be passed. For executable binaries and shared libraries that are fully linked, there
+is no ambiguity, and {\scshape null} can be passed. The only exception is \texttt{findFuncsByBlock}
+which always requires a valid \texttt{CodeRegion}.%
+\end{minipage}}
+
 \begin{apient}
 Function * findFuncByEntry(CodeRegion * cr,
                            Address entry)


### PR DESCRIPTION
Add wording to improve clarity about when a CodeRegion is strictly needed when using the lookup functions.

Closes #1102 

@wcohen @mxz297

From poking around in the code, it looks like the only place that the ParseData interface is exposed is through member functions in CodeObject. I think that's the best place to document this.

The interface for ParseData is

    1. Function * findFunc(CodeRegion *, Address);
    2. Block * findBlock(CodeRegion *, Address);
    3. int findFuncs(CodeRegion *, Address, set<Function*> &);
    4. int findFuncs(CodeRegion *, Address, Address, set<Function*> &);
    5. int findBlocks(CodeRegion *, Address, set<Block*> &);
    6. ParseFrame * findFrame(CodeRegion *, Address);
    7. ParseFrame::Status frameStatus(CodeRegion *, Address addr);
    8. void setFrameStatus(CodeRegion*,Address,ParseFrame::Status);

CodeObject provides

    Function * findFuncByEntry(CodeRegion * cr, Address entry);
			-> maps to 1

    int findFuncsByBlock(CodeRegion *cr, Block* b, std::set<Function*> &funcs);
			-> Does not map to ParseData. CodeRegion is REQUIRED.

    int findFuncs(CodeRegion * cr, Address addr, std::set<Function*> & funcs);
			-> maps to 3

    int findFuncs(CodeRegion * cr, Address start, Address end, std::set<Function*> & funcs);
			-> maps to 4

    int findCurrentFuncs(CodeRegion * cr, Address addr, std::set<Function*> & funcs);
			-> maps to 4

    Block * findBlockByEntry(CodeRegion * cr, Address entry);
			-> maps to 2

    int findBlocks(CodeRegion * cr, Address addr, std::set<Block*> & blocks);
			-> maps to 5

    int findCurrentBlocks(CodeRegion * cr, Address addr, std::set<Block*> & blocks);
			-> maps to 5

    Block * findNextBlock(CodeRegion * cr, Address addr);
			-> maps to 5
