### PR TITLE
Remove arch-specific init functions from addressSpace interface

### DIFF
--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -78,11 +78,7 @@ void initDefaultPointFrequencyTable() {
 
 /************************************* Register Space **************************************/
 
-void registerSpace::initialize32() {
-    assert(!"No 32-bit implementation for the ARM architecture!");
-}
-
-void registerSpace::initialize64() {
+static void initialize64() {
     static bool done = false;
     if (done)
         return;

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -114,7 +114,7 @@ unsigned int floatingLiveRegListSize = 14;
 // of saves that we execute. 
 
 
-void registerSpace::initialize32() {
+static void initialize32() {
     static bool done = false;
     if (done) return;
     done = true;
@@ -251,7 +251,7 @@ void registerSpace::initialize32() {
 
 }
 
-void registerSpace::initialize64() {
+static void initialize64() {
     static bool done = false;
     if (done) return;
     done = true;

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -91,7 +91,7 @@ extern "C" int cpuidCall();
  * an instruction -- used for allocating the new area
  */
 
-void registerSpace::initialize32() {
+static void initialize32() {
     static bool done = false;
     if (done) return;
     done = true;
@@ -198,7 +198,7 @@ void registerSpace::initialize32() {
 }
 
 #if defined arch_x86_64
-void registerSpace::initialize64() {
+static void initialize64() {
     static bool done = false;
     if (done) return;
     done = true;

--- a/dyninstAPI/src/registerSpace.h
+++ b/dyninstAPI/src/registerSpace.h
@@ -435,9 +435,6 @@ class registerSpace {
     std::vector<registerSlot *> realRegisters_;
 
     static void initialize();
-    static void initialize32();
-    static void initialize64();
-
 
     registerSpace &operator=(const registerSpace &src);
 


### PR DESCRIPTION
This makes the interface cleaner, allows for expansion without modifying
the addressSpace class, and doesn't require stub functions on platforms
that don't support all of the bit widths.

Fixes #1134 