### PR TITLE
Add conflict with CMake 3.19.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required (VERSION 3.4.0)
+
+# There is a bug in 3.19.0 that causes .S files to be treated like C files
+if(CMAKE_VERSION VERSION_EQUAL "3.19.0")
+  message(FATAL_ERROR "Dyninst cannot use CMake version 3.19.0")
+endif()
+
 project (Dyninst)
 
 set (DYNINST_ROOT ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
There is a bug in 3.19.0 that treats .S files like C-language files. I have tested every version of CMake from 3.18.0 to 3.24.1 (the latest as of now), and each of them is able to configure, build, and successfully execute the test suite without any regressions.

Closes #924 
Fixes #923 