### PR TITLE
DwarfWalker: clean up interfaces for findDieName and findName

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2243,10 +2243,7 @@ bool Object::dwarf_parse_aranges(Dwarf *dbg, std::set<Dwarf_Off> &/*dies_seen*/)
         auto off_die = dwarf_dieoffset(&cu_die);
         //if (dies_seen.find(off_die) != dies_seen.end()) continue;
 
-        std::string modname;
-        if (!DwarfWalker::findDieName(cu_die, modname)) {
-            modname = associated_symtab->file(); // default module
-        }
+        std::string modname = DwarfWalker::die_name(cu_die);
 
         Offset actual_start, actual_end;
         convertDebugOffset(start, actual_start);
@@ -2301,10 +2298,8 @@ bool Object::fix_global_symbol_modules_static_dwarf() {
     for (size_t i = 0; i < dies.size(); i++) {
         Dwarf_Die cu_die = dies[i];
 
-        std::string modname;
-        if (!DwarfWalker::findDieName(cu_die, modname)) {
-            modname = associated_symtab->file(); // default module
-        }
+        std::string modname = DwarfWalker::die_name(cu_die);
+
         if(modname=="<artificial>")
         {
             auto off_die = dwarf_dieoffset(&cu_die);

--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -344,9 +344,9 @@ private:
             bool &hasLineNumber,
             std::string &filename);
 public:
-    static bool findDieName(Dwarf_Die die, std::string &);
+    static std::string die_name(Dwarf_Die die);
 private:
-    bool findName(std::string &);
+    std::string die_name();
     void removeFortranUnderscore(std::string &);
     bool findSize(unsigned &size);
     bool findVisibility(visibility_t &visibility);


### PR DESCRIPTION
findDieName always returned 'true', so any checks for its return value
were meaningless. It was also not clear that 'findName' would modify its
argument. The new interface removes that surprise by making the name the
return value.