### PR TITLE
SymtabAPI::Type: add support for C++ r-value references

### DIFF
--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -638,11 +638,16 @@ class SYMTAB_EXPORT typeTypedef: public derivedType {
 };
 
 class SYMTAB_EXPORT typeRef : public derivedType {
+ private:
+	bool is_rvalue_{false};
  protected:
    void fixupUnknowns(Module *);
  public:
+   struct rvalue_t final{};
    typeRef();
    typeRef(typeId_t ID, boost::shared_ptr<Type> refType, std::string name);
+   typeRef(typeId_t ID, boost::shared_ptr<Type> refType, std::string name, rvalue_t) :
+	   typeRef(ID, refType, name) { is_rvalue_ = true; }
    typeRef(typeId_t i, Type* r, std::string n)
      : typeRef(i, r->reshare(), n) {}
    typeRef(boost::shared_ptr<Type> refType, std::string name);
@@ -655,6 +660,7 @@ class SYMTAB_EXPORT typeRef : public derivedType {
    bool isCompatible(boost::shared_ptr<Type> x) { return isCompatible(x.get()); }
    bool isCompatible(Type *otype);
    bool operator==(const Type &otype) const;
+   bool is_rvalue() const noexcept { return is_rvalue_; }
 };
 
 class SYMTAB_EXPORT typeSubrange : public rangedType {

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -429,6 +429,7 @@ bool DwarfWalker::parse_int(Dwarf_Die e, bool parseSib, bool dissociate_context)
             case DW_TAG_ptr_to_member_type:
             case DW_TAG_pointer_type:
             case DW_TAG_reference_type:
+            case DW_TAG_rvalue_reference_type:
                 ret = parseTypeReferences();
                 break;
             case DW_TAG_compile_unit:
@@ -1486,6 +1487,16 @@ bool DwarfWalker::parseTypeReferences() {
                  (void*)indirectType.get(), indirectType->getName().c_str(), type_id(),
                  offset(), indirectType->getSize(), (void*)tc());
          break;
+      case DW_TAG_rvalue_reference_type:
+    	  if(!nameDefined()) {
+    		  curName() = "&&";
+    	  }
+          indirectType = tc()->addOrUpdateType(Type::make_shared<typeRef>(
+                             type_id(), typePointedTo, curName(), typeRef::rvalue_t{}));
+          dwarf_printf("(0x%lx) Created type %p / %s for type_id %d, offset 0x%lx, size %u, in TC %p\n", id(),
+                  (void*)indirectType.get(), indirectType->getName().c_str(), type_id(),
+                  offset(), indirectType->getSize(), (void*)tc());
+          break;
       default:
          dwarf_printf("(0x%lx) Warning: nothing done for tag 0x%x, dwarf_tag(): 0x%x\n",
                  id(), tag(), (unsigned int)dwarf_tag(&e));


### PR DESCRIPTION
Fixes #1049

@kupsch @bigtrak @mxz297 Technically, this doesn't break ABI even though the size of the `typeRef` class changed because Symtab always refers to this type through a pointer. It does have the capacity to break user code if someone had a function taking a `typeRef` by value. I think making a note about this in the release notes is good enough. Thoughts?