### PR TITLE
Refactor dwarfWalker::findValue

### DIFF
--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -18,6 +18,7 @@
 #include "Object.h"
 #include <boost/shared_ptr.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/optional.hpp>
 #include <Collections.h>
 
 //Concurrent Hash Map
@@ -350,7 +351,7 @@ private:
     void removeFortranUnderscore(std::string &);
     bool findSize(unsigned &size);
     bool findVisibility(visibility_t &visibility);
-    bool findValue(long &value, bool &valid);
+    boost::optional<long> findConstValue();
     bool fixName(std::string &name, boost::shared_ptr<Type> type);
     bool fixBitFields(std::vector<VariableLocation> &locs, long &size);
 


### PR DESCRIPTION
This function always returns 'true' and few callsites checked the bool
out variable. Using an optional here makes everything simpler. Logging
has been substantially improved for better tracing. The function was
renamed to better indicate its behavior.