### PR TITLE
Improve DWARF enum parsing in Symtab::Type

### DIFF
--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -386,8 +386,6 @@ class SYMTAB_EXPORT typeEnum : public derivedType {
  public:
    struct scoped_t final {};
    typeEnum() = default;
-   typeEnum(typeId_t ID, std::string name = "");
-   typeEnum(std::string name);
    typeEnum(boost::shared_ptr<Type> underlying_type, std::string name);
    typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID);
    typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID, scoped_t) :

--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -379,7 +379,7 @@ bool Type::isDerivedType() { return dynamic_cast<derivedType*>(this) != NULL; }
 
 // Derived classes from Type
 
-class SYMTAB_EXPORT typeEnum : public Type {
+class SYMTAB_EXPORT typeEnum : public derivedType {
  private:  
    dyn_c_vector<std::pair<std::string, int> > consts;
  public:

--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -382,11 +382,15 @@ bool Type::isDerivedType() { return dynamic_cast<derivedType*>(this) != NULL; }
 class SYMTAB_EXPORT typeEnum : public derivedType {
  private:  
    dyn_c_vector<std::pair<std::string, int> > consts;
+   bool is_scoped_{false}; // C++11 scoped enum (i.e., 'enum class')?
  public:
+   struct scoped_t final {};
    typeEnum();
    typeEnum(typeId_t ID, std::string name = "");
    typeEnum(std::string name);
    typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID);
+   typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID, scoped_t) :
+	   typeEnum(underlying_type, std::move(name), ID) { is_scoped_=true; }
    static typeEnum *create(std::string &name, dyn_c_vector<std::pair<std::string, int> *>&elements,
    								Symtab *obj = NULL);
    static typeEnum *create(std::string &name, dyn_c_vector<std::string> &constNames, Symtab *obj);
@@ -395,6 +399,7 @@ class SYMTAB_EXPORT typeEnum : public derivedType {
    bool setName(const char *name);
    bool isCompatible(boost::shared_ptr<Type> x) { return isCompatible(x.get()); }
    bool isCompatible(Type *otype);
+   bool is_scoped() const noexcept { return is_scoped_; }
 };
 typeEnum& Type::asEnumType() { return dynamic_cast<typeEnum&>(*this); }
 bool Type::isEnumType() { return dynamic_cast<typeEnum*>(this) != NULL; }

--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -396,7 +396,6 @@ class SYMTAB_EXPORT typeEnum : public derivedType {
    static typeEnum *create(std::string &name, dyn_c_vector<std::string> &constNames, Symtab *obj);
    bool addConstant(const std::string &fieldname,int value);
    dyn_c_vector<std::pair<std::string, int> > &getConstants();
-   bool setName(const char *name);
    bool isCompatible(boost::shared_ptr<Type> x) { return isCompatible(x.get()); }
    bool isCompatible(Type *otype);
    bool is_scoped() const noexcept { return is_scoped_; }

--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -386,6 +386,7 @@ class SYMTAB_EXPORT typeEnum : public derivedType {
    typeEnum();
    typeEnum(typeId_t ID, std::string name = "");
    typeEnum(std::string name);
+   typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID);
    static typeEnum *create(std::string &name, dyn_c_vector<std::pair<std::string, int> *>&elements,
    								Symtab *obj = NULL);
    static typeEnum *create(std::string &name, dyn_c_vector<std::string> &constNames, Symtab *obj);

--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -385,7 +385,7 @@ class SYMTAB_EXPORT typeEnum : public derivedType {
    bool is_scoped_{false}; // C++11 scoped enum (i.e., 'enum class')?
  public:
    struct scoped_t final {};
-   typeEnum();
+   typeEnum() = default;
    typeEnum(typeId_t ID, std::string name = "");
    typeEnum(std::string name);
    typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID);

--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -388,6 +388,7 @@ class SYMTAB_EXPORT typeEnum : public derivedType {
    typeEnum() = default;
    typeEnum(typeId_t ID, std::string name = "");
    typeEnum(std::string name);
+   typeEnum(boost::shared_ptr<Type> underlying_type, std::string name);
    typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID);
    typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID, scoped_t) :
 	   typeEnum(underlying_type, std::move(name), ID) { is_scoped_=true; }

--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -392,9 +392,7 @@ class SYMTAB_EXPORT typeEnum : public derivedType {
    typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID);
    typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID, scoped_t) :
 	   typeEnum(underlying_type, std::move(name), ID) { is_scoped_=true; }
-   static typeEnum *create(std::string &name, dyn_c_vector<std::pair<std::string, int> *>&elements,
-   								Symtab *obj = NULL);
-   static typeEnum *create(std::string &name, dyn_c_vector<std::string> &constNames, Symtab *obj);
+
    bool addConstant(const std::string &fieldname,int value);
    dyn_c_vector<std::pair<std::string, int> > &getConstants();
    bool isCompatible(boost::shared_ptr<Type> x) { return isCompatible(x.get()); }

--- a/symtabAPI/src/Type.C
+++ b/symtabAPI/src/Type.C
@@ -297,16 +297,10 @@ bool Type::isCompatible(Type * /*oType*/)
  * ENUM
  */
 typeEnum::typeEnum(int ID, std::string name)
-    : Type(name, ID, dataEnum)
-{
-	size_ = sizeof(int);
-}
+    : derivedType(name, ID, sizeof(int), dataEnum){}
 
 typeEnum::typeEnum(std::string name)
-   : Type(name, ::getUniqueTypeId(), dataEnum)
-{
-   size_ = sizeof(int);
-}
+   : derivedType(name, ::getUniqueTypeId(), sizeof(int), dataEnum) {}
 
 typeEnum *typeEnum::create(std::string &name, dyn_c_vector< std::pair<std::string, int> *> &constants, Symtab *obj)
 {

--- a/symtabAPI/src/Type.C
+++ b/symtabAPI/src/Type.C
@@ -302,6 +302,11 @@ typeEnum::typeEnum(int ID, std::string name)
 typeEnum::typeEnum(std::string name)
    : derivedType(name, ::getUniqueTypeId(), sizeof(int), dataEnum) {}
 
+typeEnum::typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID) :
+		derivedType(name, ID, underlying_type->getSize(), dataEnum) {
+	baseType_ = underlying_type;
+}
+
 typeEnum *typeEnum::create(std::string &name, dyn_c_vector< std::pair<std::string, int> *> &constants, Symtab *obj)
 {
    typeEnum *typ = new typeEnum(name);

--- a/symtabAPI/src/Type.C
+++ b/symtabAPI/src/Type.C
@@ -309,31 +309,6 @@ typeEnum::typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, ty
 typeEnum::typeEnum(boost::shared_ptr<Type> underlying_type, std::string name) :
 		typeEnum(underlying_type, std::move(name), ::getUniqueTypeId()) {}
 
-typeEnum *typeEnum::create(std::string &name, dyn_c_vector< std::pair<std::string, int> *> &constants, Symtab *obj)
-{
-   typeEnum *typ = new typeEnum(name);
-   for(unsigned i=0; i<constants.size();i++)
-   	typ->addConstant(constants[i]->first, constants[i]->second);
-    
-    if(obj)
-       obj->addType(typ);
-    //obj->addType(typ); TODO: declare a static container if obj is NULL and add to it.
-    //Symtab::noObjTypes->push_back(typ); ??
-    return typ;	
-}
-
-typeEnum *typeEnum::create(std::string &name, dyn_c_vector<std::string> &constNames, Symtab *obj)
-{
-   typeEnum *typ = new typeEnum(name);
-   for(unsigned i=0; i<constNames.size();i++)
-   	typ->addConstant(constNames[i], i);
-    if(obj)
-       obj->addType(typ);
-    //obj->addType(typ); TODO: declare a static container if obj is NULL and add to it.
-    //Symtab::noObjTypes->push_back(typ); ??
-    return typ;	
-}	
-
 dyn_c_vector<std::pair<std::string, int> > &typeEnum::getConstants()
 {
    return consts;

--- a/symtabAPI/src/Type.C
+++ b/symtabAPI/src/Type.C
@@ -296,12 +296,6 @@ bool Type::isCompatible(Type * /*oType*/)
 /*
  * ENUM
  */
-typeEnum::typeEnum(int ID, std::string name)
-    : derivedType(name, ID, sizeof(int), dataEnum){}
-
-typeEnum::typeEnum(std::string name)
-   : derivedType(name, ::getUniqueTypeId(), sizeof(int), dataEnum) {}
-
 typeEnum::typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, typeId_t ID) :
 		derivedType(name, ID, underlying_type->getSize(), dataEnum) {
 	baseType_ = underlying_type;

--- a/symtabAPI/src/Type.C
+++ b/symtabAPI/src/Type.C
@@ -1694,7 +1694,6 @@ Type::Type() : ID_(0), name_(std::string("unnamedType")), size_(0),
 fieldListType::fieldListType() : derivedFieldList(NULL) {}
 rangedType::rangedType() : low_(0), hi_(0) {}
 derivedType::derivedType() : baseType_(NULL) {}
-typeEnum::typeEnum() {}
 typeFunction::typeFunction() : retType_(NULL) {}
 typeCommon::typeCommon() {}
 typeStruct::typeStruct() {}

--- a/symtabAPI/src/Type.C
+++ b/symtabAPI/src/Type.C
@@ -306,6 +306,8 @@ typeEnum::typeEnum(boost::shared_ptr<Type> underlying_type, std::string name, ty
 		derivedType(name, ID, underlying_type->getSize(), dataEnum) {
 	baseType_ = underlying_type;
 }
+typeEnum::typeEnum(boost::shared_ptr<Type> underlying_type, std::string name) :
+		typeEnum(underlying_type, std::move(name), ::getUniqueTypeId()) {}
 
 typeEnum *typeEnum::create(std::string &name, dyn_c_vector< std::pair<std::string, int> *> &constants, Symtab *obj)
 {

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -1267,6 +1267,8 @@ bool DwarfWalker::parseEnum() {
 
    curName() = std::move(die_name());
    setEnum(tc()->addOrUpdateType(Type::make_shared<typeEnum>(underlying_type, curName(), type_id())));
+   
+   dwarf_printf("(0x%lx) end parseEnum\n", id());
    return true;
 }
 
@@ -1380,6 +1382,8 @@ bool DwarfWalker::parseEnumEntry() {
    if(!value) { return false; }
 
    curEnum()->asEnumType().addConstant(name, *value);
+
+   dwarf_printf("(0x%lx) end parseEnumEntry\n", id());
    return true;
 }
 

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -1258,9 +1258,15 @@ bool DwarfWalker::parseSubrange() {
 bool DwarfWalker::parseEnum() {
    if(!tc()) return false;
    dwarf_printf("(0x%lx) parseEnum entry\n", id());
+
+   boost::shared_ptr<Type> underlying_type{};
+   if (!findType(underlying_type, false)) {
+       dwarf_printf("(0x%lx) type not found\n", id());
+       return false;
+   }
+
    curName() = std::move(die_name());
-   //setEnum(tc()->addOrUpdateType( Type::make_shared<typeEnum>( type_id(), "enum " + curName())));
-   setEnum(tc()->addOrUpdateType( Type::make_shared<typeEnum>( type_id(), curName())));
+   setEnum(tc()->addOrUpdateType(Type::make_shared<typeEnum>(underlying_type, curName(), type_id())));
    return true;
 }
 


### PR DESCRIPTION
This contains substantial updates to the correctness, capability, and interfaces for SymtabAPI::typeEnum. These changes necessarily break the ABI.

Closes #1079 

@mxz297 @kupsch @bigtrak I carefully broke these changes down into the smallest commits possible, made sure each would build and execute, and wrote as much supporting documentation in the commit messages as possible. Some of these changes fundamentally alter how users interact with this type. This is necessary in order to ensure class invariants for the type information in the derivedType interface. I think it would be a good long-term goal to clean up the interfaces for the rest of the types in Type.h, but we can do that as we make other changes to those classes.