### PR TITLE
Additional cleanup of memory emulation for hybrid analysis

### DIFF
--- a/dyninstAPI/src/IAPI_to_AST.C
+++ b/dyninstAPI/src/IAPI_to_AST.C
@@ -69,14 +69,7 @@ void ASTFactory::visit(Dereference* )
 {
     AstNodePtr effaddr = m_stack.back();
     m_stack.pop_back();
-	// We need to translate the addr to handle emulation shadow pages
-	// before we dereference
-	std::vector<AstNodePtr> args;
-	args.push_back(effaddr);
-	args.push_back(AstNode::operandNode(AstNode::Constant, (void *) 0xdeadbeef));
-	args.push_back(AstNode::operandNode(AstNode::Constant, (void *) 0xcafebabe));
-	AstNodePtr funcCall = AstNode::funcCallNode("RTtranslateMemory", args);
-	m_stack.push_back(AstNode::operandNode(AstNode::DataIndir, funcCall));	
+	m_stack.push_back(AstNode::operandNode(AstNode::DataIndir, effaddr));
 }
 
 void ASTFactory::visit(Immediate* i)

--- a/dyninstAPI_RT/h/dyninstRTExport.h
+++ b/dyninstAPI_RT/h/dyninstRTExport.h
@@ -102,9 +102,6 @@ DLLEXPORT void DYNINSTinit();
 DLLEXPORT void DYNINST_snippetBreakpoint();
 DLLEXPORT void DYNINST_stopThread(void *, void *, void *, void *);
 DLLEXPORT void DYNINST_stopInterProc(void *, void *, void *, void *, void *, void *);
-DLLEXPORT void RThandleShadow(void *, void *, void *, void *, void *);
-DLLEXPORT unsigned long RTtranslateMemory(unsigned long, unsigned long, unsigned long);
-DLLEXPORT unsigned long RTtranslateMemoryShift(unsigned long, unsigned long, unsigned long);
 DLLEXPORT void *DYNINSTos_malloc(size_t, void *, void *); 
 DLLEXPORT int DYNINSTloadLibrary(char *);
 


### PR DESCRIPTION
This should have been removed by #1146 (0b9df83c9).

Fixes #1166 