### PR TITLE
Initial support for parsing vtables out of DWARF information

### DIFF
--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -63,6 +63,7 @@ class fieldListType;
 class rangedType;
 class derivedType;
 class TypeMemManager;
+class DwarfWalker;
 
 //TODO?? class BPatch(to be  ??)function;
 
@@ -527,6 +528,9 @@ class SYMTAB_EXPORT CBlock : public AnnotatableSparse
 };
 
 class SYMTAB_EXPORT typeStruct : public fieldListType {
+  private:
+   friend class Dyninst::SymtabAPI::DwarfWalker;
+   dyn_c_vector<Type *> vtable_;
  protected:
    void updateSize();
    void postFieldInsert(int nsize);

--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -326,6 +326,7 @@ public:
 private:
 
     bool parseCallsite();
+    bool parseVTables(Type *containing_function);    
     bool hasDeclaration(bool &decl);
     bool findTag();
     bool handleAbstractOrigin(bool &isAbstractOrigin);
@@ -367,6 +368,7 @@ private:
             bool &expr,
             Dwarf_Half &form);
     bool findString(Dwarf_Half attr, std::string &str);
+
 public:
     static bool findConstant(Dwarf_Half attr, Address &value, Dwarf_Die *entry, Dwarf *dbg);
     static bool findConstantWithForm(Dwarf_Attribute &attr, Dwarf_Half form,


### PR DESCRIPTION
I took a stab at adding vtable support to SymtabAPI via the DW_AT_vtable_elem_location attribute in DWARF for #1173 .  

This is only a prototype.  It parses the attribute and adds vtable information to SymtabAPI internal data structures.  I haven't finalized a public interface, nor added tests or documentation.

BUT, I don't think the DW_AT_vtable_elem_location fields are accurate.  With GCC compilers, I'm missing information about destructors.  With clang compilers, the info is all over the place, with different functions occupying the same slots in the same class's vtable.  Based on inspection with dwarfdump, I think this code is reading DW_AT_vtable_elem_location information correctly and it's the compilers that are wrong.
Or, I've got a bug/misunderstanding.  

So I'm not immediately sure how to proceed.  @woodard , any insigned?