### PR TITLE
Remove interposed definition of _r_debug

### DIFF
--- a/dyninstAPI_RT/src/RTlinux.c
+++ b/dyninstAPI_RT/src/RTlinux.c
@@ -404,7 +404,6 @@ void dyninstTrapHandler(int sig, siginfo_t *sg, ucontext_t *context)
 #if defined(cap_binary_rewriter)
 
 extern struct r_debug _r_debug;
-DLLEXPORT struct r_debug _r_debug __attribute__ ((weak));
 
 /* Verify that the r_debug variable is visible */
 void r_debugCheck() { assert(_r_debug.r_map); }


### PR DESCRIPTION
Previously there was a dynamic relocation against _r_debug in the loader which picked up the interposed definition,
but glibc now uses a direct internal hidden symbol reference and thus no longer updates the interposed object.