### PR TITLE
Adding first stage of automated docker build

### DIFF
--- a/.github/workflows/base-containers.yaml
+++ b/.github/workflows/base-containers.yaml
@@ -43,20 +43,27 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
 
-      - name: Set Organization Name for Packages Registry
+      - name: Set Organization and Branch Name
         if: (github.event_name != 'schedule')
         env:
           org: ${{ github.event.repository.owner.login }}
-        run: echo "org=${org}" >> ${GITHUB_ENV}
+        run: |
+            branch=$(echo ${GITHUB_REF##*/})
+            echo "branch=${branch}" >> ${GITHUB_ENV}
+            echo "org=${org}" >> ${GITHUB_ENV}
 
-      - name: Set Organization Name for Packages Registry
+      - name: Set Organization and Branch Name
         if: (github.event_name == 'schedule')
-        run: echo "org=dyninst" >> ${GITHUB_ENV}
+        run: |
+            echo "org=dyninst" >> ${GITHUB_ENV}
+            echo "branch=master" >> ${GITHUB_ENV}
 
       - name: Pull Layers for "Cache"
         run: docker pull ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:latest || echo "No cache available"
 
       - name: Build Dyninst Base Container
+        env:
+          branch: ${{ env.branch }}
         run: |
            cd docker/
            docker build --build-arg ubuntu_version=${{ matrix.ubuntu }} \
@@ -64,6 +71,7 @@ jobs:
                         --build-arg ELFUTILS_VERSION=${{ matrix.elfutils }} \
                         --build-arg LIBIBERTY_VERSION=${{ matrix.libiberty }} \
                         --build-arg INTELTBB_VERSION=${{ matrix.inteltbb }} \
+                        --build-arg DYNINST_BRANCH=${branch} \
                         -f Dockerfile \
                         -t ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:latest ../
 

--- a/.github/workflows/base-containers.yaml
+++ b/.github/workflows/base-containers.yaml
@@ -1,0 +1,79 @@
+name: Build Deploy Containers
+
+on:
+
+  # Always have a base image ready to go - this is a nightly build
+  schedule:
+    - cron: 0 3 * * *
+
+  # On pull request we test updates to images
+  pull_request: []
+ 
+  # On push to main we build and deploy images
+  push: 
+    branches:
+      - main
+ 
+jobs:
+  build:
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+
+        # Note: this can be extended in two ways
+        # 1. Add more configurations to the matrix, either like this or flattening
+        # 2. Generate matrix programatically and pipe in (recommended)
+        # perl is 5.30.0 provided by 20.04 container base
+        ubuntu: ["20.04"]
+        boost: ["1.73.0"]
+        elfutils: ["0.186"]
+        libiberty: ["2.33.1"] 
+        inteltbb: ["2020.2"]
+
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Make Space For Build
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+
+      - name: Set Organization Name for Packages Registry
+        if: (github.event_name != 'schedule')
+        env:
+          org: ${{ github.event.repository.owner.login }}
+        run: echo "org=${org}" >> ${GITHUB_ENV}
+
+      - name: Set Organization Name for Packages Registry
+        if: (github.event_name == 'schedule')
+        run: echo "org=dyninst" >> ${GITHUB_ENV}
+
+      - name: Pull Layers for "Cache"
+        run: docker pull ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:latest || echo "No cache available"
+
+      - name: Build Dyninst Base Container
+        run: |
+           docker build --build-arg ubuntu_version=${{ matrix.ubuntu }} \
+                        --build-arg BOOST_VERSION=${{ matrix.boost }} \
+                        --build-arg ELFUTILS_VERSION=${{ matrix.elfutils }} \
+                        --build-arg LIBIBERTY_VERSION=${{ matrix.libiberty }} \
+                        --build-arg INTELTBB_VERSION=${{ matrix.inteltbb }} \
+                        -f Dockerfile \
+                        -t ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:latest ../
+
+      - name: GHCR Login
+        if: (github.event_name != 'pull_request')
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy
+        if: (github.event_name != 'pull_request')
+        run: docker push ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:latest

--- a/.github/workflows/base-containers.yaml
+++ b/.github/workflows/base-containers.yaml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Build Dyninst Base Container
         run: |
+           cd docker/
            docker build --build-arg ubuntu_version=${{ matrix.ubuntu }} \
                         --build-arg BOOST_VERSION=${{ matrix.boost }} \
                         --build-arg ELFUTILS_VERSION=${{ matrix.elfutils }} \

--- a/.github/workflows/base-containers.yaml
+++ b/.github/workflows/base-containers.yaml
@@ -43,27 +43,20 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
 
-      - name: Set Organization and Branch Name
+      - name: Set Organization Name
         if: (github.event_name != 'schedule')
         env:
           org: ${{ github.event.repository.owner.login }}
-        run: |
-            branch=$(echo ${GITHUB_REF##*/})
-            echo "branch=${branch}" >> ${GITHUB_ENV}
-            echo "org=${org}" >> ${GITHUB_ENV}
+        run: echo "org=${org}" >> ${GITHUB_ENV}
 
-      - name: Set Organization and Branch Name
+      - name: Set Organization Name
         if: (github.event_name == 'schedule')
-        run: |
-            echo "org=dyninst" >> ${GITHUB_ENV}
-            echo "branch=master" >> ${GITHUB_ENV}
+        run: echo "org=dyninst" >> ${GITHUB_ENV}
 
       - name: Pull Layers for "Cache"
         run: docker pull ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:latest || echo "No cache available"
 
       - name: Build Dyninst Base Container
-        env:
-          branch: ${{ env.branch }}
         run: |
            cd docker/
            docker build --build-arg ubuntu_version=${{ matrix.ubuntu }} \
@@ -71,7 +64,6 @@ jobs:
                         --build-arg ELFUTILS_VERSION=${{ matrix.elfutils }} \
                         --build-arg LIBIBERTY_VERSION=${{ matrix.libiberty }} \
                         --build-arg INTELTBB_VERSION=${{ matrix.inteltbb }} \
-                        --build-arg DYNINST_BRANCH=${branch} \
                         -f Dockerfile \
                         -t ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:latest ../
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Refactor dwarfWalker::findConst ([1160](https://github.com/dyninst/dyninst/issues/1160))
 - Add readable name for Symtab::typeRef ([1157](https://github.com/dyninst/dyninst/issues/1157))
 - DwarfWalker: clean up interfaces for findDieName and findName ([1154](https://github.com/dyninst/dyninst/issues/1154))
+- Added automated docker build for development and testing
 
 ## [12.0.0](https://github.com/dyninst/dyninst/tree/v12.0.0) (2021-11-11)
 [Full Changelog](https://github.com/dyninst/dyninst/compare/v11.0.1...v12.0.0)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@
 
 ## Build DyninstAPI and its subcomponents
 
+### Docker Containers
+
+Containers are provided that can be used for Dyninst development (e.g., make changes to Dyninst and quickly rebuild it)
+or for development of your own tools (e.g., have a container ready to go with Dyninst). Links will be added
+here when the containers are pushed to the Dyninst associated package registries. Instructions for usage
+and building locally are provided in the [docker](docker) directory.
+
+
 ### Install with Spack
 
 ```spack install dyninst```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,7 +108,7 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
     spack env activate . && \
     
     # This adds metadata for dyninst to spack.yaml
-    spack develop --path /code dyninst@master && \
+    spack develop --path /code dyninst@${DYNINST_BRANCH} && \
 
     # ...but we need spack add to add to the install list!
     spack add dyninst@${DYNINST_BRANCH} && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ ARG PERL_VERSION=5.32.1
 ARG CMAKE_VERSION=3.21.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 
-# Set the branch name for spack to use
+# Set the branch name for spack to use (should be master even for PR)
 ARG DYNINST_BRANCH=master
 ENV DYNINST_BRANCH=${DYNINST_BRANCH}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,10 @@ ARG PERL_VERSION=5.32.1
 ARG CMAKE_VERSION=3.21.2
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 
+# Set the branch name for spack to use
+ARG DYNINST_BRANCH=master
+ENV DYNINST_BRANCH=${DYNINST_BRANCH}
+
 # Note that perl 5.30.0 is provided by ubuntu
 
 # Args need to be passed into envars to be used in RUN

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,121 @@
+ARG ubuntu_version=20.04
+FROM ubuntu:${ubuntu_version}
+
+# Build the Dockerfile in this directory, context one level up
+# docker build -t dyninst -f Dockerfile ../
+
+LABEL maintainer="@hainest,@vsoch"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Los_Angeles
+
+# We can use build args to populate the specific versions of dependencies (with defaults here)
+ARG BOOST_VERSION=1.73.0
+ARG ELFUTILS_VERSION=0.186
+ARG LIBIBERTY_VERSION=2.33.1
+ARG INTELTBB_VERSION=2020.2
+ARG PERL_VERSION=5.32.1
+
+# Sort of separate from dyninst (but used to build/test)
+ARG CMAKE_VERSION=3.21.2
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+
+# Note that perl 5.30.0 is provided by ubuntu
+
+# Args need to be passed into envars to be used in RUN
+ENV BOOST_VERSION=${BOOST_VERSION}
+ENV ELFUTILS_VERSION=${ELFUTILS_VERSION}
+ENV LIBIBERTY_VERSION=${LIBIBERTY_VERSION}
+ENV INTELTBB_VERSION=${INTELTBB_VERSION}
+ENV PERL_VERSION=${PERL_VERSION}
+
+RUN apt-get -qq update && \
+    apt-get -qq install -fy tzdata && \
+    apt-get -qq install -y --no-install-recommends \
+      build-essential \
+      bzip2 \
+      ca-certificates \
+      curl \
+      dh-autoreconf \
+      git \
+      gnupg2 \
+      lcov \
+      libssl-dev \
+      ninja-build \
+      pkg-config \
+      python-dev \ 
+      python3-pip \
+      sudo \
+      valgrind \
+      vim \
+      wget \
+      xsltproc
+
+# Install Clingo for Spack
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install clingo && \
+    dpkg-reconfigure tzdata
+
+# Update gcc to 11.1.1 (otherwise we'd have 9.3.0)
+RUN apt-get install -y software-properties-common && \
+    add-apt-repository 'deb http://mirrors.kernel.org/ubuntu hirsute main universe' && \
+    apt-get update && \
+    apt-get install -y gcc-11 g++-11 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 70 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9 --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-9 --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-9 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11 --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11;
+
+# Install spack
+WORKDIR /opt
+RUN git clone --depth 1 https://github.com/spack/spack
+ENV PATH=/opt/spack/bin:$PATH
+
+# Use the autamus build cache for faster install
+# Note that autamus currently uses 18.04
+RUN python3 -m pip install botocore boto3 && \
+    spack mirror add autamus s3://autamus-cache && \
+    curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
+    spack gpg trust key.pub
+
+# Find packages already installed on system, e.g. autoconf
+RUN spack external find && \
+    spack config add 'packages:all:target:[x86_64]' && \
+    # Install a new CMake (Tim originally wanted 3.17.1 but spack doesn't have it)
+    spack install cmake@${CMAKE_VERSION} perl
+
+# Add cmake to a view
+RUN spack view --dependencies no symlink --ignore-conflicts /opt/view cmake@${CMAKE_VERSION} perl
+ENV PATH=/opt/view/bin:$PATH
+
+RUN spack external find cmake && \
+    spack config add 'packages:cmake:buildable:False'
+
+# Add Dyninst source code here (e.g., from PR or master)
+WORKDIR /code
+COPY . /code
+
+# Add test code to base container so we can build tests here
+RUN git clone https://github.com/dyninst/testsuite /opt/testsuite
+
+# Install Dyninst to its own view
+WORKDIR /opt/dyninst-env
+RUN . /opt/spack/share/spack/setup-env.sh && \
+    spack env create -d . && \
+    echo "  concretization: together" >> spack.yaml && \
+    spack env activate . && \
+    
+    # This adds metadata for dyninst to spack.yaml
+    spack develop --path /code dyninst@master && \
+
+    # ...but we need spack add to add to the install list!
+    spack add dyninst@${DYNINST_BRANCH} && \
+
+    # Add our hard coded versions here.
+    spack add boost@${BOOST_VERSION} && \
+    spack add elfutils@${ELFUTILS_VERSION} && \
+    spack add libiberty@${LIBIBERTY_VERSION} && \
+    spack add intel-tbb@${INTELTBB_VERSION} && \
+    spack install --reuse
+    
+# Build tests (but don't run)
+COPY ./docker/build.sh build.sh
+RUN /bin/bash build.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,179 @@
+# Dyninst Containers
+
+This is a testing set of Dockerfile for building a Dyninst base container.
+
+## Strategy
+
+For development, we want to be able to:
+
+ 1. Pull a container with dyninst ready to go (for development or dyninst or another library)
+ 2. Quickly update with our own source code without needing to build everything.
+
+And for testing, we want to be able to:
+
+ 1. Have a set of base containers that make dependency preparation minimal
+ 2. Use those base containers to quickly test a PR's dyninst and report results
+ 
+To do this we will have two workflows:
+
+### Base Containers
+
+The [base-containers.yaml](../.github/workflows/base-containers.yaml) workflow will build updated base
+containers nightly or at an appropriate frequency. Right now we are providing one container build with a reasonable set of dependencies
+and dyninst, and this is done by way of installing via spack, and setting versions
+in an environment via build args. The current workflow, although there is just one container,
+done by using a matrix so in the future when additional build configurations are added,
+we can just extend the matrix. When this time comes, we can have a simple script (e.g., Python) 
+that generates this same matrix, and then pipes it into the GitHub workflow to still use as 
+build args in the Dockerfile. It's setup right now to still use this build arg -> environment -> matrix
+strategy so the transition is easier.
+
+### Test Container
+
+This will be added via a second PR here! This second Dockerfile starts with a base container (ready to go with
+dependencies) and then adds Dyninst to it, updates with the changes, and then run tests. It should
+be fairly speedy given that the base containers are pre-built.
+
+**to be added**
+
+## Usage
+
+While most of this is done via recipes in CI, here is how to interact with the repository locally.
+
+### Build
+
+A [Dockerfile](Dockerfile) is provided that makes it easy to bring up a development environment.
+
+```bash
+$ docker build -t dyninst -f Dockerfile ../
+```
+
+### Develop
+
+You can then shell inside to interact with dyninst - there will be a spack environment
+directory right in the root where you shell in:
+
+```bash
+$ docker run -it dyninst bash
+```
+```bash
+# ls
+spack.lock  spack.yaml
+```
+
+This lock and spack yaml defines a spack envirironment, which is generated during the container build. If we inspect closer, we would see:
+
+```yaml
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs: [boost@1.73.0, elfutils@0.186, libiberty@2.33.1, intel-tbb@2020.2, perl@5.32.1]
+  view: true
+  concretization: together
+  develop:
+    dyninst:
+      path: /code
+      spec: dyninst@master
+```
+
+Which includes a set of depdencies and versions we want to build. If you are just running a container as a developer, you are ready to go,
+because you can find all the dyninst libraries in the spack enviroment:
+
+```bash
+.spack-env/view/lib/libdynC_API.so
+.spack-env/view/lib/libdynC_API.so.11.0
+.spack-env/view/lib/libdynC_API.so.11.0.1
+.spack-env/view/lib/libdynDwarf.so
+.spack-env/view/lib/libdynDwarf.so.11.0
+.spack-env/view/lib/libdynDwarf.so.11.0.1
+.spack-env/view/lib/libdynElf.so
+.spack-env/view/lib/libdynElf.so.11.0
+.spack-env/view/lib/libdynElf.so.11.0.1
+.spack-env/view/lib/libdyninstAPI.so
+.spack-env/view/lib/libdyninstAPI.so.11.0
+.spack-env/view/lib/libdyninstAPI.so.11.0.1
+.spack-env/view/lib/libdyninstAPI_RT.a
+.spack-env/view/lib/libdyninstAPI_RT.so
+.spack-env/view/lib/libdyninstAPI_RT.so.11.0
+.spack-env/view/lib/libdyninstAPI_RT.so.11.0.1
+```
+Which you can then activate
+
+```bash
+$ . /opt/spack/share/spack/setup-env.sh
+$ spack env activate .
+```
+
+And here is an example of what activation does to the `LD_LIBRARY_PATH`:
+
+```bash
+# env | grep LD_LIBRARY_PATH
+LD_LIBRARY_PATH=/opt/dyninst-env/.spack-env/view/lib64:/opt/dyninst-env/.spack-env/view/lib:/opt/view/lib:/opt/view/lib64
+```
+You could then make any changes to the source code at `/code` (even if you've bound from your local machine to open with your editor of choice) and then run spack install again to rebuild (without needing to rebuild dependencies!)
+
+```bash
+$ spack install --reuse
+```
+
+Note that we've added "reuse" to tell spack to be as flexible as it can to reuse what it has.
+And that's it! For a more interactive development environment, you can bind the present working directory with the
+Dyninst source code bound to `/code` instead:
+
+```bash
+$ docker run -it -v $PWD:/code dyninst
+```
+
+If you do the same steps as above, you'll be in the activated environment:
+
+```bash
+$ . /opt/spack/share/spack/setup-env.sh
+$ spack env activate .
+```
+
+And again navigate to the bound source code - this time the files are on your local machine, so you can edit
+them locally and build in the container!
+
+```bash
+# This is bound to your host - edit files there
+$ cd /code
+```
+
+And then again do:
+
+```bash
+$ spack install --reuse
+```
+
+Finally, if you just want a container for development with Dyninst ready to go, you
+can use [ghcr.io/autamus/dyninst](https://github.com/orgs/autamus/packages/container/package/dyninst)
+(view the page there for tags available). New tags are automatically detected when there is
+a release to the repository here, and the container built and deployed. You can find the libraries
+under the root `/opt/view` (and then lib, bin, share, etc.)
+
+```bash
+# ls /opt/view/lib/libd*
+libdw-0.185.so              libdynC_API.so              libdynDwarf.so.11.0         libdynElf.so.11.0.1         libdyninstAPI_RT.a
+libdw.a                     libdynC_API.so.11.0         libdynDwarf.so.11.0.1       libdyninstAPI.so            libdyninstAPI_RT.so
+libdw.so                    libdynC_API.so.11.0.1       libdynElf.so                libdyninstAPI.so.11.0       libdyninstAPI_RT.so.11.0
+libdw.so.1                  libdynDwarf.so              libdynElf.so.11.0           libdyninstAPI.so.11.0.1     libdyninstAPI_RT.so.11.0.1
+root@89e4fbb001b5:/# ls /opt/view/lib/libsym*
+libsymLite.so           libsymLite.so.11.0      libsymLite.so.11.0.1    libsymtabAPI.so         libsymtabAPI.so.11.0    libsymtabAPI.so.11.0.1
+```
+
+## Test
+
+**Note will be added in followup PR**
+
+To build the test container, you'll want to use [Dockerfile.test](Dockerfile.test). If you want to use
+the base dyninst container from GitHub packages, leave out build args (it will default to this). Otherwise, if you want to use a container you just built, specify that as the build arg `dyninst_base`:
+
+```bash
+$ docker build -f Dockerfile.test --build-arg dyninst_base=dyninst -t dyninst-test ../
+```
+
+The tests are added and run during build, so if they fail inside the container, the container build will fail
+(and trigger any CI building it to fail).

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script builds dyninst and the test suite (but does not run tests)
+
+printf "⭐️ Setting up spack environment for Dyninst\n"
+. /opt/spack/share/spack/setup-env.sh
+spack env activate .
+mkdir -p build/dyninst
+
+# 1. Build Dyninst
+printf "⭐️ Preparing to build Dyninst\n"
+echo "::group::build dyninst"   
+cd build/dyninst
+cmake -H/code -B. -DCMAKE_INSTALL_PREFIX=. > >(tee config.out) 2> >(tee config.err >&2)
+make VERBOSE=1 -j2 > >(tee build.out) 2> >(tee build.err >&2)
+make install VERBOSE=1 -j2 > >(tee build-install.out) 2> >(tee build-install.err >&2)
+echo "::endgroup::"
+
+# 2. Update the test suite
+printf "⭐️ Updating the testsuite\n"
+echo "::group::update testsuite"   
+cd /opt/testsuite
+git pull origin master
+cd -
+echo "::endgroup::"
+
+# 3. Build the test suite
+printf "⭐️ Preparing to build the testsuite\n"
+echo "::group::build tests"   
+cd /opt/dyninst-env/
+mkdir -p build/testsuite/tests
+cd build/testsuite
+
+cmake -H/opt/testsuite -B. -DCMAKE_INSTALL_PREFIX=$PWD/tests -DDyninst_DIR=/opt/dyninst-env/build/dyninst/lib/cmake/Dyninst > >(tee config.out) 2> >(tee config.err >&2)
+make VERBOSE=1 -j2 > >(tee build.out) 2> >(tee build.err >&2)
+make install VERBOSE=1 -j2 > >(tee build-install.out) 2> >(tee build-install.err >&2)
+echo "::endgroup::"


### PR DESCRIPTION
This is the first of two PRs to add automation to Dyninst, including:
 - a container base that can be used for Dyninst development or app development using dyninst
 - the same container base that provides a much quicker way to test (3.5 minutes vs 45-1hour to build from scratch)

This first PR will add the automated build for the base container, which we can leave to also build on PR, but would be okay to remove and just have build on push to main and scheduled nightly (what I recommend). The second PR after this will be to add another workflow to use this base container to run tests.

The base container uses ubuntu 20.04 and a set of dependencies chosen by Tim.  Currently this does not upload test results to Tims server, and this is only because I want to talk to him about it first and then test the workflow before PR here.

Finally, in order for this to work an org owner needs to enable packages (e.g., check the boxes for public and internal) and then the PR, when merged, should be able to deploy. For those not familar, GitHub packages == an OCI registry, and that means it's like Docker Hub in being able to push containers (and other artifacts).

While my preference is to store the Dockerfile in the root of the repository, since we will ultimately have two Dockerfile plus the README and assets that go into the containers (e.g., build.sh) it is much better organized to have a subfolder and then to tweak the build command. E.g.,:

```bash
cd docker/

# build a container with tag "dyninst" with context one level up with the Dockerfile in the present working directory
$ docker build -t dyninst -f Dockerfile ../
```
cc @hainest, master of the C++ universe and diabolical binary analysis leader!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>