### PR TITLE
Adding dyninst release trigger

### DIFF
--- a/.github/workflows/base-containers.yaml
+++ b/.github/workflows/base-containers.yaml
@@ -6,9 +6,10 @@ on:
   schedule:
     - cron: 0 3 * * *
 
-  # On pull request we test updates to images
-  pull_request: []
- 
+  # Publish packages on release
+  release:
+    types: [published] 
+    
   # On push to main we build and deploy images
   push: 
     branches:
@@ -74,6 +75,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and Push Release Image
+        if: (github.event_name == 'release')
+        run: |
+            tag=${GITHUB_REF#refs/tags/}
+            echo "Tagging and releasing ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:${tag}"
+            docker tag ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:latest ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:${tag}
+            docker push ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:${tag}
 
       - name: Deploy
         if: (github.event_name != 'pull_request')


### PR DESCRIPTION
To release a tagged (versioned) container on publication of a release we just need to add the release -> published trigger, derive the tag from the GITHUB_REF environment variable, and then tag and push the container.

cc @hainest 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>