### PR TITLE
Source file parsing fix for DWARF 5

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3388,12 +3388,9 @@ void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
         return s_name;
     };
 
-    // dwarf_line_srcfileno == 0 means unknown; 1...n means files[0...n-1]
-    // so we ensure that we're adding a block of unknown, 1...n to the string table
-    // and that offset + dwarf_line_srcfileno points to the correct string
     using namespace boost::filesystem;
     strings->emplace_back("<Unknown file>","");
-    for(size_t i = 1; i < filecount; i++)
+    for(size_t i = 0; i < filecount; i++)
     {
         auto filename = dwarf_filesrc(files, i, nullptr, nullptr);
         if(!filename) continue;
@@ -3676,12 +3673,9 @@ LineInformation* Object::parseLineInfoForObject(StringTablePtr strings)
     boost::unique_lock<dyn_mutex> l(strings->lock);
     size_t offset = strings->size();
 
-    // dwarf_line_srcfileno == 0 means unknown; 1...n means files[0...n-1]
-    // so we ensure that we're adding a block of unknown, 1...n to the string table
-    // and that offset + dwarf_line_srcfileno points to the correct string
     using namespace boost::filesystem;
     strings->emplace_back("<Unknown file>","");
-    for(size_t i = 1; i < fileCount; i++)
+    for(size_t i = 0; i < fileCount; i++)
     {
         auto filename = dwarf_filesrc(files, i, nullptr, nullptr);
         if(!filename) continue;


### PR DESCRIPTION
rocm-4.5 starts to emit AMD GPU binaries with DWARF 5. I noticed missing source line information for these binaries. The root cause is that dyninst assumes that source file table entry 0 represents "unknown file". This no longer seems to be true in DWARF 5, where entry 0 can represents a real application source file.

Fortunately, the fix seems simple: we simply just parse the entry and add it the string table. 