### PR TITLE
pin to spack release so we have consistent builds

### DIFF
--- a/.github/workflows/base-containers.yaml
+++ b/.github/workflows/base-containers.yaml
@@ -9,7 +9,9 @@ on:
   # Publish packages on release
   release:
     types: [published] 
-    
+
+  pull_request: []
+      
   # On push to main we build and deploy images
   push: 
     branches:

--- a/.github/workflows/base-containers.yaml
+++ b/.github/workflows/base-containers.yaml
@@ -30,7 +30,7 @@ jobs:
         # 2. Generate matrix programatically and pipe in (recommended)
         # perl is 5.30.0 provided by 20.04 container base
         ubuntu: ["20.04"]
-        boost: ["1.73.0"]
+        boost: ["1.72.0"]
         elfutils: ["0.186"]
         libiberty: ["2.33.1"] 
         inteltbb: ["2020.2"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,10 +70,10 @@ RUN apt-get install -y software-properties-common && \
 
 # Install spack
 WORKDIR /opt
-RUN wget https://github.com/spack/spack/releases/download/v0.17.1/spack-0.17.1.tar.gz && \
-    tar -xzvf spack-0.17.1.tar.gz && \
-    mv spack-0.17.1 /opt/spack && \
-    rm spack-0.17.1.tar.gz
+RUN wget https://github.com/spack/spack/releases/download/v0.17.0/spack-0.17.0.tar.gz && \
+    tar -xzvf spack-0.17.0.tar.gz && \
+    mv spack-0.17.0 /opt/spack && \
+    rm spack-0.17.0.tar.gz
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for faster install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,21 +70,21 @@ RUN apt-get install -y software-properties-common && \
 
 # Install spack
 WORKDIR /opt
-RUN wget https://github.com/spack/spack/releases/download/v0.17.0/spack-0.17.1.tar.gz && \
-    tar -xzvf spack-0.17.1.tar.gz && \
-    mv spack-0.17.1 /opt/spack && \
-    rm spack-0.17.1.tar.gz
+RUN git clone --depth 1 https://github.com/spack/spack
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for faster install
 # Note that autamus currently uses 18.04
-RUN python3 -m pip install botocore boto3
+RUN python3 -m pip install botocore boto3 && \
+    spack mirror add autamus s3://autamus-cache && \
+    curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
+    spack gpg trust key.pub
 
 # Find packages already installed on system, e.g. autoconf
-RUN spack external find && \
-    spack config add 'packages:all:target:[x86_64]' && \
+RUN spack -d external find && \
+    spack -d config add 'packages:all:target:[x86_64]' && \
     # Install a new CMake (Tim originally wanted 3.17.1 but spack doesn't have it)
-    spack install cmake@${CMAKE_VERSION} perl
+    spack -d install cmake@${CMAKE_VERSION} perl
 
 # Add cmake to a view
 RUN spack view --dependencies no symlink --ignore-conflicts /opt/view cmake@${CMAKE_VERSION} perl

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,18 +70,15 @@ RUN apt-get install -y software-properties-common && \
 
 # Install spack
 WORKDIR /opt
-RUN wget https://github.com/spack/spack/releases/download/v0.17.0/spack-0.17.0.tar.gz && \
-    tar -xzvf spack-0.17.0.tar.gz && \
-    mv spack-0.17.0 /opt/spack && \
-    rm spack-0.17.0.tar.gz
+RUN wget https://github.com/spack/spack/releases/download/v0.17.0/spack-0.17.1.tar.gz && \
+    tar -xzvf spack-0.17.1.tar.gz && \
+    mv spack-0.17.1 /opt/spack && \
+    rm spack-0.17.1.tar.gz
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for faster install
 # Note that autamus currently uses 18.04
-RUN python3 -m pip install botocore boto3 && \
-    spack mirror add autamus s3://autamus-cache && \
-    curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
-    spack gpg trust key.pub
+RUN python3 -m pip install botocore boto3
 
 # Find packages already installed on system, e.g. autoconf
 RUN spack external find && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
 # We can use build args to populate the specific versions of dependencies (with defaults here)
-ARG BOOST_VERSION=1.73.0
+ARG BOOST_VERSION=1.72.0
 ARG ELFUTILS_VERSION=0.186
 ARG LIBIBERTY_VERSION=2.33.1
 ARG INTELTBB_VERSION=2020.2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,7 +70,10 @@ RUN apt-get install -y software-properties-common && \
 
 # Install spack
 WORKDIR /opt
-RUN git clone --depth 1 https://github.com/spack/spack
+RUN wget https://github.com/spack/spack/releases/download/v0.17.1/spack-0.17.1.tar.gz && \
+    tar -xzvf spack-0.17.1.tar.gz && \
+    mv spack-0.17.1 /opt/spack && \
+    rm spack-0.17.1.tar.gz
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for faster install


### PR DESCRIPTION
This is a test build for the container base that uses a release of spack (and not develop). What looks to have happened is that some change to speak dealing with patches broke the install of boost (and thus our entire build) and we can't ave that happen.

I'll first test the last release, but we may need to test a little before that.

![image](https://user-images.githubusercontent.com/814322/149646847-a6400ad9-38b5-4cf7-b375-898497ed4bdc.png)


Signed-off-by: vsoch <vsoch@users.noreply.github.com>