### PR TITLE
ParseAPI: Speed up the many-called function case

### DIFF
--- a/parseAPI/h/CFG.h
+++ b/parseAPI/h/CFG.h
@@ -254,7 +254,6 @@ public:
           Address end, Address last, Function* f = NULL);
 
     virtual ~Block();
-    boost::recursive_mutex& lockable() { return boost::lockable_adapter<boost::recursive_mutex>::lockable(); }
 
     inline Address start() const { return _start; }
     inline Address end() const { return _end; }
@@ -271,15 +270,11 @@ public:
     /* Edge access */
     const edgelist & sources() const { return _srclist; }
     const edgelist & targets() const { return _trglist; }
-    void copy_sources(edgelist & src) {
-        boost::lock_guard<Block> g(*this);
-        src = _srclist;
-    }
-    void copy_targets(edgelist & trg) {
-        boost::lock_guard<Block> g(*this);
-        trg = _trglist;
-    }
+    void copy_sources(edgelist & src) const;
+    void copy_targets(edgelist & trg) const;
 
+    bool hasCallSource() const;
+    Edge* getOnlyIncomingEdge() const;
     bool consistent(Address addr, Address & prev_insn);
 
     int  containingFuncs() const;

--- a/parseAPI/src/Block.C
+++ b/parseAPI/src/Block.C
@@ -356,3 +356,26 @@ void Block::moveTargetEdges(Block* B) {
 	}
     trgs.clear();
 }
+
+void Block::copy_sources(edgelist & src) const {
+    boost::lock_guard<boost::recursive_mutex> g(lockable());
+    src = _srclist;
+}
+
+void Block::copy_targets(edgelist & trg) const {
+    boost::lock_guard<boost::recursive_mutex> g(lockable());
+    trg = _trglist;
+}
+
+bool Block::hasCallSource() const {
+    boost::lock_guard<boost::recursive_mutex> g(lockable());
+    for (auto e: _srclist)
+        if (e->type() == CALL)
+            return true;
+    return false;
+}
+
+Edge* Block::getOnlyIncomingEdge() const {
+    boost::lock_guard<boost::recursive_mutex> g(lockable());
+    return _srclist.size() == 1 ? *_srclist.begin() : nullptr;
+}

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -852,14 +852,7 @@ Parser::finalize(Function *f)
 
             Block* trg_block = e->trg();
 
-            bool trg_has_call_edge = false;
-            Block::edgelist sources;
-            trg_block->copy_sources(sources);
-            for (auto e2: sources)
-                if (e2->type() == CALL) {
-                    trg_has_call_edge = true;
-                    break;
-                }
+            bool trg_has_call_edge = trg_block->hasCallSource();
 
             // Rule 1:
             // If an edge is currently not a tail call, but the edge target has a CALL incoming edge,
@@ -900,13 +893,7 @@ Parser::finalize(Function *f)
             // Rule 3:
             // If an edge is currently a tail call, but the edge target has only the current edge as incoming edges,
             // we treat this as not tail call.        
-            bool only_incoming = true;
-            for (auto e2: sources)
-                if (e2 != e) {
-                    only_incoming = false;
-                    break;
-                }
-            if (only_incoming) {
+            if (trg_block->getOnlyIncomingEdge() == e) {
                 e->_type._interproc = false;
                 parsing_printf("from %lx to %lx, marked as not tail call (single entry), re-finalize\n", b->last(), e->trg()->start());
                 return false;


### PR DESCRIPTION
In some binaries a single function has many callers, so copying out the source edges for the entry Block takes a while and causes significant contention on the Block's lock. The case in Parser::finalize where this becomes a hotspot likely does not need to read every edge, so this commit inlines those cases into methods on Block instead.