### PR TITLE
Dockerfile: use explicit packages for 'spack external find'

### DIFF
--- a/.github/workflows/base-containers.yaml
+++ b/.github/workflows/base-containers.yaml
@@ -9,8 +9,6 @@ on:
   # Publish packages on release
   release:
     types: [published] 
-    
-  pull_request: []
 
   # On push to main we build and deploy images
   push: 

--- a/.github/workflows/base-containers.yaml
+++ b/.github/workflows/base-containers.yaml
@@ -10,6 +10,8 @@ on:
   release:
     types: [published] 
     
+  pull_request: []
+
   # On push to main we build and deploy images
   push: 
     branches:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,12 +66,8 @@ RUN apt-get install -y software-properties-common && \
     apt-get update && \
     apt-get install -y gcc-11 g++-11 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 70 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9 --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-9 --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-9 && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11 --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11; \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11 --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11;
    
-    # This is installed just for Ubuntu 20.04 and failing spack builds.
-    # Ideally we can select to not use it with external find
-    apt remove -y gettext
-
 # Install spack
 WORKDIR /opt
 RUN git clone --depth 1 https://github.com/spack/spack
@@ -85,7 +81,7 @@ RUN python3 -m pip install botocore boto3 && \
     spack gpg trust key.pub
 
 # Find packages already installed on system, e.g. autoconf
-RUN spack external find && \
+RUN spack external find gcc@11.0.1 autoconf bzip2 git tar xz && \
     spack config add 'packages:all:target:[x86_64]' && \
     # Install a new CMake (Tim originally wanted 3.17.1 but spack doesn't have it)
     spack install cmake@${CMAKE_VERSION} perl

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,7 +66,11 @@ RUN apt-get install -y software-properties-common && \
     apt-get update && \
     apt-get install -y gcc-11 g++-11 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 70 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9 --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-9 --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-9 && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11 --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11;
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11 --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11; \
+   
+    # This is installed just for Ubuntu 20.04 and failing spack builds.
+    # Ideally we can select to not use it with external find
+    apt remove -y gettext
 
 # Install spack
 WORKDIR /opt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,7 @@ RUN python3 -m pip install botocore boto3 && \
     spack gpg trust key.pub
 
 # Find packages already installed on system, e.g. autoconf
-RUN spack external find gcc@11.0.1 autoconf bzip2 git tar xz && \
+RUN spack external find gcc@11.0.1 autoconf bzip2 git tar xz perl && \
     spack config add 'packages:all:target:[x86_64]' && \
     # Install a new CMake (Tim originally wanted 3.17.1 but spack doesn't have it)
     spack install cmake@${CMAKE_VERSION} perl


### PR DESCRIPTION
This is a test to fix the current build failure of the base container. Spack had a PR merged in < 24 hours ago that allowed gettext to be added as an external dependency - and this seems to be what is triggering the error. This test will uninstall gettext before doing the spack find and hopefully will fix the error.

The build takes ~1 hour and if it works we can remove the PR trigger.

This will close #1194 