### PR TITLE
Add install rule to install headers under common/h/AMDGPU

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -136,3 +136,10 @@ target_link_libraries(common PUBLIC ${TBB_LIBRARIES})
 if(USE_OpenMP)
   set_target_properties(common PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS} LINK_FLAGS ${OpenMP_CXX_FLAGS})
 endif()
+
+# Install AMDGPU headers under subdirectory of common/h/AMDGPU
+set(AMDGPU_HEADER
+    ${DYNINST_ROOT}/common/h/AMDGPU
+)
+install(DIRECTORY ${AMDGPU_HEADER} DESTINATION ${INSTALL_INCLUDE_DIR})
+


### PR DESCRIPTION
With this commit, the common/h/AMDGPU headers will be installed to the correct path and should fix the issue that was reported in #1198 