### PR TITLE
Tidy up classes in AMDGPU

### DIFF
--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
@@ -92,40 +92,7 @@ namespace Dyninst {
 		// ****************
 
 		MachRegister InstructionDecoder_amdgpu_cdna2::makeAmdgpuRegID(MachRegister base, unsigned int encoding , unsigned int) {
-			MachRegister realBase = base;
-			/*if (base == amdgpu_cdna2::s0){
-				switch(len){
-					case 2:
-						realBase = amdgpu_cdna2::sgpr_vec2_0;
-						break;
-					case 4:
-						realBase = amdgpu_cdna2::sgpr_vec4_0;
-						break;
-					case 8:
-						realBase = amdgpu_cdna2::sgpr_vec8_0;
-						break;
-					case 16:
-						realBase = amdgpu_cdna2::sgpr_vec16_0;
-						break;
-				}
-			}else if (base == amdgpu_cdna2::v0){
-				switch(len){
-					case 2:
-						realBase = amdgpu_cdna2::vgpr_vec2_0;
-						break;
-					case 4:
-						realBase = amdgpu_cdna2::vgpr_vec4_0;
-						break;
-					case 8:
-						realBase = amdgpu_cdna2::vgpr_vec8_0;
-						break;
-					case 16:
-						realBase = amdgpu_cdna2::vgpr_vec16_0;
-						break;
-				}
-
-			}*/
-			return MachRegister(realBase.val() + encoding);
+			return MachRegister(base.val() + encoding);
 
 		}
 

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
@@ -47,11 +47,13 @@ namespace Dyninst {
 			switch(e) {
 				default: assert(!"no alias for entryID");
 			};
+			return nullptr;
 		}
 		const char* InstructionDecoder_amdgpu_cdna2::condInsnAliasMap(entryID e) {
 			switch(e) {
 				default: assert(!"no alias for entryID");
 			};
+			return nullptr;
 		}
 
 #include "amdgpu_cdna2_insn_entry.h"

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
@@ -65,9 +65,6 @@ namespace Dyninst {
 
 #include "amdgpu_cdna2_opcode_tables.C"
 
-		InstructionDecoder_amdgpu_cdna2::InstructionDecoder_amdgpu_cdna2(Architecture a)
-			: InstructionDecoderImpl(a) {}
-
 		InstructionDecoder_amdgpu_cdna2::~InstructionDecoder_amdgpu_cdna2() {
 		}
 

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
@@ -65,10 +65,6 @@ namespace Dyninst {
 
 #include "amdgpu_cdna2_opcode_tables.C"
 
-		InstructionDecoder_amdgpu_cdna2::~InstructionDecoder_amdgpu_cdna2() {
-		}
-
-
 		using namespace std;
 		void InstructionDecoder_amdgpu_cdna2::NOTHING() {
 		}

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
@@ -43,16 +43,12 @@ namespace Dyninst {
 			"lt", "gt", "le", "al", "nv",
 		} };
 
-		const char* InstructionDecoder_amdgpu_cdna2::bitfieldInsnAliasMap(entryID e) {
-			switch(e) {
-				default: assert(!"no alias for entryID");
-			};
+		const char* InstructionDecoder_amdgpu_cdna2::bitfieldInsnAliasMap(entryID) {
+			assert(!"no alias for entryID");
 			return nullptr;
 		}
-		const char* InstructionDecoder_amdgpu_cdna2::condInsnAliasMap(entryID e) {
-			switch(e) {
-				default: assert(!"no alias for entryID");
-			};
+		const char* InstructionDecoder_amdgpu_cdna2::condInsnAliasMap(entryID) {
+			assert(!"no alias for entryID");
 			return nullptr;
 		}
 

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
@@ -66,11 +66,7 @@ namespace Dyninst {
 #include "amdgpu_cdna2_opcode_tables.C"
 
 		InstructionDecoder_amdgpu_cdna2::InstructionDecoder_amdgpu_cdna2(Architecture a)
-			: InstructionDecoderImpl(a), 
-            insn_size(0), immLen(0) , num_elements(1) , isSMEM(false), isLoad(false), isStore(false),isBuffer(false),
-            isScratch(false) , isBranch(false), isConditional(false) ,isCall(false), isModifyPC(false)
-		{
-		}
+			: InstructionDecoderImpl(a) {}
 
 		InstructionDecoder_amdgpu_cdna2::~InstructionDecoder_amdgpu_cdna2() {
 		}

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
@@ -121,6 +121,7 @@ namespace Dyninst {
 				return makeRegisterExpression(amdgpu_cdna2::m0);
             cerr << " unknown offset in sgpr or m0 " << offset << endl; 
 			assert(0 && "shouldn't reach here");
+			return {};
 		}
 
 

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.h
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.h
@@ -52,7 +52,7 @@ namespace Dyninst {
             public:
     		InstructionDecoder_amdgpu_cdna2(Architecture a) : InstructionDecoderImpl(a) {}
 
-            virtual ~InstructionDecoder_amdgpu_cdna2();
+            virtual ~InstructionDecoder_amdgpu_cdna2() = default;
 
             virtual void decodeOpcode(InstructionDecoder::buffer &b);
 

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.h
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.h
@@ -78,12 +78,12 @@ namespace Dyninst {
             private:
             virtual Result_Type makeSizeType(unsigned int opType);
 
-            bool is64Bit;
+            bool is64Bit{};
 
-            unsigned int insn_size; // size of the instruction that we are currently working on
-            unsigned int insn; // the first 32 bit 
-            unsigned int insn_high; // the second 32 bit 
-            unsigned long long int insn_long; // the combined 64 bit: insn_high << 32 | insn
+            unsigned int insn_size{}; // size of the instruction that we are currently working on
+            unsigned int insn{}; // the first 32 bit
+            unsigned int insn_high{}; // the second 32 bit
+            unsigned long long int insn_long{}; // the combined 64 bit: insn_high << 32 | insn
 
             // the main process of decoding an instruciton, won't advance buffer
             void mainDecode(); 
@@ -154,23 +154,23 @@ namespace Dyninst {
             }
 
 
-            bool hasHw;
-            int hwField;
+            bool hasHw{};
+            int hwField{};
 
             void processHwFieldInsn(int, int);
 
-            bool hasShift;
-            int shiftField;
+            bool hasShift{};
+            int shiftField{};
 
             void makeBranchTarget(bool, bool, int, int);
 
             Expression::Ptr makeFallThroughExpr();
 
-            int _szField, size;
-            int _typeField;
-            int cmode;
-            int op;
-            int simdAlphabetImm;
+            int _szField{}, size{};
+            int _typeField{};
+            int cmode{};
+            int op{};
+            int simdAlphabetImm{};
 
             void processAlphabetImm();
 
@@ -200,33 +200,33 @@ namespace Dyninst {
             Expression::Ptr decodeSGPRorM0(unsigned int offset);
 
             
-            bool useImm;
-            uint32_t immLen;
-            uint32_t immLiteral;
-            uint32_t imm_at_32;
-            uint32_t imm_at_64;
-            uint32_t imm_at_96;
+            bool useImm{};
+            uint32_t immLen{};
+            uint32_t immLiteral{};
+            uint32_t imm_at_32{};
+            uint32_t imm_at_64{};
+            uint32_t imm_at_96{};
 
-            bool setSCC;
+            bool setSCC{};
 
 #define IS_LD_ST() (isLoad || isStore )
 
-            unsigned int num_elements ;  // the number of elements that will be load or store by each instruction
-            bool isSMEM; // this is set when using smem instruction
-            bool isLoad; // this is set when a smem instruction is load, will set number of elements that are loaded at the same time
-            bool isStore; // similar to isLoad, but for store instructions
-            bool isBuffer; // 
-            bool isScratch;
+            unsigned int num_elements{1};  // the number of elements that will be load or store by each instruction
+            bool isSMEM{}; // this is set when using smem instruction
+            bool isLoad{}; // this is set when a smem instruction is load, will set number of elements that are loaded at the same time
+            bool isStore{}; // similar to isLoad, but for store instructions
+            bool isBuffer{}; //
+            bool isScratch{};
 
-            bool isBranch; // this is set for all branch instructions,
-            bool isConditional; // this is set for all conditional branch instruction, will set branchCond
-            bool isCall; // this is a call function
+            bool isBranch{}; // this is set for all branch instructions,
+            bool isConditional{}; // this is set for all conditional branch instruction, will set branchCond
+            bool isCall{}; // this is a call function
 
 
 
             // this is set for instructions that directly modify pc
             // namely s_setpc and s_swappc
-            bool isModifyPC;
+            bool isModifyPC{};
 
             // reset the decoder internal state for decoding the next instruction
             void reset();

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.h
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.h
@@ -50,7 +50,7 @@ namespace Dyninst {
             enum DecodeFamily {sopp};
 
             public:
-            InstructionDecoder_amdgpu_cdna2(Architecture a);
+    		InstructionDecoder_amdgpu_cdna2(Architecture a) : InstructionDecoderImpl(a) {}
 
             virtual ~InstructionDecoder_amdgpu_cdna2();
 

--- a/instructionAPI/src/AMDGPU/cdna2/amdgpu_cdna2_decoder_impl.h
+++ b/instructionAPI/src/AMDGPU/cdna2/amdgpu_cdna2_decoder_impl.h
@@ -44,7 +44,7 @@ enum InstructionFamily{
 	ENC_VOP3B = 20,
 	ENC_VOP3P_MFMA = 21,
 };
-InstructionFamily instr_family;
+InstructionFamily instr_family{};
 typedef void (InstructionDecoder_amdgpu_cdna2::*func_ptr)(void);
 func_ptr decode_lookup_table [22] = {
 	(&InstructionDecoder_amdgpu_cdna2::decodeENC_SOP1),


### PR DESCRIPTION
These are just a few items picked up from static analysis. Some of them should have been compiler warnings (e.g., uninitialized class members).