### PR TITLE
Make a couple constant 64-bit ULL to avoid getting truncated during shifts

### DIFF
--- a/instructionAPI/h/BinaryFunction.h
+++ b/instructionAPI/h/BinaryFunction.h
@@ -263,7 +263,7 @@ namespace Dyninst
 						}
 						
 						Result one(u64, 1);
-						Result rot = arg1 & (Result(u64, (1<<arg2val) - 1));
+						Result rot = arg1 & (Result(u64, (1ULL<<arg2val) - 1));
 						
 						rightLogicalShiftResult lhsRightShift;
 						Result arg2mod = Result(arg2.type, arg2val);

--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -2870,7 +2870,7 @@ Expression::Ptr InstructionDecoder_aarch64::makeMemRefExPair2(){
                 uint64_t imm = 0;
 
                 for (int imm_index = 0; imm_index < 8; imm_index++)
-                    imm |= (simdAlphabetImm & (1 << imm_index)) ? (0xFF << (imm_index * 8)) : 0;
+                    imm |= (simdAlphabetImm & (1 << imm_index)) ? (0xFFULL << (imm_index * 8)) : 0;
 
                 insn_in_progress->appendOperand(Immediate::makeImmediate(Result(u64, imm)), true, false);
             }


### PR DESCRIPTION
Noticed constants in BinaryFunction.h and InstructionDecoder-aarch64.C were not properly sized as 64-bit value.  Shift of these constants would be done as 32-bit values and could be truncated if the shift is large. This was detected by a coverity scan.