### PR TITLE
Docker: use external-tests instead of testsuite in base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,9 +109,6 @@ RUN printf "\n\
 WORKDIR /code
 COPY . /code
 
-# Add test code to base container so we can build tests here
-RUN git clone https://github.com/dyninst/testsuite /opt/testsuite
-
 # Install Dyninst to its own view
 WORKDIR /opt/dyninst-env
 RUN . /opt/spack/share/spack/setup-env.sh && \
@@ -126,6 +123,6 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
     spack add intel-tbb@${INTELTBB_VERSION} && \
     spack install --reuse
     
-# Build tests (but don't run)
+# Build Dyninst
 COPY ./docker/build.sh build.sh
 RUN /bin/bash build.sh

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -16,8 +16,10 @@ RUN git clone --depth=1 https://github.com/dyninst/external-tests /opt
 COPY ./docker/build.sh /opt/dyninst-env/build.sh
 COPY ./docker/test.sh /opt/dyninst-env/test.sh
 
-# Previous WORKDIR, just to be careful - reinstall dyninst if needed
-# Thenbuild and run the test suite
 WORKDIR /opt/dyninst-env
-RUN /bin/bash build.sh && \
-    /bin/bash test.sh
+
+# Build Dyninst
+RUN /bin/bash build.sh
+
+# Run the tests
+RUN /bin/bash test.sh

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -10,7 +10,7 @@ COPY . /code
 #------
 # A key element of these tests is to be able to _build_ against a Dyninst installation
 # As such, we don't need to keep them in the base image
-RUN git clone --depth=1 https://github.com/dyninst/external-tests /opt
+RUN git clone --depth=1 https://github.com/dyninst/external-tests /opt/external-tests
 
 # Add build scripts to run
 COPY ./docker/build.sh /opt/dyninst-env/build.sh

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -6,7 +6,13 @@ FROM ${dyninst_base}
 # Add updated Dyninst code
 COPY . /code
 
-# Add testing and build script to run
+# Add external tests code
+#------
+# A key element of these tests is to be able to _build_ against a Dyninst installation
+# As such, we don't need to keep them in the base image
+RUN git clone --depth=1 https://github.com/dyninst/external-tests /opt
+
+# Add build scripts to run
 COPY ./docker/build.sh /opt/dyninst-env/build.sh
 COPY ./docker/test.sh /opt/dyninst-env/test.sh
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# This script builds dyninst and the test suite (but does not run tests)
-
 printf "⭐️ Setting up spack environment for Dyninst\n"
 . /opt/spack/share/spack/setup-env.sh
 spack env activate .
@@ -17,30 +15,8 @@ mkdir -p $DYNINST_BUILD_DIR
 DYNINST_INSTALL_DIR=/opt/dyninst-env/install/dyninst
 mkdir -p $DYNINST_INSTALL_DIR
 
-cmake -S /code -B $DYNINST_BUILD_DIR -DCMAKE_INSTALL_PREFIX=$DYNINST_INSTALL_DIR
+cmake -S /code -B $DYNINST_BUILD_DIR -DCMAKE_INSTALL_PREFIX=$DYNINST_INSTALL_DIR 
 cmake --build $DYNINST_BUILD_DIR -- -j2
 cmake --install $DYNINST_BUILD_DIR
 
-echo "::endgroup::"
-
-# 2. Update the test suite
-printf "⭐️ Updating the testsuite\n"
-echo "::group::update testsuite"   
-git -C /opt/testsuite pull origin master
-echo "::endgroup::"
-
-# 3. Build the test suite
-printf "⭐️ Preparing to build the testsuite\n"
-echo "::group::build tests"
-
-TESTSUITE_BUILD_DIR=/opt/dyninst-env/build/testsuite
-mkdir -p $TESTSUITE_BUILD_DIR
-
-TESTSUITE_INSTALL_DIR=/opt/dyninst-env/install/testsuite
-mkdir -p $TESTSUITE_INSTALL_DIR
-
-cmake -S /opt/testsuite -B $TESTSUITE_BUILD_DIR -DCMAKE_INSTALL_PREFIX=$TESTSUITE_INSTALL_DIR -DDyninst_DIR=$DYNINST_INSTALL_DIR/lib/cmake/Dyninst
-cmake --build $TESTSUITE_BUILD_DIR -- -j2
-cmake --install $TESTSUITE_BUILD_DIR --prefix $TESTSUITE_INSTALL_DIR
-mv $TESTSUITE_INSTALL_DIR/bin/testsuite/* $TESTSUITE_INSTALL_DIR
 echo "::endgroup::"

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -5,15 +5,21 @@ printf "⭐️ Setting up spack environment for Dyninst\n"
 . /opt/spack/share/spack/setup-env.sh
 spack env activate .
 
-# 3. Run the tests
-printf "⭐️ Running tests...\n"
-cd /opt/dyninst-env/install/testsuite
-export DYNINSTAPI_RT_LIB=/opt/dyninst-env/install/dyninst/lib/libdyninstAPI_RT.so
-export OMP_NUM_THREADS=2
-export LD_LIBRARY_PATH=/opt/dyninst-env/install/dyninst/lib:$PWD:$LD_LIBRARY_PATH
-./runTests -64 -all -log test.log -j1 > >(tee stdout.log) 2> >(tee stderr.log >&2)
+# Build the tests
+# NB: There are no tests to execute (yet), so building is the actual test
+printf "⭐️ Building external-tests\n"
+echo "::group::build external-tests"
 
-# TODO will update here to upload given merge to master
-# Run the build script to collect and process the logs then upload them
-# cd /opt/dyninst-env                                                                                   && \
-# perl /opt/testsuite/scripts/build/build.pl --hostname=ci-github --quiet --restart=build --no-run-tests --upload --auth-token=xxxxxxxxxxxxxxxxxxx
+DYNINST_INSTALL_DIR=/opt/dyninst-env/install/dyninst
+
+TESTS_BUILD_DIR=/opt/dyninst-env/build/external-tests
+mkdir -p $TESTS_BUILD_DIR
+
+TESTS_INSTALL_DIR=/opt/dyninst-env/install/external-tests
+mkdir -p $TESTS_INSTALL_DIR
+
+cmake -S /opt/external-tests -B $TESTS_BUILD_DIR -DCMAKE_INSTALL_PREFIX=$TESTS_INSTALL_DIR -DDyninst_DIR=$DYNINST_INSTALL_DIR/lib/cmake/Dyninst
+cmake --build $TESTS_BUILD_DIR
+cmake --install $TESTS_BUILD_DIR
+
+echo "::endgroup::"


### PR DESCRIPTION
We want to use -Werror to catch any warnings introduced by code changes. However, the test suite isn't ready to be built that way, so we use the external-tests instead.