### PR TITLE
Adding a workflow for release

### DIFF
--- a/.github/workflows/base-containers.yaml
+++ b/.github/workflows/base-containers.yaml
@@ -6,10 +6,6 @@ on:
   schedule:
     - cron: 0 3 * * *
 
-  # Publish packages on release
-  release:
-    types: [published] 
-
   # On push to main we build and deploy images
   push: 
     branches:
@@ -77,14 +73,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Tag and Push Release Image
-        if: (github.event_name == 'release')
-        run: |
-            tag=${GITHUB_REF#refs/tags/}
-            echo "Tagging and releasing ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:${tag}"
-            docker tag ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:latest ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:${tag}
-            docker push ghcr.io/${org}/dyninst-ubuntu-${{ matrix.ubuntu }}:${tag}
 
       - name: Deploy
         if: (github.event_name != 'pull_request')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,54 @@
+name: Build Container on Release
+
+on:
+
+  # JUST FOR TESTING
+  pull_request: []
+
+  # Publish packages on release
+  release:
+    types: [published] 
+ 
+jobs:
+  build:
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+
+    # Note this inherits the arguments for dependencies from the base container
+    # If you move this release trigger to the base-containers workflow you
+    # can tweak this, however the release will take longer.
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Make Space For Build
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+
+      - name: Build Dyninst Release Container
+        run: |
+           cd docker/
+           docker build -f Dockerfile.release -t ghcr.io/dyninst/dyninst-ubuntu-20.04:latest ../
+
+      #- name: GHCR Login
+      #  uses: docker/login-action@v1 
+      #  with:
+      #    registry: ghcr.io
+      #    username: ${{ github.actor }}
+      #    password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and Push Release Image
+        run: |
+            tag=${GITHUB_REF#refs/tags/}
+            echo "Tagging and releasing ghcr.io/dyninst/dyninst-ubuntu-20.04:${tag}"
+            docker tag ghcr.io/dyninst/dyninst-ubuntu-20.04:latest ghcr.io/dyninst/dyninst-ubuntu-20.04:${tag}
+      #      docker push ghcr.io/dyninst/dyninst-ubuntu-20.04:${tag}
+
+      #- name: Deploy
+      #  run: docker push ghcr.io/dyninst/dyninst-ubuntu-20.04:latest

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -7,7 +7,6 @@ COPY . /code
 # Add testing and build script to run
 COPY ./docker/build.sh /opt/dyninst-env/build.sh
 
-# Previous WORKDIR, just to be careful - reinstall dyninst if needed
-# Thenbuild and run the test suite
+# Previous WORKDIR, just to be careful - reinstall dyninst at release
 WORKDIR /opt/dyninst-env
 RUN /bin/bash build.sh

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,0 +1,13 @@
+ARG dyninst_base=ghcr.io/dyninst/dyninst-ubuntu-20.04:latest
+FROM ${dyninst_base}
+
+# Add updated Dyninst code
+COPY . /code
+
+# Add testing and build script to run
+COPY ./docker/build.sh /opt/dyninst-env/build.sh
+
+# Previous WORKDIR, just to be careful - reinstall dyninst if needed
+# Thenbuild and run the test suite
+WORKDIR /opt/dyninst-env
+RUN /bin/bash build.sh


### PR DESCRIPTION
Currently we do the entire build from scratch for release, and this strategy was chosen for the cleanest build. However we can use the same strategy as we do for testing and take advantage of the base container. This PR adds a workflow to do that

@hainest the PR trigger is added only to test the build. When that passes, I'll update the PR to remove it (and uncomment the parts that do the deploy) and we should be good. Hopefully there are no annoying new issues with spack that randomly show up... 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>