### PR TITLE
Remove usage of DW_AT_MIPS_linkage_name

### DIFF
--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -1634,10 +1634,8 @@ bool DwarfWalker::findFuncName() {
 
     Dwarf_Attribute linkageNameAttr;
     Dwarf_Die e = entry();
-    auto status = dwarf_attr_integrate(&e, DW_AT_MIPS_linkage_name, &linkageNameAttr);
 
-    if (status == 0)
-        status = dwarf_attr_integrate(&e, DW_AT_linkage_name, &linkageNameAttr);
+    auto status = dwarf_attr_integrate(&e, DW_AT_linkage_name, &linkageNameAttr);
     if ( status != 0 )  { // previously ==1
         const char *dwarfName = dwarf_formstring(&linkageNameAttr);
         //DWARF_FAIL_RET(dwarfName);


### PR DESCRIPTION
This isn't part of DWARF4 or DWARF5.