### PR TITLE
Correctly propagate pc ranges for blocks and local variables

### DIFF
--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -381,6 +381,12 @@ bool DwarfWalker::parse_int(Dwarf_Die e, bool parseSib, bool dissociate_context)
             case DW_TAG_lexical_block:
                 ret = parseLexicalBlock();
                 break;
+            case DW_TAG_try_block:
+                ret = parseTryBlock();
+                break;
+            case DW_TAG_catch_block:
+                ret = parseCatchBlock();
+                break;
             case DW_TAG_common_block:
                 ret = parseCommonBlock();
                 break;
@@ -856,6 +862,16 @@ vector<AddressRange> DwarfWalker::getDieRanges(Dwarf * /*dbg*/, Dwarf_Die die, O
 
 bool DwarfWalker::parseLexicalBlock() {
    dwarf_printf("(0x%lx) Parsing lexical block\n", id());
+   return parseRangeTypes(dbg(), entry());
+}
+
+bool DwarfWalker::parseTryBlock() {
+   dwarf_printf("(0x%lx) Parsing try block ranges\n", id());
+   return parseRangeTypes(dbg(), entry());
+}
+
+bool DwarfWalker::parseCatchBlock() {
+   dwarf_printf("(0x%lx) Parsing catch block ranges\n", id());
    return parseRangeTypes(dbg(), entry());
 }
 

--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -98,37 +98,18 @@ public:
     typedef boost::shared_ptr<std::vector<std::pair<Address, Address> > > range_set_ptr;
 private:
     struct Context {
-        FunctionBase *func;
-        boost::shared_ptr<Type> commonBlock;
-        boost::shared_ptr<Type> enumType;
-        boost::shared_ptr<Type> enclosure;
-        bool parseSibling;
-        bool parseChild;
-        Dwarf_Die offset;
-        Dwarf_Die specEntry;
-        Dwarf_Die abstractEntry;
-        unsigned int tag;
-        Address base;
-        range_set_ptr ranges;
-        Context() :
-            func(NULL), commonBlock(NULL),
-            enumType(NULL), enclosure(NULL),
-            parseSibling(true), parseChild(true),
-            tag(0), base(0) {
-        }
-        Context(const Context& o) noexcept :
-                func(o.func),
-                commonBlock(o.commonBlock),
-                enumType(o.enumType),
-                enclosure(o.enclosure),
-                parseSibling(o.parseSibling),
-                parseChild(o.parseChild),
-                offset(o.offset),
-                specEntry(o.specEntry),
-                abstractEntry(o.specEntry),
-                tag(o.tag),
-                base(o.base)
-        {}
+        FunctionBase *func{};
+        boost::shared_ptr<Type> commonBlock{};
+        boost::shared_ptr<Type> enumType{};
+        boost::shared_ptr<Type> enclosure{};
+        bool parseSibling{true};
+        bool parseChild{true};
+        Dwarf_Die offset{};
+        Dwarf_Die specEntry{};
+        Dwarf_Die abstractEntry{};
+        unsigned int tag{};
+        Address base{};
+        range_set_ptr ranges{};
     };
 
     std::stack<Context> c;
@@ -290,6 +271,8 @@ private:
 
     bool parseSubprogram(inline_t func_type);
     bool parseLexicalBlock();
+    bool parseTryBlock();
+    bool parseCatchBlock();
     bool parseRangeTypes(Dwarf* dbg, Dwarf_Die die);
     bool parseCommonBlock();
     bool parseConstant();


### PR DESCRIPTION
 - fix valid pc address ranges for local variables that are declared in a
  sub-block (brace, try and catch blocks) of their function
 - fix Context class's constructors so they correctly initialize and copy
   all member (use in-class initialize and default constructors)

Fixes #1225