### PR TITLE
Remove BUILD_RT option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,6 @@ if(${SYMREADER} MATCHES symtabAPI)
   add_subdirectory (parseThat)
 endif()
 
-if(BUILD_RTLIB)
   # Build the RT library as a separate project so we can change compilers
   message(STATUS "Configuring DyninstAPI_RT in ${RT_BINARY_DIR}")
   file(REMOVE_RECURSE ${RT_BINARY_DIR}/CMakeCache.txt ${RT_BINARY_DIR}/CMakeFiles ${RT_BINARY_DIR}/Makefile)
@@ -156,9 +155,6 @@ if(BUILD_RTLIB)
 
   install(SCRIPT "${RT_BINARY_DIR}/cmake_install.cmake")
 
-else()
-  message(STATUS "Skipping DyninstAPI_RT. Be sure to build this library if you're using instrumentation.")
-endif()
 set (VERSION_STRING "${DYNINST_MAJOR_VERSION}.${DYNINST_MINOR_VERSION}.${DYNINST_PATCH_VERSION}")
 set (DYNINST_NAME "DyninstAPI-${VERSION_STRING}")
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -10,7 +10,6 @@ option (SW_ANALYSIS_STEPPER "Use ParseAPI-based analysis stepper in Stackwalker"
 option (BUILD_TARBALLS "Build Dyninst package tarballs. Requires git archive, tar, gzip." OFF)
 option (BUILD_RTLIB_32 "Build 32-bit runtime library on mixed 32/64 systems" OFF)
 
-option(BUILD_RTLIB "Building runtime library (can be disabled safely for component-level builds)" ON)
 option(BUILD_DOCS "Build manuals from LaTeX sources" ON)
 
 option (ENABLE_LTO "Enable Link-Time Optimization" OFF)


### PR DESCRIPTION
When not enabled, the dyninstAPI_RT/cmake_install.cmake isn't present. This has been broken since it was implemented by e1afc6918 in 2016.

Fixes #1228 