### PR TITLE
Remove unused git files

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,3 +1,0 @@
-unreleased=true
-future-release=10.1.0
-since-tag=10.0.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "testsuite"]
-	path = testsuite
-	url = https://github.com/dyninst/testsuite


### PR DESCRIPTION
.gitmodules hasn't been used since the test suite was moved to its own repository.
.github_changelog_generate hasn't been used since v10.0.0