### PR TITLE
Use bfd linker for LTO

### DIFF
--- a/cmake/optimization.cmake
+++ b/cmake/optimization.cmake
@@ -4,7 +4,7 @@ if (CMAKE_COMPILER_IS_GNUCXX
     OR ${CMAKE_C_COMPILER_ID} MATCHES Intel)
 if(ENABLE_LTO)
     set(LTO_FLAGS "-flto")
-    set(LTO_LINK_FLAGS "-fuse-ld=gold")
+    set(LTO_LINK_FLAGS "-fuse-ld=bfd")
 else()
     set(LTO_FLAGS "")
     set(LTO_LINK_FLAGS "")


### PR DESCRIPTION
The gold linker crashes and is no longer supported.

Fixes #1230
Fixes #676