### PR TITLE
Fix format string errors in stackwalk/callchecker.C

### DIFF
--- a/stackwalk/src/callchecker.C
+++ b/stackwalk/src/callchecker.C
@@ -44,12 +44,12 @@ bool CallChecker::isPrevInstrACall(Address addr, Address & target)
    bool result;
    unsigned char buffer[max_call_length];
 
-   sw_printf("[%s:%u] - isPrevInstrACall on %lx\n", FILE__, __LINE__, addr);
+   sw_printf("[%s:%d] - isPrevInstrACall on %lx\n", FILE__, __LINE__, addr);
    Address start = addr - max_call_length;
    result = proc->readMem(buffer, start, max_call_length);
    if (!result)
    {
-      sw_printf("[%s:%u] - Address 0x%lx is not a call--unreadable\n",
+      sw_printf("[%s:%d] - Address 0x%lx is not a call--unreadable\n",
                 FILE__, __LINE__, addr);
       return false;
    }
@@ -57,7 +57,7 @@ bool CallChecker::isPrevInstrACall(Address addr, Address & target)
    if (buffer[max_call_length - 5] == 0xe8) {
       int32_t disp = *((int32_t *) (buffer+1));
       target = addr + disp;
-      sw_printf("[%s:%u] - Found call encoded by %x to %lx (addr = %lx, disp = %lx)\n",
+      sw_printf("[%s:%d] - Found call encoded by %x to %lx (addr = %lx, disp = %dx)\n",
                 FILE__, __LINE__, (int) buffer[0], target, addr, disp);
                 
       return true;
@@ -102,7 +102,7 @@ bool CallChecker::isPrevInstrACall(Address addr, Address & target)
 
       if (i + size == max_call_length)
       {
-         sw_printf("[%s:%u] - Found call of size %d encoded by: ",
+         sw_printf("[%s:%d] - Found call of size %u encoded by: ",
                    FILE__, __LINE__, size);
          for (unsigned j=i; j<i+size; j++) {
             sw_printf("%x ", buffer[j]);


### PR DESCRIPTION
These are only present when SW_ANALYSIS_STEPPER=OFF.

Fixes #1233 