### PR TITLE
Fix dyninstAPI_RT files to build with older glibc

### DIFF
--- a/dyninstAPI_RT/src/RTheap-linux.c
+++ b/dyninstAPI_RT/src/RTheap-linux.c
@@ -31,7 +31,7 @@
 /* $Id: RTheap-linux.c,v 1.9 2008/01/31 18:01:54 legendre Exp $ */
 /* RTheap-linux.c: Linux-specific heap components */
 
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/dyninstAPI_RT/src/RTheap.c
+++ b/dyninstAPI_RT/src/RTheap.c
@@ -31,7 +31,7 @@
 /* $Id: RTheap.c,v 1.25 2006/05/03 00:31:25 jodom Exp $ */
 /* RTheap.c: platform-generic heap management */
 
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/dyninstAPI_RT/src/RTlinux.c
+++ b/dyninstAPI_RT/src/RTlinux.c
@@ -33,7 +33,7 @@
  * RTlinux.c: mutatee-side library function specific to Linux
  ************************************************************************/
 
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 
 #include "dyninstAPI_RT/h/dyninstAPI_RT.h"
 #include "dyninstAPI_RT/src/RTthread.h"

--- a/dyninstAPI_RT/src/RTposix.c
+++ b/dyninstAPI_RT/src/RTposix.c
@@ -33,7 +33,7 @@
  * RTposix.c: runtime instrumentation functions for generic posix.
  ************************************************************************/
 
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/dyninstAPI_RT/src/RTsignal.c
+++ b/dyninstAPI_RT/src/RTsignal.c
@@ -32,7 +32,7 @@
  * RTsignal.c: C-language signal handling code
  ************************************************************************/
 
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 
 #include <stdio.h>
 #include <signal.h>


### PR DESCRIPTION
- replace feature test macro _GNU_SOURCE with _DEFAULT_SOURCE
  to support older version of glibc

Fixes #1251