### PR TITLE
add case in DwarfEncToReg for Arch_intelGen9

### DIFF
--- a/common/src/dyn_regs.C
+++ b/common/src/dyn_regs.C
@@ -1834,10 +1834,12 @@ MachRegister MachRegister::DwarfEncToReg(int encoding, Dyninst::Architecture arc
             break;
         case Arch_amdgpu_vega:
         case Arch_amdgpu_cdna2:
-            // ignore CUDA register encodings for now
+            // ignore AMD register encodings for now
             return Dyninst::InvalidReg;
             break;
-
+	case Arch_intelGen9:
+            return Dyninst::InvalidReg;
+            break;
         case Arch_none:
             return Dyninst::InvalidReg;
             break;


### PR DESCRIPTION
Add a missing case to MachineRegister::DwarfEncToReg for Arch_intelGen9 that returns Dyninst::InvalidReg instead of reaching the default case with an assert. 

This change was necessary to swallow DWARF variable information for Intel GPUs, which HPCToolkit ignores.