### PR TITLE
Fix bug in processing library paths in FindLibIberty.cmake

### DIFF
--- a/cmake/Modules/FindLibIberty.cmake
+++ b/cmake/Modules/FindLibIberty.cmake
@@ -71,7 +71,7 @@ find_package_handle_standard_args(LibIberty
 set(IBERTY_FOUND ${LibIberty_FOUND})
 
 if(LibIberty_FOUND)
-  foreach(l in ${LibIberty_LIBRARIES})
+  foreach(l ${LibIberty_LIBRARIES})
     get_filename_component(_dir ${l} DIRECTORY)
     list(APPEND LibIberty_LIBRARY_DIRS ${_dir})
   endforeach()


### PR DESCRIPTION
This was originally part of #1263

Co-authored-by: Jonathan R. Madsen <jrmadsen@users.noreply.github.com>