### PR TITLE
Remove endian CMake check

### DIFF
--- a/cmake/endian.cmake
+++ b/cmake/endian.cmake
@@ -1,8 +1,0 @@
-include(TestBigEndian)
-
-test_big_endian(BIGENDIAN)
-if(${BIGENDIAN})
-    add_definitions(-DDYNINST_BIG_ENDIAN)
-else()
-    add_definitions(-DDYNINST_LITTLE_ENDIAN)
-endif(${BIGENDIAN})

--- a/cmake/shared.cmake
+++ b/cmake/shared.cmake
@@ -106,7 +106,6 @@ include(${DYNINST_ROOT}/cmake/visibility.cmake)
 include(${DYNINST_ROOT}/cmake/warnings.cmake)
 include(${DYNINST_ROOT}/cmake/options.cmake)
 include(${DYNINST_ROOT}/cmake/optimization.cmake)
-include(${DYNINST_ROOT}/cmake/endian.cmake)
 
 set(BUILD_SHARED_LIBS ON)
 


### PR DESCRIPTION
The usage of the macros was removed by d233ae759 in 2020.

Support for big-endian platforms was removed by 481abaf204 in 2021. There is a larger change of removing endian checks throughout the code base.