### PR TITLE
fix races with parallel analysis of cubins

### DIFF
--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -60,8 +60,12 @@ bool LineInformation::addLine( unsigned int lineSource,
                                         lowInclusiveAddr, highExclusiveAddr);
     Statement::Ptr insert_me(the_stmt);
     insert_me->setStrings_(strings_);
-   return insert( insert_me).second;
-
+   bool result;
+#pragma omp critical (addLine)
+{
+   result = insert( insert_me).second;
+}
+   return result;
 } /* end setLineToAddressRangeMapping() */
 bool LineInformation::addLine( std::string lineSource,
                                unsigned int lineNo,
@@ -78,7 +82,10 @@ void LineInformation::addLineInfo(LineInformation *lineInfo)
 {
     if(!lineInfo)
         return;
+#pragma omp critical (addLine)
+{
     insert(lineInfo->begin(), lineInfo->end());
+}
 }
 
 bool LineInformation::addAddressRange( Offset lowInclusiveAddr, 

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3646,9 +3646,15 @@ LineInformation* Object::parseLineInfoForObject(StringTablePtr strings)
 
     int status;
 
-    while ((status = dwarf_next_lines(dbg, off = next_off, &next_off, &cu,
-			     &files, &fileCount, &lineBuffer, &lineCount)) == 0)
-    {
+    while (1) {
+
+#pragma omp critical (next_lines)
+{
+    status = dwarf_next_lines(dbg, off = next_off, &next_off, &cu,
+                              &files, &fileCount, &lineBuffer, &lineCount);
+}
+    if (status != 0) break;
+      
 
     boost::unique_lock<dyn_mutex> l(strings->lock);
     size_t offset = strings->size();


### PR DESCRIPTION
- Boost multi_index_set is not thread safe. Add an OpenMP critical section to guard against parallel inserts. 
    - Is this enough? A more comprehensive fix would be to add a reader/writer lock and also synchronize reads of this structure.
- dwarf_next_lines uses calls code that uses glibc's tsearch, which is not thread safe. A better fix would be to replace or synchronize the use of tsearch in elfutils. 

NOTE: in practice, these fixes led to safe parallel analysis using 16 threads of a 240MB LLNL export-controlled cubin that can't be used externally for testing.