### PR TITLE
Make SymtabCodeSource take a const param

### DIFF
--- a/parseAPI/h/CodeSource.h
+++ b/parseAPI/h/CodeSource.h
@@ -286,7 +286,7 @@ class PARSER_EXPORT SymtabCodeSource : public CodeSource, public boost::lockable
                                    hint_filt *, 
                                    bool allLoadedRegions=false);
     SymtabCodeSource(SymtabAPI::Symtab *);
-    SymtabCodeSource(char *);
+    SymtabCodeSource(const char *);
 
     ~SymtabCodeSource();
 

--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -260,7 +260,7 @@ SymtabCodeSource::SymtabCodeSource(SymtabAPI::Symtab * st) :
     init(NULL,false);
 }
 
-SymtabCodeSource::SymtabCodeSource(char * file) :
+SymtabCodeSource::SymtabCodeSource(const char * file) :
     _symtab(NULL),
     owns_symtab(true),
     stats_parse(new ::StatContainer()),


### PR DESCRIPTION
This just makes it slightly easier to pass in an `std::string` to the constructor, allowing `my_str.c_str()` directly, without needing to do a const cast or copy the string.