### PR TITLE
Search 'elfutils' subdirectory for libdebuginfod/includedir

### DIFF
--- a/cmake/Modules/FindLibDebuginfod.cmake
+++ b/cmake/Modules/FindLibDebuginfod.cmake
@@ -33,7 +33,7 @@ find_path(
     NAMES debuginfod.h
     HINTS ${PC_Debuginfod_INCLUDEDIR} ${PC_Debuginfod_INCLUDE_DIRS}
           ${LibDebuginfod_ROOT_DIR}/include ${LibDebuginfod_ROOT_DIR}
-          ${LibDebuginfod_INCLUDEDIR}
+          ${LibDebuginfod_INCLUDEDIR} ${PC_Debuginfod_INCLUDEDIR}/elfutils 
     PATHS ${DYNINST_SYSTEM_INCLUDE_PATHS}
     PATH_SUFFIXES ${_path_suffixes}
     DOC "libdebuginfod include directories")

--- a/cmake/Modules/FindLibDebuginfod.cmake
+++ b/cmake/Modules/FindLibDebuginfod.cmake
@@ -33,7 +33,7 @@ find_path(
     NAMES debuginfod.h
     HINTS ${PC_Debuginfod_INCLUDEDIR} ${PC_Debuginfod_INCLUDE_DIRS}
           ${LibDebuginfod_ROOT_DIR}/include ${LibDebuginfod_ROOT_DIR}
-          ${LibDebuginfod_INCLUDEDIR} ${PC_Debuginfod_INCLUDEDIR}/elfutils 
+          ${LibDebuginfod_INCLUDEDIR} ${PC_Debuginfod_INCLUDEDIR}/elfutils
     PATHS ${DYNINST_SYSTEM_INCLUDE_PATHS}
     PATH_SUFFIXES ${_path_suffixes}
     DOC "libdebuginfod include directories")


### PR DESCRIPTION
Debian distributions put the elfutils includes under <prefix>/include/elfutils. This just adds the <includedir>/elfutils subdirectory to the search where <includedir> is returned from pkg-config.