### PR TITLE
Fix possible null pointer access in BPatch_module::findFunctionByAddress

### DIFF
--- a/dyninstAPI/src/BPatch_module.C
+++ b/dyninstAPI/src/BPatch_module.C
@@ -527,7 +527,7 @@ BPatch_module::findFunctionByAddress(void *addr, BPatch_Vector<BPatch_function *
 {
    if (!isValid()) {
       if (notify_on_failure) {
-         BPatch_reportError(BPatchSerious, 100, "Module is not valid: ");
+         BPatch_reportError(BPatchSerious, 100, "Module is not valid");
       }
       return NULL;
    }

--- a/dyninstAPI/src/BPatch_module.C
+++ b/dyninstAPI/src/BPatch_module.C
@@ -527,9 +527,7 @@ BPatch_module::findFunctionByAddress(void *addr, BPatch_Vector<BPatch_function *
 {
    if (!isValid()) {
       if (notify_on_failure) {
-         using namespace std;
-         string msg = string("Module is not valid: ") + string(mod->fileName());
-         BPatch_reportError(BPatchSerious, 100, msg.c_str());
+         BPatch_reportError(BPatchSerious, 100, "Module is not valid: ");
       }
       return NULL;
    }


### PR DESCRIPTION
'isValid' checks that 'mod' is not null. The code here only runs if mod _is_ null. Oddly, this only showed up as a compile warning when ENABLE_STATIC_BUILDS=ON.