### PR TITLE
Manually add hex prefix when formatting an Operand

### DIFF
--- a/instructionAPI/src/Operand.C
+++ b/instructionAPI/src/Operand.C
@@ -134,7 +134,7 @@ namespace Dyninst
                 Result res = op_value->eval();
                 if (res.defined) {
                     char hex[20];
-                    snprintf(hex, 20, "%lux", res.convert<uintmax_t>());
+                    snprintf(hex, 20, "0x%lx", res.convert<uintmax_t>());
                     return string(hex);
                 }
             }


### PR DESCRIPTION
I believe this is a misuse of snprintf format string.
Instead of outputting the numeric value in hex, it would output the value as dec followed by a literal x which makes no sense at all.