### PR TITLE
ParseAPI: improve tail call recognition

### DIFF
--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -920,9 +920,11 @@ Parser::finalize(Function *f)
             b->copy_targets(targets);
             for (auto e : targets) {
                 if (!e->interproc() && (e->type() == INDIRECT || e->type() == DIRECT)) {
+		  if (b->last() != e->trg()->start()) { // if not an instruction that branches to itself
                     e->_type._interproc = true;
                     parsing_printf("from %lx to %lx, marked as tail call (jump at entry), re-finalize\n", b->last(), e->trg()->start());
                     return false;
+		  }
                 }
             }
         }


### PR DESCRIPTION
Don't consider a branch that is a self-loop as a potential tail call. 

Note: This commit avoids having function finalization never reach a fixed point for the bad parse of function PMPI_Accumulate in  libmpi_nvidia.so.12.0.0. However, this does nothing to fix the underlying parsing problems that led to the anomaly:

  ` 0x116d954 <PMPI_Accumulate+106900>:  jmp    0x116d954 <PMPI_Accumulate+106900>
`
which according to objdump should have been:

 ```
  0x116d951 <PMPI_Accumulate+106897>:  callq  0x2a270 <MPIR_Err_create_code@plt>
  0x116d956 <PMPI_Accumulate+106902>:  mov    %eax,%edi
```
Note that 0x116d954 is in the middle of the instruction at 0x116d951 reported by objdump.
@kupsch 