### PR TITLE
Support hash_compare concept from TBB >= 2021.1

### DIFF
--- a/common/h/concurrent.h
+++ b/common/h/concurrent.h
@@ -54,10 +54,10 @@ namespace dyn_c_annotations {
 
 template<typename K, typename V>
 class dyn_c_hash_map : protected tbb::concurrent_hash_map<K, V,
-    tbb::tbb_hash_compare<K>, std::allocator<std::pair<K,V>>> {
+    tbb::tbb_hash_compare<K>, std::allocator<std::pair<const K,V>>> {
 
     typedef tbb::concurrent_hash_map<K, V,
-        tbb::tbb_hash_compare<K>, std::allocator<std::pair<K,V>>> base;
+        tbb::tbb_hash_compare<K>, std::allocator<std::pair<const K,V>>> base;
 public:
     using typename base::value_type;
     using typename base::mapped_type;

--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -26,30 +26,28 @@
 #include <bits/stdc++.h>
 
 namespace Dyninst {
-namespace SymtabAPI {
-    typedef struct {
-        Dwarf_Off off;
-        bool file;
-        Module * m;
-    } type_key;
-}
-}
-
-namespace tbb {
-    using namespace Dyninst::SymtabAPI;
-    template<>
-    struct tbb_hash_compare<type_key> {
-        static size_t hash(const type_key& k) {
-            size_t seed = 0;
-            boost::hash_combine(seed, k.off);
-            boost::hash_combine(seed, k.file);
-            boost::hash_combine(seed, static_cast<void *>(k.m));
-            return seed;
-        }
-        static bool equal(const type_key& k1, const type_key& k2) {
-            return (k1.off==k2.off && k1.file==k2.file && k1.m==k2.m);
-        }
-    };
+	namespace SymtabAPI {
+		typedef struct {
+			Dwarf_Off off;
+			bool file;
+			Module * m;
+		} type_key;
+		inline bool operator==(type_key const& k1, type_key const& k2) {
+			return k1.off==k2.off && k1.file==k2.file && k1.m==k2.m;
+		}
+	}
+	namespace concurrent {
+		template<>
+		struct hasher<SymtabAPI::type_key> {
+			size_t operator()(const SymtabAPI::type_key& k) const {
+				size_t seed = 0;
+				boost::hash_combine(seed, k.off);
+				boost::hash_combine(seed, k.file);
+				boost::hash_combine(seed, static_cast<void *>(k.m));
+				return seed;
+			}
+		};
+	}
 }
 
 namespace Dyninst {


### PR DESCRIPTION
When OneAPI was released in 2021, the tbb:hash_compare interface was completely changed. I could not find any record of this in their release notes. This change supports both interfaces.

NB: This change does **not** add CMake support for finding TBB versions >= 2021.1.

Fixes #1306 #1304