### PR TITLE
Remove unused TBB from parseAPI

### DIFF
--- a/parseAPI/CMakeLists.txt
+++ b/parseAPI/CMakeLists.txt
@@ -102,7 +102,7 @@ if(WIN32)
 endif()
 dyninst_library(parseAPI common instructionAPI ${SYMREADER})
 
-target_link_private_libraries(parseAPI ${Boost_LIBRARIES} ${TBB_LIBRARIES} tbbmalloc)
+target_link_private_libraries(parseAPI ${Boost_LIBRARIES})
 
 if(WIN32)
     target_link_private_libraries(parseAPI shlwapi)

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -53,8 +53,6 @@
 #include <boost/timer/timer.hpp>
 #include <fstream>
 
-#include "tbb/concurrent_vector.h"
-
 using namespace std;
 using namespace Dyninst;
 using namespace Dyninst::ParseAPI;


### PR DESCRIPTION
ParseAPI doesn't use TBB directly. This only compiled because of incidental inclusion of TBB via the global CMake config.