### PR TITLE
Directly link to common in dynC_API

### DIFF
--- a/dynC_API/CMakeLists.txt
+++ b/dynC_API/CMakeLists.txt
@@ -10,4 +10,4 @@ if(WIN32)
 endif()
 
 dyninst_library(dynC_API dyninstAPI)
-target_link_private_libraries(dynC_API ${Boost_LIBRARIES})
+target_link_libraries(dynC_API PRIVATE common)


### PR DESCRIPTION
dynC is a pure C library, so it doesn't use Boost.