### PR TITLE
fix Instruction class to allow valid assignment

### DIFF
--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -317,7 +317,8 @@ namespace Dyninst
       Architecture arch_decoded_from;
       mutable std::list<CFT> m_Successors;
       static int numInsnsAllocated;
-      ArchSpecificFormatter& formatter;
+      // formatter is a non-owning pointer to a singleton object
+      ArchSpecificFormatter* formatter;
     };
   }
 }


### PR DESCRIPTION
* Allow the Instruction class to allow correct assignment semantics by changing a member from a reference to a pointer

* The formatter member is a reference (to a singleton) that can not be changed after it is initialized.  Assignment to this member wrongly assigns to the previously bound referent singleton and wrongly slices the rhs to the ArchSpecificFormatter base class.  The base class has no data members, and since the assignment does not change the type of the object (its vtable), it appears to have no effect.  Also a default constructed Instuction object sets the formatter to the x86 formatter even if the host was not x86.

@bbiiggppiigg please test that this fixes your use case. Test suite shows no regressions on x86_64 and arm.

fixes #1312