### PR TITLE
Ignore unknown pragma warnings when building without OpenMP

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -96,6 +96,11 @@ endif()
 if(DYNINST_WARNINGS_AS_ERRORS)
     list(APPEND REQUESTED_WARNING_FLAGS "Werror")
     message(STATUS "DYNINST_WARNINGS_AS_ERRORS set: treating warnings as errors")
+    
+    # If not building with OpenMP or if static libs are enabled, ignore OpenMP pragma warnings
+    if(NOT USE_OpenMP OR ENABLE_STATIC_LIBS)
+    	list(APPEND REQUESTED_WARNING_FLAGS "Wno-unknown-pragmas")
+    endif()
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang)$")


### PR DESCRIPTION
Oddly, these also show up when ENABLE_STATIC_LIBS=OFF and USE_OpenMP=ON.

Fixes #1231