### PR TITLE
Fix possible memory leak in Elf_X::findDebugFile

### DIFF
--- a/elf/src/Elf_X.C
+++ b/elf/src/Elf_X.C
@@ -1768,10 +1768,11 @@ bool Elf_X::findDebugFile(std::string origfilename, string &output_name, char* &
                                         (const unsigned char *)buildid.c_str(),
                                         0, &filename);
      debuginfod_end(client);
+     
+     string fname{filename};
+     free(filename);
 
      if (fd >= 0) {
-        string fname = string(filename);
-        free(filename);
         close(fd);
 
         bool result = loadDebugFileFromDisk(fname,


### PR DESCRIPTION
This will conflict with #1325, so I'll rebase onto whichever gets merged first.