### PR TITLE
Kupsch/fix gcc 12 warnings

### DIFF
--- a/dyninstAPI/h/BPatch_basicBlock.h
+++ b/dyninstAPI/h/BPatch_basicBlock.h
@@ -89,8 +89,10 @@ struct comparison <BPatch_basicBlock *> {
  */
 class BPatch_flowGraph;
 
-struct BPATCH_DLL_EXPORT insnPredicate : public std::unary_function<Dyninst::InstructionAPI::Instruction, bool>
+struct BPATCH_DLL_EXPORT insnPredicate
 {
+  using result_type = bool;
+  using argument_type = Dyninst::InstructionAPI::Instruction;
   virtual result_type operator()(argument_type arg) = 0;
   virtual ~insnPredicate() {}
     

--- a/dyninstAPI/src/StackMod/StackLocation.h
+++ b/dyninstAPI/src/StackMod/StackLocation.h
@@ -132,7 +132,8 @@ class StackLocation {
         ValidPCRange* _valid;
 };
 
-struct less_StackLocation: public std::binary_function<StackLocation*, StackLocation*, bool> {
+struct less_StackLocation
+{
     bool operator()(StackLocation* a, StackLocation* b) const {
         if (a->isStackMemory() && b->isStackMemory()) {
             if (a->off().height() == b->off().height()) {
@@ -178,7 +179,7 @@ class tmpObject
         ValidPCRange* _valid;
 };
 
-struct less_tmpObject: public std::binary_function<tmpObject, tmpObject, bool>
+struct less_tmpObject
 {
     bool operator()(tmpObject a, tmpObject b) const {
         if (a.offset() < b.offset()) {

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -284,7 +284,7 @@ void AddressSpace::inferiorFreeCompact() {
    unsigned i, nbuf = freeList.size();
 
    /* sort buffers by address */
-    std::sort(freeList.begin(), freeList.end(), ptr_fun(heapItemLessByAddr));
+    std::sort(freeList.begin(), freeList.end(), heapItemLessByAddr);
 
    /* combine adjacent buffers */
    bool needToCompact = false;
@@ -371,7 +371,7 @@ void AddressSpace::addHeap(heapItem *h) {
    heap_.heapFree.push_back(h2);
     
    /* When we add an item to heapFree, make sure it remains in sorted order */
-   std::sort(heap_.heapFree.begin(), heap_.heapFree.end(), ptr_fun(heapItemLessByAddr));
+   std::sort(heap_.heapFree.begin(), heap_.heapFree.end(), heapItemLessByAddr);
 
    heap_.totalFreeMemAvailable += h2->length;
 }
@@ -425,7 +425,7 @@ Address AddressSpace::inferiorMallocInternal(unsigned size,
    }
 
    /* When we update an item in heapFree, make sure it remains in sorted order */
-   std::sort(heap_.heapFree.begin(), heap_.heapFree.end(), ptr_fun(heapItemLessByAddr));
+   std::sort(heap_.heapFree.begin(), heap_.heapFree.end(), heapItemLessByAddr);
 
    // add allocated block to active list
    h->length = size;
@@ -455,7 +455,7 @@ void AddressSpace::inferiorFreeInternal(Address block) {
    heap_.heapFree.push_back(h);
 
    /* When we add an item to heapFree, make sure it remains in sorted order */
-   std::sort(heap_.heapFree.begin(), heap_.heapFree.end(), ptr_fun(heapItemLessByAddr));
+   std::sort(heap_.heapFree.begin(), heap_.heapFree.end(), heapItemLessByAddr);
 
    heap_.totalFreeMemAvailable += h->length;
    heap_.freed += h->length;
@@ -561,7 +561,7 @@ bool AddressSpace::inferiorShrinkBlock(heapItem *h,
       heap_.heapFree.push_back(freeEnd);
 
       /* When we add an item to heapFree, make sure it remains sorted */
-      std::sort(heap_.heapFree.begin(), heap_.heapFree.end(), ptr_fun(heapItemLessByAddr));
+      std::sort(heap_.heapFree.begin(), heap_.heapFree.end(), heapItemLessByAddr);
    }
 
    heap_.totalFreeMemAvailable += shrink;

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
@@ -235,7 +235,7 @@ namespace Dyninst {
 			mainDecode();
 			if(entryToCategory(insn_in_progress->getOperation().getID())==c_BranchInsn){
                 //cout << "Is Branch Instruction !! , name = " << insn_in_progress -> getOperation().mnemonic << endl;
-				//std::mem_fun(decode_lookup_table[instr_family])(this);
+				//std::mem_fn(decode_lookup_table[instr_family])(this);
 			}
 			b.start += insn_in_progress->size();
 			return *insn_in_progress;

--- a/instructionAPI/src/AMDGPU/vega/InstructionDecoder-amdgpu-vega.C
+++ b/instructionAPI/src/AMDGPU/vega/InstructionDecoder-amdgpu-vega.C
@@ -552,7 +552,7 @@ namespace Dyninst {
 		bool InstructionDecoder_amdgpu_vega::decodeOperands(const amdgpu_vega_insn_entry & insn_entry) {
 			if(insn_entry.operandCnt!=0){
 				for (std::size_t i =0 ; i < insn_entry.operandCnt; i++){
-					std::mem_fun(insn_entry.operands[i])(this);
+					std::mem_fn(insn_entry.operands[i])(this);
 				}
 			}
 			return true;
@@ -721,7 +721,7 @@ namespace Dyninst {
 			setupInsnWord(b);
 			mainDecodeOpcode(b);
 			if(entryToCategory(insn_in_progress->getOperation().getID())==c_BranchInsn){
-				std::mem_fun(decode_lookup_table[instr_family])(this);
+				std::mem_fn(decode_lookup_table[instr_family])(this);
 			}
 			b.start += insn_in_progress->size();
 			return *insn_in_progress;

--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -2960,7 +2960,7 @@ Expression::Ptr InstructionDecoder_aarch64::makeMemRefExPair2(){
                 skipRm = true;
 
             for (std::size_t i = 0; i < insn_table_entry.operandCnt; i++) {
-                std::mem_fun(insn_table_entry.operands[i])(this);
+                std::mem_fn(insn_table_entry.operands[i])(this);
             }
 
             if (insn_table_index == 0)

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -297,7 +297,7 @@ namespace Dyninst
         const power_entry* current = &power_entry::main_opcode_table[field<0,5>(insn)];
         while(current->next_table)
         {
-            current = &(std::mem_fun(current->next_table)(this));
+            current = &(std::mem_fn(current->next_table)(this));
         }
 	if (findRAAndRS(current)) {
 	    isRAWritten = true;
@@ -314,7 +314,7 @@ namespace Dyninst
             curFn != current->operands.end();
             ++curFn)
         {
-            std::mem_fun(*curFn)(this);
+            std::mem_fn(*curFn)(this);
         }
         if(current->op == power_op_bclr)
         {
@@ -1429,7 +1429,7 @@ using namespace boost::assign;
         const power_entry* current = &power_entry::main_opcode_table[field<0,5>(insn)];
         while(current->next_table)
         {
-            current = &(std::mem_fun(current->next_table)(this));
+            current = &(std::mem_fn(current->next_table)(this));
         }
         insn_in_progress = makeInstruction(current->op, current->mnemonic, 4, reinterpret_cast<unsigned char*>(&insn));
         if(current->op == power_op_b ||

--- a/symtabAPI/doc/API/LineInfo/LineInformation.tex
+++ b/symtabAPI/doc/API/LineInfo/LineInformation.tex
@@ -24,7 +24,7 @@ Return \code{true} if at least one tuple corresponding to the offset was found a
 }
 
 \begin{apient}
-bool addLine(const char * lineSource,
+bool addLine(const std::string & lineSource,
              unsigned int lineNo,
              unsigned int lineOffset,
              Offset lowInclusiveAddr,

--- a/symtabAPI/h/Aggregate.h
+++ b/symtabAPI/h/Aggregate.h
@@ -86,7 +86,7 @@ class SYMTAB_EXPORT Aggregate
       //std::vector<std::string> getAllMangledNames();
       //std::vector<std::string> getAllPrettyNames();
       //std::vector<std::string> getAllTypedNames();
-      typedef boost::transform_iterator<std::const_mem_fun_t<std::string, Symbol>, std::vector<Symbol*>::const_iterator> name_iter;
+      using name_iter = boost::transform_iterator<decltype(std::mem_fn(&Symbol::getPrettyName)), std::vector<Symbol*>::const_iterator>;
       name_iter mangled_names_begin() const;
       name_iter mangled_names_end() const;
       name_iter pretty_names_begin() const;

--- a/symtabAPI/h/LineInformation.h
+++ b/symtabAPI/h/LineInformation.h
@@ -53,7 +53,7 @@ public:
       LineInformation();
 
       /* You MAY freely deallocate the lineSource strings you pass in. */
-      bool addLine( std::string lineSource,
+      bool addLine( const std::string &lineSource,
             unsigned int lineNo, 
             unsigned int lineOffset, 
             Offset lowInclusiveAddr, 

--- a/symtabAPI/src/Aggregate.C
+++ b/symtabAPI/src/Aggregate.C
@@ -307,26 +307,26 @@ bool Aggregate::operator==(const Aggregate &a)
 
 Aggregate::name_iter Aggregate::mangled_names_begin() const
 {
-  return boost::make_transform_iterator(symbols_.begin(), std::mem_fun(&Symbol::getMangledName));
+  return boost::make_transform_iterator(symbols_.cbegin(), std::mem_fn(&Symbol::getMangledName));
 }
 
 Aggregate::name_iter Aggregate::mangled_names_end() const
 {
-  return boost::make_transform_iterator(symbols_.end(), std::mem_fun(&Symbol::getMangledName));
+  return boost::make_transform_iterator(symbols_.cend(), std::mem_fn(&Symbol::getMangledName));
 }
 Aggregate::name_iter Aggregate::pretty_names_begin() const
 {
-  return boost::make_transform_iterator(symbols_.begin(), std::mem_fun(&Symbol::getPrettyName));
+  return boost::make_transform_iterator(symbols_.cbegin(), std::mem_fn(&Symbol::getPrettyName));
 }
 Aggregate::name_iter Aggregate::pretty_names_end() const
 {
-  return boost::make_transform_iterator(symbols_.end(), std::mem_fun(&Symbol::getPrettyName));
+  return boost::make_transform_iterator(symbols_.cend(), std::mem_fn(&Symbol::getPrettyName));
 }
 Aggregate::name_iter Aggregate::typed_names_begin() const
 {
-  return boost::make_transform_iterator(symbols_.begin(), std::mem_fun(&Symbol::getTypedName));
+  return boost::make_transform_iterator(symbols_.cbegin(), std::mem_fn(&Symbol::getTypedName));
 }
 Aggregate::name_iter Aggregate::typed_names_end() const
 {
-  return boost::make_transform_iterator(symbols_.end(), std::mem_fun(&Symbol::getTypedName));
+  return boost::make_transform_iterator(symbols_.cend(), std::mem_fn(&Symbol::getTypedName));
 }

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -67,15 +67,19 @@ bool LineInformation::addLine( unsigned int lineSource,
 }
    return result;
 } /* end setLineToAddressRangeMapping() */
-bool LineInformation::addLine( std::string lineSource,
+bool LineInformation::addLine( const std::string &lineSource,
                                unsigned int lineNo,
                                unsigned int lineOffset,
                                Offset lowInclusiveAddr,
                                Offset highExclusiveAddr )
 {
-    auto i = strings_->get<1>().insert(StringTableEntry(lineSource,"")).first;
+    // lookup or insert linesource in string table and get iterator
+    auto iter = strings_->get<1>().insert(StringTableEntry(lineSource,"")).first;
 
-    return addLine(i->str, lineNo, lineOffset, lowInclusiveAddr, highExclusiveAddr);
+    // get index of string in string table
+    auto i = boost::multi_index::project<0>(*strings_, iter) - strings_->get<0>().begin();
+
+    return addLine(i, lineNo, lineOffset, lowInclusiveAddr, highExclusiveAddr);
 }
 
 void LineInformation::addLineInfo(LineInformation *lineInfo)

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -129,7 +129,7 @@ const char *pdelf_get_shnames(Elf_X *elf) {
 //
 // Compare function for use with the Vector<T> sort method.
 //
-struct SectionHeaderSortFunction : public binary_function<Elf_X_Shdr *, Elf_X_Shdr *, bool> {
+struct SectionHeaderSortFunction  {
     bool operator()(Elf_X_Shdr *hdr1, Elf_X_Shdr *hdr2) {
         return (hdr1->sh_addr() < hdr2->sh_addr());
     }
@@ -3122,7 +3122,7 @@ int read_except_table_gcc3(
 }
 
 
-struct exception_compare : public binary_function<const ExceptionBlock &, const ExceptionBlock &, bool> {
+struct exception_compare  {
     bool operator()(const ExceptionBlock &e1, const ExceptionBlock &e2) const {
         if (e1.tryStart() < e2.tryStart())
             return true;


### PR DESCRIPTION
Fixes warning produced when using gcc 12 as a compiler. There were 3 types of issues

1. use of deprecated (and removed in current C++ standard) function objects.
2. a function that unconditionally called itself resulting in infinite recursion.
3. using a non-default allocator for tbb::concurrent_hash_map causes a new/delete mismatch warning (that appears to be a false positive).  Warning produced since tbb headers are not marked as a system headers yet. Fixed in PR #1332.

All of these are now fixed and Dyninst builds cleanly with gcc version 6 to 12. Tests on all 3 platforms show no regressions.

Fixes #1320