### PR TITLE
use default allocator for tbb::concurrent_hash_map

### DIFF
--- a/common/h/concurrent.h
+++ b/common/h/concurrent.h
@@ -94,12 +94,10 @@ namespace concurrent {
 
 template<typename K, typename V>
 class dyn_c_hash_map : protected tbb::concurrent_hash_map<K, V,
-    concurrent::detail::hash_compare<TBB_VERSION_MAJOR >= 2021, K>,
-	std::allocator<std::pair<const K,V>>> {
+    concurrent::detail::hash_compare<TBB_VERSION_MAJOR >= 2021, K>> {
 
 	using base = tbb::concurrent_hash_map<K, V,
-			concurrent::detail::hash_compare<TBB_VERSION_MAJOR >= 2021, K>,
-			std::allocator<std::pair<const K,V>>>;
+			concurrent::detail::hash_compare<TBB_VERSION_MAJOR >= 2021, K>>;
 
 public:
     using typename base::value_type;


### PR DESCRIPTION
Fixes warning produced by gcc 12: a non-default allocator for tbb::concurrent_hash_map causes a new/delete mismatch warning (that appears to be a false positive).  Warning produced since tbb headers are not marked as a system headers yet. 

In the future the allocator should be changed to use the tbb scalable allocator.

Related to #1331