### PR TITLE
Lookup functions in the binding table directly

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -219,6 +219,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
    // Relocation entries
    bool getFuncBindingTable(std::vector<relocationEntry> &fbt) const;
+   bool findPltEntryByTarget(Address target_address, relocationEntry &result) const;
    bool updateFuncBindingTable(Offset stub_addr, Offset plt_addr);
 
    /**************************************


### PR DESCRIPTION
instead of making multiple redundant copies of it. Copying and making a map out of the table incurs a significant overhead when the symbol table is large.

This significantly speeds up omnitrace when using `--caller-include` (https://github.com/AMDResearch/omnitrace/pull/202, it makes use of the `caller` method on call points.)