### PR TITLE
Use OpenMP target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ include(DyninstLibrary)
 
 if(USE_OpenMP)
     find_package(OpenMP REQUIRED)
+else()
+	# Dummy target so we don't have to check 'USE_OpenMP' everywhere
+	add_library(OpenMP::OpenMP_CXX INTERFACE IMPORTED)
 endif()
 
 configure_file(cmake/version.h.in common/h/dyninstversion.h)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -113,12 +113,7 @@ if(PLATFORM MATCHES nt OR PLATFORM MATCHES windows)
 endif()
 
 target_link_libraries(common PUBLIC Dyninst::TBB Dyninst::Boost)
-target_link_libraries(common PRIVATE Dyninst::LibIberty)
-
-if(USE_OpenMP)
-    set_target_properties(common PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS}
-                                            LINK_FLAGS ${OpenMP_CXX_FLAGS})
-endif()
+target_link_libraries(common PRIVATE Dyninst::LibIberty OpenMP::OpenMP_CXX)
 
 # Install AMDGPU headers under subdirectory of common/h/AMDGPU
 set(AMDGPU_HEADER ${DYNINST_ROOT}/common/h/AMDGPU)

--- a/parseAPI/CMakeLists.txt
+++ b/parseAPI/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 dyninst_library(parseAPI common instructionAPI ${SYMREADER})
 
 target_link_libraries(parseAPI PUBLIC Dyninst::Boost_headers)
-target_link_libraries(parseAPI PUBLIC symtabAPI)
+target_link_libraries(parseAPI PUBLIC symtabAPI OpenMP::OpenMP_CXX)
 
 if(WIN32)
     target_link_private_libraries(parseAPI shlwapi)
@@ -112,11 +112,6 @@ message(STATUS "Architecture is: ${CMAKE_LIBRARY_ARCHITECTURE}")
 file(GLOB headers "h/*.h")
 file(GLOB dataflowheaders "../dataflowAPI/h/*.h")
 set_target_properties(parseAPI PROPERTIES PUBLIC_HEADER "${headers};${dataflowheaders}")
-
-if(USE_OpenMP)
-    set_target_properties(parseAPI PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS}
-                                              LINK_FLAGS ${OpenMP_CXX_FLAGS})
-endif()
 
 if(${ENABLE_STATIC_LIBS})
     set_target_properties(parseAPI_static PROPERTIES PUBLIC_HEADER

--- a/parseThat/CMakeLists.txt
+++ b/parseThat/CMakeLists.txt
@@ -13,11 +13,6 @@ add_executable(
     src/dyninstCompat.v5.C)
 add_definitions(-DHAVE_BPATCH_PROCESS_H)
 
-if(USE_OpenMP)
-    set_target_properties(parseThat PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS}
-                                               LINK_FLAGS ${OpenMP_CXX_FLAGS})
-endif()
-
 target_link_private_libraries(
     parseThat
     dyninstAPI
@@ -30,6 +25,7 @@ target_link_private_libraries(
     pcontrol
     dynDwarf
     dynElf
-    Dyninst::ElfUtils)
+    Dyninst::ElfUtils
+    OpenMP::OpenMP_CXX)
 
 install(TARGETS parseThat RUNTIME DESTINATION bin)

--- a/symtabAPI/CMakeLists.txt
+++ b/symtabAPI/CMakeLists.txt
@@ -70,11 +70,6 @@ else()
 endif()
 
 dyninst_library(symtabAPI ${DEPS})
-target_link_libraries(symtabAPI PRIVATE Dyninst::TBB)
+target_link_libraries(symtabAPI PRIVATE Dyninst::TBB OpenMP::OpenMP_CXX)
 target_link_libraries(symtabAPI PUBLIC Dyninst::ElfUtils)
 target_link_libraries(symtabAPI PUBLIC Dyninst::Boost)
-
-if(USE_OpenMP)
-    set_target_properties(symtabAPI PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS}
-                                               LINK_FLAGS ${OpenMP_CXX_FLAGS})
-endif()


### PR DESCRIPTION
This also provides a dummy target so we don't have to do any additional checking when USE_OpenMP=OFF. We only use OpenMP_CXX, so I didn't create a target for the other languages (C,Fortran).