### PR TITLE
add missing include file

### DIFF
--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -29,6 +29,7 @@
  */
 
 
+#include <deque>
 #include "Absloc.h"
 #include "AbslocInterface.h"
 


### PR DESCRIPTION
- add missing #include <deque>

  On more platforms and library combinations <deque> is included via some other header, but there is combination where this is not true