### PR TITLE
Refactor common/src/Types.h

### DIFF
--- a/common/src/Types.h
+++ b/common/src/Types.h
@@ -36,96 +36,10 @@
 #if !defined(_Types_h_)
 #define _Types_h_
 
-/* Sets up 64 and 32 bit
-   types:
-      int64_t      uint64_t      int32_t       uint32_t
-   constant macros:
-      I64_C(x)     UI64_C(x)
-   limits:
-      I64_MAX      I64_MIN       UI64_MAX
-      I32_MAX      I32_MIN       UI32_MAX
-
-   note: needs to be included before anything that includes inttypes.h
-         (eg. stdio on some systems)
-*/
-
-/* Set up the 32 AND 64 BIT TYPES ===================================== */
-/*
-   --- inttypes.h ---
-             int32_t  uint32_t  int64_t uint64_t 32B lmts 64Blmts 64BlitMacros#
-Linux        yes      yes       yes     yes      yes      yes     yes
-FreeBSD      yes      yes       yes     yes      yes      yes     yes
-WindowsNT    nonexistant
-
-  # we rename all of the 64 bit literal macros to our shortened name
-*/
-
-#if defined(os_windows)
-   typedef signed __int64 int64_t;
-   typedef signed __int32 int32_t;
-   typedef signed __int16 int16_t;
-   typedef signed __int8 int8_t;
-   typedef unsigned __int64 uint64_t;
-   typedef unsigned __int32 uint32_t;
-   typedef unsigned __int16 uint16_t;
-   typedef unsigned __int8 uint8_t;
-
-#elif defined(os_linux)
-#if !defined(__STDC_CONSTANT_MACROS)
-#define __STDC_CONSTANT_MACROS
-#endif
-#if !defined(__STDC_LIMIT_MACROS)
-#define __STDC_LIMIT_MACROS
-#endif
-#include <stdint.h>
-#if defined(arch_x86_64) || defined(arch_64bit)
-#define TYPE64BIT
-#endif
-
-#elif defined(os_freebsd)
-#if !defined(__STDC_CONSTANT_MACROS)
-#define __STDC_CONSTANT_MACROS
-#endif
-#if !defined(__STDC_LIMIT_MACROS)
-#define __STDC_LIMIT_MACROS
-#endif
-#include <stdint.h>
-
-/* FreeBSD doesn't define this */
-typedef int64_t off64_t;
-
+#if defined __cplusplus
+#  include <cstdint>
 #else
-#error Unknown architecture
-#endif
-
-
-/* Set up the 64 BIT LITERAL MACROS =================================== */
-#if defined(os_windows)
-				   /* nt ----------------------------- */
-#define I64_C(x)  (x##i64)
-#define UI64_C(x) (x##ui64)
-#else                               /* linux, freebsd ----------------- */
-#define I64_C(x)  INT64_C(x)
-#define UI64_C(x) UINT64_C(x)
-#endif
-
-/* Set up the 32 and 64 BIT LIMITS for those not already set up ======= */
-#if defined(os_windows)
-			 /* nt ----------------------------- */
-#include <limits.h>
-#define I64_MAX  _I64_MAX
-#define UI64_MAX _UI64_MAX
-#define I64_MIN  _I64_MIN
-#define I32_MAX  _I32_MAX
-#define I32_MIN  _I32_MIN
-#define UI32_MAX  _UI32_MAX
-#else                              /* linux, freebsd ----------------- */
-#define I64_MAX  INT64_MAX
-#define UI64_MAX UINT64_MAX
-#define I64_MIN  INT64_MIN
-#define I32_MAX  INT32_MAX
-#define I32_MIN  INT32_MIN
-#define UI32_MAX UINT32_MAX
+#  include <stdint.h>
 #endif
 
    /*

--- a/common/src/Types.h
+++ b/common/src/Types.h
@@ -81,7 +81,6 @@ WindowsNT    nonexistant
 #if defined(arch_x86_64) || defined(arch_64bit)
 #define TYPE64BIT
 #endif
-typedef long double double128_t;
 
 #elif defined(os_freebsd)
 #if !defined(__STDC_CONSTANT_MACROS)
@@ -91,7 +90,6 @@ typedef long double double128_t;
 #define __STDC_LIMIT_MACROS
 #endif
 #include <stdint.h>
-typedef long double double128_t;
 
 /* FreeBSD doesn't define this */
 typedef int64_t off64_t;

--- a/common/src/arch-x86.h
+++ b/common/src/arch-x86.h
@@ -1159,13 +1159,13 @@ inline bool is_disp16(long disp) {
 }
 
 inline bool is_disp32(long disp) {
-  return (disp <= I32_MAX && disp >= I32_MIN);
+  return (disp <= INT32_MAX && disp >= INT32_MIN);
 }
 inline bool is_disp32(Address a1, Address a2) {
   return is_disp32(a2 - (a1 + JUMP_REL32_SZ));
 }
 inline bool is_addr32(Address addr) {
-    return (addr < UI32_MAX);
+    return (addr < INT32_MAX);
 }
 
 COMMON_EXPORT void decode_SIB(unsigned sib, unsigned& scale, 

--- a/common/src/arch-x86.h
+++ b/common/src/arch-x86.h
@@ -1165,7 +1165,7 @@ inline bool is_disp32(Address a1, Address a2) {
   return is_disp32(a2 - (a1 + JUMP_REL32_SZ));
 }
 inline bool is_addr32(Address addr) {
-    return (addr < INT32_MAX);
+    return (addr < UINT32_MAX);
 }
 
 COMMON_EXPORT void decode_SIB(unsigned sib, unsigned& scale, 


### PR DESCRIPTION
The platform macro guards (e.g., `os_windows`) are causing issues in the CMake refactor. The simplest solution is to fix the root cause here. Moreover, the custom fixed-size types are unnecessary since we require C++11.