### PR TITLE
Update detection of DWARF languages

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3239,18 +3239,12 @@ void Object::getModuleLanguageInfo(dyn_hash_map<string, supportedLanguages> *mod
                 case DW_LANG_C:
                 case DW_LANG_C89:
                 case DW_LANG_C99:
-#ifdef DW_LANG_C11
                     case DW_LANG_C11:
-#endif
                     (*mod_langs)[working_module] = lang_C;
                     break;
                 case DW_LANG_C_plus_plus:
-#ifdef DW_LANG_C_plus_plus_03
                     case DW_LANG_C_plus_plus_03:
-#endif
-#ifdef DW_LANG_C_plus_plus_11
                     case DW_LANG_C_plus_plus_11:
-#endif
                     (*mod_langs)[working_module] = lang_CPlusPlus;
                     break;
                 case DW_LANG_Fortran77:

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3245,6 +3245,7 @@ void Object::getModuleLanguageInfo(dyn_hash_map<string, supportedLanguages> *mod
                 case DW_LANG_C_plus_plus:
                     case DW_LANG_C_plus_plus_03:
                     case DW_LANG_C_plus_plus_11:
+                    case DW_LANG_C_plus_plus_14:
                     (*mod_langs)[working_module] = lang_CPlusPlus;
                     break;
                 case DW_LANG_Fortran77:

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3251,6 +3251,8 @@ void Object::getModuleLanguageInfo(dyn_hash_map<string, supportedLanguages> *mod
                 case DW_LANG_Fortran77:
                 case DW_LANG_Fortran90:
                 case DW_LANG_Fortran95:
+                case DW_LANG_Fortran03:
+                case DW_LANG_Fortran08:
                     (*mod_langs)[working_module] = lang_Fortran;
                     break;
                 default:


### PR DESCRIPTION
This adds C++14, Fortran03, and Fortran08 language detection. I found this while debugging a DWARF issue.