### PR TITLE
Remove AObject::pickLanguage

### DIFF
--- a/symtabAPI/src/Object.C
+++ b/symtabAPI/src/Object.C
@@ -393,62 +393,6 @@ SYMTAB_EXPORT AObject::AObject(MappedFile *mf_, void (*err_func)(const char *), 
 {
 }
 
-//  a helper routine that selects a language based on information from the symtab
-supportedLanguages AObject::pickLanguage(string &working_module, char *working_options,
-      supportedLanguages working_lang)
-{
-   supportedLanguages lang = lang_Unknown;
-
-   // (2) -- check suffixes -- try to keep most common suffixes near the top of the checklist
-   string::size_type len = working_module.length();
-   if((len>2) && (working_module.substr(len-2,2) == string(".c"))) lang = lang_C;
-   else if ((len>2) && (working_module.substr(len-2,2) == string(".C"))) lang = lang_CPlusPlus;
-   else if ((len>4) && (working_module.substr(len-4,4) == string(".cpp"))) lang = lang_CPlusPlus;
-   else if ((len>2) && (working_module.substr(len-2,2) == string(".F"))) lang = lang_Fortran;
-   else if ((len>2) && (working_module.substr(len-2,2) == string(".f"))) lang = lang_Fortran;
-   else if ((len>3) && (working_module.substr(len-3,3) == string(".cc"))) lang = lang_C;
-   else if ((len>2) && (working_module.substr(len-2,2) == string(".a"))) lang = lang_Assembly; // is this right?
-   else if ((len>2) && (working_module.substr(len-2,2) == string(".S"))) lang = lang_Assembly;
-   else if ((len>2) && (working_module.substr(len-2,2) == string(".s"))) lang = lang_Assembly;
-   else
-   {
-      //(3) -- try to use options string -- if we have 'em
-      if (working_options)
-      {
-         //  NOTE:  a binary is labeled "gcc2_compiled" even if compiled w/g77 -- thus this is
-         //  quite inaccurate to make such assumptions
-         if (strstr(working_options, "gcc"))
-            lang = lang_C;
-         else if (strstr(working_options, "g++"))
-            lang = lang_CPlusPlus;
-      }
-   }
-   //  This next section tries to determine the version of the debug info generator for a
-   //  Sun fortran compiler.  Some leave the underscores on names in the debug info, and some
-   //  have the "pretty" names, we need to detect this in order to properly read the debug.
-   if (working_lang == lang_Fortran)
-   {
-      if (working_options)
-      {
-         char *dbg_gen = NULL;
-         //cerr << FILE__ << __LINE__ << ":  OPT: " << working_options << endl;			
-         if (NULL != (dbg_gen = strstr(working_options, "DBG_GEN=")))
-         {
-            //cerr << __FILE__ << __LINE__ << ":  OPT: " << dbg_gen << endl;
-            // Sun fortran compiler (probably), need to examine version
-            char *dbg_gen_ver_maj = dbg_gen + strlen("DBG_GEN=");
-            //cerr << __FILE__ << __LINE__ << ":  OPT: " << dbg_gen_ver_maj << endl;
-            char *next_dot = strchr(dbg_gen_ver_maj, '.');
-            if (NULL != next_dot)
-            {
-               *next_dot = '\0';  //terminate major version number string
-            }
-         }
-      }
-   }
-   return lang;
-}
-
 SymbolIter::SymbolIter( Object & obj ) 
 : symbols(obj.getAllSymbols()), currentPositionInVector(0) 
 {

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -98,9 +98,6 @@ public:
     SYMTAB_EXPORT bool getAllExceptions(std::vector<ExceptionBlock *>&excpBlocks) const;
     SYMTAB_EXPORT std::vector<Region *> getAllRegions() const;
 
-    SYMTAB_EXPORT supportedLanguages pickLanguage(std::string &working_module, char *working_options,
-                                                                    supportedLanguages working_lang);
-
     SYMTAB_EXPORT Offset loader_off() const;
     SYMTAB_EXPORT unsigned loader_len() const;
     SYMTAB_EXPORT int getAddressWidth() const;


### PR DESCRIPTION
This was only used by the STABs parsing code. It should have been removed by 5e142eff. Language detection is handled by `void Object::getModuleLanguageInfo` and requires DWARF (it does nothing on non-ELF binaries).