### PR TITLE
Correctly check form value in DwarfWalker::findString

### DIFF
--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -2049,7 +2049,7 @@ bool DwarfWalker::findString(Dwarf_Half attr,
     auto ret_p = dwarf_attr(&e, attr, &strattr);
     if(!ret_p) return false;
     form = dwarf_whatform(&strattr);
-    if (form != 0) {
+    if (form == 0) {
         return false;
     }
 


### PR DESCRIPTION
dwarf_whatform will only return 0 if the attribute object has no form value.