### PR TITLE
Replace DwarfWalker::findString with DwarfWalker::find_call_file

### DIFF
--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -358,7 +358,7 @@ private:
             bool &constant,
             bool &expr,
             Dwarf_Half &form);
-    bool findString(Dwarf_Half attr, std::string &str);
+    boost::optional<std::string> find_call_file();
 public:
     static bool findConstant(Dwarf_Half attr, Address &value, Dwarf_Die *entry, Dwarf *dbg);
     static bool findConstantWithForm(Dwarf_Attribute &attr, Dwarf_Half form,


### PR DESCRIPTION
The original function was only ever used to find DW_AT_call_file. During the transition to libdw, the added check for that attribute made the rest of the string processing useless. Moreover, the code update also introduced a bug in checking the return value of dwarf_whatform which rendered the function completely useless as a generic stringform parser.