### PR TITLE
Fix BinaryEdit::getResolvedLibraryPath for Ubuntu 22.04

### DIFF
--- a/dyninstAPI/src/linux.C
+++ b/dyninstAPI/src/linux.C
@@ -42,7 +42,11 @@
 #include "mapped_module.h"
 #include "linux.h"
 #include <dlfcn.h>
+
+#include <exception>
+#include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "boost/shared_ptr.hpp"
@@ -208,7 +212,8 @@ delimit(
         } catch(std::exception& e)
         {
             // print the exception but don't fail, unless maybe it should?
-            fprintf(stderr, "%s\n", e.what());
+            fprintf(stderr, "[%s:%i] %s (delimiters: %s) :: %s\n", __FILE__, __LINE__,
+                    line.c_str(), delimiters.c_str(), e.what());
         }
         // don't add empty strings
         if(!_tmp.empty())


### PR DESCRIPTION
- the main issue was `/sbin/ldconfig -p` on Ubuntu 22.04 has an extra line at the end: "Cache generated by: ldconfig (Ubuntu GLIBC 2.35-0ubuntu3) stable release version 2.35"
  - this would result in an occasionaly segfault
- refactored the rest to avoid `strtok` (which is known to have a fair amount of problems) and consistently apply checking whether path exists

### `ldconfig -p` on Ubuntu 20.04

```console
$ /sbin/ldconfig -p
89 libs found in cache `/etc/ld.so.cache'
        libzstd.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libzstd.so.1
        libz.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libz.so.1
        ...
        ld-linux-x86-64.so.2 (libc6,x86-64) => /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
```

### `ldconfig -p` on Ubuntu 22.04

```console
$ /sbin/ldconfig -p
89 libs found in cache `/etc/ld.so.cache'
        libzstd.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libzstd.so.1
        libz.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libz.so.1
        ...
        ld-linux-x86-64.so.2 (libc6,x86-64) => /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
Cache generated by: ldconfig (Ubuntu GLIBC 2.35-0ubuntu3) stable release version 2.35
```
