### PR TITLE
handle ENDBR

### DIFF
--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -202,6 +202,8 @@ enum entryID : unsigned int {
   e_vdppd,	// SSE 4.1
   e_dpps,	// SSE 4.1
   e_emms,
+  e_endbr32,
+  e_endbr64,
   e_enter,
   e_enterq,
   e_extractps,	// SSE 4.1

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -978,6 +978,8 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vdppd, "vdppd")
   (e_dpps, "dpps")
   (e_emms, "emms")
+  (e_endbr32, "endbr32")
+  (e_endbr64, "endbr64")
   (e_enter, "enter")
   (e_extractps, "extractps")
   (e_extrq, "extrq")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,7 +110,7 @@ COPY . /code
 WORKDIR /opt/dyninst-env
 RUN . /opt/spack/share/spack/setup-env.sh && \
     spack env create -d . && \
-    echo "  concretization: together" >> spack.yaml && \
+    echo "  concretizer:\n    unify: true" >> spack.yaml && \
     spack env activate . && \
     spack add cmake@${CMAKE_VERSION} && \
     spack add perl@${PERL_VERSION} && \

--- a/instructionAPI/src/InstructionDecoder-x86.C
+++ b/instructionAPI/src/InstructionDecoder-x86.C
@@ -1797,7 +1797,17 @@ namespace Dyninst
                                     decodedInstruction->getPrefix(), locs, m_Arch);
                         return;
                 }
-            }
+            } else if (decodedInstruction->getPrefix()->getPrefix(0) == PREFIX_REP &&
+                        *(b.start+1) == (unsigned char)(0x0F) && *(b.start+2) == (unsigned char)(0x1E)) {
+                // handling ENDBR family
+                if (*(b.start+3) == (unsigned char)(0xFB)) {
+                    m_Operation = Operation(e_endbr32, entryNames_IAPI[e_endbr32], m_Arch);
+                    return;
+                } else if (*(b.start+3) == (unsigned char)(0xFA)) {
+                    m_Operation = Operation(e_endbr64, entryNames_IAPI[e_endbr64], m_Arch);
+                    return;
+                }
+            } 
             m_Operation = Operation(decodedInstruction->getEntry(),
                         decodedInstruction->getPrefix(), locs, m_Arch);
 


### PR DESCRIPTION
patch for handling ENDBR instructions

Known issue:
decoder->decode().format() would produce `endbr32 %ebx` and `endbr64 %edx`, but expecting `endbr32` and `endbr64`