### PR TITLE
handle ENDBR64

### DIFF
--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -202,6 +202,8 @@ enum entryID : unsigned int {
   e_vdppd,	// SSE 4.1
   e_dpps,	// SSE 4.1
   e_emms,
+  e_endbr32,
+  e_endbr64,
   e_enter,
   e_enterq,
   e_extractps,	// SSE 4.1

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -978,6 +978,8 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vdppd, "vdppd")
   (e_dpps, "dpps")
   (e_emms, "emms")
+  (e_endbr32, "endbr32")
+  (e_endbr64, "endbr64")
   (e_enter, "enter")
   (e_extractps, "extractps")
   (e_extrq, "extrq")

--- a/instructionAPI/src/InstructionDecoder-x86.C
+++ b/instructionAPI/src/InstructionDecoder-x86.C
@@ -1841,9 +1841,9 @@ namespace Dyninst
 
         if (decodedInstruction->getEntry()->getID() == e_ret_near ||
             decodedInstruction->getEntry()->getID() == e_ret_far) {
-            Expression::Ptr ret_addr = makeDereferenceExpression(makeRegisterExpression(is64BitMode ? x86_64::rsp : x86::esp),
+           Expression::Ptr ret_addr = makeDereferenceExpression(makeRegisterExpression(is64BitMode ? x86_64::rsp : x86::esp),
                                                                 is64BitMode ? u64 : u32);
-            insn_to_complete->addSuccessor(ret_addr, false, true, false, false);
+           insn_to_complete->addSuccessor(ret_addr, false, true, false, false);
 	    }
         if (insn_to_complete->getOperation().getID() == e_endbr32 ||
             insn_to_complete->getOperation().getID() == e_endbr64) {

--- a/instructionAPI/src/InstructionDecoder-x86.C
+++ b/instructionAPI/src/InstructionDecoder-x86.C
@@ -1797,7 +1797,17 @@ namespace Dyninst
                                     decodedInstruction->getPrefix(), locs, m_Arch);
                         return;
                 }
-            }
+            } else if (decodedInstruction->getPrefix()->getPrefix(0) == PREFIX_REP &&
+                        *(b.start+1) == (unsigned char)(0x0F) && *(b.start+2) == (unsigned char)(0x1E)) {
+                // handling ENDBR family
+                if (*(b.start+3) == (unsigned char)(0xFB)) {
+                    m_Operation = Operation(e_endbr32, entryNames_IAPI[e_endbr32], m_Arch);
+                    return;
+                } else if (*(b.start+3) == (unsigned char)(0xFA)) {
+                    m_Operation = Operation(e_endbr64, entryNames_IAPI[e_endbr64], m_Arch);
+                    return;
+                }
+            } 
             m_Operation = Operation(decodedInstruction->getEntry(),
                         decodedInstruction->getPrefix(), locs, m_Arch);
 
@@ -1831,10 +1841,15 @@ namespace Dyninst
 
         if (decodedInstruction->getEntry()->getID() == e_ret_near ||
             decodedInstruction->getEntry()->getID() == e_ret_far) {
-           Expression::Ptr ret_addr = makeDereferenceExpression(makeRegisterExpression(is64BitMode ? x86_64::rsp : x86::esp),
+            Expression::Ptr ret_addr = makeDereferenceExpression(makeRegisterExpression(is64BitMode ? x86_64::rsp : x86::esp),
                                                                 is64BitMode ? u64 : u32);
-           insn_to_complete->addSuccessor(ret_addr, false, true, false, false);
-	}
+            insn_to_complete->addSuccessor(ret_addr, false, true, false, false);
+	    }
+        if (insn_to_complete->getOperation().getID() == e_endbr32 ||
+            insn_to_complete->getOperation().getID() == e_endbr64) {
+            insn_to_complete->m_Operands.clear();
+            return true;
+        }
 
         for(int i = 0; i < 3; i++)
         {


### PR DESCRIPTION
Add support for endbr64 and endbr32 instructions, so they are parsed correctly instead of as nop instructions.

Fixes #1327.