### PR TITLE
Remove use of couts in the AMDGPU instruction decoders

### DIFF
--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
@@ -205,8 +205,6 @@ namespace Dyninst {
 			insn = insn_high = insn_long = 0;
 			useImm = false;
 			isCall = false;
-			if (!getenv("DEBUG_DECODE"))
-				cout.setstate(ios_base::badbit);
 		}
 		// here we assemble the first 64 bit (if available) as an instruction
 
@@ -220,7 +218,6 @@ namespace Dyninst {
 			imm_at_64 = get32bit(b,8);
 
 			insn_long = ( ((uint64_t) insn_high) << 32) | insn;
-            cout << " setup insn_long = " <<  std::hex << insn_long << endl;
 
 		}
 		void InstructionDecoder_amdgpu_cdna2::decodeOpcode(InstructionDecoder::buffer &b) {
@@ -230,9 +227,7 @@ namespace Dyninst {
 		}
 		
 		void InstructionDecoder_amdgpu_cdna2::debug_instr(){
-			cout << "decoded instruction " <<  insn_in_progress->getOperation().mnemonic << " " << std::hex << insn_long << " insn_family = " << instr_family 
-				<< "  length = " <<  insn_in_progress->size()<< endl << endl;
-
+		//	cout << "decoded instruction " <<  insn_in_progress->getOperation().mnemonic << " " << std::hex << insn_long << " insn_family = " << instr_family << "  length = " <<  insn_in_progress->size()<< endl << endl;
 		}
 
 		Instruction InstructionDecoder_amdgpu_cdna2::decode(InstructionDecoder::buffer &b) {
@@ -242,8 +237,6 @@ namespace Dyninst {
                 //cout << "Is Branch Instruction !! , name = " << insn_in_progress -> getOperation().mnemonic << endl;
 				//std::mem_fun(decode_lookup_table[instr_family])(this);
 			}
-			debug_instr();
-			cout.clear();
 			b.start += insn_in_progress->size();
 			return *insn_in_progress;
 		}
@@ -253,8 +246,6 @@ namespace Dyninst {
 			InstructionDecoder::buffer b(insn_to_complete->ptr(), insn_to_complete->size());
 			setupInsnWord(b);
 			mainDecode();
-			debug_instr();
-			cout.clear();
 			Instruction* iptr = const_cast<Instruction*>(insn_to_complete);
             *iptr = *(insn_in_progress.get());
 		}

--- a/instructionAPI/src/AMDGPU/vega/InstructionDecoder-amdgpu-vega.C
+++ b/instructionAPI/src/AMDGPU/vega/InstructionDecoder-amdgpu-vega.C
@@ -389,7 +389,6 @@ namespace Dyninst {
 		void InstructionDecoder_amdgpu_vega::finalizeVOP1Operands(){
 
 			layout_vop1 & layout = insn_layout.vop1;
-			//cout << " finalizing vop1 operands , vdst = " << std::dec << layout.vdst << " src0 = " << layout.src0 <<endl;
 
 			insn_in_progress->appendOperand(decodeVDST(layout.vdst),false,true);
 			insn_in_progress->appendOperand(decodeSSRC(layout.src0),true,false);
@@ -408,11 +407,9 @@ namespace Dyninst {
 							makeAmdgpuRegID(amdgpu_vega::sgpr0,layout.ssrc0,2)
 							);
 
-					// TODO : addSuccessors commented out to avoid jump table analysis aborts
 					if(insn_in_progress->getOperation().operationID == amdgpu_op_s_setpc_b64){
                         
                         //RegisterAST::Ptr tmpqq = boost::dynamic_pointer_cast<RegisterAST>(new_pc_ast);
-                        //std::cout << "setting pc to offset " << std::hex <<tmpqq->getID()<< std::endl; 
                         // non fall through branches are added as Successor
 						//insn_in_progress->appendOperand(new_pc_ast,true,false);
 					    insn_in_progress->addSuccessor(new_pc_ast, false, false, false, false);
@@ -452,7 +449,6 @@ namespace Dyninst {
 
 			if(isBranch){
 				if(!isModifyPC){	
-					//cout << "calling make branch target "<< endl;
 					makeBranchTarget(isCall,isConditional,layout.simm16);
 				}	
 
@@ -466,7 +462,6 @@ namespace Dyninst {
 
 			if(isBranch){
 				if(!isModifyPC){	
-					//cout << "calling make branch target "<< endl;
 
 					makeBranchTarget(isCall,isConditional,layout.simm16);
 				}	
@@ -516,9 +511,7 @@ namespace Dyninst {
 					offset_expr = layout.soe ? 
 						decodeSGPRorM0(layout.soffset) : Immediate::makeImmediate(Result(u64,0));
 				}
-				//                cout << "layout.sbase = " << std::hex << layout.sbase << endl;
 				//MachRegister mr = makeAmdgpuRegID(amdgpu_vega::sgpr0,4,2);
-				//                cout << " shouldn't it be " << amdgpu_vega::sgpr_vec2_0 << " " << mr << endl; 
 				Expression::Ptr sbase_expr = makeRegisterExpression(makeAmdgpuRegID(amdgpu_vega::sgpr0,layout.sbase << 1,2));
 				if(isScratch)
 					offset_expr = makeMultiplyExpression(offset_expr,
@@ -698,8 +691,6 @@ namespace Dyninst {
 			insn = insn_high = insn_long = 0;
 			useImm = false;
 			isCall = false;
-			if (!getenv("DEBUG_DECODE"))
-				cout.setstate(ios_base::badbit);
 		}
 		// here we assemble the first 64 bit (if available) as an instruction
 
@@ -721,9 +712,7 @@ namespace Dyninst {
 		}
 		
 		void InstructionDecoder_amdgpu_vega::debug_instr(){
-			cout << "\ndecoded instruction " <<  insn_in_progress->getOperation().mnemonic 
-				<< "  length = " <<  insn_in_progress->size()<< endl;
-
+			//cout << "\ndecoded instruction " <<  insn_in_progress->getOperation().mnemonic << "  length = " <<  insn_in_progress->size()<< endl;
 		}
 
 
@@ -733,8 +722,6 @@ namespace Dyninst {
 			if(entryToCategory(insn_in_progress->getOperation().getID())==c_BranchInsn){
 				std::mem_fun(decode_lookup_table[instr_family])(this);
 			}
-			debug_instr();
-			cout.clear();
 			b.start += insn_in_progress->size();
 			return *insn_in_progress;
 		}
@@ -743,8 +730,6 @@ namespace Dyninst {
 			InstructionDecoder::buffer b(insn_to_complete->ptr(), insn_to_complete->size());
 			setupInsnWord(b);
 			mainDecode(b);
-			//debug_instr();
-			cout.clear();
 			Instruction* iptr = const_cast<Instruction*>(insn_to_complete);
             *iptr = *(insn_in_progress.get());
 			b.start += insn_in_progress->size();


### PR DESCRIPTION
As title, remove the use of cout in the AMDGPU instruction decoders.
Debug information should be controlled by the debug_printfs, which is still missing for instructionAPI.