### PR TITLE
Insure intel 8 bit immediate values are interpreted correctly on other systems.

### DIFF
--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -10490,7 +10490,7 @@ static unsigned int ia32_decode_modrm(const unsigned int addrSzAttr, const unsig
    addr++;
 
    /* Get displacements we're going to use */
-   const char* disp8 = (const char*)addr;
+   const signed char* disp8 = (const signed char*)addr;
    const short* disp16 = (const short*)addr;
    const int* disp32 = (const int*)addr;
 
@@ -10675,7 +10675,7 @@ static unsigned int ia32_decode_modrm(const unsigned int addrSzAttr, const unsig
       }
 
       /* Update displacement pointers  */
-      disp8 = (const char*)addr;
+      disp8 = (const signed char*)addr;
       disp16 = (const short*)addr;
       disp32 = (const int*)addr;
 
@@ -10953,7 +10953,7 @@ unsigned int ia32_decode_operands (const ia32_prefixes& pref,
                nib += wordSzB * addrSzAttr;
                if(mac)
                {
-                  int offset = 0;
+                  long offset = 0;
                   switch(addrSzAttr)
                   {
                      case 1: // 16-bit offset
@@ -11744,7 +11744,7 @@ int displacement(const unsigned char *instr, unsigned type) {
       disp = *(const int *)(instr+2);
    } else if (type & IS_JUMP) {
       if (type & REL_B) {
-         disp = *(const char *)(instr+1);
+         disp = *(const signed char *)(instr+1);
       } else if (type & REL_W) {
          disp = *(const short *)(instr+1); // skip opcode
       } else if (type & REL_D) {
@@ -11752,7 +11752,7 @@ int displacement(const unsigned char *instr, unsigned type) {
       }
    } else if (type & IS_JCC) {
       if (type & REL_B) {
-         disp = *(const char *)(instr+1);
+         disp = *(const signed char *)(instr+1);
       } else if (type & REL_W) {
          disp = *(const short *)(instr+2); // skip two byte opcode
       } else if (type & REL_D) {

--- a/common/src/arch-x86.h
+++ b/common/src/arch-x86.h
@@ -48,7 +48,8 @@
 namespace NS_x86 {
 
 /* operand types */
-typedef char byte_t;   /* a byte operand */
+/* signed char required for correct immediate value interpretation */
+typedef signed char byte_t;   /* a byte operand */
 typedef short word_t;  /* a word (16-bit) operand */
 typedef int dword_t;   /* a double word (32-bit) operand */
 

--- a/instructionAPI/h/Result.h
+++ b/instructionAPI/h/Result.h
@@ -56,7 +56,8 @@ namespace Dyninst
         {
             unsigned char bitval : 1;
             unsigned char u8val;
-            char s8val;
+	    /* char can be signed or unsigned, must be signed for s8val */
+            signed char s8val;
             uint16_t u16val;
             int16_t s16val;
             uint32_t u24val:24;
@@ -132,7 +133,7 @@ namespace Dyninst
         };
         template < > struct Result_type2type<s8>
         {
-            typedef char type;
+            typedef signed char type;
         };
         template < > struct Result_type2type<u8>
         {


### PR DESCRIPTION
Intel 8 bit immediate values are signed.   They were being interpreted
as unsigned on power and arm due to char differences.   This PR
ensures 8 bit values related to x86 are interpreted correctly on other
systems.   This resolves issue #1372 which the Rice group had with
incorrect CFG interpretation cross-arch.   As well as other problems
such as normal immediate values being interpreted incorrectly.