### PR TITLE
Prevent fall-through analysis of amd gpu swap/set pc instructions.

### DIFF
--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -540,7 +540,10 @@ namespace Dyninst
                 case e_sysexit:
                 case e_call:
                 case e_syscall:
+                case amdgpu_op_s_setpc_b64:
                 case amdgpu_op_s_swappc_b64:
+                case amdgpu_cdna2_op_S_SETPC_B64:
+                case amdgpu_cdna2_op_S_SWAPPC_B64:
                     return false;
                 case e_jnb:
                 case e_jb:


### PR DESCRIPTION
Both amdgpu setpc and swappc instructions are _not_ fall-through
branch instructions.  We need to stop analysis at that instruction.

The CDNA2 (MI200) instructions of swappc and setpc were missing. 
 They have been added for similar fall-through prevention on that architecture.

This PR Resolves #1375 

