### PR TITLE
Allow CFG analysis based on instructionAPI alone w/out semantics.

### DIFF
--- a/dataflowAPI/src/SymEval.C
+++ b/dataflowAPI/src/SymEval.C
@@ -57,6 +57,9 @@
 
 #include "boost/tuple/tuple.hpp"
 
+/* once flag for the warning of unimplemented symbolic expansion */
+#include <mutex>
+
 using namespace std;
 using namespace Dyninst;
 using namespace InstructionAPI;
@@ -536,8 +539,14 @@ bool SymEval::expandInsn(const Instruction &insn,
                                    break;
                                }
         default:
-                               assert(0 && "Unimplemented symbolic expansion architecture");
-                               break;
+            /* once per arch would be better, but ... */
+            static std::once_flag arch_warning_flag;
+            std::call_once(arch_warning_flag, [&]{
+                cerr << "Unimplemented symbolic expansion architecture: " << insn.getArch() << endl;
+            }
+            );
+            return false;
+            break;
     }
 
     return true;


### PR DESCRIPTION
Dyninst can generate a CFG just based on instructions and decoding.

However, up to this point if a semantics package was not available
for an architecture, a non-semantics architecture would result in a panic.

With this change, a warning message, similar to the crash message, 
is output once to allow users to know that they aren't using semantic 
info, and relying only on instruction decoding.

Fixes #1377 