### PR TITLE
Remove trailing usage of cout.clear()

### DIFF
--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.C
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.C
@@ -261,7 +261,6 @@ namespace Dyninst {
 			InstructionDecoder::buffer b(insn_to_complete->ptr(), insn_to_complete->size());
 			setupInsnWord(b);
 			mainDecode();
-			cout.clear();
 			Instruction* iptr = const_cast<Instruction*>(insn_to_complete);
             *iptr = *(insn_in_progress.get());
 		}


### PR DESCRIPTION
As title.
This should have been removed when we've stopped using cout and its badbit as a way of outputting debug message, but it was overlooked.