### PR TITLE
explicitly include missing <array>

### DIFF
--- a/instructionAPI/src/InstructionDecoder-aarch64.h
+++ b/instructionAPI/src/InstructionDecoder-aarch64.h
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <array>
 #include "InstructionDecoderImpl.h"
 #include <iostream>
 #include "Immediate.h"


### PR DESCRIPTION
std::array is used in this file, but not included explicitly as on many systems this header is implicitly included recursively via another included file.  On new versions of headers this may no longer be the case, so explicitly include it.

I have not been able to reproduce this, but this seems to be the fix from the user provide issue.

Fixes #1378