### PR TITLE
Fix ambiguous override of InstructionDecoder_amdgpu_*::makeRegisterExpression

### DIFF
--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.C
@@ -162,7 +162,7 @@ namespace Dyninst {
         Expression::Ptr InstructionDecoder_amdgpu_cdna2::decodeOPR_WAITCNT(uint64_t input){
 		    return Immediate::makeImmediate(Result(s16, input));
         }
-        Expression::Ptr InstructionDecoder_amdgpu_cdna2::makeRegisterExpression(MachRegister registerID){
+        Expression::Ptr InstructionDecoder_amdgpu_cdna2::makeRegisterExpression(MachRegister registerID, uint32_t ){
             if(registerID == amdgpu_cdna2::src_literal){
                 return Immediate::makeImmediate(Result(u32,decodeOPR_LITERAL()));
             }

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.h
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.h
@@ -305,6 +305,7 @@ namespace Dyninst {
             Expression::Ptr decodeOPR_SIMM16(uint64_t input);
             Expression::Ptr decodeOPR_SIMM32(uint64_t input);
             Expression::Ptr decodeOPR_WAITCNT(uint64_t input);
+            using InstructionDecoderImpl::makeRegisterExpression;
             Expression::Ptr makeRegisterExpression(MachRegister registerID, uint32_t num_elements = 1);
             Expression::Ptr makeRegisterExpression(MachRegister registerID, uint32_t low , uint32_t high );
             void specialHandle();

--- a/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.h
+++ b/instructionAPI/src/AMDGPU/cdna2/InstructionDecoder-amdgpu-cdna2.h
@@ -305,8 +305,7 @@ namespace Dyninst {
             Expression::Ptr decodeOPR_SIMM16(uint64_t input);
             Expression::Ptr decodeOPR_SIMM32(uint64_t input);
             Expression::Ptr decodeOPR_WAITCNT(uint64_t input);
-            using InstructionDecoderImpl::makeRegisterExpression;
-            Expression::Ptr makeRegisterExpression(MachRegister registerID);
+            Expression::Ptr makeRegisterExpression(MachRegister registerID, uint32_t num_elements = 1);
             Expression::Ptr makeRegisterExpression(MachRegister registerID, uint32_t low , uint32_t high );
             void specialHandle();
             #include "amdgpu_cdna2_decoder_impl.h"    

--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.C
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.C
@@ -178,7 +178,7 @@ namespace Dyninst {
         Expression::Ptr InstructionDecoder_amdgpu_gfx908::decodeOPR_WAITCNT(uint64_t input){
 		    return Immediate::makeImmediate(Result(s16, input));
         }
-        Expression::Ptr InstructionDecoder_amdgpu_gfx908::makeRegisterExpression(MachRegister registerID){
+        Expression::Ptr InstructionDecoder_amdgpu_gfx908::makeRegisterExpression(MachRegister registerID, uint32_t ){
             if(registerID == amdgpu_gfx908::src_literal){
                 return Immediate::makeImmediate(Result(u32,decodeOPR_LITERAL()));
             }

--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
@@ -298,6 +298,7 @@ namespace Dyninst {
             Expression::Ptr decodeOPR_SIMM16(uint64_t input);
             Expression::Ptr decodeOPR_SIMM32(uint64_t input);
             Expression::Ptr decodeOPR_WAITCNT(uint64_t input);
+            using InstructionDecoderImpl::makeRegisterExpression;
             Expression::Ptr makeRegisterExpression(MachRegister registerID, uint32_t num_elements = 1);
             Expression::Ptr makeRegisterExpression(MachRegister registerID, uint32_t low , uint32_t high );
             void specialHandle();

--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
@@ -298,8 +298,7 @@ namespace Dyninst {
             Expression::Ptr decodeOPR_SIMM16(uint64_t input);
             Expression::Ptr decodeOPR_SIMM32(uint64_t input);
             Expression::Ptr decodeOPR_WAITCNT(uint64_t input);
-            using InstructionDecoderImpl::makeRegisterExpression;
-            Expression::Ptr makeRegisterExpression(MachRegister registerID);
+            Expression::Ptr makeRegisterExpression(MachRegister registerID, uint32_t num_elements = 1);
             Expression::Ptr makeRegisterExpression(MachRegister registerID, uint32_t low , uint32_t high );
             void specialHandle();
             #include "amdgpu_gfx908_decoder_impl.h"    


### PR DESCRIPTION
makeRegisterExpression in the derived class had
an incorrect function signature, which made
compilation fails on gcc-6 and clang.

Fix #1388 