### PR TITLE
Restore PPC special-purpose registers in opposite order of saving them

### DIFF
--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1003,6 +1003,8 @@ unsigned restoreSPRegisters(codeGen &gen,
 	fpscr_off = STK_FP_CR_64;
     }
 
+    restoreFPSCR(gen, 10, save_off + fpscr_off); num_restored++;
+
     registerSlot *regXER = (*(gen.rs()))[registerSpace::xer];
     assert (regXER != NULL);
     if (force_save || regXER->liveState == registerSlot::spilled)
@@ -1021,7 +1023,6 @@ unsigned restoreSPRegisters(codeGen &gen,
     {
     restoreCR(gen, 10, save_off + cr_off); num_restored++;
     }
-    restoreFPSCR(gen, 10, save_off + fpscr_off); num_restored++;
 
     return num_restored;
 }

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1003,11 +1003,11 @@ unsigned restoreSPRegisters(codeGen &gen,
 	fpscr_off = STK_FP_CR_64;
     }
 
-    registerSlot *regCR = (*(gen.rs()))[registerSpace::cr]; 
-    assert (regCR != NULL); 
-    if (force_save || regCR->liveState == registerSlot::spilled) 
+    registerSlot *regXER = (*(gen.rs()))[registerSpace::xer];
+    assert (regXER != NULL);
+    if (force_save || regXER->liveState == registerSlot::spilled)
     {
-    restoreCR(gen, 10, save_off + cr_off); num_restored++;
+    restoreSPR(gen, 10, SPR_XER, save_off + xer_off); num_restored++;
     }
     registerSlot *regCTR = (*(gen.rs()))[registerSpace::ctr]; 
     assert (regCTR != NULL); 
@@ -1015,11 +1015,11 @@ unsigned restoreSPRegisters(codeGen &gen,
     {
     restoreSPR(gen, 10, SPR_CTR, save_off + ctr_off); num_restored++;
     }
-    registerSlot *regXER = (*(gen.rs()))[registerSpace::xer]; 
-    assert (regXER != NULL); 
-    if (force_save || regXER->liveState == registerSlot::spilled) 
+    registerSlot *regCR = (*(gen.rs()))[registerSpace::cr];
+    assert (regCR != NULL);
+    if (force_save || regCR->liveState == registerSlot::spilled)
     {
-    restoreSPR(gen, 10, SPR_XER, save_off + xer_off); num_restored++;
+    restoreCR(gen, 10, save_off + cr_off); num_restored++;
     }
     restoreFPSCR(gen, 10, save_off + fpscr_off); num_restored++;
 


### PR DESCRIPTION
This is the same fix as for aarch64 (https://github.com/dyninst/dyninst/pull/1000), but for PowerPC. x86 does not have this issue.