### PR TITLE
enable compiler warnings in dataflowAPI

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -181,7 +181,7 @@ if(HAS_CPP_FLAG_Wframe_larger_than AND NOT DYNINST_DISABLE_DIAGNOSTIC_SUPPRESSIO
         else()
             set(debugMaxFrameSizeOverridePowerOpcodeTable 30000)
         endif()
-        set(nonDebugMaxFrameSizeOverridePowerOpcodeTable 38000)
+        set(nonDebugMaxFrameSizeOverridePowerOpcodeTable 39000)
         set(debugMaxFrameSizeOverrideFinalizeOperands 29000)
         set(nonDebugMaxFrameSizeOverrideFinalizeOperands 29000)
     endif()

--- a/common/h/compiler_diagnostics.h
+++ b/common/h/compiler_diagnostics.h
@@ -63,6 +63,8 @@
 //      DUPLICATED_BRANCHES
 //              similar to LOGICAL_OP except the expressions are the
 //              conditionals of a chain of if/then/else's. Only gcc 7-8.
+//      UNUSED_VARIABLE
+//              clang <10 warns about variables defined solely for RIAA (locks)
 //
 // Define DYNINST_DIAGNOSTIC_NO_SUPPRESSIONS to prevents suppressions.
 
@@ -85,6 +87,9 @@
  #define DYNINST_SUPPRESS_CODE_FLEX_ARRAY                  "-Wpedantic"
  #define DYNINST_SUPPRESS_CODE_VLA                         "-Wvla"
  #define DYNINST_SUPPRESS_CODE_VLA_EXTENSION               "-Wvla-extension"
+ #if __clang_major__ < 10
+  #define DYNINST_SUPPRESS_CODE_UNUSED_VARIABLE            "-Wunused-variable"
+ #endif
 #elif defined(_MSC_VER)
  #define DYNINST_SUPPRESS_CODE_FLEX_ARRAY                  4200
 #endif
@@ -134,6 +139,14 @@
 #else
  #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_DUPLICATED_BRANCHES
  #define DYNINST_DIAGNOSTIC_END_SUPPRESS_DUPLICATED_BRANCHES
+#endif
+
+#ifdef DYNINST_SUPPRESS_CODE_UNUSED_VARIABLE
+ #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_UNUSED_VARIABLE     DYNINST_DIAGNOSTIC_PUSH_SUPPRESS_CODE(UNUSED_VARIABLE)
+ #define DYNINST_DIAGNOSTIC_END_SUPPRESS_UNUSED_VARIABLE       DYNINST_DIAGNOSTIC_POP
+#else
+ #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_UNUSED_VARIABLE
+ #define DYNINST_DIAGNOSTIC_END_SUPPRESS_UNUSED_VARIABLE
 #endif
 
 // gcc <9, 11.0 and 11.1 (there may be others) have a bug where 'pragma

--- a/common/h/compiler_diagnostics.h
+++ b/common/h/compiler_diagnostics.h
@@ -47,6 +47,14 @@
 //
 //      FLEX_ARRAY
 //              warning about C flexible arrays in C++
+//      VLA
+//              warning about C VLAs (variable length arrays) in C++
+//      VLA_EXTENSION
+//              clang warning about C VLAs in C++ if VLA is suppressed
+//      VLA_ALL`
+//              both of the above
+//      VLA_GCC_PRAGMA_BUG
+//              gcc <9, 11.0, and 11.1 workaround macro
 //      LOGICAL_OP
 //              warning about duplicate subexpressions in a logical expression
 //              Is a false positive due compiler checks after macro/constant
@@ -66,6 +74,7 @@
 //
 #if defined(__GNUC__) && !defined(__clang__)
  #define DYNINST_SUPPRESS_CODE_FLEX_ARRAY                  "-Wpedantic"
+ #define DYNINST_SUPPRESS_CODE_VLA                         "-Wvla"
  #if __GNUC__ < 9
   #define DYNINST_SUPPRESS_CODE_LOGICAL_OP                 "-Wlogical-op"
  #endif
@@ -74,6 +83,8 @@
  #endif
 #elif defined(__clang__)
  #define DYNINST_SUPPRESS_CODE_FLEX_ARRAY                  "-Wpedantic"
+ #define DYNINST_SUPPRESS_CODE_VLA                         "-Wvla"
+ #define DYNINST_SUPPRESS_CODE_VLA_EXTENSION               "-Wvla-extension"
 #elif defined(_MSC_VER)
  #define DYNINST_SUPPRESS_CODE_FLEX_ARRAY                  4200
 #endif
@@ -86,6 +97,28 @@
  #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_FLEX_ARRAY
  #define DYNINST_DIAGNOSTIC_END_SUPPRESS_FLEX_ARRAY
 #endif
+
+#ifdef DYNINST_SUPPRESS_CODE_VLA
+ #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA             DYNINST_DIAGNOSTIC_PUSH_SUPPRESS_CODE(VLA)
+ #define DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA               DYNINST_DIAGNOSTIC_POP
+#else
+ #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA
+ #define DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA
+#endif
+
+#ifdef DYNINST_SUPPRESS_CODE_VLA_EXTENSION
+ #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA_EXTENSION   DYNINST_DIAGNOSTIC_PUSH_SUPPRESS_CODE(VLA_EXTENSION)
+ #define DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA_EXTENSION     DYNINST_DIAGNOSTIC_POP
+#else
+ #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA_EXTENSION
+ #define DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA_EXTENSION
+#endif
+
+#define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA_ALL          DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA_EXTENSION
+#define DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA_ALL            DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA_EXTENSION
+
+
+// Suppressions to work around compiler specific diagnostic bugs
 
 #ifdef DYNINST_SUPPRESS_CODE_LOGICAL_OP
  #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_LOGICAL_OP      DYNINST_DIAGNOSTIC_PUSH_SUPPRESS_CODE(LOGICAL_OP)
@@ -101,6 +134,17 @@
 #else
  #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_DUPLICATED_BRANCHES
  #define DYNINST_DIAGNOSTIC_END_SUPPRESS_DUPLICATED_BRANCHES
+#endif
+
+// gcc <9, 11.0 and 11.1 (there may be others) have a bug where 'pragma
+// diagnostic ignores' do not take affect until the next line, so this is a
+// workaround for the suppression and VLA are in the same macro
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 9 || __GNUC__ == 11 && __GNUC_MINOR__ < 2)
+ #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA_GCC_PRAGMA_BUG DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA
+ #define DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA_GCC_PRAGMA_BUG   DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA
+#else
+ #define DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA_GCC_PRAGMA_BUG
+ #define DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA_GCC_PRAGMA_BUG
 #endif
 
 

--- a/common/h/compiler_diagnostics.h
+++ b/common/h/compiler_diagnostics.h
@@ -66,6 +66,11 @@
 //      UNUSED_VARIABLE
 //              clang <10 warns about variables defined solely for RIAA (locks)
 //
+// Macros to silence unused variable warnings
+//
+//      DYNINST_SUPPRESS_UNUSED_VARIABLE(var)
+//              indicate that variable var OK to be unused
+//
 // Define DYNINST_DIAGNOSTIC_NO_SUPPRESSIONS to prevents suppressions.
 
 
@@ -199,5 +204,16 @@
 #define DYNINST_DIAGNOSTIC_PUSH_SUPPRESS(x)     DYNINST_DIAGNOSTIC_PUSH         \
                                                     DYNINST_DIAGNOSTIC_SUPPRESS(x)
 #define DYNINST_DIAGNOSTIC_PUSH_SUPPRESS_CODE(x) DYNINST_DIAGNOSTIC_PUSH_SUPPRESS(DYNINST_SUPPRESS_CODE_##x)
+
+
+// use the variable in a void expression to indicate use
+#ifndef DYNINST_DIAGNOSTIC_NO_SUPPRESSIONS
+ #define DYNINST_SUPPRESS_UNUSED_VARIABLE(var) (void)(var)
+#endif
+
+// if not defined, expand to nothing
+#ifndef DYNINST_SUPPRESS_UNUSED_VARIABLE
+ #define DYNINST_SUPPRESS_UNUSED_VARIABLE(var)
+#endif
 
 #endif /* COMPILER_DIAGNOSTICS_H */

--- a/dataflowAPI/rose/RegisterDescriptor.h
+++ b/dataflowAPI/rose/RegisterDescriptor.h
@@ -25,37 +25,37 @@ struct RegisterDescriptor {
 public:
     RegisterDescriptor()
             : majr(0), minr(0), offset(0), nbits(0) {}
-    RegisterDescriptor(unsigned majr, unsigned minr, unsigned offset, unsigned nbits)
-            : majr(majr), minr(minr), offset(offset), nbits(nbits) {}
+    RegisterDescriptor(unsigned majr_, unsigned minr_, unsigned offset_, unsigned nbits_)
+            : majr(majr_), minr(minr_), offset(offset_), nbits(nbits_) {}
     unsigned get_major() const {
         return majr;
     }
     bool is_valid() const {
         return nbits!=0;
     }
-    RegisterDescriptor &set_major(unsigned majr) {
-        this->majr = majr;
+    RegisterDescriptor &set_major(unsigned majr_) {
+        this->majr = majr_;
         return *this;
     }
     unsigned get_minor() const {
         return minr;
     }
-    RegisterDescriptor &set_minor(unsigned minr) {
-        this->minr = minr;
+    RegisterDescriptor &set_minor(unsigned minr_) {
+        this->minr = minr_;
         return *this;
     }
     unsigned get_offset() const {
         return offset;
     }
-    RegisterDescriptor &set_offset(unsigned offset) {
-        this->offset = offset;
+    RegisterDescriptor &set_offset(unsigned offset_) {
+        this->offset = offset_;
         return *this;
     }
     unsigned get_nbits() const {
         return nbits;
     }
-    RegisterDescriptor &set_nbits(unsigned nbits) {
-        this->nbits = nbits;
+    RegisterDescriptor &set_nbits(unsigned nbits_) {
+        this->nbits = nbits_;
         return *this;
     }
     bool operator<(const RegisterDescriptor &other) const;

--- a/dataflowAPI/rose/SgAsmExpression.h
+++ b/dataflowAPI/rose/SgAsmExpression.h
@@ -49,6 +49,8 @@ public:
 
     SgAsmExpression();
 
+    SgAsmExpression(const SgAsmExpression&) = default;
+
 protected:
     std::string p_replacement;
 
@@ -575,6 +577,8 @@ public:
 
 public:
     virtual ~SgAsmBinaryExpression();
+    SgAsmBinaryExpression& operator=(const SgAsmBinaryExpression&) = default;
+    SgAsmBinaryExpression(const SgAsmBinaryExpression&) = default;
 
 
 public:

--- a/dataflowAPI/rose/SgAsmType.h
+++ b/dataflowAPI/rose/SgAsmType.h
@@ -31,6 +31,7 @@ public:
 
 public:
     SgAsmNode();
+    SgAsmNode(const SgAsmNode &) = default;
 };
 
 //TODO: check for other members
@@ -62,6 +63,7 @@ public:
 
 public:
     SgAsmType();
+    SgAsmType(const SgAsmType &) = default;
 
 protected:
 

--- a/dataflowAPI/rose/SgNode.h
+++ b/dataflowAPI/rose/SgNode.h
@@ -11,6 +11,8 @@ class SgNode {
     virtual VariantT variantT() const = 0; // MS: new variant used in tree traversal    
     
     virtual ~SgNode() {}
+    SgNode() = default;
+    SgNode(const SgNode&) = default;
 
 };
 #endif

--- a/dataflowAPI/rose/SgNode.h
+++ b/dataflowAPI/rose/SgNode.h
@@ -10,7 +10,7 @@ class SgNode {
     /*! \brief returns new style SageIII enum values */
     virtual VariantT variantT() const = 0; // MS: new variant used in tree traversal    
     
-    virtual ~SgNode() {};
+    virtual ~SgNode() {}
 
 };
 #endif

--- a/dataflowAPI/rose/rangemap.h
+++ b/dataflowAPI/rose/rangemap.h
@@ -581,7 +581,7 @@ public:
      *  copying and then deleting other_value.
      *
      *  Returns true if merging occurred, false otherwise. */
-    bool merge(const Range &my_range, const Range &other_range, const RangeMapVoid &other_value) {
+    bool merge(const Range &my_range, const Range &other_range, const RangeMapVoid &/*other_value*/) {
         assert(!my_range.empty() && !other_range.empty());
         return true;
     }
@@ -595,7 +595,7 @@ public:
         return RangeMapVoid();
     }
 
-    void print(std::ostream &o) const {}
+    void print(std::ostream &/*o*/) const {}
     friend std::ostream& operator<<(std::ostream &o, const RangeMapVoid &x) {
         x.print(o);
         return o;

--- a/dataflowAPI/rose/semantics/BaseSemantics2.h
+++ b/dataflowAPI/rose/semantics/BaseSemantics2.h
@@ -1641,7 +1641,7 @@ namespace rose {
                         ASSERT_not_null(insn);
                         ASSERT_require(currentInsn_ == insn);
                         currentInsn_ = NULL;
-                    };
+                    }
 
 
                     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/dataflowAPI/rose/semantics/BaseSemantics2.h
+++ b/dataflowAPI/rose/semantics/BaseSemantics2.h
@@ -553,7 +553,7 @@ namespace rose {
                     // Normal, protected, C++ constructors
                 protected:
                     explicit SValue(size_t nbits) : width(nbits) { }  // hot
-                    SValue(const SValue &other) : width(other.width) { }
+                    SValue(const SValue &other) : SharedObject(other), width(other.width) { }
 
                 public:
                     /** Shared-ownership pointer for an @ref SValue object. See @ref heap_object_shared_ownership. */
@@ -1167,7 +1167,8 @@ namespace rose {
 
                     // deep-copy the registers and memory
                     State(const State &other)
-                            : protoval_(other.protoval_) {
+                            : boost::enable_shared_from_this<State>(other),
+                              protoval_(other.protoval_) {
                         registers_ = other.registers_->clone();
                         memory_ = other.memory_->clone();
                     }

--- a/dataflowAPI/rose/semantics/BaseSemantics2.h
+++ b/dataflowAPI/rose/semantics/BaseSemantics2.h
@@ -416,7 +416,7 @@ namespace rose {
                     Formatter &fmt;
                     std::string old_line_prefix;
                 public:
-                    Indent(Formatter &fmt) : fmt(fmt) {
+                    Indent(Formatter &fmt_) : fmt(fmt_) {
                         old_line_prefix = fmt.get_line_prefix();
                         fmt.set_line_prefix(old_line_prefix + fmt.get_indentation_suffix());
                     }
@@ -461,16 +461,16 @@ namespace rose {
                 public:
                     SgAsmInstruction *insn;
 
-                    Exception(const std::string &mesg, SgAsmInstruction *insn) : std::runtime_error(mesg),
-                                                                                 insn(insn) { }
+                    Exception(const std::string &mesg, SgAsmInstruction *insn_) : std::runtime_error(mesg),
+                                                                                 insn(insn_) { }
 
                     void print(std::ostream &) const;
                 };
 
                 class NotImplemented : public Exception {
                 public:
-                    NotImplemented(const std::string &mesg, SgAsmInstruction *insn)
-                            : Exception(mesg, insn) { }
+                    NotImplemented(const std::string &mesg, SgAsmInstruction *insn_)
+                            : Exception(mesg, insn_) { }
                 };
 
 
@@ -723,7 +723,7 @@ namespace rose {
                         SValuePtr obj;
                         Formatter &fmt;
                     public:
-                        WithFormatter(const SValuePtr &svalue, Formatter &fmt) : obj(svalue), fmt(fmt) { }
+                        WithFormatter(const SValuePtr &svalue, Formatter &fmt_) : obj(svalue), fmt(fmt_) { }
 
                         void print(std::ostream &stream) const { obj->print(stream, fmt); }
                     };
@@ -774,8 +774,8 @@ namespace rose {
                     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                     // Real constructors
                 protected:
-                    RegisterState(const SValuePtr &protoval, const RegisterDictionary *regdict)
-                            : protoval_(protoval), regdict(regdict) {
+                    RegisterState(const SValuePtr &protoval, const RegisterDictionary *regdict_)
+                            : protoval_(protoval), regdict(regdict_) {
                         ASSERT_not_null(protoval_);
                     }
 
@@ -906,7 +906,7 @@ namespace rose {
                         RegisterStatePtr obj;
                         Formatter &fmt;
                     public:
-                        WithFormatter(const RegisterStatePtr &obj, Formatter &fmt) : obj(obj), fmt(fmt) { }
+                        WithFormatter(const RegisterStatePtr &obj_, Formatter &fmt_) : obj(obj_), fmt(fmt_) { }
 
                         void print(std::ostream &stream) const { obj->print(stream, fmt); }
                     };
@@ -1105,7 +1105,7 @@ namespace rose {
                         MemoryStatePtr obj;
                         Formatter &fmt;
                     public:
-                        WithFormatter(const MemoryStatePtr &obj, Formatter &fmt) : obj(obj), fmt(fmt) { }
+                        WithFormatter(const MemoryStatePtr &obj_, Formatter &fmt_) : obj(obj_), fmt(fmt_) { }
 
                         void print(std::ostream &stream) const { obj->print(stream, fmt); }
                     };
@@ -1345,7 +1345,7 @@ namespace rose {
                         StatePtr obj;
                         Formatter &fmt;
                     public:
-                        WithFormatter(const StatePtr &obj, Formatter &fmt) : obj(obj), fmt(fmt) { }
+                        WithFormatter(const StatePtr &obj_, Formatter &fmt_) : obj(obj_), fmt(fmt_) { }
 
                         void print(std::ostream &stream) const { obj->print(stream, fmt); }
                     };
@@ -1587,7 +1587,7 @@ namespace rose {
                         RiscOperatorsPtr obj;
                         Formatter &fmt;
                     public:
-                        WithFormatter(const RiscOperatorsPtr &obj, Formatter &fmt) : obj(obj), fmt(fmt) { }
+                        WithFormatter(const RiscOperatorsPtr &obj_, Formatter &fmt_) : obj(obj_), fmt(fmt_) { }
 
                         void print(std::ostream &stream) const { obj->print(stream, fmt); }
                     };
@@ -2263,8 +2263,8 @@ namespace rose {
                         return regdict;
                     }
 
-                    virtual void set_register_dictionary(const RegisterDictionary *regdict) {
-                        this->regdict = regdict;
+                    virtual void set_register_dictionary(const RegisterDictionary *regdict_) {
+                        this->regdict = regdict_;
                     }
                     /** @} */
 

--- a/dataflowAPI/rose/semantics/BinarySymbolicExpr.h
+++ b/dataflowAPI/rose/semantics/BinarySymbolicExpr.h
@@ -1343,7 +1343,7 @@ namespace rose {
                     }
                 }
 
-                VisitAction postVisit(const Ptr &node) {
+                VisitAction postVisit(const Ptr &/*node*/) {
                     return CONTINUE;
                 }
             } visitor;

--- a/dataflowAPI/rose/semantics/BinarySymbolicExpr.h
+++ b/dataflowAPI/rose/semantics/BinarySymbolicExpr.h
@@ -533,7 +533,7 @@ namespace rose {
                 Ptr node;
                 Formatter &formatter;
             public:
-                WithFormatter(const Ptr &node, Formatter &formatter) : node(node), formatter(formatter) { }
+                WithFormatter(const Ptr &node_, Formatter &formatter_) : node(node_), formatter(formatter_) { }
 
                 void print(std::ostream &stream) const { node->print(stream, formatter); }
             };
@@ -764,19 +764,19 @@ namespace rose {
         struct ShiftSimplifier : Simplifier {
             bool newbits;
 
-            ShiftSimplifier(bool newbits) : newbits(newbits) { }
+            ShiftSimplifier(bool newbits_) : newbits(newbits_) { }
 
             Ptr combine_strengths(Ptr strength1, Ptr strength2, size_t value_width) const;
         };
 
         struct ShlSimplifier : ShiftSimplifier {
-            ShlSimplifier(bool newbits) : ShiftSimplifier(newbits) { }
+            ShlSimplifier(bool newbits_) : ShiftSimplifier(newbits_) { }
 
             virtual Ptr rewrite(Interior *) const;
         };
 
         struct ShrSimplifier : ShiftSimplifier {
-            ShrSimplifier(bool newbits) : ShiftSimplifier(newbits) { }
+            ShrSimplifier(bool newbits_) : ShiftSimplifier(newbits_) { }
 
             virtual Ptr rewrite(Interior *) const;
         };

--- a/dataflowAPI/rose/semantics/Registers.h
+++ b/dataflowAPI/rose/semantics/Registers.h
@@ -51,9 +51,6 @@ public:
 
     RegisterDictionary(const std::string &name_)
         :name(name_) {}
-    RegisterDictionary(const RegisterDictionary& other) {
-        *this = other;
-    }
 
     /** Obtain the name of the dictionary. */
     const std::string &get_architecture_name() const {

--- a/dataflowAPI/rose/semantics/Registers.h
+++ b/dataflowAPI/rose/semantics/Registers.h
@@ -49,8 +49,8 @@ public:
     static const RegisterDictionary *dictionary_amdgpu_vega();                // ARMv8-A architecture
     static const RegisterDictionary *dictionary_powerpc();
 
-    RegisterDictionary(const std::string &name)
-        :name(name) {}
+    RegisterDictionary(const std::string &name_)
+        :name(name_) {}
     RegisterDictionary(const RegisterDictionary& other) {
         *this = other;
     }
@@ -62,8 +62,8 @@ public:
 
     /** Set the name of the dictionary. Dictionary names are generally architecture names.  Dictionaries created by one of the
      *  built-in static methods of this class have the same name as the method that created it. */
-    void set_architecture_name(const std::string &name) {
-        this->name = name;
+    void set_architecture_name(const std::string &name_) {
+        this->name = name_;
     }
 
     /** Insert a definition into the dictionary.  If the name already exists in the dictionary then the new RegisterDescriptor

--- a/dataflowAPI/rose/semantics/SMTSolver.h
+++ b/dataflowAPI/rose/semantics/SMTSolver.h
@@ -75,7 +75,7 @@ namespace rose {
             virtual SymbolicExpr::Ptr evidence_for_variable(uint64_t varno) {
                 char buf[64];
                 //FIXME
-                snprintf(buf, sizeof(buf), "v%llu"/*PRIu64*/, varno);
+                snprintf(buf, sizeof(buf), "v%" PRIu64, varno);
                 return evidence_for_name(buf);
             }
 

--- a/dataflowAPI/rose/semantics/SMTSolver.h
+++ b/dataflowAPI/rose/semantics/SMTSolver.h
@@ -141,7 +141,7 @@ namespace rose {
 
             /** Parses evidence of satisfiability.  Some solvers can emit information about what variable bindings satisfy the
              *  expression.  This information is parsed by this function and added to a mapping of variable to value. */
-            virtual void parse_evidence() { };
+            virtual void parse_evidence() { }
 
             /** Additional output obtained by satisfiable(). */
             std::string output_text;

--- a/dataflowAPI/rose/semantics/SMTSolver.h
+++ b/dataflowAPI/rose/semantics/SMTSolver.h
@@ -19,7 +19,7 @@ namespace rose {
         class SMTSolver {
         public:
             struct Exception {
-                Exception(const std::string &mesg) : mesg(mesg) { }
+                Exception(const std::string &mesg_) : mesg(mesg_) { }
 
                 friend std::ostream &operator<<(std::ostream &, const SMTSolver::Exception &);
 

--- a/dataflowAPI/rose/semantics/SymEvalSemantics.h
+++ b/dataflowAPI/rose/semantics/SymEvalSemantics.h
@@ -63,12 +63,12 @@ namespace rose {
                         return SValuePtr(new SValue(32, nbits));
                     }
 
-                    virtual BaseSemantics::SValuePtr unspecified_(size_t nbits) const {
+                    virtual BaseSemantics::SValuePtr unspecified_(size_t /*nbits*/) const {
                         return SValuePtr(new SValue(Dyninst::DataflowAPI::BottomAST::create(false)));
                     }
 
                     //TODO
-                    virtual BaseSemantics::SValuePtr bottom_(size_t nbits) const {
+                    virtual BaseSemantics::SValuePtr bottom_(size_t /*nbits*/) const {
                         return SValuePtr(new SValue(Dyninst::DataflowAPI::BottomAST::create(true)));
                     }
 
@@ -88,7 +88,7 @@ namespace rose {
                     }
 
                     virtual Sawyer::Optional<BaseSemantics::SValuePtr>
-                            createOptionalMerge(const BaseSemantics::SValuePtr &other, const BaseSemantics::MergerPtr&, SMTSolver*) const {
+                            createOptionalMerge(const BaseSemantics::SValuePtr &/*other*/, const BaseSemantics::MergerPtr&, SMTSolver*) const {
                         ASSERT_not_implemented("SValue::createOptionalMerge not implemented for use in dyninst");
                     }
 
@@ -174,7 +174,7 @@ namespace rose {
 
                     virtual void print(std::ostream &, BaseSemantics::Formatter &) const {}
 
-                    virtual bool merge(const BaseSemantics::RegisterStatePtr &other, BaseSemantics::RiscOperators *ops) {
+                    virtual bool merge(const BaseSemantics::RegisterStatePtr &/*other*/, BaseSemantics::RiscOperators * /*ops*/) {
                         return true;
                     }
 
@@ -316,7 +316,7 @@ namespace rose {
                         //
                     }
 
-                    virtual bool merge(const BaseSemantics::MemoryStatePtr &other, BaseSemantics::RiscOperators *addrOps, BaseSemantics::RiscOperators *valOps) {
+                    virtual bool merge(const BaseSemantics::MemoryStatePtr &/*other*/, BaseSemantics::RiscOperators * /*addrOps*/, BaseSemantics::RiscOperators * /*valOps*/) {
                         return true;
                     }
 

--- a/dataflowAPI/rose/semantics/SymEvalSemantics.h
+++ b/dataflowAPI/rose/semantics/SymEvalSemantics.h
@@ -347,7 +347,7 @@ namespace rose {
                                Dyninst::Architecture ac,
                                Dyninst::InstructionAPI::Instruction insn_,
                                const BaseSemantics::RegisterStatePtr &registers,
-                               const BaseSemantics::MemoryStatePtr &memory): BaseSemantics::State(registers, memory), res(r), addr(a), arch(ac), insn(insn_) {
+                               const BaseSemantics::MemoryStatePtr &memory): BaseSemantics::State(registers, memory), res(r), arch(ac), addr(a), insn(insn_) {
                         for (Dyninst::DataflowAPI::Result_t::iterator iter = r.begin();
                              iter != r.end(); ++iter) {
                             Dyninst::Assignment::Ptr a = iter->first;

--- a/dataflowAPI/rose/semantics/SymEvalSemantics.h
+++ b/dataflowAPI/rose/semantics/SymEvalSemantics.h
@@ -33,12 +33,12 @@ namespace rose {
                         expr = Dyninst::DataflowAPI::ConstantAST::create(Dyninst::DataflowAPI::Constant(num, nbits));
                     }
 
-                    SValue(Dyninst::AST::Ptr expr): BaseSemantics::SValue(64) {
-                        this->expr = expr;
+                    SValue(Dyninst::AST::Ptr expr_): BaseSemantics::SValue(64) {
+                        this->expr = expr_;
                     }
                     // Added this version to set register size according to descriptor 
-                    SValue(Dyninst::AST::Ptr expr, size_t nbits ): BaseSemantics::SValue(nbits) {
-                        this->expr = expr;
+                    SValue(Dyninst::AST::Ptr expr_, size_t nbits ): BaseSemantics::SValue(nbits) {
+                        this->expr = expr_;
                     }
                 public:
                     static SValuePtr instance(Dyninst::Absloc r, Dyninst::Address addr) {
@@ -137,7 +137,7 @@ namespace rose {
                 class RegisterStateAST : public BaseSemantics::RegisterState {
                 public:
                     RegisterStateAST(const BaseSemantics::SValuePtr &protoval,
-                                     const RegisterDictionary *regdict) : RegisterState(protoval, regdict) { }
+                                     const RegisterDictionary *regdict_) : RegisterState(protoval, regdict_) { }
 
                 public:
                     static RegisterStateASTPtr instance(const BaseSemantics::SValuePtr &protoval,
@@ -146,8 +146,8 @@ namespace rose {
                     }
 
                     virtual BaseSemantics::RegisterStatePtr create(const BaseSemantics::SValuePtr &protoval,
-                                                                   const RegisterDictionary *regdict) const {
-                        return instance(protoval, regdict);
+                                                                   const RegisterDictionary *regdict_) const {
+                        return instance(protoval, regdict_);
                     }
 
                     virtual BaseSemantics::RegisterStatePtr clone() const {
@@ -194,7 +194,7 @@ namespace rose {
 		class RegisterStateASTARM64 : public RegisterStateAST {
 		public:
 		    RegisterStateASTARM64(const BaseSemantics::SValuePtr &protoval,
-                                          const RegisterDictionary *regdict) : RegisterStateAST(protoval, regdict) { }
+                                          const RegisterDictionary *regdict_) : RegisterStateAST(protoval, regdict_) { }
 
                     static RegisterStateASTARM64Ptr instance(const BaseSemantics::SValuePtr &protoval,
                                                              const RegisterDictionary *regdict) {
@@ -214,7 +214,7 @@ namespace rose {
 		class RegisterStateASTPPC32 : public RegisterStateAST {
 		public:
 		    RegisterStateASTPPC32(const BaseSemantics::SValuePtr &protoval,
-                                          const RegisterDictionary *regdict) : RegisterStateAST(protoval, regdict) { }
+                                          const RegisterDictionary *regdict_) : RegisterStateAST(protoval, regdict_) { }
 
                     static RegisterStateASTPPC32Ptr instance(const BaseSemantics::SValuePtr &protoval,
                                                              const RegisterDictionary *regdict) {
@@ -233,7 +233,7 @@ namespace rose {
 		class RegisterStateASTPPC64 : public RegisterStateAST {
 		public:
 		    RegisterStateASTPPC64(const BaseSemantics::SValuePtr &protoval,
-                                          const RegisterDictionary *regdict) : RegisterStateAST(protoval, regdict) { }
+                                          const RegisterDictionary *regdict_) : RegisterStateAST(protoval, regdict_) { }
 
                     static RegisterStateASTPPC64Ptr instance(const BaseSemantics::SValuePtr &protoval,
                                                              const RegisterDictionary *regdict) {
@@ -258,7 +258,7 @@ namespace rose {
 		class RegisterStateAST_AMDGPU_VEGA : public RegisterStateAST {
 		public:
 		    RegisterStateAST_AMDGPU_VEGA(const BaseSemantics::SValuePtr &protoval,
-                                          const RegisterDictionary *regdict) : RegisterStateAST(protoval, regdict) { }
+                                          const RegisterDictionary *regdict_) : RegisterStateAST(protoval, regdict_) { }
 
                     static RegisterStateAST_AMDGPU_VEGA_Ptr instance(const BaseSemantics::SValuePtr &protoval,
                                                              const RegisterDictionary *regdict) {
@@ -350,21 +350,21 @@ namespace rose {
                                const BaseSemantics::MemoryStatePtr &memory): BaseSemantics::State(registers, memory), res(r), arch(ac), addr(a), insn(insn_) {
                         for (Dyninst::DataflowAPI::Result_t::iterator iter = r.begin();
                              iter != r.end(); ++iter) {
-                            Dyninst::Assignment::Ptr a = iter->first;
+                            Dyninst::Assignment::Ptr ap = iter->first;
                             // For a different instruction...
-                            if (a->addr() != addr)
+                            if (ap->addr() != addr)
                                 continue;
-                            Dyninst::AbsRegion &o = a->out();
+                            Dyninst::AbsRegion &o = ap->out();
 
                             if (o.containsOfType(Dyninst::Absloc::Register)) {
                                 // We're assuming this is a single register...
-                                //std::cerr << "Marking register " << a << std::endl;
-                                aaMap[o.absloc()] = a;
+                                //std::cerr << "Marking register " << ap << std::endl;
+                                aaMap[o.absloc()] = ap;
                             }
                             else {
                                 // Use sufficiently-unique (Heap,0) Absloc
                                 // to represent a definition to a memory absloc
-                                aaMap[Dyninst::Absloc(0)] = a;
+                                aaMap[Dyninst::Absloc(0)] = ap;
                             }
                         }
                     }

--- a/dataflowAPI/rose/semantics/SymEvalSemantics.h
+++ b/dataflowAPI/rose/semantics/SymEvalSemantics.h
@@ -379,6 +379,7 @@ namespace rose {
                         return StateASTPtr(new StateAST(r, a, ac, insn_, registers, memory));
                     }
 
+                    using BaseSemantics::State::create;
                     virtual BaseSemantics::StatePtr create(Dyninst::DataflowAPI::Result_t &r,
                                                  Dyninst::Address a,
                                                  Dyninst::Architecture ac,
@@ -397,6 +398,7 @@ namespace rose {
                 public:
                     virtual BaseSemantics::SValuePtr readRegister(const RegisterDescriptor &reg, const BaseSemantics::SValuePtr &dflt, BaseSemantics::RiscOperators *ops);
                     virtual void writeRegister(const RegisterDescriptor &reg, const BaseSemantics::SValuePtr &value, BaseSemantics::RiscOperators *ops);
+                    using BaseSemantics::State::readMemory;
                     virtual BaseSemantics::SValuePtr readMemory(const BaseSemantics::SValuePtr &address, const BaseSemantics::SValuePtr &dflt,
                                                                 BaseSemantics::RiscOperators *addrOps, BaseSemantics::RiscOperators *valOps, size_t readSize = 0);
                     virtual void writeMemory(const BaseSemantics::SValuePtr &addr, const BaseSemantics::SValuePtr &value, BaseSemantics::RiscOperators *addrOps,

--- a/dataflowAPI/rose/util/BitVectorSupport.h
+++ b/dataflowAPI/rose/util/BitVectorSupport.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA_GCC_PRAGMA_BUG
+
 namespace Sawyer {
 namespace Container {
 
@@ -1449,4 +1451,7 @@ void fromBinary(Word *vec, const BitRange &range, const std::string &input) {
 } // namespace
 } // namespace
 } // namespace
+
+DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA_GCC_PRAGMA_BUG
+
 #endif

--- a/dataflowAPI/rose/util/BitVectorSupport.h
+++ b/dataflowAPI/rose/util/BitVectorSupport.h
@@ -1051,7 +1051,7 @@ void negate(Word *vec1, const BitRange &range) {
 template<class Word>
 struct AddBits {
     bool carry;
-    AddBits(bool carry): carry(carry) {}
+    AddBits(bool carry_): carry(carry_) {}
     bool operator()(const Word &w1, Word &w2, size_t nbits) {
         Word mask = bitMask<Word>(0, nbits);
         Word addend1(carry ? 1 : 0);

--- a/dataflowAPI/rose/util/IntervalMap.h
+++ b/dataflowAPI/rose/util/IntervalMap.h
@@ -46,7 +46,7 @@ public:
      *
      *  The @p rightValue is merged into the @p leftValue if possible, or this method returns false without changing either
      *  value.  After a successful merge, the @p rightValue will be removed from the IntervalMap and its destructor called. */
-    bool merge(const Interval &leftInterval, Value &leftValue, const Interval &rightInterval, Value &rightValue) {
+    bool merge(const Interval &/*leftInterval*/, Value &leftValue, const Interval &/*rightInterval*/, Value &rightValue) {
         return leftValue == rightValue;
     }
 
@@ -56,13 +56,13 @@ public:
      *  splitPoint argument is the split point and becomes the least value of the right interval. The @p value argument is
      *  modified in place to become the left value, and the right value is returned. This method is only invoked when the
      *  result would be two non-empty intervals. */
-    Value split(const Interval &interval, Value &value, const typename Interval::Value &splitPoint) { return value; }
+    Value split(const Interval &/*interval*/, Value &value, const typename Interval::Value &/*splitPoint*/) { return value; }
 
     /** Discard the right part of a value.
      *
      *  This method is the same as @ref split except the right part of the resulting value is discarded.  This is sometimes
      *  more efficient than calling @ref split and then destroying the return value. */
-    void truncate(const Interval &interval, Value &value, const typename Interval::Value &splitPoint) {}
+    void truncate(const Interval &/*interval*/, Value &/*value*/, const typename Interval::Value &/*splitPoint*/) {}
 };
 
 /** An associative container whose keys are non-overlapping intervals.

--- a/dataflowAPI/rose/util/IntervalSet.h
+++ b/dataflowAPI/rose/util/IntervalSet.h
@@ -342,7 +342,7 @@ public:
      *
      * @{ */
     template<class Interval2>
-    bool isDistinct(const Interval2 &interval) const {
+    bool isDistinct(const Interval2 &/*interval*/) const {
         return !isOverlapping();
     }
 

--- a/dataflowAPI/rose/util/Map.h
+++ b/dataflowAPI/rose/util/Map.h
@@ -128,7 +128,6 @@ public:
         typedef                BidirectionalIterator<NodeIterator, Node, typename StlMap::iterator> Super;
     public:
         NodeIterator() {}
-        NodeIterator(const NodeIterator &other): Super(other) {}
         // std::map stores std::pair nodes, but we want to return Node, which must have the same layout.
         Node& operator*() const { return *(Node*)&*this->base_; }
         Node* operator->() const { return (Node*)&*this->base_; }

--- a/dataflowAPI/rose/util/Map.h
+++ b/dataflowAPI/rose/util/Map.h
@@ -100,7 +100,13 @@ public:
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 private:
     template<class Derived, class Value, class BaseIterator>
-    class BidirectionalIterator: public std::iterator<std::bidirectional_iterator_tag, Value> {
+    class BidirectionalIterator {
+    public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = Value;
+        using difference_type = std::ptrdiff_t;
+        using pointer = value_type*;
+        using reference = value_type&;
     protected:
         BaseIterator base_;
         BidirectionalIterator() {}

--- a/dataflowAPI/rose/util/Optional.h
+++ b/dataflowAPI/rose/util/Optional.h
@@ -300,13 +300,13 @@ public:
 //    if (x && *x == y) // what they really meant
 //    if (x.isEqual(y)) // another valid way to write it
 template<typename T, typename U>
-bool operator==(const Optional<T> &lhs, const U &rhs) {
+bool operator==(const Optional<T> &lhs, const U &/*rhs*/) {
     lhs.this_type_does_not_support_comparisons();
     return false;
 }
 
 template<typename T, typename U>
-bool operator!=(const Optional<T> &lhs, const U &rhs) {
+bool operator!=(const Optional<T> &lhs, const U &/*rhs*/) {
     lhs.this_type_does_not_support_comparisons();
     return false;
 }

--- a/dataflowAPI/rose/util/PoolAllocator.h
+++ b/dataflowAPI/rose/util/PoolAllocator.h
@@ -108,7 +108,7 @@ private:
         const Chunk *chunk;
         size_t nUsed;
         ChunkInfo(): chunk(NULL), nUsed(0) {}
-        ChunkInfo(const Chunk *chunk, size_t nUsed): chunk(chunk), nUsed(nUsed) {}
+        ChunkInfo(const Chunk *chunk_, size_t nUsed_): chunk(chunk_), nUsed(nUsed_) {}
         bool operator==(const ChunkInfo &other) const {
             return chunk==other.chunk && nUsed==other.nUsed;
         }
@@ -192,7 +192,7 @@ private:
             if (!freeLists_[freeListIdx]) {
                 Chunk *chunk = new Chunk;
                 freeLists_[freeListIdx] = chunk->fill(cellSize_);
-                SAWYER_THREAD_TRAITS::LockGuard lock(chunkMutex_);
+                SAWYER_THREAD_TRAITS::LockGuard chunkLock(chunkMutex_);
                 chunks_.push_back(chunk);
             }
             ASSERT_not_null(freeLists_[freeListIdx]);

--- a/dataflowAPI/rose/util/PoolAllocator.h
+++ b/dataflowAPI/rose/util/PoolAllocator.h
@@ -180,6 +180,8 @@ private:
                 delete *ci;
         }
 
+DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_UNUSED_VARIABLE
+
         bool isEmpty() const {
             SAWYER_THREAD_TRAITS::LockGuard lock(chunkMutex_);
             return chunks_.empty();
@@ -211,6 +213,8 @@ private:
             freedCell->next = freeLists_[freeListIdx];
             freeLists_[freeListIdx] = freedCell;
         }
+
+DYNINST_DIAGNOSTIC_END_SUPPRESS_UNUSED_VARIABLE
 
         // Information about each chunk.
         ChunkInfoMap chunkInfoNS() const {

--- a/dataflowAPI/rose/util/Sawyer.h
+++ b/dataflowAPI/rose/util/Sawyer.h
@@ -464,8 +464,9 @@ SAWYER_EXPORT std::string generateSequentialName(size_t length=3);
 // causes the initialization to happen as early as possible after the C++ runtime.
 # define SAWYER_STATIC_INIT __attribute__((init_priority(101)))
 
+#include "compiler_diagnostics.h"
 # define SAWYER_VARIABLE_LENGTH_ARRAY(TYPE, NAME, SIZE) \
-    TYPE NAME[SIZE];
+    DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_VLA_ALL TYPE NAME[SIZE]; DYNINST_DIAGNOSTIC_END_SUPPRESS_VLA_ALL
 
 #endif
 

--- a/dataflowAPI/rose/util/Set.h
+++ b/dataflowAPI/rose/util/Set.h
@@ -83,7 +83,7 @@ public:
 
     template<class InputIterator>
     explicit Set(const boost::iterator_range<InputIterator> &range,
-                 const Comparator &comparator = Comparator(), const Allocator &allocator = Allocator())
+                 const Comparator &/*comparator*/ = Comparator(), const Allocator &/*allocator*/ = Allocator())
         : set_(range.begin(), range.end()) {}
     /** @} */
 

--- a/dataflowAPI/rose/util/SharedPointer.h
+++ b/dataflowAPI/rose/util/SharedPointer.h
@@ -353,6 +353,8 @@ public:
 //                                      Implementations
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_UNUSED_VARIABLE
+
 template<class T>
 inline size_t SharedPointer<T>::ownershipCount(T *rawPtr) {
     if (rawPtr) {
@@ -380,6 +382,8 @@ inline size_t SharedPointer<T>::releaseOwnership(Pointee *rawPtr) {
         return 0;
     }
 }
+
+DYNINST_DIAGNOSTIC_END_SUPPRESS_UNUSED_VARIABLE
 
 } // namespace
 #endif

--- a/dataflowAPI/rose/x86InstructionSemantics.h
+++ b/dataflowAPI/rose/x86InstructionSemantics.h
@@ -39,8 +39,8 @@ struct X86InstructionSemantics {
 
     Policy& policy;
 
-    X86InstructionSemantics(Policy& policy)
-        : policy(policy)
+    X86InstructionSemantics(Policy& policy_)
+        : policy(policy_)
         {}
     virtual ~X86InstructionSemantics() {}
 

--- a/dataflowAPI/rose/x86InstructionSemantics.h
+++ b/dataflowAPI/rose/x86InstructionSemantics.h
@@ -1350,7 +1350,6 @@ struct X86InstructionSemantics {
                     case 4: {
                         Word(32) op1 = read32(operands[0]);
                         Word(32) op2 = read32(operands[1]);
-                        Word(5) shiftCount = extract<0, 5>(read8(operands[2]));
                         Word(32) output1 = policy.shiftLeft(op1, shiftCount);
                         Word(32) output2 = policy.ite(policy.equalToZero(shiftCount),
                                                       number<32>(0),

--- a/dataflowAPI/rose/x86_64InstructionSemantics.h
+++ b/dataflowAPI/rose/x86_64InstructionSemantics.h
@@ -49,8 +49,8 @@ struct X86_64InstructionSemantics {
 
     Policy& policy;
 
-    X86_64InstructionSemantics(Policy& policy)
-        : policy(policy)
+    X86_64InstructionSemantics(Policy& policy_)
+        : policy(policy_)
         {}
     virtual ~X86_64InstructionSemantics() {}
 

--- a/dataflowAPI/rose/x86_64InstructionSemantics.h
+++ b/dataflowAPI/rose/x86_64InstructionSemantics.h
@@ -193,6 +193,7 @@ struct X86_64InstructionSemantics {
                             default: ROSE_ASSERT(!"Bad position in register");
                         }
                     }
+                    break;
                     default: {
                         fprintf(stderr, "Bad register class %s\n", regclassToString(rre->get_register_class()));
                         throw rose::BinaryAnalysis::InstructionSemantics2::BaseSemantics::Exception("", NULL);;
@@ -302,6 +303,7 @@ struct X86_64InstructionSemantics {
 			      ROSE_ASSERT(!"bad position in register");
                         }
                     }
+                    break;
                     case x86_regclass_segment: {
                         ROSE_ASSERT(rre->get_position_in_register() == x86_regpos_dword ||
                                     rre->get_position_in_register() == x86_regpos_all);
@@ -366,6 +368,7 @@ struct X86_64InstructionSemantics {
                                         ROSE_ASSERT(!"bad position in register");
                         }
                     }
+                    break;
                     case x86_regclass_segment: {
                                 ROSE_ASSERT(rre->get_position_in_register() == x86_regpos_dword ||
                                             rre->get_position_in_register() == x86_regpos_all);

--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -256,7 +256,7 @@ void ExpressionConversionVisitor::visit(Dereference *deref) {
 }
 
 SgAsmExpression *ExpressionConversionVisitor::archSpecificRegisterProc(InstructionAPI::RegisterAST *regast,
-        uint64_t addr, uint64_t size) {
+        uint64_t addr_, uint64_t size_) {
     
     MachRegister machReg = regast->getID();
 
@@ -264,7 +264,7 @@ SgAsmExpression *ExpressionConversionVisitor::archSpecificRegisterProc(Instructi
     switch (arch) {
         case Arch_x86:
         case Arch_x86_64: {
-                              int regClass;
+                              int regClass_;
                               int regNum;
                               int regPos;
 
@@ -275,60 +275,60 @@ SgAsmExpression *ExpressionConversionVisitor::archSpecificRegisterProc(Instructi
                                   // but the address of the next instruction.
                                   SgAsmExpression *constAddrExpr;
                                   if (arch == Arch_x86)
-                                      constAddrExpr = new SgAsmDoubleWordValueExpression(addr + size);
+                                      constAddrExpr = new SgAsmDoubleWordValueExpression(addr_ + size_);
                                   else
-                                      constAddrExpr = new SgAsmQuadWordValueExpression(addr + size);
+                                      constAddrExpr = new SgAsmQuadWordValueExpression(addr_ + size_);
 
                                   return constAddrExpr;
                               }
-                              machReg.getROSERegister(regClass, regNum, regPos);
-                              if (regClass < 0) return NULL;
-                              return new SgAsmx86RegisterReferenceExpression((X86RegisterClass) regClass,
+                              machReg.getROSERegister(regClass_, regNum, regPos);
+                              if (regClass_ < 0) return NULL;
+                              return new SgAsmx86RegisterReferenceExpression((X86RegisterClass) regClass_,
                                       regNum,
                                       (X86PositionInRegister) regPos);
                           }
         case Arch_ppc32: 
         case Arch_ppc64: {
-                             int regClass;
+                             int regClass_;
                              int regNum;
                              int regPos;
                              SgAsmDirectRegisterExpression *dre;
-                             machReg.getROSERegister(regClass, regNum, regPos);
-                             if (regClass < 0) return NULL;
-                             if (regClass == powerpc_regclass_cr) {
+                             machReg.getROSERegister(regClass_, regNum, regPos);
+                             if (regClass_ < 0) return NULL;
+                             if (regClass_ == powerpc_regclass_cr) {
                                  // ROSE treats CR as one register, so regNum is always 0. 
                                  // CR0 to CR7 are 8 subfields within CR.
                                  // CR0 has register offset 0
                                  // CR1 has register offset 4
-                                 dre = new SgAsmDirectRegisterExpression(RegisterDescriptor(regClass, regNum, regPos * 4, 4));
+                                 dre = new SgAsmDirectRegisterExpression(RegisterDescriptor(regClass_, regNum, regPos * 4, 4));
                                  dre->set_type(new SgAsmIntegerType(ByteOrder::ORDER_LSB, 4, false));
                              } else {
-                                 dre = new SgAsmDirectRegisterExpression(RegisterDescriptor(regClass, regNum, regPos, machReg.size() * 8));
+                                 dre = new SgAsmDirectRegisterExpression(RegisterDescriptor(regClass_, regNum, regPos, machReg.size() * 8));
                                  dre->set_type(new SgAsmIntegerType(ByteOrder::ORDER_LSB, machReg.size() * 8, false));
                              }
                              return dre;
                          }
         case Arch_aarch64: {
-                               int regClass;
+                               int regClass_;
                                int regNum;
                                int regPos;
 
-                               machReg.getROSERegister(regClass, regNum, regPos);
-                               if (regClass < 0) return NULL;
-                               SgAsmDirectRegisterExpression *dre = new SgAsmDirectRegisterExpression(RegisterDescriptor(regClass, regNum, regPos, machReg.size() * 8));
+                               machReg.getROSERegister(regClass_, regNum, regPos);
+                               if (regClass_ < 0) return NULL;
+                               SgAsmDirectRegisterExpression *dre = new SgAsmDirectRegisterExpression(RegisterDescriptor(regClass_, regNum, regPos, machReg.size() * 8));
                                dre->set_type(new SgAsmIntegerType(ByteOrder::ORDER_LSB, machReg.size() * 8, false));
                                return dre;
                            }
         case Arch_amdgpu_vega: {
-                               int regClass;
+                               int regClass_;
                                int regNum;
                                int regPos;
 
-                               machReg.getROSERegister(regClass, regNum, regPos);
-                               if (regClass < 0) return NULL;
-                               //std::cout << " after get rose register, regClass = " << regClass << " regNum = " << regNum    << std::endl;
+                               machReg.getROSERegister(regClass_, regNum, regPos);
+                               if (regClass_ < 0) return NULL;
+                               //std::cout << " after get rose register, regClass_ = " << regClass_ << " regNum = " << regNum    << std::endl;
                                // TODO : it is not clear how regsize adn such should be set, for now we just follow aarch64's implementation
-                               SgAsmDirectRegisterExpression *dre = new SgAsmDirectRegisterExpression(RegisterDescriptor(regClass, regNum, regPos, machReg.size() * 8));
+                               SgAsmDirectRegisterExpression *dre = new SgAsmDirectRegisterExpression(RegisterDescriptor(regClass_, regNum, regPos, machReg.size() * 8));
                                dre->set_type(new SgAsmIntegerType(ByteOrder::ORDER_LSB, machReg.size() * 8, false));
                                return dre;
                            }

--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -268,7 +268,6 @@ SgAsmExpression *ExpressionConversionVisitor::archSpecificRegisterProc(Instructi
                               int regNum;
                               int regPos;
 
-                              MachRegister machReg = regast->getID();
                               if (machReg.isPC()) {
                                   // ideally this would be symbolic
                                   // When ip is read, the value read is not the address of the current instruction,

--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -33,6 +33,7 @@
 #include "Immediate.h"
 #include "BinaryFunction.h"
 #include "Dereference.h"
+#include "compiler_annotations.h"
 
 #include <list>
 
@@ -58,6 +59,7 @@ void ExpressionConversionVisitor::visit(InstructionAPI::Immediate *immed) {
         switch (value.type) {
             case s8:
                 isSigned = true;
+                DYNINST_FALLTHROUGH;
             case u8:
                 roseExpression = new SgAsmIntegerValueExpression(value.val.u8val,
                         new SgAsmIntegerType(ByteOrder::ORDER_UNSPECIFIED, 8,
@@ -65,6 +67,7 @@ void ExpressionConversionVisitor::visit(InstructionAPI::Immediate *immed) {
                 break;
             case s16:
                 isSigned = true;
+                DYNINST_FALLTHROUGH;
             case u16:
                 roseExpression = new SgAsmIntegerValueExpression(value.val.u16val,
                         new SgAsmIntegerType(ByteOrder::ORDER_LSB, 16,
@@ -72,6 +75,7 @@ void ExpressionConversionVisitor::visit(InstructionAPI::Immediate *immed) {
                 break;
             case s32:
                 isSigned = true;
+                DYNINST_FALLTHROUGH;
             case u32:
                 roseExpression = new SgAsmIntegerValueExpression(value.val.u32val,
                         new SgAsmIntegerType(ByteOrder::ORDER_LSB, 32,
@@ -79,6 +83,7 @@ void ExpressionConversionVisitor::visit(InstructionAPI::Immediate *immed) {
                 break;
             case s48:
                 isSigned = true;
+                DYNINST_FALLTHROUGH;
             case u48:
                 roseExpression = new SgAsmIntegerValueExpression(value.val.u32val,
                         new SgAsmIntegerType(ByteOrder::ORDER_LSB, 32,
@@ -86,6 +91,7 @@ void ExpressionConversionVisitor::visit(InstructionAPI::Immediate *immed) {
                 break;
             case s64:
                 isSigned = true;
+                DYNINST_FALLTHROUGH;
             case u64:
                 roseExpression = new SgAsmIntegerValueExpression(value.val.u64val,
                         new SgAsmIntegerType(ByteOrder::ORDER_LSB, 64,
@@ -172,21 +178,25 @@ void ExpressionConversionVisitor::visit(Dereference *deref) {
         switch (deref->eval().type) {
             case s8:
                 isSigned = true;
+                DYNINST_FALLTHROUGH;
             case u8:
                 type = new SgAsmIntegerType(ByteOrder::ORDER_LSB, 8, isSigned);
                 break;
             case s16:
                 isSigned = true;
+                DYNINST_FALLTHROUGH;
             case u16:
                 type = new SgAsmIntegerType(ByteOrder::ORDER_LSB, 16, isSigned);
                 break;
             case s32:
                 isSigned = true;
+                DYNINST_FALLTHROUGH;
             case u32:
                 type = new SgAsmIntegerType(ByteOrder::ORDER_LSB, 32, isSigned);
                 break;
             case s64:
                 isSigned = true;
+                DYNINST_FALLTHROUGH;
             case u64:
                 type = new SgAsmIntegerType(ByteOrder::ORDER_LSB, 64, isSigned);
                 break;

--- a/dataflowAPI/src/ExpressionConversionVisitor.h
+++ b/dataflowAPI/src/ExpressionConversionVisitor.h
@@ -64,7 +64,7 @@ namespace Dyninst
 
     public:
     DATAFLOW_EXPORT ExpressionConversionVisitor(Architecture a, uint64_t ad, uint64_t s) :
-      roseExpression(NULL), arch(a), addr(ad), size(s) {};
+      roseExpression(NULL), arch(a), addr(ad), size(s) {}
       
       DATAFLOW_EXPORT SgAsmExpression *getRoseExpression() { return roseExpression; }
       

--- a/dataflowAPI/src/RegisterMap.C
+++ b/dataflowAPI/src/RegisterMap.C
@@ -857,5 +857,5 @@ RegisterMap &machRegIndex_aarch64() {
    return *mrmap;
 }
 
-};
-};
+}
+}

--- a/dataflowAPI/src/RegisterMap.h
+++ b/dataflowAPI/src/RegisterMap.h
@@ -44,7 +44,7 @@ RegisterMap &machRegIndex_ppc();
 RegisterMap &machRegIndex_ppc_64();
 RegisterMap &machRegIndex_aarch64();
 
-};
-};
+}
+}
 #endif //REGISTERMAP_H
 

--- a/dataflowAPI/src/RoseImpl.C
+++ b/dataflowAPI/src/RoseImpl.C
@@ -725,12 +725,12 @@ SgAsmFloatValueExpression::~SgAsmFloatValueExpression() {
 
 }
 
-SgAsmFloatValueExpression::SgAsmFloatValueExpression(double value, SgAsmType *type) {
+SgAsmFloatValueExpression::SgAsmFloatValueExpression(double value, SgAsmType * /*type*/) {
     p_nativeValue = value;
     p_nativeValueIsValid = true;
 }
 
-SgAsmFloatValueExpression::SgAsmFloatValueExpression(const Sawyer::Container::BitVector &bv, SgAsmType *type) {
+SgAsmFloatValueExpression::SgAsmFloatValueExpression(const Sawyer::Container::BitVector &bv, SgAsmType * /*type*/) {
     p_nativeValue = 0.0;
     p_nativeValueIsValid = false;
     p_bitVector = bv;

--- a/dataflowAPI/src/RoseImpl.C
+++ b/dataflowAPI/src/RoseImpl.C
@@ -795,10 +795,7 @@ SgAsmBinaryAdd::SgAsmBinaryAdd(SgAsmExpression *lhs, SgAsmExpression *rhs)
 }
 
 SgAsmType *SgAsmBinaryAdd::get_type() const {
-    SgAsmBinaryExpression *addExpr = &(*(const_cast<SgAsmBinaryAdd *>(this)));
-    SgAsmBinaryExpression binExpr = *addExpr;
-    return (&binExpr)->get_type();
-    //return ((SgAsmBinaryExpression *) this)->get_type();
+    return SgAsmBinaryExpression::get_type();
 }
 
 std::string SgAsmBinaryAdd::class_name() const {
@@ -838,7 +835,7 @@ SgAsmBinaryMultiply::SgAsmBinaryMultiply(SgAsmExpression *lhs, SgAsmExpression *
 }
 
 SgAsmType *SgAsmBinaryMultiply::get_type() const {
-    return static_cast<const SgAsmBinaryExpression *>(this)->get_type();
+    return SgAsmBinaryExpression::get_type();
 }
 
 std::string SgAsmBinaryMultiply::class_name() const {

--- a/dataflowAPI/src/RoseImpl.C
+++ b/dataflowAPI/src/RoseImpl.C
@@ -838,7 +838,7 @@ SgAsmBinaryMultiply::SgAsmBinaryMultiply(SgAsmExpression *lhs, SgAsmExpression *
 }
 
 SgAsmType *SgAsmBinaryMultiply::get_type() const {
-    return ((SgAsmBinaryExpression *) this)->get_type();
+    return static_cast<const SgAsmBinaryExpression *>(this)->get_type();
 }
 
 std::string SgAsmBinaryMultiply::class_name() const {

--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -389,7 +389,7 @@ void RoseInsnPPCFactory::massageOperands(const Instruction &insn,
   return;
 }
 
-void RoseInsnArmv8Factory::setSizes(SgAsmInstruction */*insn*/) {
+void RoseInsnArmv8Factory::setSizes(SgAsmInstruction * /*insn*/) {
 
 }
 
@@ -406,13 +406,13 @@ bool RoseInsnArmv8Factory::handleSpecialCases(entryID, SgAsmInstruction *, SgAsm
   return false;
 }
 
-void RoseInsnArmv8Factory::massageOperands(const Instruction &insn,
-        std::vector<InstructionAPI::Operand> &operands) {
+void RoseInsnArmv8Factory::massageOperands(const Instruction &/*insn*/,
+        std::vector<InstructionAPI::Operand> &/*operands*/) {
 
 }
  
 
-void RoseInsnAmdgpuVegaFactory::setSizes(SgAsmInstruction */*insn*/) {
+void RoseInsnAmdgpuVegaFactory::setSizes(SgAsmInstruction * /*insn*/) {
 
 }
 

--- a/dataflowAPI/src/RoseInsnFactory.h
+++ b/dataflowAPI/src/RoseInsnFactory.h
@@ -83,9 +83,9 @@ namespace Dyninst {
             typedef boost::shared_ptr<InstructionAPI::Instruction> InstructionPtr;
             uint64_t _addr = 0 ;
         public:
-            DATAFLOW_EXPORT RoseInsnFactory(void) { };
+            DATAFLOW_EXPORT RoseInsnFactory(void) { }
 
-            DATAFLOW_EXPORT virtual ~RoseInsnFactory(void) { };
+            DATAFLOW_EXPORT virtual ~RoseInsnFactory(void) { }
 
             DATAFLOW_EXPORT virtual SgAsmInstruction *convert(const InstructionAPI::Instruction &insn, uint64_t addr);
 
@@ -105,14 +105,14 @@ namespace Dyninst {
 
             friend class ExpressionConversionVisitor;
 
-            virtual Architecture arch() { return Arch_none; };
+            virtual Architecture arch() { return Arch_none; }
         };
 
         class RoseInsnX86Factory : public RoseInsnFactory {
         public:
-            DATAFLOW_EXPORT RoseInsnX86Factory(Architecture arch) : a(arch) { };
+            DATAFLOW_EXPORT RoseInsnX86Factory(Architecture arch) : a(arch) { }
 
-            DATAFLOW_EXPORT virtual ~RoseInsnX86Factory() { };
+            DATAFLOW_EXPORT virtual ~RoseInsnX86Factory() { }
 
         private:
             Architecture a;
@@ -130,14 +130,14 @@ namespace Dyninst {
 
             X86InstructionKind convertKind(entryID opcode, prefixEntryID prefix);
 
-            virtual Architecture arch() { return a; };
+            virtual Architecture arch() { return a; }
         };
 
         class RoseInsnPPCFactory : public RoseInsnFactory {
         public:
-            DATAFLOW_EXPORT RoseInsnPPCFactory(void) { };
+            DATAFLOW_EXPORT RoseInsnPPCFactory(void) { }
 
-            DATAFLOW_EXPORT virtual ~RoseInsnPPCFactory(void) { };
+            DATAFLOW_EXPORT virtual ~RoseInsnPPCFactory(void) { }
 
         private:
             virtual SgAsmInstruction *createInsn();
@@ -155,15 +155,15 @@ namespace Dyninst {
 
             PowerpcInstructionKind makeRoseBranchOpcode(entryID iapi_opcode, bool isAbsolute, bool isLink);
 
-            virtual Architecture arch() { return Arch_ppc32; };
+            virtual Architecture arch() { return Arch_ppc32; }
             PowerpcInstructionKind kind;
         };
 
         class RoseInsnArmv8Factory : public RoseInsnFactory {
         public:
-            DATAFLOW_EXPORT RoseInsnArmv8Factory(Architecture arch) : a(arch) { };
+            DATAFLOW_EXPORT RoseInsnArmv8Factory(Architecture arch) : a(arch) { }
 
-            DATAFLOW_EXPORT virtual ~RoseInsnArmv8Factory() { };
+            DATAFLOW_EXPORT virtual ~RoseInsnArmv8Factory() { }
 
         private:
             Architecture a;
@@ -181,14 +181,14 @@ namespace Dyninst {
 
             ARMv8InstructionKind convertKind(entryID opcode);
 
-            virtual Architecture arch() { return a; };
+            virtual Architecture arch() { return a; }
         };
          
         class RoseInsnAmdgpuVegaFactory : public RoseInsnFactory {
         public:
-            DATAFLOW_EXPORT RoseInsnAmdgpuVegaFactory(Architecture arch) : a(arch) { };
+            DATAFLOW_EXPORT RoseInsnAmdgpuVegaFactory(Architecture arch) : a(arch) { }
 
-            DATAFLOW_EXPORT virtual ~RoseInsnAmdgpuVegaFactory() { };
+            DATAFLOW_EXPORT virtual ~RoseInsnAmdgpuVegaFactory() { }
 
         private:
             Architecture a;
@@ -206,10 +206,10 @@ namespace Dyninst {
 
             AmdgpuVegaInstructionKind convertKind(entryID opcode);
 
-            virtual Architecture arch() { return a; };
+            virtual Architecture arch() { return a; }
         };
        
-    };
-};
+    }
+}
 
 #endif

--- a/dataflowAPI/src/SymEvalPolicy.C
+++ b/dataflowAPI/src/SymEvalPolicy.C
@@ -49,20 +49,20 @@ SymEvalPolicy::SymEvalPolicy(Result_t &r,
   // We also need to build aaMap FTW!!!
   for (Result_t::iterator iter = r.begin();
        iter != r.end(); ++iter) {
-    Assignment::Ptr a = iter->first;
+    Assignment::Ptr ap = iter->first;
     // For a different instruction...
-    if (a->addr() != addr) continue; 
-    AbsRegion &o = a->out();
+    if (ap->addr() != addr) continue; 
+    AbsRegion &o = ap->out();
 
     if (o.containsOfType(Absloc::Register)) {
       // We're assuming this is a single register...
-      //std::cerr << "Marking register " << a << std::endl;
-      aaMap[o.absloc()] = a;
+      //std::cerr << "Marking register " << ap << std::endl;
+      aaMap[o.absloc()] = ap;
     }
     else {
       // Use sufficiently-unique (Heap,0) Absloc
       // to represent a definition to a memory absloc
-      aaMap[Absloc(0)] = a;
+      aaMap[Absloc(0)] = ap;
     }
   }
 }
@@ -259,20 +259,20 @@ SymEvalPolicy_64::SymEvalPolicy_64(Result_t &r,
   // We also need to build aaMap FTW!!!
   for (Result_t::iterator iter = r.begin();
        iter != r.end(); ++iter) {
-    Assignment::Ptr a = iter->first;
+    Assignment::Ptr ap = iter->first;
     // For a different instruction...
-    if (a->addr() != addr) continue; 
-    AbsRegion &o = a->out();
+    if (ap->addr() != addr) continue; 
+    AbsRegion &o = ap->out();
 
     if (o.containsOfType(Absloc::Register)) {
       // We're assuming this is a single register...
       //std::cerr << "Marking register " << a << std::endl;
-      aaMap[o.absloc()] = a;
+      aaMap[o.absloc()] = ap;
     }
     else {
       // Use sufficiently-unique (Heap,0) Absloc
       // to represent a definition to a memory absloc
-      aaMap[Absloc(0)] = a;
+      aaMap[Absloc(0)] = ap;
     }
   }
 }

--- a/dataflowAPI/src/SymEvalPolicy.h
+++ b/dataflowAPI/src/SymEvalPolicy.h
@@ -198,7 +198,7 @@ struct Handle {
    }
     void systemCall(unsigned char value)
     {
-        fprintf(stderr, "WARNING: syscall %d detected; unhandled by semantics!\n", (unsigned int)(value));
+        fprintf(stderr, "WARNING: syscall %u detected; unhandled by semantics!\n", (unsigned int)(value));
     }
    void writeSegreg(X86SegmentRegister r, Handle<16> value) {
      std::map<Absloc, Assignment::Ptr>::iterator i = aaMap.find(convert(r));
@@ -718,7 +718,7 @@ struct Handle {
    }
     void systemCall(unsigned char value)
     {
-        fprintf(stderr, "WARNING: syscall %d detected; unhandled by semantics!\n", (unsigned int)(value));
+        fprintf(stderr, "WARNING: syscall %u detected; unhandled by semantics!\n", (unsigned int)(value));
     }
    void writeSegreg(X86SegmentRegister r, Handle<16> value) {
      std::map<Absloc, Assignment::Ptr>::iterator i = aaMap.find(convert(r));

--- a/dataflowAPI/src/SymEvalPolicy.h
+++ b/dataflowAPI/src/SymEvalPolicy.h
@@ -242,32 +242,32 @@ struct Handle {
     
    template <size_t Len>
      Handle<Len> readMemory(X86SegmentRegister /*segreg*/,
-			    Handle<32> addr,
+			    Handle<32> addr_,
 			    Handle<1> cond) {
      if (cond == true_()) {
        return Handle<Len>(getUnaryAST(ROSEOperation::derefOp,
-				      addr.var(),
+				      addr_.var(),
                                       Len));
      }
      else {
        return Handle<Len>(getBinaryAST(ROSEOperation::derefOp,
-				       addr.var(),
+				       addr_.var(),
 				       cond.var(),
                                        Len));
      }
    }
         
    template <size_t Len>
-     Handle<Len> readMemory(Handle<32> addr,
+     Handle<Len> readMemory(Handle<32> addr_,
                             Handle<1> cond) {
     return Handle<Len>(getBinaryAST(ROSEOperation::derefOp,
-                                    addr.var(),
+                                    addr_.var(),
                                     cond.var(),
                                     Len));
      }
      template <size_t Len>
      void writeMemory(X86SegmentRegister,
-		      Handle<32> addr,
+		      Handle<32> addr_,
 		      Handle<Len> data,
 		      Handle<32> repeat,
 		      Handle<1> cond) {
@@ -278,7 +278,7 @@ struct Handle {
 
      std::map<Absloc, Assignment::Ptr>::iterator i = aaMap.find(Absloc(0));
      if (i != aaMap.end()) {
-       i->second->out().setGenerator(addr.var());
+       i->second->out().setGenerator(addr_.var());
        i->second->out().setSize(Len);
        
        if (cond == true_()) {
@@ -296,12 +296,12 @@ struct Handle {
    }
 
    template <size_t Len>
-   void writeMemory(Handle<32> addr,
+   void writeMemory(Handle<32> addr_,
                     Handle<Len> data,
                     Handle<1> cond) {
         std::map<Absloc, Assignment::Ptr>::iterator i = aaMap.find(Absloc(0));
         if (i != aaMap.end()) {
-            i->second->out().setGenerator(addr.var());
+            i->second->out().setGenerator(addr_.var());
             i->second->out().setSize(Len);
             if (cond == true_()) {
                 // Thinking about it... I think we avoid the "writeOp"
@@ -321,12 +321,12 @@ struct Handle {
    
    template <size_t Len>
      void writeMemory(X86SegmentRegister,
-		      Handle<32> addr,
+		      Handle<32> addr_,
 		      Handle<Len> data,
 		      Handle<1> cond) {
      std::map<Absloc, Assignment::Ptr>::iterator i = aaMap.find(Absloc(0));
      if (i != aaMap.end()) {
-       i->second->out().setGenerator(addr.var());
+       i->second->out().setGenerator(addr_.var());
        i->second->out().setSize(Len);
        if (cond == true_()) {	 
 	 // Thinking about it... I think we avoid the "writeOp"
@@ -762,32 +762,32 @@ struct Handle {
     
    template <size_t Len>
      Handle<Len> readMemory(X86SegmentRegister /*segreg*/,
-			    Handle<64> addr,
+			    Handle<64> addr_,
 			    Handle<1> cond) {
      if (cond == true_()) {
        return Handle<Len>(getUnaryAST(ROSEOperation::derefOp,
-				      addr.var(),
+				      addr_.var(),
                                       Len));
      }
      else {
        return Handle<Len>(getBinaryAST(ROSEOperation::derefOp,
-				       addr.var(),
+				       addr_.var(),
 				       cond.var(),
                                        Len));
      }
    }
         
    template <size_t Len>
-     Handle<Len> readMemory(Handle<64> addr,
+     Handle<Len> readMemory(Handle<64> addr_,
                             Handle<1> cond) {
     return Handle<Len>(getBinaryAST(ROSEOperation::derefOp,
-                                    addr.var(),
+                                    addr_.var(),
                                     cond.var(),
                                     Len));
      }
      template <size_t Len>
      void writeMemory(X86SegmentRegister,
-		      Handle<64> addr,
+		      Handle<64> addr_,
 		      Handle<Len> data,
 		      Handle<64> repeat,
 		      Handle<1> cond) {
@@ -798,7 +798,7 @@ struct Handle {
 
      std::map<Absloc, Assignment::Ptr>::iterator i = aaMap.find(Absloc(0));
      if (i != aaMap.end()) {
-       i->second->out().setGenerator(addr.var());
+       i->second->out().setGenerator(addr_.var());
        i->second->out().setSize(Len);
        
        if (cond == true_()) {
@@ -816,12 +816,12 @@ struct Handle {
    }
 
    template <size_t Len>
-   void writeMemory(Handle<64> addr,
+   void writeMemory(Handle<64> addr_,
                     Handle<Len> data,
                     Handle<1> cond) {
         std::map<Absloc, Assignment::Ptr>::iterator i = aaMap.find(Absloc(0));
         if (i != aaMap.end()) {
-            i->second->out().setGenerator(addr.var());
+            i->second->out().setGenerator(addr_.var());
             i->second->out().setSize(Len);
             if (cond == true_()) {
                 // Thinking about it... I think we avoid the "writeOp"
@@ -841,12 +841,12 @@ struct Handle {
    
    template <size_t Len>
      void writeMemory(X86SegmentRegister,
-		      Handle<64> addr,
+		      Handle<64> addr_,
 		      Handle<Len> data,
 		      Handle<1> cond) {
      std::map<Absloc, Assignment::Ptr>::iterator i = aaMap.find(Absloc(0));
      if (i != aaMap.end()) {
-       i->second->out().setGenerator(addr.var());
+       i->second->out().setGenerator(addr_.var());
        i->second->out().setSize(Len);
        if (cond == true_()) {	 
 	 // Thinking about it... I think we avoid the "writeOp"

--- a/dataflowAPI/src/SymEvalPolicy.h
+++ b/dataflowAPI/src/SymEvalPolicy.h
@@ -92,11 +92,11 @@ struct Handle {
   AST::Ptr *v_;
   Handle() : v_(NULL) {
     assert(0);
-  };
+  }
   Handle(AST::Ptr v) {
     assert(v);
     v_ = new AST::Ptr(v);
-  };
+  }
   Handle(const Handle &rhs) {
     v_ = new AST::Ptr(rhs.var());
   }
@@ -105,7 +105,7 @@ struct Handle {
     v_ = new AST::Ptr(rhs.var());
     return  *this;
   }
-    ~Handle() { if (v_) delete v_; };
+    ~Handle() { if (v_) delete v_; }
   
   template <size_t Len2>
   bool operator==(const Handle<Len2> &rhs) {
@@ -129,7 +129,7 @@ struct Handle {
                    Dyninst::Architecture a,
                    InstructionAPI::Instruction insn);
 
-   ~SymEvalPolicy() {};
+   ~SymEvalPolicy() {}
 
    void undefinedInstruction(SgAsmx86Instruction *);
    void undefinedInstruction(SgAsmPowerpcInstruction *);
@@ -545,8 +545,8 @@ struct Handle {
 
    // Misc
     
-   void hlt() {};
-   void interrupt(uint8_t) {};
+   void hlt() {}
+   void interrupt(uint8_t) {}
     
    Handle<64> rdtsc() {
      return number<64>(0);
@@ -649,7 +649,7 @@ struct Handle {
 		      Dyninst::Architecture a,
 		      Dyninst::InstructionAPI::Instruction insn);
 
-   ~SymEvalPolicy_64() {};
+   ~SymEvalPolicy_64() {}
 
    void undefinedInstruction(SgAsmx86Instruction *);
    void undefinedInstruction(SgAsmPowerpcInstruction *);
@@ -1065,8 +1065,8 @@ struct Handle {
 
    // Misc
     
-   void hlt() {};
-   void interrupt(uint8_t) {};
+   void hlt() {}
+   void interrupt(uint8_t) {}
     
    Handle<64> rdtsc() {
      return number<64>(0);
@@ -1157,6 +1157,6 @@ struct Handle {
       return RoseAST::create(ROSEOperation(op, s), a, b, c);
     }    
 };
-};
-};
+}
+}
 #endif

--- a/dataflowAPI/src/SymEvalVisitors.h
+++ b/dataflowAPI/src/SymEvalVisitors.h
@@ -49,7 +49,7 @@ class StackVisitor : public ASTVisitor {
 	       ParseAPI::Function *func,
 	       StackAnalysis::Height &stackHeight,
 	       StackAnalysis::Height &frameHeight) :
-    addr_(a), func_(func), stack_(stackHeight), frame_(frameHeight) {};
+    addr_(a), func_(func), stack_(stackHeight), frame_(frameHeight) {}
 
     DATAFLOW_EXPORT virtual AST::Ptr visit(AST *);
     DATAFLOW_EXPORT virtual AST::Ptr visit(BottomAST *);
@@ -57,13 +57,13 @@ class StackVisitor : public ASTVisitor {
     DATAFLOW_EXPORT virtual AST::Ptr visit(VariableAST *);
     DATAFLOW_EXPORT virtual AST::Ptr visit(RoseAST *);
     DATAFLOW_EXPORT virtual AST::Ptr visit(StackAST *);
-    DATAFLOW_EXPORT virtual ASTPtr visit(InputVariableAST *) {return AST::Ptr();};
-    DATAFLOW_EXPORT virtual ASTPtr visit(ReferenceAST *) {return AST::Ptr();};
-    DATAFLOW_EXPORT virtual ASTPtr visit(StpAST *) {return AST::Ptr();};
-    DATAFLOW_EXPORT virtual ASTPtr visit(YicesAST *) {return AST::Ptr();};
-    DATAFLOW_EXPORT virtual ASTPtr visit(SemanticsAST *) {return AST::Ptr();};
+    DATAFLOW_EXPORT virtual ASTPtr visit(InputVariableAST *) {return AST::Ptr();}
+    DATAFLOW_EXPORT virtual ASTPtr visit(ReferenceAST *) {return AST::Ptr();}
+    DATAFLOW_EXPORT virtual ASTPtr visit(StpAST *) {return AST::Ptr();}
+    DATAFLOW_EXPORT virtual ASTPtr visit(YicesAST *) {return AST::Ptr();}
+    DATAFLOW_EXPORT virtual ASTPtr visit(SemanticsAST *) {return AST::Ptr();}
 
-    DATAFLOW_EXPORT virtual ~StackVisitor() {};
+    DATAFLOW_EXPORT virtual ~StackVisitor() {}
 
   private:
   Address addr_;
@@ -75,7 +75,7 @@ class StackVisitor : public ASTVisitor {
   // Simplify boolean expressions for PPC
 class BooleanVisitor : public ASTVisitor {
  public:
-    BooleanVisitor() {};
+    BooleanVisitor() {}
 
     DATAFLOW_EXPORT virtual AST::Ptr visit(AST *);
     DATAFLOW_EXPORT virtual AST::Ptr visit(BottomAST *);
@@ -83,19 +83,19 @@ class BooleanVisitor : public ASTVisitor {
     DATAFLOW_EXPORT virtual AST::Ptr visit(VariableAST *);
     DATAFLOW_EXPORT virtual AST::Ptr visit(RoseAST *);
     DATAFLOW_EXPORT virtual AST::Ptr visit(StackAST *);
-    DATAFLOW_EXPORT virtual ASTPtr visit(InputVariableAST *) {return AST::Ptr();};
-    DATAFLOW_EXPORT virtual ASTPtr visit(ReferenceAST *) {return AST::Ptr();};
-    DATAFLOW_EXPORT virtual ASTPtr visit(StpAST *) {return AST::Ptr();};
-    DATAFLOW_EXPORT virtual ASTPtr visit(YicesAST *) {return AST::Ptr();};
-    DATAFLOW_EXPORT virtual ASTPtr visit(SemanticsAST *) {return AST::Ptr();};
+    DATAFLOW_EXPORT virtual ASTPtr visit(InputVariableAST *) {return AST::Ptr();}
+    DATAFLOW_EXPORT virtual ASTPtr visit(ReferenceAST *) {return AST::Ptr();}
+    DATAFLOW_EXPORT virtual ASTPtr visit(StpAST *) {return AST::Ptr();}
+    DATAFLOW_EXPORT virtual ASTPtr visit(YicesAST *) {return AST::Ptr();}
+    DATAFLOW_EXPORT virtual ASTPtr visit(SemanticsAST *) {return AST::Ptr();}
 
   
-    DATAFLOW_EXPORT virtual ~BooleanVisitor() {};
+    DATAFLOW_EXPORT virtual ~BooleanVisitor() {}
     
   private:
 };
 
-};
-};
+}
+}
 
 #endif

--- a/dataflowAPI/src/SymbolicExpansion.C
+++ b/dataflowAPI/src/SymbolicExpansion.C
@@ -70,7 +70,7 @@ bool SymbolicExpansion::expandX86_64(SgAsmInstruction *rose_insn,
 
 bool SymbolicExpansion::expandPPC32(SgAsmInstruction *rose_insn,
                                     BaseSemantics::RiscOperatorsPtr ops, 
-				    const std::string &insn_dump) {
+				    const std::string &/*insn_dump*/) {
     SgAsmPowerpcInstruction *insn = static_cast<SgAsmPowerpcInstruction *>(rose_insn);
 
     BaseSemantics::DispatcherPtr cpu = DispatcherPowerpc::instance(ops, 32);
@@ -85,7 +85,7 @@ bool SymbolicExpansion::expandPPC32(SgAsmInstruction *rose_insn,
 }
 bool SymbolicExpansion::expandPPC64(SgAsmInstruction *rose_insn,
                                     BaseSemantics::RiscOperatorsPtr ops, 
-				    const std::string &insn_dump) {
+				    const std::string &/*insn_dump*/) {
     SgAsmPowerpcInstruction *insn = static_cast<SgAsmPowerpcInstruction *>(rose_insn);
 
     BaseSemantics::DispatcherPtr cpu = DispatcherPowerpc::instance(ops, 64);
@@ -100,7 +100,7 @@ bool SymbolicExpansion::expandPPC64(SgAsmInstruction *rose_insn,
     return true;
 }
 
-bool SymbolicExpansion::expandAarch64(SgAsmInstruction *rose_insn, BaseSemantics::RiscOperatorsPtr ops, const std::string &insn_dump) {
+bool SymbolicExpansion::expandAarch64(SgAsmInstruction *rose_insn, BaseSemantics::RiscOperatorsPtr ops, const std::string &/*insn_dump*/) {
     SgAsmArmv8Instruction *insn = static_cast<SgAsmArmv8Instruction *>(rose_insn);
 
     BaseSemantics::DispatcherPtr cpu = DispatcherARM64::instance(ops, 64);
@@ -114,7 +114,7 @@ bool SymbolicExpansion::expandAarch64(SgAsmInstruction *rose_insn, BaseSemantics
     return false;
 }
 
-bool SymbolicExpansion::expandAmdgpuVega(SgAsmInstruction *rose_insn, BaseSemantics::RiscOperatorsPtr ops, const std::string &insn_dump) {
+bool SymbolicExpansion::expandAmdgpuVega(SgAsmInstruction *rose_insn, BaseSemantics::RiscOperatorsPtr ops, const std::string &/*insn_dump*/) {
     SgAsmAmdgpuVegaInstruction *insn = static_cast<SgAsmAmdgpuVegaInstruction *>(rose_insn);
 
     BaseSemantics::DispatcherPtr cpu = DispatcherAmdgpuVega::instance(ops, 64);

--- a/dataflowAPI/src/SymbolicExpansion.h
+++ b/dataflowAPI/src/SymbolicExpansion.h
@@ -73,6 +73,6 @@ namespace Dyninst {
         };
 
 
-    };
-};
+    }
+}
 #endif

--- a/dataflowAPI/src/debug_dataflow.h
+++ b/dataflowAPI/src/debug_dataflow.h
@@ -32,6 +32,7 @@
 #define _DATAFLOW_DEBUG_H_
 
 #include <string>
+#include "compiler_annotations.h"
 
 extern int df_debug_slicing_on();
 extern int df_debug_stackanalysis_on();
@@ -45,11 +46,16 @@ extern int df_debug_liveness_on();
 #define expand_cerr        if (df_debug_expand_on()) cerr
 #define liveness_cerr      if (df_debug_liveness_on()) cerr
 
-extern int slicing_printf_int(const char *format, ...);
-extern int stackanalysis_printf_int(const char *format, ...);
-extern int convert_printf_int(const char *format, ...);
-extern int expand_printf_int(const char *format, ...);
-extern int liveness_printf_int(const char *format, ...);
+extern int slicing_printf_int(const char *format, ...)
+        DYNINST_PRINTF_ANNOTATION(1, 2);
+extern int stackanalysis_printf_int(const char *format, ...)
+        DYNINST_PRINTF_ANNOTATION(1, 2);
+extern int convert_printf_int(const char *format, ...)
+        DYNINST_PRINTF_ANNOTATION(1, 2);
+extern int expand_printf_int(const char *format, ...)
+        DYNINST_PRINTF_ANNOTATION(1, 2);
+extern int liveness_printf_int(const char *format, ...)
+        DYNINST_PRINTF_ANNOTATION(1, 2);
 
 
 #define dataflow_debug_printf(debug_sys, ...) do {if (df_debug_##debug_sys##_on()) debug_sys##_printf_int(__VA_ARGS__); } while(0)

--- a/dataflowAPI/src/debug_dataflow.h
+++ b/dataflowAPI/src/debug_dataflow.h
@@ -51,23 +51,14 @@ extern int convert_printf_int(const char *format, ...);
 extern int expand_printf_int(const char *format, ...);
 extern int liveness_printf_int(const char *format, ...);
 
-#if defined(__GNUC__)
-#define slicing_printf(format, args...) do {if (df_debug_slicing_on()) slicing_printf_int(format, ## args); } while(0)
-#define stackanalysis_printf(format, args...) do {if (df_debug_stackanalysis_on()) stackanalysis_printf_int(format, ## args); } while(0)
-#define convert_printf(format, args...) do {if (df_debug_convert_on()) convert_printf_int(format, ## args); } while(0)
-#define expand_printf(format, args...) do {if (df_debug_expand_on()) expand_printf_int(format, ## args); } while(0)
-#define liveness_printf(format, args...) do {if (df_debug_liveness_on()) liveness_printf_int(format, ## args); } while(0)
 
-#else
-// Non-GCC doesn't have the ## macro
-#define slicing_printf slicing_printf_int
-#define stackanalysis_printf stackanalysis_printf_int
-#define convert_printf convert_printf_int
-#define expand_printf expand_printf_int
-#define liveness_printf liveness_printf_int
+#define dataflow_debug_printf(debug_sys, ...) do {if (df_debug_##debug_sys##_on()) debug_sys##_printf_int(__VA_ARGS__); } while(0)
 
-
-#endif
+#define slicing_printf(...)       dataflow_debug_printf(slicing, __VA_ARGS__)
+#define stackanalysis_printf(...) dataflow_debug_printf(stackanalysis, __VA_ARGS__)
+#define convert_printf(...)       dataflow_debug_printf(convert, __VA_ARGS__)
+#define expand_printf(...)        dataflow_debug_printf(expand, __VA_ARGS__)
+#define liveness_printf(...)      dataflow_debug_printf(liveness, __VA_ARGS__)
 
 // And initialization
 

--- a/dataflowAPI/src/slicing.C
+++ b/dataflowAPI/src/slicing.C
@@ -1376,11 +1376,11 @@ Slicer::Slicer(Assignment::Ptr a,
                ParseAPI::Function *func,
 	       bool cache,
 	       bool stackAnalysis) : 
+  insnCache_(new InsnCache()),
+  own_insnCache(true),
   a_(a),
   b_(block),
   f_(func),
-  insnCache_(new InsnCache()),
-  own_insnCache(true),
   converter(new AssignmentConverter(cache, stackAnalysis)),
   own_converter(true)
 {
@@ -1390,11 +1390,11 @@ Slicer::Slicer(Assignment::Ptr a,
                ParseAPI::Block *block,
                ParseAPI::Function *func,
                AssignmentConverter* ac):
+  insnCache_(new InsnCache()),
+  own_insnCache(true),
   a_(a),
   b_(block),
   f_(func),
-  insnCache_(new InsnCache()),
-  own_insnCache(true),
   converter(ac),
   own_converter(false)
 {
@@ -1405,11 +1405,11 @@ Slicer::Slicer(Assignment::Ptr a,
                ParseAPI::Function *func,
                AssignmentConverter* ac,
                InsnCache* c):
+  insnCache_(c),
+  own_insnCache(false),
   a_(a),
   b_(block),
   f_(func),
-  insnCache_(c),
-  own_insnCache(false),
   converter(ac),
   own_converter(false)
 {

--- a/dataflowAPI/src/slicing.C
+++ b/dataflowAPI/src/slicing.C
@@ -780,8 +780,7 @@ Slicer::getPredecessors(
       //a predicate for each active abstract region to see whether
       //we should continue
       bool cont = false;
-      SliceFrame::ActiveMap::const_iterator ait = cand.active.begin();
-      for( ; ait != cand.active.end(); ++ait) {
+      for (SliceFrame::ActiveMap::const_iterator ait = cand.active.begin(); ait != cand.active.end(); ++ait) {
         bool add = p.addPredecessor((*ait).first);
         if(add) {
           if (nf == NULL) {
@@ -799,8 +798,7 @@ Slicer::getPredecessors(
           nf->loc.addr());
         slicing_printf("\t\t\t\t Current regions are:\n");
         if(df_debug_slicing_on()) {
-          SliceFrame::ActiveMap::const_iterator ait = cand.active.begin();
-          for( ; ait != cand.active.end(); ++ait) {
+          for (SliceFrame::ActiveMap::const_iterator ait = cand.active.begin(); ait != cand.active.end(); ++ait) {
             slicing_printf("\t\t\t\t%s\n",
               (*ait).first.format().c_str());
 

--- a/dataflowAPI/src/slicing.C
+++ b/dataflowAPI/src/slicing.C
@@ -176,10 +176,10 @@ Slicer::sliceInternal(
 
     if(dir == forward) {
         slicing_printf("Inserting entry node %p/%s\n",
-            aP.get(),aP->format().c_str());
+            static_cast<void*>(aP.get()),aP->format().c_str());
     } else {
         slicing_printf("Inserting exit node %p/%s\n",
-            aP.get(),aP->format().c_str());
+            static_cast<void*>(aP.get()),aP->format().c_str());
     }
 
     // add to graph
@@ -218,7 +218,7 @@ void Slicer::sliceInternalAux(
     vector<SliceFrame> nextCands;
     DefCache& mydefs = singleCache[cand.addr()];
 
-    slicing_printf("\tslicing from %lx, currently watching %ld regions\n",
+    slicing_printf("\tslicing from %lx, currently watching %lu regions\n",
         cand.addr(),cand.active.size());
 
     // Find assignments at this point that affect the active
@@ -228,7 +228,7 @@ void Slicer::sliceInternalAux(
 
     if (!skip) {
         if (!updateAndLink(g,dir,cand, mydefs, p)) return;
-	    slicing_printf("\t\tfinished udpateAndLink, active.size: %ld\n",
+	    slicing_printf("\t\tfinished udpateAndLink, active.size: %lu\n",
                        cand.active.size());
         // If the analysis that uses the slicing can stop for 
 	// analysis specifc reasons on a path, the cache
@@ -251,7 +251,7 @@ void Slicer::sliceInternalAux(
         widenAll(g,dir,cand);
     }
 
-    slicing_printf("\t\tgetNextCandidates returned %ld, success: %d\n",
+    slicing_printf("\t\tgetNextCandidates returned %lu, success: %d\n",
                    nextCands.size(),success);
 
     for (unsigned i=0; i < nextCands.size(); ++i) {
@@ -263,7 +263,7 @@ void Slicer::sliceInternalAux(
 
         CacheEdge e(cand.addr(),f.addr());
 
-        slicing_printf("\t\t candidate %d is at %lx, %ld active\n",
+        slicing_printf("\t\t candidate %u is at %lx, %lu active\n",
                        i,f.addr(),f.active.size());
 
         if (visited.find(e) != visited.end()) {
@@ -1079,7 +1079,7 @@ Slicer::handleReturnDetails(
 
     assert(!cur.con.empty());
 
-    slicing_printf("\t%s, \n",
+    slicing_printf("\t%s (%d), \n",
         (cur.con.front().func ? cur.con.front().func->name().c_str() : "NULL"),
         cur.con.front().stackDepth);
 

--- a/dataflowAPI/src/slicing.C
+++ b/dataflowAPI/src/slicing.C
@@ -1479,7 +1479,7 @@ void Slicer::pushContext(Context &context,
 	       << endl;
 
     context.push_front(ContextElement(callee, stackDepth));
-};
+}
 
 void Slicer::popContext(Context &context) {
   context.pop_front();

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -45,6 +45,7 @@
 #include "instructionAPI/h/Result.h"
 #include "parseAPI/h/CFG.h"
 #include "parseAPI/h/CodeObject.h"
+#include "common/h/compiler_diagnostics.h"
 
 #include "ABI.h"
 #include "Annotatable.h"
@@ -2827,6 +2828,7 @@ void StackAnalysis::createEntryInput(AbslocState &input) {
       input[Absloc(x86_64::esp)].addInitSet(Height(-word_size));
    }
 #else
+   DYNINST_SUPPRESS_UNUSED_VARIABLE(input);
    STACKANALYSIS_ASSERT(0 && "Unimplemented architecture");
 #endif
 }

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -588,7 +588,7 @@ void StackAnalysis::summarize() {
       Block *block = bIter->first;
       for (auto aIter = (*intervals_)[block].begin();
          aIter != (*intervals_)[block].end(); aIter++) {
-         Address addr = aIter->first;
+         //Address addr = aIter->first;
          AbslocState &as = aIter->second;
          for (auto tIter = as.begin(); tIter != as.end(); tIter++) {
             const Absloc &target = tIter->first;
@@ -3310,7 +3310,7 @@ StackAnalysis::DefHeightSet StackAnalysis::TransferFunc::apply(
       for (auto iter = fromRegs.begin(); iter != fromRegs.end(); ++iter) {
          Absloc curLoc = (*iter).first;
          long curScale = (*iter).second.first;
-         bool curTopBottom = (*iter).second.second;
+         //bool curTopBottom = (*iter).second.second;
          auto findLoc = inputs.find(curLoc);
          Height locInput;
          if (findLoc == inputs.end()) {
@@ -3347,7 +3347,7 @@ StackAnalysis::DefHeightSet StackAnalysis::TransferFunc::apply(
       // Copy the input value from whatever we're a copy of.
       AbslocState::const_iterator iter2 = inputs.find(from);
       if (iter2 != inputs.end()) {
-         const Definition &def = iter2->second.getDefSet();
+         //const Definition &def = iter2->second.getDefSet();
          const Height &h = iter2->second.getHeightSet();
          if (!h.isBottom() && !h.isTop()) {
             if ((from.isSP() || from.isFP()) &&

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -386,7 +386,7 @@ void getRetAndTailCallBlocks(Function *func, std::set<Block *> &retBlocks) {
       );
    }
 }
-};  // namespace
+}  // namespace
 
 
 // Looks for return edges in the function, following tail calls if necessary.

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -1728,7 +1728,7 @@ void StackAnalysis::handleLEA(Instruction insn,
 
    if (readSet.size() == 0) {
       // op1: imm
-      STACKANALYSIS_ASSERT(typeid(*srcExpr) == typeid(Immediate));
+      STACKANALYSIS_ASSERT(dynamic_cast<Immediate*>(srcExpr.get()));
       long immVal = srcExpr->eval().convert<long>();
       xferFuncs.push_back(TransferFunc::absFunc(writeloc, immVal));
       retopBaseSubReg(written, xferFuncs);

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -733,24 +733,24 @@ void StackAnalysis::computeInsnEffects(ParseAPI::Block *block,
    }
 }
 
-StackAnalysis::Height StackAnalysis::getStackCleanAmount(Function *func) {
+StackAnalysis::Height StackAnalysis::getStackCleanAmount(Function *func_) {
    // Cache previous work...
-   if (funcCleanAmounts.find(func) != funcCleanAmounts.end()) {
-      return funcCleanAmounts[func];
+   if (funcCleanAmounts.find(func_) != funcCleanAmounts.end()) {
+      return funcCleanAmounts[func_];
    }
 
-   if (!func->cleansOwnStack()) {
-      funcCleanAmounts[func] = 0;
-      return funcCleanAmounts[func];
+   if (!func_->cleansOwnStack()) {
+      funcCleanAmounts[func_] = 0;
+      return funcCleanAmounts[func_];
    }
 
    InstructionDecoder decoder((const unsigned char*) NULL, 0,
-      func->isrc()->getArch());
+      func_->isrc()->getArch());
    unsigned char *cur;
 
    std::set<Height> returnCleanVals;
 
-   Function::const_blocklist returnBlocks = func->returnBlocks();
+   Function::const_blocklist returnBlocks = func_->returnBlocks();
    for (auto rets = returnBlocks.begin(); rets != returnBlocks.end(); ++rets) {
       Block *ret = *rets;
       cur = (unsigned char *) ret->region()->getPtrToInstruction(
@@ -778,7 +778,7 @@ StackAnalysis::Height StackAnalysis::getStackCleanAmount(Function *func) {
       // Non-returning or tail-call exits?
       clean = Height::bottom;
    }
-   funcCleanAmounts[func] = clean;
+   funcCleanAmounts[func_] = clean;
 
    return clean;
 }
@@ -3296,9 +3296,9 @@ StackAnalysis::DefHeightSet StackAnalysis::TransferFunc::apply(
       return inputSet;
    }
 
-   AbslocState::const_iterator iter = inputs.find(target);
-   if (iter != inputs.end()) {
-      inputSet = iter->second;
+   AbslocState::const_iterator iter_ = inputs.find(target);
+   if (iter_ != inputs.end()) {
+      inputSet = iter_->second;
    } else {
       inputSet.makeTopSet();
    }
@@ -3708,8 +3708,8 @@ void StackAnalysis::SummaryFunc::add(TransferFuncs &xferFuncs) {
    // We need to update our register->xferFunc map
    // with the effects of each of the transferFuncs.
    for (auto iter = xferFuncs.begin(); iter != xferFuncs.end(); ++iter) {
-      TransferFunc &func = *iter;
-      func.accumulate(accumFuncs);
+      TransferFunc &func_ = *iter;
+      func_.accumulate(accumFuncs);
    }
    validate();
 }
@@ -3719,8 +3719,8 @@ void StackAnalysis::SummaryFunc::addSummary(const TransferSet &summary) {
    TransferSet newAccumFuncs = accumFuncs;
    for (auto iter = summary.begin(); iter != summary.end(); ++iter) {
       const Absloc &loc = iter->first;
-      const TransferFunc &func = iter->second;
-      newAccumFuncs[loc] = func.summaryAccumulate(accumFuncs);
+      const TransferFunc &func_ = iter->second;
+      newAccumFuncs[loc] = func_.summaryAccumulate(accumFuncs);
    }
    accumFuncs = newAccumFuncs;
    validate();
@@ -3729,11 +3729,11 @@ void StackAnalysis::SummaryFunc::addSummary(const TransferSet &summary) {
 void StackAnalysis::SummaryFunc::validate() const {
    for (TransferSet::const_iterator iter = accumFuncs.begin(); 
       iter != accumFuncs.end(); ++iter) {
-      const TransferFunc &func = iter->second;
-      STACKANALYSIS_ASSERT(func.target.isValid());
-      if (func.isCopy()) STACKANALYSIS_ASSERT(!func.isAbs());
-      if (func.isAbs()) STACKANALYSIS_ASSERT(!func.isCopy());
-      if (func.isBottom()) STACKANALYSIS_ASSERT(!func.isCopy());
+      const TransferFunc &func_ = iter->second;
+      STACKANALYSIS_ASSERT(func_.target.isValid());
+      if (func_.isCopy()) STACKANALYSIS_ASSERT(!func_.isAbs());
+      if (func_.isAbs()) STACKANALYSIS_ASSERT(!func_.isCopy());
+      if (func_.isBottom()) STACKANALYSIS_ASSERT(!func_.isCopy());
    }
 }
 

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -305,7 +305,7 @@ void StackAnalysis::fixpoint(bool verbose) {
          }
       } else {
          if (verbose) {
-            stackanalysis_printf("\t Calculating meet with block [%x-%x]\n",
+            stackanalysis_printf("\t Calculating meet with block [%lx-%lx]\n",
                block->start(), block->lastInsnAddr());
          }
          meetInputs(block, blockInputs[block], input);

--- a/instructionAPI/h/Operand.h
+++ b/instructionAPI/h/Operand.h
@@ -60,7 +60,7 @@ namespace Dyninst
     {
     public:
         typedef boost::shared_ptr<Operand> Ptr;
-    Operand() : m_isRead(false), m_isWritten(false), m_isImplicit(false), m_isTruePredicate(false), m_isFalsePredicate(false) {}
+    Operand() noexcept : m_isRead(false), m_isWritten(false), m_isImplicit(false), m_isTruePredicate(false), m_isFalsePredicate(false) {}
       /// \brief Create an operand from a %Expression and flags describing whether the %ValueComputation
       /// is read, written or both.
       /// \param val Reference-counted pointer to the %Expression that will be contained in the %Operand being constructed

--- a/instructionAPI/h/Visitor.h
+++ b/instructionAPI/h/Visitor.h
@@ -52,8 +52,8 @@ namespace InstructionAPI
         /// should not be invoked by user code ordinarily.
        
         public:
-            Visitor() {}
-            virtual ~Visitor() {}
+            virtual ~Visitor() = default;
+            Visitor& operator=(const Visitor&) = default;
             virtual void visit(BinaryFunction* b) = 0;
             virtual void visit(Immediate* i) = 0;
             virtual void visit(RegisterAST* r) = 0;

--- a/parseAPI/CMakeLists.txt
+++ b/parseAPI/CMakeLists.txt
@@ -30,7 +30,6 @@ set(SRC_LIST
     src/BoundFactCalculator.C
     src/BoundFactData.C
     src/ThunkData.C
-    ../dataflowAPI/src/ABI.C
     src/dominator.C
     src/LoopAnalyzer.C
     src/Loop.C
@@ -38,7 +37,7 @@ set(SRC_LIST
     src/IdiomModelDesc.C
     src/ProbabilisticParser.C)
 
-set(ROSE_SRC
+set(DATAFLOW_SRC
     ../dataflowAPI/src/ABI.C
     ../dataflowAPI/src/Absloc.C
     ../dataflowAPI/src/AbslocInterface.C
@@ -56,7 +55,9 @@ set(ROSE_SRC
     ../dataflowAPI/src/SymEval.C
     ../dataflowAPI/src/SymEvalPolicy.C
     ../dataflowAPI/src/templates.C
-    ../dataflowAPI/src/Visitors.C
+    ../dataflowAPI/src/Visitors.C)
+
+set(ROSE_SRC
     ../dataflowAPI/rose/ExtentMap.C
     ../dataflowAPI/rose/rangemap.C
     ../dataflowAPI/rose/util/Assert.C
@@ -82,7 +83,7 @@ set(ROSE_SRC
 
 # FIXME: Rose needs a bunch of warning cleanup
 set_source_files_properties(${ROSE_SRC} PROPERTIES LANGUAGE CXX COMPILE_FLAGS -w)
-set(SRC_LIST ${SRC_LIST} ${ROSE_SRC})
+set(SRC_LIST ${SRC_LIST} ${DATAFLOW_SRC} ${ROSE_SRC})
 
 if(LIGHTWEIGHT_SYMTAB)
     set(SRC_LIST ${SRC_LIST} src/SymLiteCodeSource.C)


### PR DESCRIPTION
Enable warnings in source files contained in dataflowAPI/src.  Source files in dataflowAPI/rose continue to have warnings disabled.

Fix the code to eliminate warning produced by these files.  Now builds cleanly with gcc 6-13 and clang 7-15, and C++ versions 11, 14, 17, 20 and 23 with the exception of clang and C++20 and C++23 (due to an error with `operator==` in dataflowAPI/rose that might be fixed by C++ DR).

Also fixed infinite recursion in SgAsmBinaryMultiply::get_type() as it did not call the base class's get_type in a sane way.

Fixes #1396
Fixes #1138