### PR TITLE
Fix link bug in insnCodeGen::loadImmIntoReg on aarch64

### DIFF
--- a/dyninstAPI/src/codegen-aarch64.C
+++ b/dyninstAPI/src/codegen-aarch64.C
@@ -159,7 +159,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
         // use Link Register as scratch since it will be overwritten at return
         scratch = 30;
         //load disp to r30
-        loadImmIntoReg<Address>(gen, scratch, to);
+        loadImmIntoReg(gen, scratch, to);
         //generate call
         generateBReg(scratch);
         return;
@@ -181,7 +181,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
         return;
     }
 
-    loadImmIntoReg<Address>(gen, scratch, to);
+    loadImmIntoReg(gen, scratch, to);
     generateBReg(scratch);
 }
 
@@ -481,24 +481,9 @@ Register insnCodeGen::moveValueToReg(codeGen &gen, long int val, std::vector<Reg
         assert(0);
     }
 
-    loadImmIntoReg<long int>(gen, scratchReg, val);
+    loadImmIntoReg(gen, scratchReg, static_cast<Address>(val));
 
     return scratchReg;
-}
-
-
-template <typename T>
-void insnCodeGen::loadImmIntoReg(codeGen &gen, Register rt, T value)
-{
-    assert(value >= 0);
-
-    insnCodeGen::generateMove(gen, (value & 0xFFFF), 0, rt, MovOp_MOVZ);
-    if(value > 0xFFFF)
-        insnCodeGen::generateMove(gen, ((value >> 16) & 0xFFFF), 0x1, rt, MovOp_MOVK);
-    if(value > 0xFFFFFFFF)
-        insnCodeGen::generateMove(gen, ((value >> 32) & 0xFFFF), 0x2, rt, MovOp_MOVK);
-    if(value > 0xFFFFFFFFFFFF)
-        insnCodeGen::generateMove(gen, ((value >> 48) & 0xFFFF), 0x3, rt, MovOp_MOVK);
 }
 
 // Generate memory access through Load or Store
@@ -830,7 +815,7 @@ bool insnCodeGen::modifyData(Address target,
         //Else, generate move instructions to move the value to the same register
         else {
             //Register rd = raw & 0x1F;
-            //loadImmIntoReg<Address>(gen, rd, target);
+            //loadImmIntoReg(gen, rd, target);
             instruction newInsn;
             instruction newInsn2;
             newInsn.clear();
@@ -871,7 +856,7 @@ bool insnCodeGen::modifyData(Address target,
                         address into for a PC-relative data access using LDR/LDRSW!");
 
             // Load the target address into scratch register
-            loadImmIntoReg<Address>(gen, scratch, target);
+            loadImmIntoReg(gen, scratch, target);
 
             // Generate LDR(immediate) to load into r the the content of [scratch]
             Register r = raw & 0x1F;

--- a/dyninstAPI/src/codegen-aarch64.h
+++ b/dyninstAPI/src/codegen-aarch64.h
@@ -111,8 +111,6 @@ public:
 
     static inline void loadImmIntoReg(codeGen &gen, Register rt, Address value)
     {
-        assert(value >= 0);
-
         insnCodeGen::generateMove(gen, (value & 0xFFFF), 0, rt, MovOp_MOVZ);
         if(value > 0xFFFF)
             insnCodeGen::generateMove(gen, ((value >> 16) & 0xFFFF), 0x1, rt, MovOp_MOVK);

--- a/dyninstAPI/src/codegen-aarch64.h
+++ b/dyninstAPI/src/codegen-aarch64.h
@@ -109,8 +109,18 @@ public:
     static void generateMemAccessFP(codeGen &gen, LoadStore accType, Register rt,
             Register rn, int immd, int size, bool is128bit, IndexMode im=Offset);
 
-    template<typename T>
-    static void loadImmIntoReg(codeGen &gen, Register rt, T value);
+    static inline void loadImmIntoReg(codeGen &gen, Register rt, Address value)
+    {
+        assert(value >= 0);
+
+        insnCodeGen::generateMove(gen, (value & 0xFFFF), 0, rt, MovOp_MOVZ);
+        if(value > 0xFFFF)
+            insnCodeGen::generateMove(gen, ((value >> 16) & 0xFFFF), 0x1, rt, MovOp_MOVK);
+        if(value > 0xFFFFFFFF)
+            insnCodeGen::generateMove(gen, ((value >> 32) & 0xFFFF), 0x2, rt, MovOp_MOVK);
+        if(value > 0xFFFFFFFFFFFF)
+            insnCodeGen::generateMove(gen, ((value >> 48) & 0xFFFF), 0x3, rt, MovOp_MOVK);
+    }
 
     static void saveRegister(codeGen &gen, Register r, int sp_offset, IndexMode im=Offset);
 

--- a/dyninstAPI/src/emit-aarch64.C
+++ b/dyninstAPI/src/emit-aarch64.C
@@ -81,7 +81,7 @@ codeBufIndex_t EmitterAARCH64::emitIf(
 
 void EmitterAARCH64::emitLoadConst(Register dest, Address imm, codeGen &gen)
 {
-    insnCodeGen::loadImmIntoReg<Address>(gen, dest, imm);
+    insnCodeGen::loadImmIntoReg(gen, dest, imm);
 }
 
 
@@ -89,7 +89,7 @@ void EmitterAARCH64::emitLoad(Register dest, Address addr, int size, codeGen &ge
 {
     Register scratch = gen.rs()->getScratchRegister(gen);
 
-    insnCodeGen::loadImmIntoReg<Address>(gen, scratch, addr);
+    insnCodeGen::loadImmIntoReg(gen, scratch, addr);
     insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, dest,
             scratch, 0, size, insnCodeGen::Post);
 
@@ -102,7 +102,7 @@ void EmitterAARCH64::emitStore(Address addr, Register src, int size, codeGen &ge
 {
     Register scratch = gen.rs()->getScratchRegister(gen);
 
-    insnCodeGen::loadImmIntoReg<Address>(gen, scratch, addr);
+    insnCodeGen::loadImmIntoReg(gen, scratch, addr);
     insnCodeGen::generateMemAccess(gen, insnCodeGen::Store, src,
             scratch, 0, size, insnCodeGen::Pre);
 
@@ -153,14 +153,14 @@ void EmitterAARCH64::emitRelOp(
     insnCodeGen::generateAddSubShifted(gen, insnCodeGen::Sub, 0, 0, src2, src1, dest, true);
 
     // make dest = 1, meaning true
-    insnCodeGen::loadImmIntoReg<Address>(gen, dest, 0x1);
+    insnCodeGen::loadImmIntoReg(gen, dest, 0x1);
 
     // insert conditional jump to skip dest=0 in case the comparison resulted true
     // therefore keeping dest=1
     insnCodeGen::generateConditionalBranch(gen, 8, opcode, s);
 
     // make dest = 0, in case it fails the branch
-    insnCodeGen::loadImmIntoReg<Address>(gen, dest, 0x0);
+    insnCodeGen::loadImmIntoReg(gen, dest, 0x0);
 }
 
 
@@ -209,14 +209,14 @@ void EmitterAARCH64::emitRelOpImm(
     insnCodeGen::generateAddSubShifted(gen, insnCodeGen::Sub, 0, 0, src2, src1, dest, true);
 
     // make dest = 1, meaning true
-    insnCodeGen::loadImmIntoReg<Address>(gen, dest, 0x1);
+    insnCodeGen::loadImmIntoReg(gen, dest, 0x1);
 
     // insert conditional jump to skip dest=0 in case the comparison resulted true
     // therefore keeping dest=1
     insnCodeGen::generateConditionalBranch(gen, 8, opcode, s);
 
     // make dest = 0, in case it fails the branch
-    insnCodeGen::loadImmIntoReg<Address>(gen, dest, 0x0);
+    insnCodeGen::loadImmIntoReg(gen, dest, 0x0);
 
     gen.rs()->freeRegister(src2);
     gen.markRegDefined(dest);

--- a/dyninstAPI/src/emit-aarch64.C
+++ b/dyninstAPI/src/emit-aarch64.C
@@ -260,7 +260,7 @@ void EmitterAARCH64::emitLoadOrigRegRelative(
     {
         // load the stored register 'base' into dest
 	emitLoadOrigRegister(base, scratch, gen);
-	insnCodeGen::loadImmIntoReg<long int>(gen, dest, offset);
+	insnCodeGen::loadImmIntoReg(gen, dest, offset);
 	insnCodeGen::generateAddSubShifted(gen, insnCodeGen::Add, 0, 0, dest, scratch, dest, true);
     }
 }

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -681,7 +681,7 @@ Register EmitterAARCH64::emitCall(opCode op,
 
         insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, scratch, scratch, 0, 8, insnCodeGen::Offset);
     } else {
-        insnCodeGen::loadImmIntoReg<Address>(gen, scratch, callee->addr());
+        insnCodeGen::loadImmIntoReg(gen, scratch, callee->addr());
     }
 
     instruction branchInsn;
@@ -884,14 +884,14 @@ void emitASload(const BPatch_addrSpec_NP *as, Register dest, int stackShift,
         if(ra == 32) {
 	    // Special case where the actual address is store in imm.
 	    // Need to change this for rewriting PIE or shared libraries
-	    insnCodeGen::loadImmIntoReg<long int>(gen, dest, imm);
+	    insnCodeGen::loadImmIntoReg(gen, dest, static_cast<Address>(imm));
 	    return;
 	}
 	else {
 	    restoreGPRtoGPR(gen, ra, dest);
 	}
     } else {
-        insnCodeGen::loadImmIntoReg<long int>(gen, dest, 0);
+        insnCodeGen::loadImmIntoReg(gen, dest, static_cast<Address>(0));
     }
     if(rb > -1) {
         std::vector<Register> exclude;


### PR DESCRIPTION
The function template has a separate declaration and "definition" AND is called from translation units where neither is located. This only happens to work correctly when the TUs are linked in a specific order.