### PR TITLE
fix tbb detection

### DIFF
--- a/cmake/Modules/FindTBB.cmake
+++ b/cmake/Modules/FindTBB.cmake
@@ -153,11 +153,16 @@ find_path(
 #
 if(TBB_INCLUDE_DIRS)
     # Starting in 2020.1.1, tbb_stddef.h is replaced by version.h
+    # As of 2021.1.1, the old tbb/version.h no longer has the right defines.
+    # Look for the old tbb_stdef.h first, then the new oneapi/tbb/version.h, and if we do not find that, try tbb/version.h
+    # Break when we find a valid match. This should result in finding the version in all known situations.
     set(_version_files "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h"
+                       "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h"
                        "${TBB_INCLUDE_DIRS}/tbb/version.h")
     foreach(f IN ITEMS ${_version_files})
         if(EXISTS ${f})
             set(_version_file ${f})
+            break()
         endif()
     endforeach()
     unset(_version_files)


### PR DESCRIPTION
The FindTBB.cmake module does not find current TBB (after 2021.1.1) because it is trying to find version defines in tbb/version.h. tbb/version.h still exists, but only as a forward to the new oneapi/tbb/version.h, which does have the right defines in it.

This change adjusts the logic in FindTBB.cmake such that:

It looks first for tbb/tbb_stddef.h (location of defines before 2020.1.1), then oneapi/tbb/version.h (current location of defines), and finally, tbb/version.h (home of defines between 2020.1.1 and 2021.1.1). It searches in that specific order (and break()s out of the foreach loop if it finds one) because that _should_ work in all known scenarios.