### PR TITLE
Add CI workflow to build consumers of Dyninst

### DIFF
--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -1,0 +1,35 @@
+# Build the latest versions of applications that consume Dyninst
+
+name: Build Consumers
+
+on:
+  pull_request:
+    branches:
+      - master
+#  schedule:
+#    - cron: '0 2 3 * *' # Every 3rd of the month
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        consumer: [
+          "hpctoolkit"
+          # must+stackwalker  - python is broken
+          # stat              - takes >6hrs
+          # extrae+dyninst    - not yet tested, may not support dyninst >10.0.0
+          # omnitrace         - Needs updated cmake
+          # timemory          - Needs updated cmake
+          # systemtap         - No public repo?
+        ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: ${{ matrix.consumer }}
+      run: |
+        sudo apt update -qq
+        sudo apt install -y -qq --no-install-recommends build-essential gcc g++ gfortran m4 cmake autoconf python3 git unzip
+        git clone --depth=1 --branch=develop https://github.com/spack/spack
+        spack/bin/spack compiler find
+        spack/bin/spack external find --not-buildable cmake
+        spack/bin/spack install ${{ matrix.consumer }} ^dyninst@master


### PR DESCRIPTION
This was previously https://github.com/dyninst/external-tests/pull/12, but I think it would fit better in this repo.