### PR TITLE
Fix race condition in parsing w/ isSyscall().

### DIFF
--- a/parseAPI/src/IA_IAPI.h
+++ b/parseAPI/src/IA_IAPI.h
@@ -167,6 +167,7 @@ protected:
         static std::map<Architecture, Dyninst::InstructionAPI::RegisterAST::Ptr> framePtr;
         static std::map<Architecture, Dyninst::InstructionAPI::RegisterAST::Ptr> stackPtr;
         static std::map<Architecture, Dyninst::InstructionAPI::RegisterAST::Ptr> thePC;
+        static Dyninst::InstructionAPI::RegisterAST::Ptr         theGS;
         static std::map<Address, bool> thunkAtTarget;
         static void initASTs();
 };


### PR DESCRIPTION
Move isSyscall() scoped static variable to the existing IA_IAPI thread safe initizlizer.

This eliminate a scoped static race condition in the parser. This fix resolves a 1% rate of parsing failures.

Fixes #1413 