### PR TITLE
Make InstructionAPI::isArrayIndexValid const

### DIFF
--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
@@ -76,7 +76,7 @@ namespace Dyninst {
 
             //Check if the index (2nd arg) is valid for the array (1st arg)
             template <typename ArrayType, std::size_t n, typename IndexType>
-                constexpr bool isArrayIndexValid(ArrayType (&)[n], const IndexType& i) {
+                constexpr bool isArrayIndexValid(ArrayType (&)[n], const IndexType& i) const {
                     return 0 <= i && i < n;
                 }
 

--- a/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.h
+++ b/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.h
@@ -77,7 +77,7 @@ namespace Dyninst {
 
             //Check if the index (2nd arg) is valid for the array (1st arg)
             template <typename ArrayType, std::size_t n, typename IndexType>
-            constexpr bool isArrayIndexValid(ArrayType (&)[n], const IndexType& i) {
+            constexpr bool isArrayIndexValid(ArrayType (&)[n], const IndexType& i) const {
                 return 0 <= i && i < n;
             }
 


### PR DESCRIPTION
clang complains:

  'constexpr' non-static member function will not be implicitly 'const'
  in C++14; add 'const' to avoid a change in behavior [-Werror,-Wconstexpr-not-const]