### PR TITLE
warning fix:  stack frame size

### DIFF
--- a/cmake/DyninstWarnings.cmake
+++ b/cmake/DyninstWarnings.cmake
@@ -163,7 +163,7 @@ if(HAS_CPP_FLAG_Wframe_larger_than AND NOT DYNINST_DISABLE_DIAGNOSTIC_SUPPRESSIO
       set(nonDebugMaxFrameSizeOverrideFinalizeOperands 30000)
     endif()
   elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-    if(${CMAKE_CXX_COMPILER_VERSION} MATCHES "^14(\.|$)")
+    if(${CMAKE_CXX_COMPILER_VERSION} MATCHES "^1[4-6](\.|$)")
       set(debugMaxFrameSizeOverridePowerOpcodeTable 40000)
     else()
       set(debugMaxFrameSizeOverridePowerOpcodeTable 30000)


### PR DESCRIPTION
When compiling with clang 15 and 16 allow a 40000 stack frame size.  clang 14 already had an exception to allow 40000.

Fixes #1417.