### PR TITLE
Fix x86 misspelled, incorrect, and invalid opcodes

### DIFF
--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -187,7 +187,7 @@ enum entryID : unsigned int {
   e_aesimc, 
   e_vaesimc, 
   e_pclmullqlqdq, 
-  e_vpclmullqlqdq, 
+  e_vpclmulqdq,
   e_vpperm,
   e_daa,
   e_das,

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -186,7 +186,7 @@ enum entryID : unsigned int {
   e_vaeskeygenassist,
   e_aesimc, 
   e_vaesimc, 
-  e_pclmullqlqdq, 
+  e_pclmulqdq,
   e_vpclmulqdq,
   e_vpperm,
   e_daa,

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -855,7 +855,6 @@ enum entryID : unsigned int {
   e_vmovsd,
   e_vmovshdup,
   e_vmovsldup,
-  e_movslq,
   e_vmovss,
   e_vmovupd,
   e_vmovups,

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -589,7 +589,6 @@ enum entryID : unsigned int {
   e_prefetchwt1,
   e_clflushopt,
   e_clwb,
-  e_pcommit,
   e_sidt,
   e_sldt,
   e_smsw,

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -518,7 +518,7 @@ enum entryID : unsigned int {
   e_punpckhqd,
   e_punpckhwd,
   e_punpcklbw,
-  e_punpcklqd,
+  e_punpckldq,
   e_punpcklqld,
   e_punpcklwd,
   e_push,

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -424,7 +424,7 @@ enum entryID : unsigned int {
   e_pcmpeqw,
   e_pcmpestri,	// SSE 4.2
   e_pcmpestrm,	// SSE 4.2
-  e_pcmpgdt,
+  e_pcmpgtd,
   e_pcmpgtb,
   e_pcmpgtq,	// SSE 4.2
   e_pcmpgtw,

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -338,7 +338,6 @@ enum entryID : unsigned int {
   e_minps,
   e_minsd,
   e_minss,
-  e_mmxud,
   e_mov,
   e_movbe,
   e_movsl,

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -515,7 +515,7 @@ enum entryID : unsigned int {
   e_ptest,	// SSE 4.1
   e_punpckhbw,
   e_punpckhdq,
-  e_punpckhqd,
+  e_punpckhqdq,
   e_punpckhwd,
   e_punpcklbw,
   e_punpckldq,

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -896,7 +896,6 @@ enum entryID : unsigned int {
   e_vpbroadcastq,
   e_vpbroadcastw,
   e_vpcmpeqd,
-  e_vpcmpequd,
   e_vpcmpub,
   e_vpcmpb,
   e_vpcmpeqb,

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1164,7 +1164,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_movsd_sse, "movsd")
   (e_movshdup, "movshdup")
   (e_movsldup, "movsldup")
-  (e_movslq, "movslq")
   (e_movss, "movss")
   (e_movsw, "movsw")
   (e_movsx, "movsx")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1387,7 +1387,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_prefetchwt1, "prefetchwt1")
   (e_clflushopt, "clflushopt")
   (e_clwb, "clwb")
-  (e_pcommit, "pcommit")
   (e_sidt, "sidt")
   (e_sldt, "sldt")
   (e_smsw, "smsw")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1283,7 +1283,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_prefetchT0, "prefetchT0")
   (e_prefetchT1, "prefetchT1")
   (e_prefetchT2, "prefetchT2")
-  (e_prefetch_w, "prefetch(w)")
+  (e_prefetch_w, "prefetchw")
   (e_prefetchw, "prefetchw")
   (e_prefetchwt1, "prefetchwt1")
   (e_psadbw, "psadbw")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -2018,9 +2018,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vdbpsadbw, "vdbpsadbw")
   (e_vphsubsw, "vphsubsw")
 
-/* What are these? */
- (e_vpmovswb, "vpmovswb")
-
  (e_fp_generic, "[FIXME: GENERIC FPU INSN]")
  (e_3dnow_generic, "[FIXME: GENERIC 3DNow INSN]")
  (e_No_Entry, "No_Entry")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -2020,7 +2020,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
 
 /* What are these? */
  (e_vpmovswb, "vpmovswb")
- (e_vpmovsdb, "vpmovsdb")
  (e_vpmovsqb, "vpmovsqb")
  (e_vpmovsdw, "vpmovsdw")
  (e_vpmovsqw, "vpmovsqw")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1440,7 +1440,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vaesdeclast, "vaesdeclast")
   (e_vaeskeygenassist, "vaeskeygenassist")
   (e_vaesimc, "vaesimc")
-  (e_vpclmullqlqdq, "vpclmullqlqdq")
+  (e_vpclmulqdq, "vpclmulqdq")
   (e_vpperm, "vpperm")
   (e_vmpsadbw, "vmpsadbw") 
   (e_vmwrite, "vmwrite") 
@@ -7780,7 +7780,7 @@ ia32_entry sseMapTerMult[][3] =
         { e_vdbpsadbw, t_done, 0, true, { Vps, Hps, Wps }, 0, s1W2R3R4R, 0 }
     }, { /* SSET44_66 */
         { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-        { e_vpclmullqlqdq, t_done, 0, true, { Vps, Hps, Wps }, 0, s1W2R3R4R, 0 },
+        { e_vpclmulqdq, t_done, 0, true, { Vps, Hps, Wps }, 0, s1W2R3R4R, 0 },
         { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
     }, { /* SSET4A_66 */
         { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1749,7 +1749,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vpcmpgtd, "vpcmpgtd")
   (e_vpcmpgtq, "vpcmpgtq")
   (e_vpcmpgtw, "vpcmpgtw")
-  (e_vpcomd, "vpcmod")
+  (e_vpcomd, "vpcomd")
   (e_vpcompressd, "vpcompressd")
   (e_vpcompressq, "vpcompressq")
   (e_vpconflictd, "vpconflictd")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -935,7 +935,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_cmpps, "cmpps")
   (e_cmpsb, "cmpsb")
   (e_cmpsd, "cmpsd")
-  (e_cmpsd_sse, "cmpsd")
   (e_cmpss, "cmpss")
   (e_cmpsw, "cmpsw")
   (e_cmpxch, "cmpxch")
@@ -4592,7 +4591,7 @@ static ia32_entry sseMap[][4] = {
     { e_cmpps, t_sse_mult, SSEC2_NO, true, { Vps, Wps, Ib }, 0, s1RW2R3R, 0 }, // comparison writes to dest!
     { e_cmpss, t_sse_mult, SSEC2_F3, true, { Vss, Wss, Ib }, 0, s1RW2R3R, 0 },
     { e_cmppd, t_sse_mult, SSEC2_66, true, { Vpd, Wpd, Ib }, 0, s1RW2R3R, 0 },
-    { e_cmpsd_sse, t_sse_mult, SSEC2_F2, true, { Vsd, Wsd, Ib }, 0, s1RW2R3R, 0 },
+    { e_cmpsd, t_sse_mult, SSEC2_F2, true, { Vsd, Wsd, Ib }, 0, s1RW2R3R, 0 },
   },
   { /* SSEC4 */
     { e_pinsrw, t_done, 0, true, { Pq, Ed, Ib }, 0, s1RW2R3R, 0 },

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1740,7 +1740,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vpcmov, "vpcmov")
   (e_vpcmpub, "vpcmpub")
   (e_vpcmpb, "vpcmpb")
-  (e_vpcmpequd, "vpcmpequd")
   (e_vpcmpeqb, "vpcmpeqb")
   (e_vpcmpeqd, "vpcmpeqd")
   (e_vpcmpeqq, "vpcmpeqq")
@@ -7701,7 +7700,7 @@ ia32_entry sseMapTerMult[][3] =
     }, { /* SSET1E_66 */
         { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
         { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-        { e_vpcmpequd, t_done, 0, true, { Wpd, Hps, IK }, 0, s1W2R3R, 0 }
+		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
     }, { /* SSET1F_66 */
         { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
         { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1134,7 +1134,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_minps, "minps")
   (e_minsd, "minsd")
   (e_minss, "minss")
-  (e_mmxud, "mmxud")
   (e_mov, "mov")
   (e_movapd, "movapd")
   (e_movaps, "movaps")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1982,7 +1982,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_ktestd, "ktestd")
   (e_ktestw, "ktestw")
   (e_ktestq, "ktestq")
-  (e_vcmppd, "vcmppd")
   (e_vcmpps, "vcmpps")
   (e_vcmpsd, "vcmpsd")
   (e_vcmpss, "vcmpss")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1483,7 +1483,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vblendps, "vblendps")
   (e_vblendvpd, "vblendvpd")
   (e_vblendvps, "vblendvps")
-  (e_vblendvpd, "vblendvpd")
   (e_vpblendmb, "vpblendmb")
   (e_vpblendmw, "vpblendmw")
   (e_vpblendvb, "vpblendvb")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1383,7 +1383,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_sha256msg2, "sha256msg2")
   (e_shlx, "shlx")
   (e_sarx, "sarx")
-  (e_prefetchwt1, "prefetchwt1")
   (e_clflushopt, "clflushopt")
   (e_clwb, "clwb")
   (e_sidt, "sidt")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -2021,7 +2021,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
 /* What are these? */
  (e_vpmovswb, "vpmovswb")
  (e_vpmovsqw, "vpmovsqw")
- (e_vpmovsqd, "vpmovsqd")
 
  (e_fp_generic, "[FIXME: GENERIC FPU INSN]")
  (e_3dnow_generic, "[FIXME: GENERIC 3DNow INSN]")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1982,7 +1982,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_ktestd, "ktestd")
   (e_ktestw, "ktestw")
   (e_ktestq, "ktestq")
-  (e_vcmpss, "vcmpss")
   (e_vmovntpd, "vmovntpd")
   (e_vcvttsd2usi, "vcvttsd2usi")
   (e_vcvttss2usi, "vcvttss2usi")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1840,7 +1840,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vpor, "vpor")
   (e_vpord, "vpord")
   (e_vporq, "vporq")
-  (e_vprolvd, "vporlvd")
+  (e_vprolvd, "vprolvd")
   (e_vprolvq, "vporlvq")
   (e_vprold, "vprold")
   (e_vprolq, "vprolq")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1462,7 +1462,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_pdep, "pdep")
   (e_pext, "pext")
   (e_rorx, "rorx")
-  (e_sarx, "sarx")
   (e_shlx, "shlx")
   (e_shrx, "shrx")
   (e_tzcnt, "tzcnt")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1441,7 +1441,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vaeskeygenassist, "vaeskeygenassist")
   (e_vaesimc, "vaesimc")
   (e_vpclmullqlqdq, "vpclmullqlqdq")
-  (e_vpperm, "e_vpperm")
+  (e_vpperm, "vpperm")
   (e_vmpsadbw, "vmpsadbw") 
   (e_vmwrite, "vmwrite") 
   (e_vmread, "vmread") 

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1841,7 +1841,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vpord, "vpord")
   (e_vporq, "vporq")
   (e_vprolvd, "vprolvd")
-  (e_vprolvq, "vporlvq")
+  (e_vprolvq, "vprolvq")
   (e_vprold, "vprold")
   (e_vprolq, "vprolq")
   (e_vprorvd, "vprorvd")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1230,7 +1230,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_phsubd, "phsubd")
   (e_phsubsw, "phsubsw")
   (e_phsubw, "phsubw")
-  (e_phsubsw, "phsubsw")
   (e_pinsrb, "pinsrb")
   (e_pinsrd_pinsrq, "pinsrd/pinsrq")
   (e_pinsrw, "pinsrw")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1982,7 +1982,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_ktestd, "ktestd")
   (e_ktestw, "ktestw")
   (e_ktestq, "ktestq")
-  (e_vcmpsd, "vcmpsd")
   (e_vcmpss, "vcmpss")
   (e_vmovntpd, "vmovntpd")
   (e_vcvttsd2usi, "vcvttsd2usi")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1443,7 +1443,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vmread, "vmread") 
   (e_vphaddw, "vphaddw")
   (e_vphaddd, "vphaddd")
-  (e_vphaddsw, "vpaddsw")
+  (e_vphaddsw, "vphaddsw")
   (e_vphsubw, "vphsubw")
   (e_vphsubd, "vphsubd")
   (e_vpmovb2m, "vpmovb2m")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1485,7 +1485,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vblendmps, "vblendmps")
   (e_vblendmpd, "vblendmpd")
   (e_vblendps, "vblendps")
-  (e_vblendvpd, "vblendpd")
+  (e_vblendvpd, "vblendvpd")
   (e_vblendvps, "vblendvps")
   (e_vblendvpd, "vblendvpd")
   (e_vpblendmb, "vpblendmb")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1318,7 +1318,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_punpckhqd, "punpckhqd")
   (e_punpckhwd, "punpckhwd")
   (e_punpcklbw, "punpcklbw")
-  (e_punpcklqd, "punpcklqd")
+  (e_punpckldq, "punpckldq")
   (e_punpcklqld, "punpcklqld")
   (e_punpcklwd, "punpcklwd")
   (e_push, "push")
@@ -4365,9 +4365,9 @@ static ia32_entry sseMap[][4] = {
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
   },
   { /* SSE62 */
-    { e_punpcklqd, t_done, 0, true, { Pq, Qd, Zz }, 0, s1RW2R, 0 },
+    { e_punpckldq, t_done, 0, true, { Pq, Qd, Zz }, 0, s1RW2R, 0 },
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-    { e_punpcklqd, t_sse_mult, SSE62_66, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+    { e_punpckldq, t_sse_mult, SSE62_66, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
   },
   { /* SSE63 */

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -2020,7 +2020,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
 
 /* What are these? */
  (e_vpmovswb, "vpmovswb")
- (e_vpmovsqb, "vpmovsqb")
  (e_vpmovsqw, "vpmovsqw")
  (e_vpmovsqd, "vpmovsqd")
 

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1782,7 +1782,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vpinsrd, "vpinsrd")
   (e_vpinsrq, "vpinsrq")
   (e_vpinsrw, "vpinsrw")
-  (e_vpmaddubsw, "vpmaddubsw")
   (e_vpmaddwd, "vpmaddwd")
   (e_vpmaskmovd, "vpmaskmovd")
   (e_vpmaskmovq, "vpmaskmovq")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1982,7 +1982,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_ktestd, "ktestd")
   (e_ktestw, "ktestw")
   (e_ktestq, "ktestq")
-  (e_vcmpps, "vcmpps")
   (e_vcmpsd, "vcmpsd")
   (e_vcmpss, "vcmpss")
   (e_vmovntpd, "vmovntpd")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1380,7 +1380,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_sha256rnds2, "sha256rnds2")
   (e_sha256msg1, "sha256msg1")
   (e_sha256msg2, "sha256msg2")
-  (e_shlx, "shlx")
   (e_sarx, "sarx")
   (e_clflushopt, "clflushopt")
   (e_clwb, "clwb")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -2021,7 +2021,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
 /* What are these? */
  (e_vpmovswb, "vpmovswb")
  (e_vpmovsqb, "vpmovsqb")
- (e_vpmovsdw, "vpmovsdw")
  (e_vpmovsqw, "vpmovsqw")
  (e_vpmovsqd, "vpmovsqd")
 

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1879,7 +1879,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vpsrld, "vpsrld")
   (e_vpsrlq, "vpsrlq")
   (e_vpsrlvd, "vpsrlvd")
-  (e_vpsrlvq, "vprlvq")
   (e_vpsrlvq, "vpsrlvq")
   (e_vpsrlw, "vpsrlw")
   (e_vpsubb, "vpsubb")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -2020,7 +2020,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
 
 /* What are these? */
  (e_vpmovswb, "vpmovswb")
- (e_vpmovsqw, "vpmovsqw")
 
  (e_fp_generic, "[FIXME: GENERIC FPU INSN]")
  (e_3dnow_generic, "[FIXME: GENERIC 3DNow INSN]")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1782,7 +1782,6 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vpinsrd, "vpinsrd")
   (e_vpinsrq, "vpinsrq")
   (e_vpinsrw, "vpinsrw")
-  (e_vpmaddwd, "vpmaddwd")
   (e_vpmaskmovd, "vpmaskmovd")
   (e_vpmaskmovq, "vpmaskmovq")
   (e_vpmaxsq, "vpmaxsq")

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1217,7 +1217,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_pcmpeqw, "pcmpeqw")
   (e_pcmpestri, "pcmpestri")
   (e_pcmpestrm, "pcmpestrm")
-  (e_pcmpgdt, "pcmpgdt")
+  (e_pcmpgtd, "pcmpgtd")
   (e_pcmpgtb, "pcmpgtb")
   (e_pcmpgtq, "pcmpgtq")
   (e_pcmpgtw, "pcmpgtw")
@@ -4389,9 +4389,9 @@ static ia32_entry sseMap[][4] = {
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
   },
   { /* SSE66 */
-    { e_pcmpgdt, t_done, 0, true, { Pq, Qq, Zz }, 0, s1R2R, 0 },
+    { e_pcmpgtd, t_done, 0, true, { Pq, Qq, Zz }, 0, s1R2R, 0 },
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-    { e_pcmpgdt, t_sse_mult, SSE66_66, true, { Vdq, Wdq, Zz }, 0, s1R2R, 0 },
+    { e_pcmpgtd, t_sse_mult, SSE66_66, true, { Vdq, Wdq, Zz }, 0, s1R2R, 0 },
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
   },
   { /* SSE67 */

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -1315,7 +1315,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_ptest, "ptest")
   (e_punpckhbw, "punpckhbw")
   (e_punpckhdq, "punpckhdq")
-  (e_punpckhqd, "punpckhqd")
+  (e_punpckhqdq, "punpckhqdq")
   (e_punpckhwd, "punpckhwd")
   (e_punpcklbw, "punpcklbw")
   (e_punpckldq, "punpckldq")
@@ -4433,7 +4433,7 @@ static ia32_entry sseMap[][4] = {
   { /* SSE6D */
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-    { e_punpckhqd, t_sse_mult, SSE6D_66, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+    { e_punpckhqdq, t_sse_mult, SSE6D_66, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
   },
   { /* SSE6E */

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -887,7 +887,7 @@ COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_aesdeclast, "aesdeclast")
   (e_aeskeygenassist, "aeskeygenassist")
   (e_aesimc, "aesimc")
-  (e_pclmullqlqdq, "pclmullqlqdq")
+  (e_pclmulqdq, "pclmulqdq")
   (e_and, "and")
   (e_andnpd, "andnpd")
   (e_andnps, "andnps")
@@ -6039,7 +6039,7 @@ static ia32_entry sseMapTer[][3] =
         { e_mpsadbw, t_done, 0, true, { Vdq, Wdq, Ib }, 0, s1RW2R3R, 0 },
     }, { /* SSET44 */
         { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-        { e_pclmullqlqdq, t_sse_ter_mult, SSET44_66, true, { Vps, Wps, Ib }, 0, s1RW2R3R, 0 },
+        { e_pclmulqdq, t_sse_ter_mult, SSET44_66, true, { Vps, Wps, Ib }, 0, s1RW2R3R, 0 },
         { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
     }, { /* SSET46 */
         { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },

--- a/dataflowAPI/src/convertOpcodes.C
+++ b/dataflowAPI/src/convertOpcodes.C
@@ -760,8 +760,8 @@ X86InstructionKind RoseInsnX86Factory::convertKind(entryID opcode, prefixEntryID
             return x86_punpckhbw;
         case e_punpckhdq:
             return x86_punpckhdq;
-        case e_punpckhqd:
-            return x86_punpckhdq;
+        case e_punpckhqdq:
+            return x86_punpckhqdq;
         case e_punpckhwd:
             return x86_punpckhwd;
         case e_punpcklbw:

--- a/dataflowAPI/src/convertOpcodes.C
+++ b/dataflowAPI/src/convertOpcodes.C
@@ -766,7 +766,7 @@ X86InstructionKind RoseInsnX86Factory::convertKind(entryID opcode, prefixEntryID
             return x86_punpckhwd;
         case e_punpcklbw:
             return x86_punpcklbw;
-        case e_punpcklqd:
+        case e_punpckldq:
             return x86_punpckldq;
         case e_punpcklqld:
             return x86_punpcklqdq;

--- a/dataflowAPI/src/convertOpcodes.C
+++ b/dataflowAPI/src/convertOpcodes.C
@@ -668,7 +668,7 @@ X86InstructionKind RoseInsnX86Factory::convertKind(entryID opcode, prefixEntryID
             return x86_pcmpeqd;
         case e_pcmpeqw:
             return x86_pcmpeqw;
-        case e_pcmpgdt:
+        case e_pcmpgtd:
             return x86_pcmpgtd;
         case e_pcmpgtb:
             return x86_pcmpgtb;

--- a/dataflowAPI/src/convertOpcodes.C
+++ b/dataflowAPI/src/convertOpcodes.C
@@ -528,8 +528,6 @@ X86InstructionKind RoseInsnX86Factory::convertKind(entryID opcode, prefixEntryID
             return x86_minsd;
         case e_minss:
             return x86_minss;
-        case e_mmxud:
-            return x86_unknown_instruction;
         case e_mov:
             return x86_mov;
         case e_movapd:


### PR DESCRIPTION
These were found when comparing against Capstone. There are a few breakages in here. For example, 1dcab37d renames `e_cmpsd_sse` to `e_cmpsd`, consistent with the rest of the SEE opcodes.