### PR TITLE
Github CI: use default TBB when doing spack build

### DIFF
--- a/.github/workflows/spack-build.yaml
+++ b/.github/workflows/spack-build.yaml
@@ -15,4 +15,4 @@ jobs:
         git clone --depth=1 --branch=develop https://github.com/spack/spack
         spack/bin/spack compiler find
         spack/bin/spack external find --not-buildable cmake
-        spack/bin/spack install dyninst@master ^intel-tbb@2018.6
+        spack/bin/spack install dyninst@master


### PR DESCRIPTION
Dyninst now requires TBB >= 2019.9.