### PR TITLE
Github CI: make compiler multi-build a cron job

### DIFF
--- a/.github/workflows/compiler-multibuild.yaml
+++ b/.github/workflows/compiler-multibuild.yaml
@@ -4,10 +4,8 @@
 name: Compiler multibuild
 
 on:
-  pull_request:
-    branches: ['master']
-#  schedule:
-#    - cron: '0 3 * * 1'
+  schedule:
+    - cron: '0 3 * * 1'  # 3AM on Monday
 
 jobs:
   gcc-ubuntu-20_04:


### PR DESCRIPTION
This should have been included in #1415.