### PR TITLE
Make CondVar non-copyable, non-moveable

### DIFF
--- a/common/src/dthread.h
+++ b/common/src/dthread.h
@@ -117,6 +117,11 @@ class PC_EXPORT CondVar {
    }
    ~CondVar() { if(created_mutex) delete mutex; }
 
+   CondVar(CondVar const&) = delete;
+   CondVar& operator=(CondVar const&) = delete;
+   CondVar(CondVar &&) = delete;
+   CondVar& operator=(CondVar &&rhs) = delete;
+
    void unlock() { mutex->unlock(); }
    bool trylock() { return mutex->try_lock(); }
    void lock() { mutex->lock(); }


### PR DESCRIPTION
This makes it consistent with std::condition_variable.

Found using cppcheck:

common/src/dthread.h:114:4: warning: Class 'CondVar' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s). [noCopyConstructor]
   mutex = new mutex_t;
   ^
common/src/dthread.h:114:4: warning: Class 'CondVar' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s). [noOperatorEq]
   mutex = new mutex_t;