### PR TITLE
Remove virtual calls in constructor/destructor

### DIFF
--- a/common/src/NodeIterator.h
+++ b/common/src/NodeIterator.h
@@ -391,7 +391,7 @@ class NodeIteratorPredicateFunc : public NodeIteratorImpl {
         // next is now a matching node. If the start wasn't,
         // then we need to increment...
         if ((cur != end) && !pred(*cur, user_arg)) {
-            inc();
+        	NodeIteratorPredicateFunc::inc();
         }
     }
     void setNext() {

--- a/common/src/NodeIterator.h
+++ b/common/src/NodeIterator.h
@@ -328,7 +328,7 @@ class NodeIteratorPredicateObj : public NodeIteratorImpl {
         // next is now a matching node. If the start wasn't,
         // then we need to increment...
         if ((cur != end) && !pred->predicate(*cur)) {
-            inc();
+        	NodeIteratorPredicateObj::inc();
         }
     }
     void setNext() {

--- a/common/src/addrtranslate-win.C
+++ b/common/src/addrtranslate-win.C
@@ -165,7 +165,7 @@ AddressTranslateWin::AddressTranslateWin(PID pid, PROC_HANDLE phandle_) :
 	AddressTranslate(pid, phandle_),
    no_proc(false)
 {
-	init();
+	AddressTranslateWin::init();
 }
 
 Address AddressTranslateWin::getLibraryTrapAddrSysV()

--- a/instructionAPI/src/InstructionDecoder-x86.C
+++ b/instructionAPI/src/InstructionDecoder-x86.C
@@ -141,7 +141,7 @@ namespace Dyninst
       sizePrefixPresent(false),
       addrSizePrefixPresent(false)
     {
-      if(a == Arch_x86_64) setMode(true);
+      if(a == Arch_x86_64) InstructionDecoder_x86::setMode(true);
       
     }
     INSTRUCTION_EXPORT InstructionDecoder_x86::~InstructionDecoder_x86()

--- a/parseAPI/src/CFGFactory.C
+++ b/parseAPI/src/CFGFactory.C
@@ -202,7 +202,7 @@ std::string to_str(EdgeState e)
 void
 CFGFactory::destroy_edge(Edge *e, Dyninst::ParseAPI::EdgeState reason) {
     if(reason == destroyed_all) {
-        free_edge(e);
+        CFGFactory::free_edge(e);
     }
 }
 

--- a/parseAPI/src/CFGFactory.C
+++ b/parseAPI/src/CFGFactory.C
@@ -169,7 +169,7 @@ CFGFactory::mkedge(Block * src, Block * trg, EdgeTypeEnum type) {
 }
 
 void CFGFactory::destroy_func(Function *f) {
-   free_func(f);
+   CFGFactory::free_func(f);
 }
 
 void

--- a/parseAPI/src/CFGFactory.C
+++ b/parseAPI/src/CFGFactory.C
@@ -179,7 +179,7 @@ CFGFactory::free_func(Function *f) {
 
 void
 CFGFactory::destroy_block(Block *b) {
-    free_block(b);
+    CFGFactory::free_block(b);
 }
 
 void

--- a/proccontrol/src/freebsd.C
+++ b/proccontrol/src/freebsd.C
@@ -792,7 +792,7 @@ freebsd_process::freebsd_process(Dyninst::PID pid_, int_process *p) :
 
 freebsd_process::~freebsd_process() 
 {
-    int eventQueue = getEventQueue();
+    int eventQueue = freebsd_process::getEventQueue();
     if( -1 != eventQueue ) {
         // Remove the event for this process
         struct kevent event;


### PR DESCRIPTION
Not technically bugs, but it's better to be explicit to remove any ambiguity. Found using cppcheck's virtualCallInConstructor.