### PR TITLE
Protect against self-assignment in copy constructors

### DIFF
--- a/common/src/Edge.C
+++ b/common/src/Edge.C
@@ -107,7 +107,7 @@ bool EdgeIterator::operator==(const EdgeIterator &rhs) const {
 
 EdgeIterator &EdgeIterator::operator=(const EdgeIterator &rhs) {
     if(this == &rhs) return *this;
-	if (rhs.iter_ == NULL) {
+    if (rhs.iter_ == NULL) {
         if (iter_) delete iter_; // No leaking!
         iter_ = rhs.iter_; 
         return *this;

--- a/common/src/Edge.C
+++ b/common/src/Edge.C
@@ -106,7 +106,8 @@ bool EdgeIterator::operator==(const EdgeIterator &rhs) const {
 }
 
 EdgeIterator &EdgeIterator::operator=(const EdgeIterator &rhs) {
-    if (rhs.iter_ == NULL) {
+    if(this == &rhs) return *this;
+	if (rhs.iter_ == NULL) {
         if (iter_) delete iter_; // No leaking!
         iter_ = rhs.iter_; 
         return *this;

--- a/common/src/Node.C
+++ b/common/src/Node.C
@@ -196,7 +196,8 @@ bool NodeIterator::operator==(const NodeIterator &rhs) const {
 }
 
 NodeIterator &NodeIterator::operator=(const NodeIterator &rhs) {
-    if (iter_) delete iter_;
+    if(this == &rhs) return *this;
+	if (iter_) delete iter_;
     iter_ = rhs.copy();
     return *this;
 }

--- a/common/src/Node.C
+++ b/common/src/Node.C
@@ -197,7 +197,7 @@ bool NodeIterator::operator==(const NodeIterator &rhs) const {
 
 NodeIterator &NodeIterator::operator=(const NodeIterator &rhs) {
     if(this == &rhs) return *this;
-	if (iter_) delete iter_;
+    if (iter_) delete iter_;
     iter_ = rhs.copy();
     return *this;
 }


### PR DESCRIPTION
These were found by cppcheck:

common/src/Node.C:198:29: warning: 'operator=' should check for assignment to self to avoid problems with dynamic memory. [operatorEqToSelf]
NodeIterator &NodeIterator::operator=(const NodeIterator &rhs) {
                            ^
common/src/Edge.C:108:29: warning: 'operator=' should check for assignment to self to avoid problems with dynamic memory. [operatorEqToSelf]
EdgeIterator &EdgeIterator::operator=(const EdgeIterator &rhs) {