### PR TITLE
Fix uninitialized member variables

### DIFF
--- a/common/h/IBSTree.h
+++ b/common/h/IBSTree.h
@@ -100,9 +100,9 @@ class SimpleInterval
     virtual T high() const { return high_; }
     virtual U id() const { return id_; }
   protected:
-    T low_;
-    T high_;
-    U id_; // some arbitrary unique identifier
+    T low_{};
+    T high_{};
+    U id_{}; // some arbitrary unique identifier
 };
 
 template<class ITYPE>

--- a/dataflowAPI/rose/SgAsmExpression.h
+++ b/dataflowAPI/rose/SgAsmExpression.h
@@ -1236,7 +1236,7 @@ public:
 
 protected:
     // Start of memberFunctionString
-    SgAsmType *p_type;
+    SgAsmType *p_type{};
 
     // End of memberFunctionString
 public:

--- a/dataflowAPI/rose/SgAsmPowerpcInstruction.h
+++ b/dataflowAPI/rose/SgAsmPowerpcInstruction.h
@@ -52,7 +52,7 @@ class SgAsmPowerpcInstruction : public SgAsmInstruction
                 powerpc_unknown_instruction);
 
     protected:
-        rose_addr_t p_address;
+        rose_addr_t p_address{};
         PowerpcInstructionKind p_kind;
         SgAsmOperandList* p_operandList;
         std::string p_mnemonic;

--- a/dataflowAPI/rose/util/PoolAllocator.h
+++ b/dataflowAPI/rose/util/PoolAllocator.h
@@ -163,7 +163,7 @@ private:
         Pool(const Pool&);                              // nonsense
 
     public:
-        Pool(): cellSize_(0) {}
+        Pool(): cellSize_(0), freeLists_{} {}
 
         void init(size_t cellSize) {
             assert(cellSize_ == 0);

--- a/dwarf/h/dwarfResult.h
+++ b/dwarf/h/dwarfResult.h
@@ -166,12 +166,12 @@ public:
     bool eval(MachRegisterVal &v);
 
 private:
-    ProcessReader *reader;
+    ProcessReader *reader{};
 
     // For getting access to other expressions
-    Address pc;
-    Dwarf * dbg;
-    Elf * dbg_eh_frame;
+    Address pc{};
+    Dwarf * dbg{};
+    Elf * dbg_eh_frame{};
 
     // Dwarf lets you access within the "stack", so we model 
     // it as a vector.

--- a/dynC_API/h/snippetGen.h
+++ b/dynC_API/h/snippetGen.h
@@ -65,7 +65,7 @@ class SnippetGenerator{
 
   private:
    std::stringstream lastError;
-   SGError lastErrorInfo;   
+   SGError lastErrorInfo{};
    BPatch_point *point;
    BPatch_addressSpace *addSpace;
    BPatch_image *image;

--- a/dyninstAPI/h/BPatch_type.h
+++ b/dyninstAPI/h/BPatch_type.h
@@ -226,7 +226,7 @@ private:
   // which functions use this list
   BPatch_Vector<BPatch_function *> functions;
 
-  Dyninst::SymtabAPI::CBlock *cBlk;
+  Dyninst::SymtabAPI::CBlock *cBlk{};
 
   void fixupUnknowns(BPatch_module *);
 public:
@@ -323,11 +323,11 @@ class BPATCH_DLL_EXPORT BPatch_localVar{
     friend class BPatch;
     friend class BPatch_function;
 
-    BPatch_type *type;
-    BPatch_storageClass storageClass;
+    BPatch_type *type{};
+    BPatch_storageClass storageClass{};
     // scope_t scope;
 
-    Dyninst::SymtabAPI::localVar *lVar;
+    Dyninst::SymtabAPI::localVar *lVar{};
 
 public:
     //  Internal use only

--- a/dyninstAPI/h/StackMod.h
+++ b/dyninstAPI/h/StackMod.h
@@ -77,8 +77,8 @@ class BPATCH_DLL_EXPORT StackMod
         virtual std::string format() const { return ""; }
 
     protected:
-        MOrder _order;
-        MType _type;
+        MOrder _order{};
+        MType _type{};
 };
 
 /* Modification to insert stack space at [low, high) */
@@ -99,8 +99,8 @@ class BPATCH_DLL_EXPORT Insert : public StackMod
     private:
         Insert(MOrder, int, int);
 
-        int _low;
-        int _high;
+        int _low{};
+        int _high{};
 };
 
 /* Modification to remove stack space at [low, high) */
@@ -121,8 +121,8 @@ class BPATCH_DLL_EXPORT Remove : public StackMod
     private:
         Remove(MOrder, int, int);
 
-        int _low;
-        int _high;
+        int _low{};
+        int _high{};
 };
 
 /* Modification to move stack space from [srcLow, srcHigh)
@@ -144,10 +144,10 @@ class BPATCH_DLL_EXPORT Move : public StackMod
         std::string format() const;
 
     private:
-        int _srcLow;
-        int _srcHigh;
-        int _destLow;
-        int _destHigh;
+        int _srcLow{};
+        int _srcHigh{};
+        int _destLow{};
+        int _destHigh{};
 };
 
 /* Modification to insert a stack canary at function entry
@@ -180,9 +180,9 @@ class BPATCH_DLL_EXPORT Canary : public StackMod
         std::string format() const;
 
     private:
-        int _low;
-        int _high;
-        BPatch_function* _failFunc;
+        int _low{};
+        int _high{};
+        BPatch_function* _failFunc{};
 };
 
 /* Modification to randomize the locations of the DWARF-specified
@@ -201,8 +201,8 @@ class BPATCH_DLL_EXPORT Randomize : public StackMod
         std::string format() const;
 
     private:
-        bool _isSeeded;
-        int _seed;
+        bool _isSeeded{};
+        int _seed{};
 };
 
 #endif

--- a/dyninstAPI/src/Relocation/Widgets/RelDataWidget.h
+++ b/dyninstAPI/src/Relocation/Widgets/RelDataWidget.h
@@ -82,12 +82,12 @@ struct RelDataPatch : public Patch {
   void setBlock(block_instance *_block) { block = _block; }
   
   InstructionAPI::Instruction orig_insn;
-  Address target_addr;
-  Address orig;
+  Address target_addr{};
+  Address orig{};
 
 private:
-  func_instance *func;
-  block_instance *block;
+  func_instance *func{};
+  block_instance *block{};
 };
 
 

--- a/dyninstAPI/src/StackMod/StackLocation.h
+++ b/dyninstAPI/src/StackMod/StackLocation.h
@@ -79,8 +79,11 @@ class StackLocation {
     {}
 
         StackLocation() :
+            _type(StackAccess::StackAccessType::UNKNOWN),
+            _size{},
             _isStackMemory(false),
             _isRegister(false),
+			_reg{},
             _isNull(true),
             _valid(NULL)
     {}
@@ -122,7 +125,7 @@ class StackLocation {
 
         bool _isStackMemory;
         StackAnalysis::Height _off;
-        bool _isRegisterHeight;
+        bool _isRegisterHeight{};
 
         bool _isRegister;
         MachRegister _reg;

--- a/dyninstAPI/src/ast.h
+++ b/dyninstAPI/src/ast.h
@@ -492,9 +492,9 @@ class AstStackRemoveNode : public AstNode {
     int size;
     MSpecialType type;
 
-    func_instance* func_;
-    bool canaryAfterPrologue_;
-    long canaryHeight_;
+    func_instance* func_{};
+    bool canaryAfterPrologue_{};
+    long canaryHeight_{};
 };
 
 class AstStackGenericNode : public AstNode {
@@ -570,7 +570,7 @@ class AstOperatorNode : public AstNode {
     bool generateOptimizedAssignment(codeGen &gen, int size, bool noCost);
 
     AstOperatorNode() {}
-    opCode op;
+    opCode op{};
     AstNodePtr loperand;
     AstNodePtr roperand;
     AstNodePtr eoperand;
@@ -839,8 +839,8 @@ class AstMemoryNode : public AstNode {
                                      Register &retReg);
     
     AstMemoryNode() {}
-    memoryType mem_;
-    unsigned which_;
+    memoryType mem_{};
+    unsigned which_{};
 };
 
 class AstOriginalAddrNode : public AstNode {

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -232,8 +232,8 @@ class image_variable {
     pdmodule *pdmod() const { return pdmod_; }
     SymtabAPI::Variable *svar() const { return var_; }
 
-    SymtabAPI::Variable *var_;
-    pdmodule *pdmod_;
+    SymtabAPI::Variable *var_{};
+    pdmodule *pdmod_{};
     
 };
 

--- a/dyninstAPI/src/inst-x86.h
+++ b/dyninstAPI/src/inst-x86.h
@@ -237,7 +237,7 @@ struct stackItem {
       reg_item,
       stacktop,
       framebase
-   } item;
+   } item{};
    RealRegister reg;
    stackItem(stackItem_t i) { assert(i != reg_item); item = i; }
    stackItem(RealRegister r) { item = reg_item; reg = r; }

--- a/dyninstAPI/src/mapped_object.h
+++ b/dyninstAPI/src/mapped_object.h
@@ -98,12 +98,12 @@ class int_variable {
     //AddressSpace *as() const { return mod()->proc(); }
     const image_variable *ivar() const { return ivar_; }
 
-    Address addr_;
-    unsigned size_;
+    Address addr_{};
+    unsigned size_{};
     // type?
-    image_variable *ivar_;
+    image_variable *ivar_{};
 
-    mapped_module *mod_;
+    mapped_module *mod_{};
 };
 
 struct edgeStub {
@@ -114,7 +114,7 @@ struct edgeStub {
     block_instance* src;
     Address trg;
     EdgeTypeEnum type;
-    bool checked;
+    bool checked{};
 };
 
 

--- a/dyninstAPI/src/registerSpace.h
+++ b/dyninstAPI/src/registerSpace.h
@@ -150,7 +150,13 @@ class registerSlot {
         name("DEFAULT REGISTER"),
         initialState(deadAlways),
         offLimits(true),
-        type(invalid)
+        type(invalid),
+        refCount(0),
+        liveState(live),
+        keptValue(false),
+        beenUsed(false),
+        spilledState(unspilled),
+        saveOffset(-1)
         {}
 
     registerSlot(Register num,

--- a/dyninstAPI/src/syscallNotification.h
+++ b/dyninstAPI/src/syscallNotification.h
@@ -62,7 +62,8 @@ class syscallNotification {
     syscallNotification() :
     preForkInst(NULL), postForkInst(NULL),
     preExecInst(NULL), postExecInst(NULL),
-    preExitInst(NULL), preLwpExitInst(NULL)
+    preExitInst(NULL), preLwpExitInst(NULL),
+    proc(NULL)
        { assert(0 && "ILLEGAL USE OF DEFAULT CONSTRUCTOR"); }
 
     syscallNotification(PCProcess *p) :

--- a/elf/h/Elf_X.h
+++ b/elf/h/Elf_X.h
@@ -129,24 +129,24 @@ class DYNELF_EXPORT Elf_X {
     Dyninst::Architecture getArch() const;
 
   protected:
-    Elf *elf;
-    Elf32_Ehdr *ehdr32;
-    Elf64_Ehdr *ehdr64;
-    Elf32_Phdr *phdr32;
-    Elf64_Phdr *phdr64;
-    int filedes;
-    bool is64;
-    bool isArchive;
-    bool isBigEndian;
+    Elf *elf{};
+    Elf32_Ehdr *ehdr32{};
+    Elf64_Ehdr *ehdr64{};
+    Elf32_Phdr *phdr32{};
+    Elf64_Phdr *phdr64{};
+    int filedes{};
+    bool is64{};
+    bool isArchive{};
+    bool isBigEndian{};
     std::vector<Elf_X_Shdr> shdrs;
     std::vector<Elf_X_Phdr> phdrs;
-    unsigned int ref_count;
+    unsigned int ref_count{};
     std::string filename;
 
-    char *cached_debug_buffer;
-    unsigned long cached_debug_size;
+    char *cached_debug_buffer{};
+    unsigned long cached_debug_size{};
     std::string cached_debug_name;
-    bool cached_debug;
+    bool cached_debug{};
 
     Elf_X();
     Elf_X(int input, Elf_Cmd cmd, Elf_X *ref = NULL);

--- a/instructionAPI/h/Ternary.h
+++ b/instructionAPI/h/Ternary.h
@@ -90,7 +90,7 @@ namespace Dyninst
       Expression::Ptr cond;
       Expression::Ptr first;
       Expression::Ptr second;
-      Result_Type result_type;
+      Result_Type result_type{};
 
     protected:
       virtual bool isStrictEqual(const InstructionAST& rhs) const;

--- a/instructionAPI/src/InstructionDecoder-aarch64.h
+++ b/instructionAPI/src/InstructionDecoder-aarch64.h
@@ -152,23 +152,23 @@ namespace Dyninst {
         private:
             virtual Result_Type makeSizeType(unsigned int opType);
 
-            bool isPstateRead, isPstateWritten;
-            bool isFPInsn, isSIMDInsn;
-	    bool skipRn, skipRm;
-            bool is64Bit;
-            bool isValid;
+            bool isPstateRead{}, isPstateWritten{};
+            bool isFPInsn{}, isSIMDInsn{};
+	    bool skipRn{}, skipRm{};
+            bool is64Bit{};
+            bool isValid{};
 
             void mainDecode();
 
             int findInsnTableIndex(unsigned int);
 
             /*members for handling operand re-ordering, will be removed later once a generic operand ordering method is incorporated*/
-            int oprRotateAmt;
-            bool hasb5;
+            int oprRotateAmt{};
+            bool hasb5{};
 
             void reorderOperands();
 
-            unsigned int insn;
+            unsigned int insn{};
             boost::shared_ptr<Instruction> insn_in_progress;
 
             template<int start, int end>
@@ -220,42 +220,42 @@ namespace Dyninst {
                 return -1;
             }
 
-            int op1Field, op2Field, crmField;
+            int op1Field{}, op2Field{}, crmField{};
 
             void processSystemInsn();
 
-            bool hasHw;
-            int hwField;
+            bool hasHw{};
+            int hwField{};
 
             void processHwFieldInsn(int, int);
 
-            bool hasShift;
-            int shiftField;
+            bool hasShift{};
+            int shiftField{};
 
             void processShiftFieldShiftedInsn(int, int);
 
             void processShiftFieldImmInsn(int, int);
 
-            bool hasOption;
-            int optionField;
+            bool hasOption{};
+            int optionField{};
 
             void processOptionFieldLSRegOffsetInsn();
 
-            bool hasN;
-            int immr, immrLen;
-            int sField, nField, nLen;
+            bool hasN{};
+            int immr, immrLen{};
+            int sField{}, nField{}, nLen{};
 
-            int immlo, immloLen;
+            int immlo{}, immloLen{};
 
             void makeBranchTarget(bool, bool, int, int);
 
             Expression::Ptr makeFallThroughExpr();
 
-            int _szField, size;
-            int _typeField;
-            int cmode;
-            int op;
-            int simdAlphabetImm;
+            int _szField{}, size{};
+            int _typeField{};
+            int cmode{};
+            int op{};
+            int simdAlphabetImm{};
 
             void processAlphabetImm();
 
@@ -503,9 +503,9 @@ namespace Dyninst {
 
             void setFlags();
 
-            unsigned int _Q;
-            unsigned int _L;
-            unsigned int _R;
+            unsigned int _Q{};
+            unsigned int _L{};
+            unsigned int _R{};
 
             void getSIMD_MULT_RptSelem(unsigned int &rpt, unsigned int &selem);
 

--- a/parseAPI/src/BoundFactData.h
+++ b/parseAPI/src/BoundFactData.h
@@ -157,7 +157,7 @@ struct BoundFact {
     } pred;
 
     struct StackTop {
-        int64_t value;
+        int64_t value{};
 	bool valid;
 
 	StackTop(): valid(false) {}

--- a/parseAPI/src/ParserDetails.h
+++ b/parseAPI/src/ParserDetails.h
@@ -273,19 +273,19 @@ class ParseWorkElem
     };
 
  private:
-    ParseWorkBundle * _bundle;
-    Edge * _edge;
-    Address _src;
-    Address _targ;
-    bool _can_resolve;
-    bool _tailcall;
-    parse_work_order _order;
-    bool _call_processed;
+    ParseWorkBundle * _bundle{};
+    Edge * _edge{};
+    Address _src{};
+    Address _targ{};
+    bool _can_resolve{};
+    bool _tailcall{};
+    parse_work_order _order{};
+    bool _call_processed{};
 
     // Data for continuing parsing jump tables
-    Block* _cur;
-    InsnAdapter::IA_IAPI* _ah;
-    Function * _shared_func;
+    Block* _cur{};
+    InsnAdapter::IA_IAPI* _ah{};
+    Function * _shared_func{};
 };
 
 // ParseWorkElem container

--- a/parseAPI/src/ProbabilisticParser.h
+++ b/parseAPI/src/ProbabilisticParser.h
@@ -86,7 +86,7 @@ namespace hd {
 #define ARG2_MASK (((uint64_t)(1<<ARG_SIZE)-1) << ARG2_SHIFT)
 
 struct IdiomTerm {
-    unsigned short entry_id, arg1, arg2;
+    unsigned short entry_id{}, arg1{}, arg2{};
     IdiomTerm() {}
     IdiomTerm(unsigned short a, unsigned short b, unsigned short c):
         entry_id(a), arg1(b), arg2(c) {}
@@ -101,8 +101,8 @@ static IdiomTerm WILDCARD_TERM(WILDCARD_ENTRY_ID, NOARG, NOARG);
 
 struct Idiom {
     std::vector<IdiomTerm> terms;
-    double w;
-    bool prefix;
+    double w{};
+    bool prefix{};
     Idiom() {}
     Idiom(std::string f, double weight, bool pre);
     bool operator < (const Idiom& i) const;
@@ -114,9 +114,9 @@ public:
     typedef std::vector<std::pair<IdiomTerm, IdiomPrefixTree*> > ChildrenType;
     typedef dyn_hash_map<unsigned short, ChildrenType> ChildrenByEntryID;
 private:
-    ChildrenByEntryID childrenClusters;
-    double w;
-    bool feature;
+    ChildrenByEntryID childrenClusters{};
+    double w{};
+    bool feature{};
     void addIdiom(int cur, const Idiom& idiom);
 
 
@@ -133,11 +133,11 @@ public:
 };
 
 class IdiomModel {
-    IdiomPrefixTree normal;
-    IdiomPrefixTree prefix;
+    IdiomPrefixTree normal{};
+    IdiomPrefixTree prefix{};
 
-    double bias;
-    double prob_threshold;
+    double bias{};
+    double prob_threshold{};
     IdiomModel() {}
 
 public:

--- a/patchAPI/h/AddrSpace.h
+++ b/patchAPI/h/AddrSpace.h
@@ -79,7 +79,7 @@ class PATCHAPI_EXPORT AddrSpace {
 
   protected:
     ObjMap obj_map_;
-    PatchObject* first_object_;
+    PatchObject* first_object_{};
     PatchMgrPtr mgr_;
 
     bool init(PatchObject*);

--- a/patchAPI/h/Point.h
+++ b/patchAPI/h/Point.h
@@ -264,12 +264,12 @@ class PATCHAPI_EXPORT Point {
 
 
     InstanceList instanceList_;
-    Address addr_;
-    Type type_;
+    Address addr_{};
+    Type type_{};
     PatchMgrPtr mgr_;
-    PatchBlock* the_block_;
-    PatchEdge* the_edge_;
-    PatchFunction* the_func_;
+    PatchBlock* the_block_{};
+    PatchEdge* the_edge_{};
+    PatchFunction* the_func_{};
     InstructionAPI::Instruction insn_;
 };
 

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -714,15 +714,15 @@ class SYMTAB_EXPORT ExceptionBlock : public AnnotatableSparse {
 
       friend SYMTAB_EXPORT std::ostream &operator<<(std::ostream &os, const ExceptionBlock &q);
    private:
-      Offset tryStart_;
-      unsigned trySize_;
-      Offset catchStart_;
-      bool hasTry_;
-      Offset tryStart_ptr;
-      Offset tryEnd_ptr;
-      Offset catchStart_ptr;
-      Offset fdeStart_ptr;
-      Offset fdeEnd_ptr;
+      Offset tryStart_{};
+      unsigned trySize_{};
+      Offset catchStart_{};
+      bool hasTry_{};
+      Offset tryStart_ptr{};
+      Offset tryEnd_ptr{};
+      Offset catchStart_ptr{};
+      Offset fdeStart_ptr{};
+      Offset fdeEnd_ptr{};
 };
 
 // relocation information for calls to functions not in this image

--- a/symtabAPI/src/Object-nt.C
+++ b/symtabAPI/src/Object-nt.C
@@ -1184,9 +1184,9 @@ void Object::parseFileLineInfo()
 }
 
 typedef struct localsStruct {
-    Function *func;
-    Offset base;
-    HANDLE p;
+    Function *func{};
+    Offset base{};
+    HANDLE p{};
     map<unsigned, unsigned> foundSyms;
     localsStruct() : foundSyms() {}
 } localsStruct;

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -205,7 +205,7 @@ namespace Dyninst {
             std::map<unsigned, std::vector<std::string> > verdauxEntries;
             std::map<std::string, unsigned> versionNames;
             std::vector<Elf_Half> versionSymTable;
-            int curVersionNum, verneednum, verdefnum, dynsym_info;
+            int curVersionNum, verneednum, verdefnum, dynsym_info{};
 
             // Needed when adding a new segment
             Elf_Off newSegmentStart;


### PR DESCRIPTION
These were detected by cppcheck's uninitMemberVar*. No attempt was made to be consistent in solving each item. Some are directly initialized in the class declaration, others have modified constructor initializer lists.

@kupsch I'll take a careful look over these once the CI runs to see if there are any enum members that should have better defaults.