### PR TITLE
Fix use of null pointer after check

### DIFF
--- a/parseAPI/src/BoundFactData.C
+++ b/parseAPI/src/BoundFactData.C
@@ -506,8 +506,8 @@ void BoundFact::KillFact(const AST::Ptr ast, bool isConditionalJump) {
     for (auto rit = relation.begin(); rit != relation.end();) {
 	// If the one of them is changed,
 	// we no longer know their relationship
-	if (*((*rit)->left) == *ast || *((*rit)->right) == *ast) {
-	    if (*rit != NULL) delete *rit;
+    if (*((*rit)->left) == *ast || *((*rit)->right) == *ast) {
+	    delete *rit;
 	    rit = relation.erase(rit);
 	} else ++rit;
     }

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -875,7 +875,7 @@ Parser::finalize(Function *f)
             // the edge is a tail call.
             // For example, if a jump from .text to .plt (different sections), then
             // no matter what, this edge is a tail call.
-            if (trg_func->region() != b->region()) continue;
+            if (trg_func && trg_func->region() != b->region()) continue;
 
             // Rule 2:
             // Find a tail call targeting a block within the same function.

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -2298,11 +2298,11 @@ void int_process::updateSyncState(Event::ptr ev, bool gen)
      }
       case Event::sync_thread: {
          int_thread *thrd = ev->getThread()->llthrd();
-         int_thread::StateTracker &st = gen ? thrd->getGeneratorState() : thrd->getHandlerState();
          if (!thrd) {
             pthrd_printf("No thread for sync thread event, assuming thread exited\n");
             return;
          }
+         int_thread::StateTracker &st = gen ? thrd->getGeneratorState() : thrd->getHandlerState();
          int_thread::State old_state = st.getState();
          if (old_state == int_thread::exited) {
             //Silly, linux.  Giving us events on processes that have exited.

--- a/proccontrol/src/procset.C
+++ b/proccontrol/src/procset.C
@@ -510,6 +510,7 @@ static int_addressSet::iterator get_end(AddressSet::ptr as) {
 static void thread_err_check(int_thread *ithr, err_t *thread_error) {
    if (!ithr) {
       *thread_error = err_exited;
+      return;
    }
    if (ithr->getUserState().getState() == int_thread::running) {
       *thread_error = err_notrunning;
@@ -3343,8 +3344,7 @@ bool ThreadTrackingSet::refreshThreads() const
    for (int_processSet::iterator i = iter.begin(procset); i != iter.end(); i = iter.inc()) {
       int_threadTracking *proc = (*i)->llproc()->getThreadTracking();
       if (!proc) {
-         perr_printf("Thread tracking not supported on process %d\n", proc->getPid());
-         proc->setLastError(err_unsupported, "No thread tracking on this platform\n");
+         perr_printf("Thread tracking not supported on process\n");
          had_error = true;
          continue;
       }
@@ -3402,8 +3402,7 @@ bool LWPTrackingSet::refreshLWPs() const
    for (int_processSet::iterator i = iter.begin(procset); i != iter.end(); i = iter.inc()) {
       int_LWPTracking *proc = (*i)->llproc()->getLWPTracking();
       if (!proc) {
-         perr_printf("LWP tracking not supported on process %d\n", proc->getPid());
-         proc->setLastError(err_unsupported, "No LWP tracking on this platform\n");
+         perr_printf("LWP tracking not supported on process\n");
          had_error = true;
          continue;
       }
@@ -3479,8 +3478,7 @@ bool FollowForkSet::setFollowFork(FollowFork::follow_t f) const
    for (int_processSet::iterator i = iter.begin(procset); i != iter.end(); i = iter.inc()) {
       int_followFork *proc = (*i)->llproc()->getFollowFork();
       if (!proc) {
-         perr_printf("Follow Fork not supported on process %d\n", proc->getPid());
-         proc->setLastError(err_unsupported, "No follow fork control on this platform\n");
+         perr_printf("Follow Fork not supported on process\n");
          had_error = true;
          continue;
       }
@@ -3608,8 +3606,7 @@ bool RemoteIOSet::getFileNames(FileSet *fset)
    for (int_processSet::iterator i = iter.begin(procset); i != iter.end(); i = iter.inc()) {
       int_remoteIO *proc = (*i)->llproc()->getRemoteIO();
       if (!proc) {
-         perr_printf("getFileNames attempted on non RemoteIO process %d\n", proc->getPid());
-         proc->setLastError(err_unsupported, "getFileNames not supported on this platform");
+         perr_printf("getFileNames attempted on non RemoteIO process\n");
          had_error = true;
          continue;
       }
@@ -3663,8 +3660,7 @@ bool RemoteIOSet::getFileStatData(FileSet *fset)
       fflush(stderr);
       int_remoteIO *proc = i->first->llproc()->getRemoteIO();
       if (!proc) {
-         perr_printf("getFileStatData attempted on non RemoteIO process %d\n", proc->getPid());
-         proc->setLastError(err_unsupported, "getFileStatData not supported on this platform");
+         perr_printf("getFileStatData attempted on non RemoteIO process\n");
          had_error = true;
          continue;
       }
@@ -3710,8 +3706,7 @@ bool RemoteIOSet::readFileContents(const FileSet *fset)
    for (FileSet::const_iterator i = fset->begin(); i != fset->end(); i++) {
       int_remoteIO *proc = i->first->llproc()->getRemoteIO();
       if (!proc) {
-         perr_printf("getFileStatData attempted on non RemoteIO process %d\n", proc->getPid());
-         proc->setLastError(err_unsupported, "getFileStatData not supported on this platform");
+         perr_printf("getFileStatData attempted on non RemoteIO\n");
          had_error = true;
          continue;
       }
@@ -3782,8 +3777,7 @@ bool MemoryUsageSet::usedX(std::map<Process::const_ptr, unsigned long> &used, Me
    for (int_processSet::iterator i = iter.begin(procset); i != iter.end(); i = iter.inc()) {
       int_memUsage *proc = (*i)->llproc()->getMemUsage();
       if (!proc) {
-         perr_printf("GetMemUsage not supported on process %d\n", proc->getPid());
-         proc->setLastError(err_unsupported, "No getMemUsage on this platform\n");
+         perr_printf("GetMemUsage not supported\n");
          had_error = true;
          continue;
       }

--- a/symtabAPI/src/Object-nt.C
+++ b/symtabAPI/src/Object-nt.C
@@ -631,10 +631,13 @@ void Object::AddTLSFunctions()
 
    // calculate the address of the TLS callback array and make sure it's valid
    secn = findEnclosingRegion(tlsDir->AddressOfCallBacks - imgBase);
+   if (!secn) {
+      return;
+   }
    Offset cbOffSec = tlsDir->AddressOfCallBacks 
       - secn->getMemOffset() 
       - imgBase;
-   if (!secn || cbOffSec > secn->getDiskSize()) {
+   if (cbOffSec > secn->getDiskSize()) {
       return;
    }
    Offset cbOffDisk = cbOffSec + secn->getDiskOffset();


### PR DESCRIPTION
These were found using cppcheck's nullPointerRedundantCheck.