### PR TITLE
Include CheckCXXSourceCompiles for check_cxx_source_compiles

### DIFF
--- a/cmake/DyninstWarnings.cmake
+++ b/cmake/DyninstWarnings.cmake
@@ -116,6 +116,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang)$")
   include(CheckCXXCompilerFlag)
+  include(CheckCXXSourceCompiles)
   foreach(f IN LISTS REQUESTED_WARNING_FLAGS)
     string(REGEX REPLACE "[^a-zA-Z0-9]" "_" v "HAS_CPP_FLAG_${f}")
     set(CMAKE_REQUIRED_FLAGS "-${f}")


### PR DESCRIPTION
Building 12.3.0 with cmake 3.27 fails with:
```
-- Performing Test HAS_C_FLAG_Wwrite_strings - Success
CMake Error at cmake/warnings.cmake:133 (check_cxx_source_compiles):
  Unknown CMake command "check_cxx_source_compiles".
Call Stack (most recent call first):
  cmake/shared.cmake:106 (include)
  CMakeLists.txt:43 (include)
```
This should fix that on the master branch.