### PR TITLE
add header files to directly define std:: syms

### DIFF
--- a/common/h/Annotatable.h
+++ b/common/h/Annotatable.h
@@ -35,6 +35,7 @@
 #define DYN_DETAIL_BOOST_NO_INTRINSIC_WCHAR_T 1
 #endif
 #include "dyntypes.h"
+#include <stddef.h>
 #include <vector>
 #include <map>
 #include <typeinfo>

--- a/common/h/DynAST.h
+++ b/common/h/DynAST.h
@@ -31,6 +31,7 @@
 #if !defined(AST_H)
 #define AST_H
 
+#include <assert.h>
 #include <vector>
 #include <string>
 #include <sstream>

--- a/common/h/Edge.h
+++ b/common/h/Edge.h
@@ -33,6 +33,7 @@
 
 #include "boost/shared_ptr.hpp"
 #include "boost/weak_ptr.hpp"
+#include <stddef.h>
 #include <set>
 #include "Annotatable.h"
 #include <unordered_set>

--- a/common/h/Graph.h
+++ b/common/h/Graph.h
@@ -36,6 +36,7 @@
 
 #include "dyntypes.h"
 #include "boost/shared_ptr.hpp"
+#include <string>
 #include <set>
 #include <list>
 #include <queue>

--- a/common/h/IBSTree-fast.h
+++ b/common/h/IBSTree-fast.h
@@ -40,6 +40,8 @@
 #include <boost/mpl/insert_range.hpp>
 #include <boost/mpl/inherit_linearly.hpp>
 #include <boost/mpl/inherit.hpp>
+#include <assert.h>
+#include <set>
 #include <iostream>
 
 #include "concurrent.h"

--- a/common/h/IBSTree.h
+++ b/common/h/IBSTree.h
@@ -41,6 +41,8 @@
 #include "dyntypes.h"
 #include "concurrent.h"
 
+#include <stddef.h>
+#include <vector>
 #include <set>
 #include <limits>
 #include <iostream>

--- a/common/h/Node.h
+++ b/common/h/Node.h
@@ -33,6 +33,8 @@
 
 #include <set>
 #include <string>
+#include <stddef.h>
+#include <unordered_set>
 #include "Edge.h"
 #include "Annotatable.h"
 

--- a/common/h/SymReader.h
+++ b/common/h/SymReader.h
@@ -34,6 +34,7 @@
 #include "util.h"
 #include "dyn_regs.h"
 #include <string>
+#include <stddef.h>
 
 namespace Dyninst
 {

--- a/common/h/concurrent.h
+++ b/common/h/concurrent.h
@@ -33,6 +33,8 @@
 
 #include "util.h"
 #include <memory>
+#include <stddef.h>
+#include <vector>
 #include <boost/atomic.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>

--- a/common/h/dyntypes.h
+++ b/common/h/dyntypes.h
@@ -40,6 +40,7 @@
 #endif
 
 #ifndef FILE__
+#include <string.h>
 #if defined(_MSC_VER)
 #define FILE__ (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
 #else
@@ -47,6 +48,9 @@
 #endif
 #endif
 
+#include <functional>
+#include <memory>
+#include <utility>
 #include <unordered_set>
 #include <unordered_map>
 

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -31,6 +31,7 @@
 #if !defined(ENTRYIDS_IA32_H)
 #define ENTRYIDS_IA32_H
 
+#include <string>
 #include "dyntypes.h"
 #include "util.h"
 

--- a/common/src/IntervalTree.h
+++ b/common/src/IntervalTree.h
@@ -33,6 +33,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <utility>
 #include <vector>
 #include <map>
 

--- a/common/src/NodeIterator.h
+++ b/common/src/NodeIterator.h
@@ -33,6 +33,10 @@
 #if !defined(NODE_ITERATOR_H)
 #define NODE_ITERATOR_H
 
+#include <assert.h>
+#include <deque>
+#include <set>
+#include <unordered_set>
 #include "Node.h"
 #include "Edge.h"
 

--- a/common/src/addrRange.h
+++ b/common/src/addrRange.h
@@ -37,6 +37,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <string>
 #include <vector>
 #include "common/src/Types.h"
 #include "common/src/std_namesp.h"

--- a/common/src/addrtranslate-sysv.h
+++ b/common/src/addrtranslate-sysv.h
@@ -31,6 +31,9 @@
 #if !defined(addrtranslate_sysv_h_)
 #define addrtranslate_sysv_h_
 
+#include <map>
+#include <string>
+#include <utility>
 #include "common/src/addrtranslate.h"
 
 namespace Dyninst {

--- a/common/src/arch-aarch64.h
+++ b/common/src/arch-aarch64.h
@@ -37,6 +37,7 @@
 
 #include "common/src/Types.h"
 #include "common/h/dyn_regs.h"
+#include <assert.h>
 #include <vector>
 class AddressSpace;
 

--- a/common/src/arch-x86.h
+++ b/common/src/arch-x86.h
@@ -35,6 +35,7 @@
 #define _ARCH_X86_H
 
 #include "common/src/Types.h"
+#include <assert.h>
 #include <stdio.h>
 #include <set>
 #include <map>

--- a/common/src/freebsdHeaders.h
+++ b/common/src/freebsdHeaders.h
@@ -33,6 +33,8 @@
 #define _freebsd_headers_h
 
 #include <assert.h>
+#include <stddef.h>
+#include <string>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/common/src/headers.h
+++ b/common/src/headers.h
@@ -35,6 +35,8 @@
 #define KLUDGES_H
 
 #include <sys/types.h>
+#include <stddef.h>
+#include <string.h>
 
 #ifndef FILE__
 #define FILE__ strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__

--- a/common/src/linuxHeaders.h
+++ b/common/src/linuxHeaders.h
@@ -32,6 +32,8 @@
 #if !defined(_linux_headers_h)
 #define _linux_headers_h
 
+#include <stddef.h>
+#include <string>
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>

--- a/common/src/ntHeaders.h
+++ b/common/src/ntHeaders.h
@@ -46,6 +46,8 @@
 #include <assert.h>
 #include <stdio.h>
 
+#include <stddef.h>
+#include <string>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/common/src/singleton_object_pool.h
+++ b/common/src/singleton_object_pool.h
@@ -30,6 +30,7 @@
 #if !defined(SINGLETON_OBJECT_POOL_H)
 #define SINGLETON_OBJECT_POOL_H
 
+#include <memory>
 #include "pool_allocators.h"
 #include "dthread.h"
 #include "compiler_annotations.h"

--- a/dataflowAPI/h/Absloc.h
+++ b/dataflowAPI/h/Absloc.h
@@ -48,6 +48,12 @@
 #include <values.h>
 #endif
 
+#include <assert.h>
+#include <ostream>
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <vector>
 #include "Instruction.h"
 #include "DynAST.h"
 

--- a/dataflowAPI/h/AbslocInterface.h
+++ b/dataflowAPI/h/AbslocInterface.h
@@ -32,6 +32,8 @@
 #if !defined(Absloc_Interface_H)
 #define Absloc_Interface_H
 
+#include <map>
+#include <vector>
 #include "Instruction.h"
 #include "Register.h"
 #include "Expression.h"

--- a/dataflowAPI/h/SymEval.h
+++ b/dataflowAPI/h/SymEval.h
@@ -34,6 +34,13 @@
 #define SymEval_h
 
 #include <map>
+#include <ostream>
+#include <sstream>
+#include <set>
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
+#include <utility>
 
 #include "Absloc.h"
 #include "DynAST.h"

--- a/dataflowAPI/h/bitArray.h
+++ b/dataflowAPI/h/bitArray.h
@@ -32,6 +32,7 @@
 
 #ifndef _BITARRAY_
 #define _BITARRAY_
+#include <memory>
 #include <boost/dynamic_bitset.hpp>
 typedef boost::dynamic_bitset<unsigned long, std::allocator<unsigned long> > bitArray;
 

--- a/dataflowAPI/h/slicing.h
+++ b/dataflowAPI/h/slicing.h
@@ -42,6 +42,10 @@
 #include <unordered_map>
 #include <list>
 #include <stack>
+#include <deque>
+#include <stddef.h>
+#include <string>
+#include <utility>
 
 #include "util.h"
 #include "Node.h"

--- a/dataflowAPI/h/stackanalysis.h
+++ b/dataflowAPI/h/stackanalysis.h
@@ -35,6 +35,10 @@
 #include <values.h>
 #endif
 
+#include <ostream>
+#include <sstream>
+#include <utility>
+#include <vector>
 #include <list>
 #include <map>
 #include <set>

--- a/dataflowAPI/rose/ExtentMap.h
+++ b/dataflowAPI/rose/ExtentMap.h
@@ -5,6 +5,8 @@
 #ifndef DYNINST_EXTENTMAP_H
 #define DYNINST_EXTENTMAP_H
 
+#include <iosfwd>
+#include <string>
 #include "rangemap.h"
 #include "typedefs.h"
 #include "util/Interval.h"

--- a/dataflowAPI/rose/SgAsmAmdgpuVegaInstruction.h
+++ b/dataflowAPI/rose/SgAsmAmdgpuVegaInstruction.h
@@ -1,6 +1,7 @@
 #ifndef SG_ASM_AMDGPU_VEGA_INSN_H
 #define SG_ASM_AMDGPU_VEGA_INSN_H
 
+#include <string>
 #include "external/rose/amdgpuInstructionEnum.h"
 #include "typedefs.h"
 #include "SgAsmInstruction.h"

--- a/dataflowAPI/rose/SgAsmArmv8Instruction.h
+++ b/dataflowAPI/rose/SgAsmArmv8Instruction.h
@@ -1,6 +1,7 @@
 #ifndef SG_ASM_ARMV8_INSN_H
 #define SG_ASM_ARMV8_INSN_H
 
+#include <string>
 #include "external/rose/armv8InstructionEnum.h"
 #include "typedefs.h"
 #include "SgAsmInstruction.h"

--- a/dataflowAPI/rose/SgAsmExpression.h
+++ b/dataflowAPI/rose/SgAsmExpression.h
@@ -7,6 +7,9 @@
 #include "SgAsmType.h"
 #include "external/rose/powerpcInstructionEnum.h"
 
+#include <stddef.h>
+#include <string>
+#include <utility>
 #include <inttypes.h>
 
 

--- a/dataflowAPI/rose/SgAsmInstruction.h
+++ b/dataflowAPI/rose/SgAsmInstruction.h
@@ -13,6 +13,7 @@
 #include "SgNode.h"
 
 #include "SgAsmOperandList.h"
+#include <stddef.h>
 #include <string>
 
 class SgAsmStatement : public SgAsmNode {

--- a/dataflowAPI/rose/SgAsmOperandList.h
+++ b/dataflowAPI/rose/SgAsmOperandList.h
@@ -2,6 +2,7 @@
 #if !defined(SG_ASM_OPERAND_LIST_H)
 #define SG_ASM_OPERAND_LIST_H
 
+#include <string>
 #include "SgAsmType.h"
 #include "typedefs.h"
 

--- a/dataflowAPI/rose/SgAsmPowerpcInstruction.h
+++ b/dataflowAPI/rose/SgAsmPowerpcInstruction.h
@@ -13,6 +13,7 @@
 #if !defined(SG_ASM_POWERPC_INSN_H)
 #define SG_ASM_POWERPC_INSN_H
 
+#include <string>
 #include "external/rose/rose-compat.h"
 #include "typedefs.h"
 #include "external/rose/powerpcInstructionEnum.h"

--- a/dataflowAPI/rose/SgAsmType.h
+++ b/dataflowAPI/rose/SgAsmType.h
@@ -1,6 +1,9 @@
 #if !defined(SG_ASM_TYPE_H)
 #define SG_ASM_TYPE_H
 
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
 #include "SgNode.h"
 #include "util/Sawyer.h"
 #include "util/BitVector.h"

--- a/dataflowAPI/rose/SgAsmx86Instruction.h
+++ b/dataflowAPI/rose/SgAsmx86Instruction.h
@@ -7,6 +7,8 @@
 // All methods that do not appear to be used by x86InstructionSemantics.h
 // have been commented out. 
 
+#include <stdint.h>
+#include <string>
 #include "external/rose/rose-compat.h"
 #include "typedefs.h"
 #include "SgAsmInstruction.h"

--- a/dataflowAPI/rose/conversions.h
+++ b/dataflowAPI/rose/conversions.h
@@ -1,6 +1,8 @@
 #if !defined(ROSE_CONVERSIONS_H)
 #define ROSE_CONVERSIONS_H
 
+#include <stdint.h>
+
 class SgNode;
 class SgAsmExpression;
 class SgAsmValueExpression;

--- a/dataflowAPI/rose/integerOps.h
+++ b/dataflowAPI/rose/integerOps.h
@@ -1,6 +1,8 @@
 #ifndef ROSE_INTEGEROPS_H
 #define ROSE_INTEGEROPS_H
 
+#include <stddef.h>
+#include <stdint.h>
 #include <cassert>
 #include <limits>
 #include <boost/static_assert.hpp>

--- a/dataflowAPI/rose/rangemap.h
+++ b/dataflowAPI/rose/rangemap.h
@@ -18,6 +18,8 @@
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
+#include <stddef.h>
+#include <utility>
 #include <inttypes.h>
 
 #include <cassert>

--- a/dataflowAPI/rose/rose.h
+++ b/dataflowAPI/rose/rose.h
@@ -1,6 +1,7 @@
 #if !defined(ROSE_H)
 #define ROSE_H
 
+#include <assert.h>
 #define ROSE_ASSERT assert
 
 #endif

--- a/dataflowAPI/rose/semantics/BaseSemantics2.h
+++ b/dataflowAPI/rose/semantics/BaseSemantics2.h
@@ -7,6 +7,11 @@
 #include "../conversions.h"
 #include "SMTSolver.h"
 
+#include <ostream>
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
+#include <vector>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/optional.hpp>

--- a/dataflowAPI/rose/semantics/BinarySymbolicExpr.h
+++ b/dataflowAPI/rose/semantics/BinarySymbolicExpr.h
@@ -7,6 +7,9 @@
 
 #include "../util/Map.h"
 
+#include <iosfwd>
+#include <stddef.h>
+#include <string>
 #include <cassert>
 #include <boost/any.hpp>
 #include <inttypes.h>

--- a/dataflowAPI/rose/semantics/ByteOrder.h
+++ b/dataflowAPI/rose/semantics/ByteOrder.h
@@ -1,6 +1,8 @@
 #ifndef ROSE_ByteOrder_H
 #define ROSE_ByteOrder_H
 
+#include <stddef.h>
+#include <stdint.h>
 #include "../typedefs.h"
 
 namespace ByteOrder {

--- a/dataflowAPI/rose/semantics/ConcreteSemantics2.h
+++ b/dataflowAPI/rose/semantics/ConcreteSemantics2.h
@@ -5,6 +5,8 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
+#include <iosfwd>
+#include <stddef.h>
 #include <inttypes.h>
 
 #include "../integerOps.h"

--- a/dataflowAPI/rose/semantics/DispatcherARM64.h
+++ b/dataflowAPI/rose/semantics/DispatcherARM64.h
@@ -1,6 +1,9 @@
 #ifndef ROSE_DispatcherARM64_H
 #define ROSE_DispatcherARM64_H
 
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
 #include "BaseSemantics2.h"
 #include "../SgAsmArmv8Instruction.h"
 #include "external/rose/armv8InstructionEnum.h"

--- a/dataflowAPI/rose/semantics/DispatcherAmdgpuVega.h
+++ b/dataflowAPI/rose/semantics/DispatcherAmdgpuVega.h
@@ -1,6 +1,9 @@
 #ifndef ROSE_DispatcherAMDGPU_VEGA_H
 #define ROSE_DispatcherAMDGPU_VEGA_H
 
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
 #include "BaseSemantics2.h"
 #include "../SgAsmAmdgpuVegaInstruction.h"
 #include "external/rose/amdgpuInstructionEnum.h"

--- a/dataflowAPI/rose/semantics/DispatcherPowerpc.h
+++ b/dataflowAPI/rose/semantics/DispatcherPowerpc.h
@@ -9,6 +9,8 @@
 #ifndef ROSE_DispatcherPpc_H
 #define ROSE_DispatcherPpc_H
 
+#include <assert.h>
+#include <stddef.h>
 #include "BaseSemantics2.h"
 #include "../SgAsmPowerpcInstruction.h"
 #include "external/rose/powerpcInstructionEnum.h"

--- a/dataflowAPI/rose/semantics/MemoryMap.h
+++ b/dataflowAPI/rose/semantics/MemoryMap.h
@@ -1,6 +1,11 @@
 #ifndef ROSE_MemoryMap_H
 #define ROSE_MemoryMap_H
 
+#include <iosfwd>
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
+#include <vector>
 #include "ByteOrder.h"
 
 #include "../util/Access.h"

--- a/dataflowAPI/rose/semantics/RegisterParts.h
+++ b/dataflowAPI/rose/semantics/RegisterParts.h
@@ -1,6 +1,8 @@
 #ifndef ROSE_BinaryAnalysis_RegisterParts_H
 #define ROSE_BinaryAnalysis_RegisterParts_H
 
+#include <stddef.h>
+#include <vector>
 #include "../util/IntervalSet.h"
 #include "../util/Map.h"
 #include "../RegisterDescriptor.h"

--- a/dataflowAPI/rose/semantics/RegisterStateGeneric.h
+++ b/dataflowAPI/rose/semantics/RegisterStateGeneric.h
@@ -1,6 +1,11 @@
 #ifndef ROSE_BinaryAnalysis_InstructionSemantics2_RegisterStateGeneric_H
 #define ROSE_BinaryAnalysis_InstructionSemantics2_RegisterStateGeneric_H
 
+#include <iosfwd>
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <vector>
 #include "BaseSemantics2.h"
 
 namespace rose {

--- a/dataflowAPI/rose/semantics/Registers.h
+++ b/dataflowAPI/rose/semantics/Registers.h
@@ -5,6 +5,11 @@
 #include "../util/Map.h"
 #include "RegisterParts.h"
 
+#include <iosfwd>
+#include <stddef.h>
+#include <stdint.h>
+#include <utility>
+#include <vector>
 #include <map>
 #include <queue>
 #include <string>

--- a/dataflowAPI/rose/semantics/SMTSolver.h
+++ b/dataflowAPI/rose/semantics/SMTSolver.h
@@ -1,6 +1,11 @@
 #ifndef Rose_SMTSolver_H
 #define Rose_SMTSolver_H
 
+#include <iosfwd>
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <vector>
 #include "BinarySymbolicExpr.h"
 #include <boost/thread/mutex.hpp>
 

--- a/dataflowAPI/rose/semantics/SymEvalSemantics.h
+++ b/dataflowAPI/rose/semantics/SymEvalSemantics.h
@@ -5,6 +5,11 @@
 #ifndef DYNINST_SYMEVALSEMANTICS_H
 #define DYNINST_SYMEVALSEMANTICS_H
 
+#include <assert.h>
+#include <iosfwd>
+#include <map>
+#include <stddef.h>
+#include <stdint.h>
 #include "external/rose/armv8InstructionEnum.h"
 #include "external/rose/amdgpuInstructionEnum.h"
 #include "BaseSemantics2.h"

--- a/dataflowAPI/rose/util/AddressMap.h
+++ b/dataflowAPI/rose/util/AddressMap.h
@@ -17,6 +17,12 @@
 #include "IntervalMap.h"
 #include "IntervalSet.h"
 #include "Sawyer.h"
+#include <ostream>
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
+#include <utility>
+#include <vector>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/foreach.hpp>

--- a/dataflowAPI/rose/util/AddressSegment.h
+++ b/dataflowAPI/rose/util/AddressSegment.h
@@ -8,6 +8,9 @@
 #ifndef Sawyer_AddressSegment_H
 #define Sawyer_AddressSegment_H
 
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
 #include <boost/cstdint.hpp>
 #include "Access.h"
 #include "AllocatingBuffer.h"

--- a/dataflowAPI/rose/util/Attribute.h
+++ b/dataflowAPI/rose/util/Attribute.h
@@ -48,6 +48,7 @@
 #ifndef Sawyer_Attribute_H
 #define Sawyer_Attribute_H
 
+#include <stddef.h>
 #include <boost/any.hpp>
 #include <boost/lexical_cast.hpp>
 #include "Exception.h"

--- a/dataflowAPI/rose/util/BitVector.h
+++ b/dataflowAPI/rose/util/BitVector.h
@@ -8,6 +8,11 @@
 #ifndef Sawyer_BitVector_H
 #define Sawyer_BitVector_H
 
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
+#include <string.h>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/cstdint.hpp>
 #include "Assert.h"

--- a/dataflowAPI/rose/util/BitVectorSupport.h
+++ b/dataflowAPI/rose/util/BitVectorSupport.h
@@ -8,6 +8,7 @@
 #ifndef Sawyer_BitVectorSupport_H
 #define Sawyer_BitVectorSupport_H
 
+#include <stddef.h>
 #include <boost/cstdint.hpp>
 #include <algorithm>
 #include <boost/foreach.hpp>

--- a/dataflowAPI/rose/util/Combinatorics.h
+++ b/dataflowAPI/rose/util/Combinatorics.h
@@ -3,6 +3,7 @@
 
 #include "LinearCongruentialGenerator.h"
 
+#include <stddef.h>
 #include <algorithm>
 #include <cassert>
 #include <list>

--- a/dataflowAPI/rose/util/Exception.h
+++ b/dataflowAPI/rose/util/Exception.h
@@ -8,6 +8,7 @@
 #ifndef Sawyer_Exception_H
 #define Sawyer_Exception_H
 
+#include <string>
 #include "Sawyer.h"
 
 namespace Sawyer {

--- a/dataflowAPI/rose/util/FileSystem.h
+++ b/dataflowAPI/rose/util/FileSystem.h
@@ -1,6 +1,7 @@
 #ifndef ROSE_FileSystem_H
 #define ROSE_FileSystem_H
 
+#include <string>
 #include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 #include <vector>

--- a/dataflowAPI/rose/util/Interval.h
+++ b/dataflowAPI/rose/util/Interval.h
@@ -10,6 +10,7 @@
 
 #include "Assert.h"
 #include "Sawyer.h"
+#include <utility>
 #include <boost/integer_traits.hpp>
 
 namespace Sawyer {

--- a/dataflowAPI/rose/util/IntervalMap.h
+++ b/dataflowAPI/rose/util/IntervalMap.h
@@ -8,6 +8,7 @@
 #ifndef Sawyer_IntervalMap_H
 #define Sawyer_IntervalMap_H
 
+#include <stddef.h>
 #include <boost/cstdint.hpp>
 #include "Assert.h"
 #include "Map.h"

--- a/dataflowAPI/rose/util/IntervalSet.h
+++ b/dataflowAPI/rose/util/IntervalSet.h
@@ -12,6 +12,8 @@
 #include "Optional.h"
 #include "Sawyer.h"
 
+#include <stddef.h>
+#include <utility>
 #include <boost/integer_traits.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 

--- a/dataflowAPI/rose/util/IntervalSetMap.h
+++ b/dataflowAPI/rose/util/IntervalSetMap.h
@@ -8,6 +8,7 @@
 #ifndef Sawyer_Container_IntervalSetMap_H
 #define Sawyer_Container_IntervalSetMap_H
 
+#include <stddef.h>
 #include <boost/foreach.hpp>
 #include "IntervalMap.h"
 #include "Sawyer.h"

--- a/dataflowAPI/rose/util/LinearCongruentialGenerator.h
+++ b/dataflowAPI/rose/util/LinearCongruentialGenerator.h
@@ -1,6 +1,7 @@
 #ifndef ROSE_LinearCongruentialGenerator_H
 #define ROSE_LinearCongruentialGenerator_H
 
+#include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/dataflowAPI/rose/util/Map.h
+++ b/dataflowAPI/rose/util/Map.h
@@ -11,6 +11,9 @@
 #include "Interval.h"
 #include "Optional.h"
 #include "Sawyer.h"
+#include <memory>
+#include <stddef.h>
+#include <utility>
 #include <boost/range/iterator_range.hpp>
 #include <map>
 #include <stdexcept>

--- a/dataflowAPI/rose/util/MappedBuffer.h
+++ b/dataflowAPI/rose/util/MappedBuffer.h
@@ -12,6 +12,7 @@
 #include "Buffer.h"
 #include "Sawyer.h"
 
+#include <string.h>
 #include <boost/iostreams/device/mapped_file.hpp>
 #include <boost/lexical_cast.hpp>
 #include <string>

--- a/dataflowAPI/rose/util/Message.h
+++ b/dataflowAPI/rose/util/Message.h
@@ -15,6 +15,8 @@
 #include "SharedPointer.h"
 #include "Synchronization.h"
 
+#include <stddef.h>
+#include <utility>
 #include <boost/config.hpp>
 #include <boost/logic/tribool.hpp>
 #include <cassert>

--- a/dataflowAPI/rose/util/PoolAllocator.h
+++ b/dataflowAPI/rose/util/PoolAllocator.h
@@ -8,6 +8,12 @@
 #ifndef Sawyer_PoolAllocator_H
 #define Sawyer_PoolAllocator_H
 
+#include <assert.h>
+#include <ostream>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <utility>
 #include <boost/version.hpp>
 #include <boost/foreach.hpp>
 #include <boost/static_assert.hpp>

--- a/dataflowAPI/rose/util/Sawyer.h
+++ b/dataflowAPI/rose/util/Sawyer.h
@@ -8,6 +8,9 @@
 #ifndef Sawyer_H
 #define Sawyer_H
 
+#include <stddef.h>
+#include <stdint.h>
+#include <vector>
 #include <boost/cstdint.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 #include <cstdio>

--- a/dataflowAPI/rose/util/Set.h
+++ b/dataflowAPI/rose/util/Set.h
@@ -11,6 +11,8 @@
 #include "Interval.h"
 #include "Sawyer.h"
 
+#include <memory>
+#include <stddef.h>
 #include <boost/foreach.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <set>

--- a/dataflowAPI/rose/util/SharedPointer.h
+++ b/dataflowAPI/rose/util/SharedPointer.h
@@ -8,6 +8,8 @@
 #ifndef Sawyer_SharedPtr_H
 #define Sawyer_SharedPtr_H
 
+#include <assert.h>
+#include <stddef.h>
 #include <cstddef>
 #include <ostream>
 #include "Assert.h"

--- a/dataflowAPI/rose/util/SmallObject.h
+++ b/dataflowAPI/rose/util/SmallObject.h
@@ -8,6 +8,7 @@
 #ifndef Sawyer_SmallObject_H
 #define Sawyer_SmallObject_H
 
+#include <stddef.h>
 #include "PoolAllocator.h"
 #include "Sawyer.h"
 

--- a/dataflowAPI/rose/util/StaticBuffer.h
+++ b/dataflowAPI/rose/util/StaticBuffer.h
@@ -8,6 +8,8 @@
 #ifndef Sawyer_StaticBuffer_H
 #define Sawyer_StaticBuffer_H
 
+#include <string>
+#include <string.h>
 #include "AllocatingBuffer.h"
 #include "Assert.h"
 #include "Buffer.h"

--- a/dataflowAPI/rose/util/Stopwatch.h
+++ b/dataflowAPI/rose/util/Stopwatch.h
@@ -8,6 +8,7 @@
 #ifndef Sawyer_Stopwatch_H
 #define Sawyer_Stopwatch_H
 
+#include <iosfwd>
 #include "Sawyer.h"
 
 #ifdef SAWYER_HAVE_BOOST_CHRONO

--- a/dataflowAPI/rose/util/StringUtility.h
+++ b/dataflowAPI/rose/util/StringUtility.h
@@ -2,6 +2,8 @@
 #define ROSE_StringUtility_H
 
 //#include "commandline_processing.h"
+#include <ostream>
+#include <stddef.h>
 #include <vector>
 #include <map>
 #include <list>

--- a/dataflowAPI/rose/util/Synchronization.h
+++ b/dataflowAPI/rose/util/Synchronization.h
@@ -9,6 +9,7 @@
 #define Sawyer_Synchronization_H
 
 #include "Sawyer.h"
+#include <stddef.h>
 
 #if SAWYER_MULTI_THREADED
     // It appears as though a certain version of GNU libc interacts badly with C++03 GCC and LLVM compilers. Some system header

--- a/dataflowAPI/rose/x86InstructionSemantics.h
+++ b/dataflowAPI/rose/x86InstructionSemantics.h
@@ -3,6 +3,8 @@
 
 //#include "rose.h"
 #include "semanticsModule.h"
+#include <stddef.h>
+#include <stdint.h>
 #include <cassert>
 #include <cstdio>
 #include <iostream>

--- a/dataflowAPI/rose/x86_64InstructionSemantics.h
+++ b/dataflowAPI/rose/x86_64InstructionSemantics.h
@@ -2,6 +2,9 @@
 #define ROSE_X86_64INSTRUCTIONSEMANTICS_H
 
 //#include "rose.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
 #include "semanticsModule.h"
 #include <cassert>
 #include <cstdio>

--- a/dataflowAPI/src/RoseInsnFactory.h
+++ b/dataflowAPI/src/RoseInsnFactory.h
@@ -41,6 +41,8 @@
 #include "common/h/util.h"
 #include "boost/shared_ptr.hpp"
 #include <vector>
+#include <stddef.h>
+#include <string>
 
 #include <stdint.h>
 

--- a/dataflowAPI/src/SymEvalPolicy.h
+++ b/dataflowAPI/src/SymEvalPolicy.h
@@ -56,6 +56,9 @@
 #include "Operation_impl.h"
 #include "../h/Absloc.h"
 
+#include <assert.h>
+#include <map>
+#include <stddef.h>
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/dataflowAPI/src/SymbolicExpansion.h
+++ b/dataflowAPI/src/SymbolicExpansion.h
@@ -29,6 +29,7 @@
  */
 #include <dataflowAPI/rose/SgAsmInstruction.h>
 #include "../rose/semantics/SymEvalSemantics.h"
+#include <string>
 
 #if !defined(_SYMBOLIC_EXPANSION_H_)
 #define _SYMBOLIC_EXPANSION_H_

--- a/dwarf/h/dwarfFrameParser.h
+++ b/dwarf/h/dwarfFrameParser.h
@@ -31,6 +31,8 @@
 #if !defined(DWARF_SW_H_)
 #define DWARF_SW_H_
 
+#include <map>
+#include <utility>
 #include <stack>
 #include <vector>
 #include "dyntypes.h"

--- a/dynC_API/h/dynC.h
+++ b/dynC_API/h/dynC.h
@@ -39,6 +39,7 @@
 #include <sstream>
 #include <string>
 #include <map>
+#include <vector>
 
 #if !defined(DYNC_EXPORT)
   #if defined(_MSC_VER)

--- a/dynC_API/h/snippetGen.h
+++ b/dynC_API/h/snippetGen.h
@@ -38,6 +38,7 @@
 #include "BPatch.h"
 #include <sstream>
 #include <string>
+#include <vector>
 
 
 

--- a/dyninstAPI/h/BPatch.h
+++ b/dyninstAPI/h/BPatch.h
@@ -41,6 +41,7 @@
 #include "BPatch_enums.h"
 #include "BPatch_callbacks.h"
 #include <set>
+#include <string>
 
 #include "dyninstversion.h"
 

--- a/dyninstAPI/h/BPatch_Vector.h
+++ b/dyninstAPI/h/BPatch_Vector.h
@@ -31,6 +31,7 @@
 #ifndef _BPatch_Vector_h_
 #define _BPatch_Vector_h_
 
+#include <memory>
 #include <vector>
 
 template <typename T, typename Alloc = std::allocator<T>>

--- a/dyninstAPI/h/BPatch_addressSpace.h
+++ b/dyninstAPI/h/BPatch_addressSpace.h
@@ -38,6 +38,8 @@
 #include "BPatch_instruction.h" // for register type
 #include "BPatch_callbacks.h"
 #include "dyntypes.h"
+#include <string>
+#include <utility>
 #include <vector>
 #include <set>
 #include <stdio.h>

--- a/dyninstAPI/h/BPatch_basicBlock.h
+++ b/dyninstAPI/h/BPatch_basicBlock.h
@@ -31,6 +31,10 @@
 #ifndef _BPatch_basicBlock_h_
 #define _BPatch_basicBlock_h_
 
+#include <iosfwd>
+#include <set>
+#include <utility>
+#include <vector>
 #include "BPatch_dll.h"
 #include "BPatch_Vector.h"
 #include "BPatch_Set.h"

--- a/dyninstAPI/h/BPatch_basicBlockLoop.h
+++ b/dyninstAPI/h/BPatch_basicBlockLoop.h
@@ -33,6 +33,8 @@
 
 #include <stdlib.h>
 #include <string>
+#include <set>
+#include <vector>
 #include "Annotatable.h"
 #include "BPatch_dll.h"
 #include "BPatch_Vector.h"

--- a/dyninstAPI/h/BPatch_binaryEdit.h
+++ b/dyninstAPI/h/BPatch_binaryEdit.h
@@ -41,6 +41,8 @@
 #include "BPatch_callbacks.h"
 
 #include <vector>
+#include <map>
+#include <string>
 
 #include <stdio.h>
 #include <signal.h>

--- a/dyninstAPI/h/BPatch_callbacks.h
+++ b/dyninstAPI/h/BPatch_callbacks.h
@@ -31,6 +31,7 @@
 #ifndef _BPATCH_ERROR_H_
 #define _BPATCH_ERROR_H_
 
+#include <utility>
 #include "BPatch_Vector.h"
 class BPatch_process;
 class BPatch_thread;

--- a/dyninstAPI/h/BPatch_flowGraph.h
+++ b/dyninstAPI/h/BPatch_flowGraph.h
@@ -33,6 +33,7 @@
 
 #include <string>
 #include <set>
+#include <map>
 #include "Annotatable.h"
 #include "BPatch_dll.h"
 #include "BPatch_Vector.h"

--- a/dyninstAPI/h/BPatch_function.h
+++ b/dyninstAPI/h/BPatch_function.h
@@ -31,6 +31,10 @@
 #ifndef _BPatch_function_h_
 #define _BPatch_function_h_
 
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
 #include "Annotatable.h"
 #include "BPatch_dll.h"
 #include "BPatch_Vector.h"

--- a/dyninstAPI/h/BPatch_image.h
+++ b/dyninstAPI/h/BPatch_image.h
@@ -41,6 +41,8 @@
 #include "BPatch_parRegion.h"
 #include "dyntypes.h"
 
+#include <string>
+#include <utility>
 #include <vector>
 #include <map>
 

--- a/dyninstAPI/h/BPatch_loopTreeNode.h
+++ b/dyninstAPI/h/BPatch_loopTreeNode.h
@@ -31,6 +31,8 @@
 #ifndef _BPatch_loopTreeNode_h_
 #define _BPatch_loopTreeNode_h_
 
+#include <map>
+#include <string>
 #include "BPatch_dll.h"
 #include "BPatch_Vector.h"
 #include "BPatch_function.h"

--- a/dyninstAPI/h/BPatch_module.h
+++ b/dyninstAPI/h/BPatch_module.h
@@ -35,6 +35,7 @@
 #include "BPatch_sourceObj.h"
 #include "BPatch_enums.h"
 #include "dyntypes.h"
+#include <stddef.h>
 #include <vector>
 #include <map>
 

--- a/dyninstAPI/h/BPatch_object.h
+++ b/dyninstAPI/h/BPatch_object.h
@@ -33,6 +33,8 @@
 
 #include <vector>
 #include <string>
+#include <set>
+#include <utility>
 #include "dyntypes.h"
 #include "BPatch_dll.h"
 #include "StackMod.h"

--- a/dyninstAPI/h/BPatch_parRegion.h
+++ b/dyninstAPI/h/BPatch_parRegion.h
@@ -31,6 +31,7 @@
 #ifndef _BPatch_parRegion_h_
 #define _BPatch_parRegion_h_
 
+#include <vector>
 #include "BPatch_dll.h"
 #include "BPatch_Vector.h"
 

--- a/dyninstAPI/h/BPatch_point.h
+++ b/dyninstAPI/h/BPatch_point.h
@@ -31,6 +31,8 @@
 #ifndef _BPatch_point_h_
 #define _BPatch_point_h_
 
+#include <string>
+#include <vector>
 #include "BPatch_dll.h"
 #include "BPatch_Vector.h"
 #include "BPatch_Set.h"

--- a/dyninstAPI/h/BPatch_process.h
+++ b/dyninstAPI/h/BPatch_process.h
@@ -41,6 +41,10 @@
 #include "BPatch_callbacks.h"
 #include "PCProcess.h"
 
+#include <map>
+#include <set>
+#include <stddef.h>
+#include <utility>
 #include <vector>
 
 #include <cstdio>

--- a/dyninstAPI/h/BPatch_snippet.h
+++ b/dyninstAPI/h/BPatch_snippet.h
@@ -31,6 +31,7 @@
 #ifndef _BPatch_snippet_h_
 #define _BPatch_snippet_h_
 
+#include <string>
 #include "BPatch_dll.h"
 #include "BPatch_Vector.h"
 #include "BPatch_sourceObj.h"

--- a/dyninstAPI/h/BPatch_type.h
+++ b/dyninstAPI/h/BPatch_type.h
@@ -34,6 +34,8 @@
 #include "BPatch_dll.h"
 #include "BPatch_Vector.h"
 #include <string.h>	
+#include <assert.h>
+#include <map>
 
 #include "Type.h"
 #include "Variable.h"

--- a/dyninstAPI/h/StackMod.h
+++ b/dyninstAPI/h/StackMod.h
@@ -31,6 +31,7 @@
 #ifndef _StackMod_h_
 #define _StackMod_h_
 
+#include <string>
 #include "BPatch_dll.h"
 #include "stackanalysis.h"
 

--- a/dyninstAPI/src/BPatch_private.h
+++ b/dyninstAPI/src/BPatch_private.h
@@ -36,6 +36,7 @@ class BPatchSnippetHandle;
 class BPatch_point;
 class BPatch_snippet;
 
+#include <vector>
 #include "BPatch_snippet.h"
 
 // TODO: this is bpatch-specific, move to BPatch_private.h?

--- a/dyninstAPI/src/Parsing.h
+++ b/dyninstAPI/src/Parsing.h
@@ -30,6 +30,9 @@
 #ifndef _PARSING_H_
 #define _PARSING_H_
 
+#include <assert.h>
+#include <string>
+#include <vector>
 #include "parseAPI/h/CFGFactory.h"
 #include "parseAPI/h/CodeSource.h"
 #include "parseAPI/h/InstructionSource.h"

--- a/dyninstAPI/src/Relocation/CFG/RelocBlock.h
+++ b/dyninstAPI/src/Relocation/CFG/RelocBlock.h
@@ -31,6 +31,9 @@
 #if !defined(PATCHAPI_TRACE_H_)
 #define PATCHAPI_TRACE_H_
 
+#include <list>
+#include <string>
+#include <utility>
 #include "common/src/Types.h" // Address
 #include "dyninstAPI/src/codegen.h" // codeGen
 #include "dyninstAPI/src/function.h"

--- a/dyninstAPI/src/Relocation/CFG/RelocEdge.h
+++ b/dyninstAPI/src/Relocation/CFG/RelocEdge.h
@@ -30,6 +30,8 @@
 #if !defined(RELOC_EDGE_H_)
 #define RELOC_EDGE_H_
 
+#include <list>
+
 namespace Dyninst {
 namespace Relocation {
 

--- a/dyninstAPI/src/Relocation/CFG/RelocGraph.h
+++ b/dyninstAPI/src/Relocation/CFG/RelocGraph.h
@@ -37,6 +37,8 @@
 #include "RelocTarget.h" // Targets
 #include <vector>
 #include <map>
+#include <list>
+#include <utility>
 
 class codeGen;
 class block_instance;

--- a/dyninstAPI/src/Relocation/CFG/RelocTarget.h
+++ b/dyninstAPI/src/Relocation/CFG/RelocTarget.h
@@ -31,6 +31,8 @@
 #if !defined (_R_E_TARGET_H_)
 #define _R_E_TARGET_H_
 
+#include <assert.h>
+#include <string>
 #include "../Widgets/Widget.h"
 #include "RelocBlock.h"
 

--- a/dyninstAPI/src/Relocation/CodeBuffer.h
+++ b/dyninstAPI/src/Relocation/CodeBuffer.h
@@ -56,6 +56,9 @@
 //  of code they have provided.
 
 #include "common/h/dyntypes.h"
+#include <assert.h>
+#include <map>
+#include <vector>
 #include <list>
 #include "dyninstAPI/src/codegen.h"
 

--- a/dyninstAPI/src/Relocation/CodeMover.h
+++ b/dyninstAPI/src/Relocation/CodeMover.h
@@ -34,6 +34,9 @@
 
 #include "CFG.h"
 #include "common/src/Types.h"
+#include <set>
+#include <string>
+#include <utility>
 #include <list>
 #include <map>
 #include "dyninstAPI/src/codegen.h" // codeGen structure

--- a/dyninstAPI/src/Relocation/CodeTracker.h
+++ b/dyninstAPI/src/Relocation/CodeTracker.h
@@ -35,6 +35,8 @@
 #define _R_CODE_TRACKER_H_
 
 #include "common/h/dyntypes.h"
+#include <assert.h>
+#include <map>
 #include <vector>
 #include <set>
 #include <list>

--- a/dyninstAPI/src/Relocation/DynAddrSpace.h
+++ b/dyninstAPI/src/Relocation/DynAddrSpace.h
@@ -32,6 +32,8 @@
 #ifndef PATCHAPI_H_DYNINST_DYNADDRSPACE_H_
 #define PATCHAPI_H_DYNINST_DYNADDRSPACE_H_
 
+#include <set>
+#include <stddef.h>
 #include "DynCommon.h"
 
 class AddressSpace;

--- a/dyninstAPI/src/Relocation/Springboard.h
+++ b/dyninstAPI/src/Relocation/Springboard.h
@@ -32,6 +32,9 @@
 
 #if !defined(_R_SPRINGBOARD_H_)
 #define _R_SPRINGBOARD_H_
+#include <assert.h>
+#include <list>
+#include <set>
 #include <map>
 #include "common/src/IntervalTree.h"
 #include "common/h/dyntypes.h"

--- a/dyninstAPI/src/Relocation/Transformers/Instrumenter.h
+++ b/dyninstAPI/src/Relocation/Transformers/Instrumenter.h
@@ -31,6 +31,9 @@
 #if !defined(_R_T_INSTRUMENTER_H_)
 #define _R_T_INSTRUMENTER_H_
 
+#include <list>
+#include <map>
+#include <utility>
 #include "Transformer.h"
 #include "dyninstAPI/src/instPoint.h"
 

--- a/dyninstAPI/src/Relocation/Transformers/Modification.h
+++ b/dyninstAPI/src/Relocation/Transformers/Modification.h
@@ -34,6 +34,7 @@
 #include "Transformer.h"
 #include "../Widgets/Widget.h"
 #include "dyninstAPI/src/addressSpace.h"
+#include <string>
 #include <list>
 #include <set>
 #include <map>

--- a/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.h
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.h
@@ -33,6 +33,8 @@
 
 class AddressSpace;
 
+#include <map>
+#include <utility>
 #include "Transformer.h"
 
 #include "dataflowAPI/h/Absloc.h"

--- a/dyninstAPI/src/Relocation/Transformers/Movement-analysis.h
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-analysis.h
@@ -31,6 +31,9 @@
 #if !defined(_R_T_MOVEMENT_ANALYSIS_H_)
 #define _R_T_MOVEMENT_ANALYSIS_H_
 
+#include <list>
+#include <map>
+#include <utility>
 #include "Transformer.h"
 #include "dyninstAPI/src/LinearVariable.h"
 

--- a/dyninstAPI/src/Relocation/Widgets/ASTWidget.h
+++ b/dyninstAPI/src/Relocation/Widgets/ASTWidget.h
@@ -31,6 +31,7 @@
 #if !defined (_R_E_AST_H_)
 #define _R_E_AST_H_
 
+#include <string>
 #include "Widget.h"
 
 class AstNode;

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget.h
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget.h
@@ -31,6 +31,8 @@
 #if !defined (_R_E_CONTROL_FLOW_H_)
 #define _R_E_CONTROL_FLOW_H_
 
+#include <map>
+#include <string>
 #include "Widget.h"
 
 class block_instance;

--- a/dyninstAPI/src/Relocation/Widgets/CallbackWidget.h
+++ b/dyninstAPI/src/Relocation/Widgets/CallbackWidget.h
@@ -31,6 +31,7 @@
 #if !defined (_R_E_CALLBACK_H_)
 #define _R_E_CALLBACK_H_
 
+#include <string>
 #include "Widget.h"
 
 

--- a/dyninstAPI/src/Relocation/Widgets/InsnWidget.h
+++ b/dyninstAPI/src/Relocation/Widgets/InsnWidget.h
@@ -31,6 +31,7 @@
 #if !defined (_PATCHAPI_INSN_ATOM_H_)
 #define _PATCHAPI_INSN_ATOM_H_
 
+#include <string>
 #include "Widget.h"
 
 class block_instance;

--- a/dyninstAPI/src/Relocation/Widgets/InstWidget.h
+++ b/dyninstAPI/src/Relocation/Widgets/InstWidget.h
@@ -31,6 +31,7 @@
 #if !defined (_R_E_INSTRUMENTATION_H_)
 #define _R_E_INSTRUMENTATION_H_
 
+#include <string>
 #include "Widget.h"
 
 class instPoint;

--- a/dyninstAPI/src/Relocation/Widgets/PCWidget.h
+++ b/dyninstAPI/src/Relocation/Widgets/PCWidget.h
@@ -31,6 +31,7 @@
 #if !defined (_PATCHAPI_PC_ATOM_H_)
 #define _PATCHAPI_PC_ATOM_H_
 
+#include <string>
 #include "Widget.h"
 
 // Define where the PC value is supposed to go

--- a/dyninstAPI/src/Relocation/Widgets/RelDataWidget.h
+++ b/dyninstAPI/src/Relocation/Widgets/RelDataWidget.h
@@ -31,6 +31,7 @@
 #if !defined (_PATCHAPI_REL_DATA_ATOM_H_)
 #define _PATCHAPI_REL_DATA_ATOM_H_
 
+#include <string>
 #include "Widget.h"
 class block_instance;
 

--- a/dyninstAPI/src/Relocation/Widgets/StackModWidget.h
+++ b/dyninstAPI/src/Relocation/Widgets/StackModWidget.h
@@ -31,6 +31,7 @@
 #ifndef _STACKMODWIDGET_H_
 #define _STACKMODWIDGET_H_
 
+#include <string>
 #include "Widget.h"
 class block_instance;
 

--- a/dyninstAPI/src/Relocation/Widgets/Widget.h
+++ b/dyninstAPI/src/Relocation/Widgets/Widget.h
@@ -33,6 +33,7 @@
 
 #include "common/src/Types.h" // Address
 #include "instructionAPI/h/Instruction.h" // Instruction::Ptr
+#include <string>
 #include <list> // stl::list
 
 class baseTramp;

--- a/dyninstAPI/src/StackMod/OffsetVector.h
+++ b/dyninstAPI/src/StackMod/OffsetVector.h
@@ -31,6 +31,9 @@
 #ifndef _OFFSETVECTOR_H_
 #define _OFFSETVECTOR_H_
 
+#include <map>
+#include <set>
+#include <utility>
 #include "dyn_regs.h"
 #include "common/src/IntervalTree.h"
 #include "stackanalysis.h"

--- a/dyninstAPI/src/StackMod/StackAccess.h
+++ b/dyninstAPI/src/StackMod/StackAccess.h
@@ -31,6 +31,9 @@
 #ifndef _STACKACCESS_H_
 #define _STACKACCESS_H_
 
+#include <map>
+#include <set>
+#include <string>
 #include "dyn_regs.h"
 #include "Instruction.h"
 #include "stackanalysis.h"

--- a/dyninstAPI/src/StackMod/StackLocation.h
+++ b/dyninstAPI/src/StackMod/StackLocation.h
@@ -31,6 +31,7 @@
 #ifndef _STACKLOCATION_H_
 #define _STACKLOCATION_H_
 
+#include <string>
 #include <functional>
 
 #include "dyn_regs.h"

--- a/dyninstAPI/src/StackMod/StackModChecker.h
+++ b/dyninstAPI/src/StackMod/StackModChecker.h
@@ -31,6 +31,10 @@
 #ifndef _StackModChecker_h_
 #define _StackModChecker_h_
 
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
 #include "BPatch_function.h"
 
 #include "Instruction.h"

--- a/dyninstAPI/src/StackMod/TMap.h
+++ b/dyninstAPI/src/StackMod/TMap.h
@@ -31,6 +31,8 @@
 #ifndef _TMAP_H_
 #define _TMAP_H_
 
+#include <map>
+#include <utility>
 #include "dyn_regs.h"
 
 #include "StackLocation.h"

--- a/dyninstAPI/src/addressSpace.h
+++ b/dyninstAPI/src/addressSpace.h
@@ -38,6 +38,12 @@
 #include "ast.h"
 #include "symtabAPI/h/Symtab.h"
 #include "dyninstAPI/src/trapMappings.h"
+#include <assert.h>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 #include <list>
 
 #include "common/src/IntervalTree.h"

--- a/dyninstAPI/src/ast.h
+++ b/dyninstAPI/src/ast.h
@@ -38,6 +38,9 @@
 //
 
 
+#include <assert.h>
+#include <utility>
+#include <vector>
 #include <stdio.h>
 #include <string>
 #include <unordered_map>

--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -33,6 +33,9 @@
 #ifndef BINARY_H
 #define BINARY_H
 
+#include <string>
+#include <string.h>
+#include <vector>
 #include <map>
 #include <memory>
 

--- a/dyninstAPI/src/block.h
+++ b/dyninstAPI/src/block.h
@@ -31,6 +31,9 @@
 #if !defined(_DYN_BLOCK_H_)
 #define _DYN_BLOCK_H_
 
+#include <set>
+#include <string>
+#include <vector>
 #include "parse-cfg.h"
 #include "parseAPI/h/CFG.h"
 #include "instPoint.h"

--- a/dyninstAPI/src/codegen-aarch64.h
+++ b/dyninstAPI/src/codegen-aarch64.h
@@ -31,6 +31,8 @@
 #ifndef _CODEGEN_AARCH64_H
 #define _CODEGEN_AARCH64_H
 
+#include <vector>
+
 class AddressSpace;
 
 class codeGen;

--- a/dyninstAPI/src/codegen-power.h
+++ b/dyninstAPI/src/codegen-power.h
@@ -31,6 +31,8 @@
 #ifndef _CODEGEN_POWER_H
 #define _CODEGEN_POWER_H
 
+#include <vector>
+
 class AddressSpace;
 class codeGen;
 

--- a/dyninstAPI/src/codegen.h
+++ b/dyninstAPI/src/codegen.h
@@ -30,6 +30,7 @@
 #if !defined(_codegen_h_)
 #define _codegen_h_
 
+#include <utility>
 #include <vector>
 #include <string>
 #include <map>

--- a/dyninstAPI/src/dynProcess.h
+++ b/dyninstAPI/src/dynProcess.h
@@ -36,6 +36,11 @@
  * A class that encapsulates a ProcControlAPI Process for the rest of Dyninst.
  */
 
+#include <assert.h>
+#include <list>
+#include <stddef.h>
+#include <utility>
+#include <vector>
 #include <string>
 #include <map>
 #include <set>

--- a/dyninstAPI/src/dynThread.h
+++ b/dyninstAPI/src/dynThread.h
@@ -31,6 +31,7 @@
 #ifndef DYNTHREAD_H
 #define DYNTHREAD_H
 
+#include <vector>
 #include "frame.h"
 
 #include "PCProcess.h"

--- a/dyninstAPI/src/emit-aarch64.h
+++ b/dyninstAPI/src/emit-aarch64.h
@@ -32,6 +32,8 @@
 #ifndef _EMITTER_AARCH64_H
 #define _EMITTER_AARCH64_H
 
+#include <assert.h>
+#include <vector>
 #include "common/src/headers.h"
 #include "dyninstAPI/src/instPoint.h"
 #include "dyninstAPI/src/baseTramp.h"

--- a/dyninstAPI/src/emit-power.h
+++ b/dyninstAPI/src/emit-power.h
@@ -36,6 +36,8 @@
 #ifndef _EMITTER_POWER_H
 #define _EMITTER_POWER_H
 
+#include <assert.h>
+#include <vector>
 #include "common/src/headers.h"
 #include "dyninstAPI/src/instPoint.h"
 #include "dyninstAPI/src/baseTramp.h"

--- a/dyninstAPI/src/emit-x86.h
+++ b/dyninstAPI/src/emit-x86.h
@@ -36,6 +36,8 @@
 #ifndef _EMIT_X86_H
 #define _EMIT_X86_H
 
+#include <assert.h>
+#include <vector>
 #include "common/src/headers.h"
 #include "common/src/arch.h"
 #include "dyninstAPI/src/instPoint.h"

--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -36,6 +36,8 @@
 #ifndef _EMITTER_H
 #define _EMITTER_H
 
+#include <assert.h>
+#include <vector>
 #include "common/src/headers.h"
 #include "dyninstAPI/src/instPoint.h"
 #include "dyninstAPI/src/baseTramp.h"

--- a/dyninstAPI/src/frame.h
+++ b/dyninstAPI/src/frame.h
@@ -33,6 +33,8 @@
 #ifndef FRAME_H
 #define FRAME_H
 
+#include <iosfwd>
+#include <vector>
 #include "common/src/std_namesp.h"
 #include "common/src/Types.h"
 

--- a/dyninstAPI/src/frameChecker.h
+++ b/dyninstAPI/src/frameChecker.h
@@ -31,6 +31,8 @@
 #if !defined(FRAMECHECKER_H)
 #define FRAMECHECKER_H
 
+#include <stddef.h>
+#include <vector>
 #include "instructionAPI/h/Instruction.h"
 
 class frameChecker

--- a/dyninstAPI/src/function.h
+++ b/dyninstAPI/src/function.h
@@ -34,6 +34,11 @@
 #define FUNCTION_H
 
 #include <string>
+#include <list>
+#include <map>
+#include <set>
+#include <stddef.h>
+#include <vector>
 #include "common/src/Types.h"
 #include "common/src/Pair.h"
 #include "codegen.h"

--- a/dyninstAPI/src/hybridAnalysis.h
+++ b/dyninstAPI/src/hybridAnalysis.h
@@ -32,6 +32,8 @@
 #define _HYBRIDANALYSIS_H_
 
 #include <stdio.h>
+#include <string>
+#include <utility>
 #include <set>
 #include <map>
 #include <vector>

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -34,6 +34,9 @@
 #define SYMTAB_HDR
 #define REGEX_CHARSET "^*|?"
 
+#include <map>
+#include <utility>
+#include <vector>
 #include <sys/types.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/dyninstAPI/src/inst-aarch64.h
+++ b/dyninstAPI/src/inst-aarch64.h
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stdint.h>
 #include <cassert>
 
 #ifndef INST_AARCH64_H

--- a/dyninstAPI/src/inst-power.h
+++ b/dyninstAPI/src/inst-power.h
@@ -36,6 +36,8 @@
 #ifndef INST_POWER_H
 #define INST_POWER_H
 
+#include <stdint.h>
+
 
 /* "pseudo" instructions that are placed in the tramp code for the inst funcs
  *   to patch up.   This must be invalid instructions (any instruction with

--- a/dyninstAPI/src/inst-x86.h
+++ b/dyninstAPI/src/inst-x86.h
@@ -55,6 +55,7 @@
 
 */
 
+#include <assert.h>
 #include "dyninstAPI/src/registerSpace.h"
 
 #define NUM_VIRTUAL_REGISTERS (32)   /* number of virtual registers */

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -34,6 +34,8 @@
 #define INST_HDR
 
 #include <string>
+#include <map>
+#include <vector>
 #include <unordered_map>
 #include "opcode.h" // enum opCode now defined here.
 #include "common/src/Types.h"

--- a/dyninstAPI/src/instPoint.h
+++ b/dyninstAPI/src/instPoint.h
@@ -34,6 +34,8 @@
 #ifndef _INST_POINT_H_
 #define _INST_POINT_H_
 
+#include <string>
+#include <utility>
 #include <stdlib.h>
 #include "common/src/Types.h"
 #include "dyninstAPI/src/inst.h"

--- a/dyninstAPI/src/mapped_module.h
+++ b/dyninstAPI/src/mapped_module.h
@@ -44,6 +44,8 @@ class pdmodule;
 class image;
 
 #include <string>
+#include <set>
+#include <vector>
 #include "common/src/Types.h"
 #include "dyninstAPI/src/image.h"
 #include "symtabAPI/h/Symtab.h"

--- a/dyninstAPI/src/mapped_object.h
+++ b/dyninstAPI/src/mapped_object.h
@@ -34,6 +34,11 @@
 #define _mapped_object_h
 
 #include <string>
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 #include "common/src/Types.h"
 #include "dyninstAPI/src/image.h"
 #include "dyninstAPI/h/BPatch_enums.h"

--- a/dyninstAPI/src/os.h
+++ b/dyninstAPI/src/os.h
@@ -52,6 +52,7 @@
 #endif
 
 #include <string>
+#include <vector>
 #include "common/src/Types.h"
 
 class OS {

--- a/dyninstAPI/src/parRegion.h
+++ b/dyninstAPI/src/parRegion.h
@@ -32,6 +32,7 @@
 #ifndef PARREGION_H
 #define PARREGION_H
 
+#include <string.h>
 #include <string>
 #include "common/src/Types.h"
 #include "common/src/Pair.h"

--- a/dyninstAPI/src/parse-cfg.h
+++ b/dyninstAPI/src/parse-cfg.h
@@ -33,6 +33,12 @@
 #ifndef IMAGE_FUNC_H
 #define IMAGE_FUNC_H
 
+#include <assert.h>
+#include <list>
+#include <map>
+#include <stddef.h>
+#include <utility>
+#include <vector>
 #include <string>
 #include "common/src/Types.h"
 #include "common/src/Pair.h"

--- a/dyninstAPI/src/pcEventMuxer.h
+++ b/dyninstAPI/src/pcEventMuxer.h
@@ -38,6 +38,7 @@
 #include "dyninstAPI/h/BPatch_process.h"
 #include "dyninstAPI/src/syscallNotification.h"
 
+#include <map>
 #include <queue>
 /*
  * Overall design comment

--- a/dyninstAPI/src/registerSpace.h
+++ b/dyninstAPI/src/registerSpace.h
@@ -35,6 +35,8 @@
 
 #include <stdio.h>
 #include <string>
+#include <assert.h>
+#include <vector>
 #include <map>
 #include <set>
 #include <unordered_map>

--- a/dyninstAPI/src/unix.h
+++ b/dyninstAPI/src/unix.h
@@ -108,6 +108,7 @@ typedef pthread_cond_t EventCond_t;
 #define STRERROR(x,y) strerror(x)
 #endif
 
+#include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <pthread.h>

--- a/dyninstAPI/src/util.h
+++ b/dyninstAPI/src/util.h
@@ -34,6 +34,7 @@
 #define UTIL_H
 
 #ifndef FILE__
+#include <string.h>
 #define FILE__ strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__
 #endif
 

--- a/dyninstAPI_RT/h/dyninstAPI_RT.h
+++ b/dyninstAPI_RT/h/dyninstAPI_RT.h
@@ -54,6 +54,7 @@
 #define DYNINST_BREAKPOINT_SIGNUM (SIGRTMIN+4)
 
 #include <stdio.h>
+#include <stdint.h>
 #include "dyninstRTExport.h"
 #include "common/src/Types.h"
 #include "common/h/compiler_diagnostics.h"

--- a/dyninstAPI_RT/h/dyninstRTExport.h
+++ b/dyninstAPI_RT/h/dyninstRTExport.h
@@ -35,6 +35,8 @@
       libraries.
   */
 
+#include <stddef.h>
+
 #if !defined(DLLEXPORT)
 #if defined (_MSC_VER)
 /* If we're on Windows, we need to explicetely export these functions: */

--- a/dyninstAPI_RT/src/RTcommon.h
+++ b/dyninstAPI_RT/src/RTcommon.h
@@ -33,6 +33,7 @@
 
 #include "dyninstAPI_RT/h/dyninstAPI_RT.h"
 #include "RTthread.h"
+#include <stddef.h>
 #include <stdarg.h>
 #include "common/h/compiler_annotations.h"
 

--- a/elf/h/Elf_X.h
+++ b/elf/h/Elf_X.h
@@ -32,6 +32,8 @@
 #define __ELF_X_H__
 
 #include "libelf.h"
+#include <stddef.h>
+#include <utility>
 #include <string>
 #include <map>
 #include <vector>

--- a/instructionAPI/h/BinaryFunction.h
+++ b/instructionAPI/h/BinaryFunction.h
@@ -35,6 +35,10 @@
 #include "Register.h"
 #include "Result.h"
 #include "ArchSpecificFormatters.h"
+#include <assert.h>
+#include <stdint.h>
+#include <string>
+#include <vector>
 #include <sstream>
 
 namespace Dyninst

--- a/instructionAPI/h/Dereference.h
+++ b/instructionAPI/h/Dereference.h
@@ -39,7 +39,8 @@
 #include "Visitor.h"
 #include "ArchSpecificFormatters.h"
 
-#include <sstream>
+#include <string>
+#include <vector>
 
 namespace Dyninst
 {

--- a/instructionAPI/h/Expression.h
+++ b/instructionAPI/h/Expression.h
@@ -35,6 +35,7 @@
 #include "InstructionAST.h"
 #include "Result.h"
 
+#include <string>
 #include <vector>
 #include <sstream>
 

--- a/instructionAPI/h/Immediate.h
+++ b/instructionAPI/h/Immediate.h
@@ -32,6 +32,8 @@
 #define IMMEDIATE_H
 
 #include "Expression.h"
+#include <map>
+#include <string>
 #include <sstream>
 
 namespace Dyninst

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -32,6 +32,9 @@
 #define INSTRUCTION_H
 
 
+#include <stddef.h>
+#include <string>
+#include <string.h>
 #include <vector>
 #include <set>
 #include <list>

--- a/instructionAPI/h/InstructionAST.h
+++ b/instructionAPI/h/InstructionAST.h
@@ -33,6 +33,7 @@
 
 
 #include "util.h"
+#include <string>
 #include <vector>
 #include <set>
 #include <iostream>

--- a/instructionAPI/h/InstructionDecoder.h
+++ b/instructionAPI/h/InstructionDecoder.h
@@ -32,6 +32,7 @@
 #define INSTRUCTION_DECODER_H
 
 #include "Instruction.h"
+#include <stddef.h>
 
 namespace Dyninst
 {

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -35,6 +35,8 @@
 #include "Expression.h"
 #include "entryIDs.h"
 #include "Result.h"
+#include <stddef.h>
+#include <string>
 #include <set>
 #include <mutex>
 

--- a/instructionAPI/h/Register.h
+++ b/instructionAPI/h/Register.h
@@ -32,6 +32,8 @@
 #define REGISTER_H
 
 #include "Expression.h"
+#include <stdint.h>
+#include <string>
 #include <vector>
 #include <map>
 #include <sstream>

--- a/instructionAPI/h/RegisterIDs.h
+++ b/instructionAPI/h/RegisterIDs.h
@@ -31,6 +31,7 @@
 #if !defined(REGISTER_IDS_X86_H)
 #define REGISTER_IDS_X86_H
 
+#include <string>
 #include <vector>
 #include <map>
 #include "util.h"

--- a/instructionAPI/h/Ternary.h
+++ b/instructionAPI/h/Ternary.h
@@ -32,6 +32,7 @@
 #define TERNARY_H
 
 #include "Expression.h"
+#include <string>
 #include <vector>
 #include <map>
 #include <sstream>

--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
@@ -28,6 +28,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <array>
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
 #include "InstructionDecoderImpl.h"
 #include <iostream>
 #include "Immediate.h"

--- a/instructionAPI/src/AMDGPU/gfx908/amdgpu_gfx908_decoder_impl.h
+++ b/instructionAPI/src/AMDGPU/gfx908/amdgpu_gfx908_decoder_impl.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 static bool IS_ENC_SOP1(uint64_t I);
 static bool IS_ENC_SOPC(uint64_t I);
 static bool IS_ENC_SOPP(uint64_t I);

--- a/instructionAPI/src/AMDGPU/gfx908/amdgpu_gfx908_insn_entry.h
+++ b/instructionAPI/src/AMDGPU/gfx908/amdgpu_gfx908_insn_entry.h
@@ -1,4 +1,4 @@
-#include <cstdint>
+#include <cstddef>
 
 struct amdgpu_gfx908_insn_entry {
 	entryID op;

--- a/instructionAPI/src/AMDGPU/gfx908/amdgpu_gfx908_insn_entry.h
+++ b/instructionAPI/src/AMDGPU/gfx908/amdgpu_gfx908_insn_entry.h
@@ -1,3 +1,5 @@
+#include <cstdint>
+
 struct amdgpu_gfx908_insn_entry {
 	entryID op;
 	const char *mnemonic;

--- a/instructionAPI/src/AMDGPU/gfx908/decodeOperands.h
+++ b/instructionAPI/src/AMDGPU/gfx908/decodeOperands.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 Expression::Ptr decodeOPR_ACCVGPR(uint64_t input, uint32_t _num_elements = 1 );
 Expression::Ptr decodeOPR_ATTR(uint64_t input, uint32_t _num_elements = 1 );
 Expression::Ptr decodeOPR_DSMEM(uint64_t input, uint32_t _num_elements = 1 );

--- a/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.h
+++ b/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.h
@@ -28,6 +28,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <array>
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
 #include "InstructionDecoderImpl.h"
 #include <iostream>
 #include "Immediate.h"

--- a/instructionAPI/src/AMDGPU/gfx90a/amdgpu_gfx90a_decoder_impl.h
+++ b/instructionAPI/src/AMDGPU/gfx90a/amdgpu_gfx90a_decoder_impl.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 static bool IS_ENC_SOP1(uint64_t I);
 static bool IS_ENC_SOPC(uint64_t I);
 static bool IS_ENC_SOPP(uint64_t I);

--- a/instructionAPI/src/AMDGPU/gfx90a/amdgpu_gfx90a_insn_entry.h
+++ b/instructionAPI/src/AMDGPU/gfx90a/amdgpu_gfx90a_insn_entry.h
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 struct amdgpu_gfx90a_insn_entry {
 	entryID op;
 	const char *mnemonic;

--- a/instructionAPI/src/AMDGPU/gfx90a/decodeOperands.h
+++ b/instructionAPI/src/AMDGPU/gfx90a/decodeOperands.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 Expression::Ptr decodeOPR_ACCVGPR(uint64_t input, uint32_t _num_elements = 1 );
 Expression::Ptr decodeOPR_DSMEM(uint64_t input, uint32_t _num_elements = 1 );
 Expression::Ptr decodeOPR_FLAT_SCRATCH(uint64_t input, uint32_t _num_elements = 1 );

--- a/instructionAPI/src/AMDGPU/vega/InstructionDecoder-amdgpu-vega.h
+++ b/instructionAPI/src/AMDGPU/vega/InstructionDecoder-amdgpu-vega.h
@@ -28,6 +28,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <array>
+#include <assert.h>
+#include <stdint.h>
+#include <string>
 #include "InstructionDecoderImpl.h"
 #include <iostream>
 #include "Immediate.h"

--- a/instructionAPI/src/AMDGPU/vega/amdgpu_vega_insn_entry.h
+++ b/instructionAPI/src/AMDGPU/vega/amdgpu_vega_insn_entry.h
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 struct amdgpu_vega_insn_entry {
 	entryID op;
 	const char *mnemonic;

--- a/instructionAPI/src/InstructionDecoder-aarch64.h
+++ b/instructionAPI/src/InstructionDecoder-aarch64.h
@@ -28,6 +28,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stdint.h>
+#include <string>
 #include <array>
 #include "InstructionDecoderImpl.h"
 #include <iostream>

--- a/instructionAPI/src/InstructionDecoder-power.h
+++ b/instructionAPI/src/InstructionDecoder-power.h
@@ -31,6 +31,8 @@
 
 #include "InstructionDecoderImpl.h"
 #include <iostream>
+#include <stddef.h>
+#include <string>
 #include "Immediate.h"
 #include "dyn_regs.h"
 //#define DEBUG_FIELD

--- a/instructionAPI/src/InstructionDecoderImpl.h
+++ b/instructionAPI/src/InstructionDecoderImpl.h
@@ -31,6 +31,7 @@
 #if !defined(INSTRUCTION_DECODER_IMPL_H)
 #define INSTRUCTION_DECODER_IMPL_H
 
+#include <stdint.h>
 #include "Expression.h"
 #include "dyn_regs.h"
 #include "Operation_impl.h"

--- a/instructionAPI/src/test/test_aarch64_decoder_table.h
+++ b/instructionAPI/src/test/test_aarch64_decoder_table.h
@@ -1,3 +1,6 @@
+#include <map>
+#include <vector>
+
 struct aarch64_mask_entry;
 struct aarch64_insn_entry;
 

--- a/parseAPI/h/CFG.h
+++ b/parseAPI/h/CFG.h
@@ -30,6 +30,10 @@
 #ifndef _PARSER_CFG_H_
 #define _PARSER_CFG_H_
 
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <utility>
 #include <vector>
 #include <set>
 #include <map>
@@ -96,14 +100,6 @@ class PARSER_EXPORT Edge {
     bool _from_index;
 
  private:
-
-#if defined(_MSC_VER)
-	typedef unsigned __int16 uint16_t;
-	typedef unsigned __int8 uint8_t;
-#else
-	typedef unsigned short uint16_t;
-	typedef unsigned char uint8_t;
-#endif
 
     struct EdgeType {
         EdgeType(EdgeTypeEnum t, bool s) :

--- a/parseAPI/h/CFGFactory.h
+++ b/parseAPI/h/CFGFactory.h
@@ -30,6 +30,8 @@
 #ifndef _CFG_FACTORY_H_
 #define _CFG_FACTORY_H_
 
+#include <string>
+
 #include "dyntypes.h"
 
 #include "LockFreeQueue.h"

--- a/parseAPI/h/CFGModifier.h
+++ b/parseAPI/h/CFGModifier.h
@@ -31,6 +31,7 @@
 #ifndef _CFG_MODIFIER_H_
 #define _CFG_MODIFIER_H_
 
+#include <vector>
 #include "dyntypes.h"
 
 // A collection of methods for user-triggered modification of a ParseAPI CFG. 

--- a/parseAPI/h/CodeObject.h
+++ b/parseAPI/h/CodeObject.h
@@ -31,6 +31,9 @@
 #ifndef CODE_OBJECT_H
 #define CODE_OBJECT_H
 
+#include <set>
+#include <string>
+#include <vector>
 #include <map>
 
 #include "Symtab.h"

--- a/parseAPI/h/CodeSource.h
+++ b/parseAPI/h/CodeSource.h
@@ -30,6 +30,7 @@
 #ifndef _CODE_SOURCE_H_
 #define _CODE_SOURCE_H_
 
+#include <set>
 #include <map>
 #include <vector>
 #include <utility>

--- a/parseAPI/h/GraphAdapter.h
+++ b/parseAPI/h/GraphAdapter.h
@@ -1,6 +1,8 @@
 
 
 #include "CFG.h"
+#include <stddef.h>
+#include <utility>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
 

--- a/parseAPI/h/InstructionAdapter.h
+++ b/parseAPI/h/InstructionAdapter.h
@@ -31,6 +31,12 @@
 #if !defined(INSTRUCTION_ADAPTER_H)
 #define INSTRUCTION_ADAPTER_H
 
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "dyntypes.h"
 
 #include "CodeObject.h"

--- a/parseAPI/h/Location.h
+++ b/parseAPI/h/Location.h
@@ -39,6 +39,9 @@
 #include "Instruction.h"
 
 #include <string>
+#include <assert.h>
+#include <utility>
+#include <vector>
 
 namespace Dyninst{
 namespace ParseAPI{

--- a/parseAPI/h/LockFreeQueue.h
+++ b/parseAPI/h/LockFreeQueue.h
@@ -30,6 +30,8 @@
 #ifndef _LOCK_FREE_QUEUE_H_
 #define _LOCK_FREE_QUEUE_H_
 
+#include <assert.h>
+#include <utility>
 #include <iterator>
 #include <boost/atomic.hpp>
 

--- a/parseAPI/h/ParseCallback.h
+++ b/parseAPI/h/ParseCallback.h
@@ -38,6 +38,10 @@
     during parsing.
 **/
 
+#include <list>
+#include <stddef.h>
+#include <utility>
+#include <vector>
 #include "InstructionAdapter.h"
 #include "dyntypes.h"
 

--- a/parseAPI/src/BoundFactCalculator.h
+++ b/parseAPI/src/BoundFactCalculator.h
@@ -7,6 +7,7 @@
 #include "SymbolicExpression.h"
 #include "slicing.h"
 
+#include <vector>
 #include <unordered_set>
 #include <unordered_map>
 

--- a/parseAPI/src/BoundFactData.h
+++ b/parseAPI/src/BoundFactData.h
@@ -10,6 +10,10 @@
 #include "entryIDs.h"
 
 #include <climits>
+#include <map>
+#include <stdint.h>
+#include <string>
+#include <utility>
 using namespace std;
 using namespace Dyninst;
 using namespace Dyninst::ParseAPI;

--- a/parseAPI/src/IA_IAPI.h
+++ b/parseAPI/src/IA_IAPI.h
@@ -31,6 +31,12 @@
 #if !defined(IA_IAPI_H)
 #define IA_IAPI_H
 
+#include <map>
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <utility>
+#include <vector>
 #include <boost/tuple/tuple.hpp>
 #include <boost/static_assert.hpp>
 

--- a/parseAPI/src/IA_aarch64.h
+++ b/parseAPI/src/IA_aarch64.h
@@ -29,6 +29,7 @@
  */
 #if !defined(IA_AARCH64__H)
 #define IA_AARCH64__H
+#include <string>
 #include "common/h/DynAST.h"
 #include "dataflowAPI/h/Absloc.h"
 #include "dataflowAPI/h/SymEval.h"

--- a/parseAPI/src/IA_amdgpu.h
+++ b/parseAPI/src/IA_amdgpu.h
@@ -29,6 +29,7 @@
  */
 #if !defined(IA_AMDGPU__H)
 #define IA_AMDGPU__H
+#include <string>
 #include "common/h/DynAST.h"
 #include "dataflowAPI/h/Absloc.h"
 #include "dataflowAPI/h/SymEval.h"

--- a/parseAPI/src/IA_power.h
+++ b/parseAPI/src/IA_power.h
@@ -29,6 +29,7 @@
  */
 #if !defined(IA_POWER__H)
 #define IA_POWER__H
+#include <string>
 #include "common/h/DynAST.h"
 #include "dataflowAPI/h/Absloc.h"
 #include "dataflowAPI/h/SymEval.h"

--- a/parseAPI/src/IA_x86.h
+++ b/parseAPI/src/IA_x86.h
@@ -29,6 +29,7 @@
  */
 #if !defined(IA_X86__H)
 #define IA_X86__H
+#include <string>
 #include "common/h/DynAST.h"
 #include "dataflowAPI/h/Absloc.h"
 #include "dataflowAPI/h/SymEval.h"

--- a/parseAPI/src/IndirectASTVisitor.h
+++ b/parseAPI/src/IndirectASTVisitor.h
@@ -1,6 +1,7 @@
 #ifndef INDIRECT_AST_VISITOR_H
 #define INDIRECT_AST_VISITOR_H
 
+#include <stdint.h>
 #include <set>
 
 #include "DynAST.h"

--- a/parseAPI/src/IndirectAnalyzer.h
+++ b/parseAPI/src/IndirectAnalyzer.h
@@ -1,6 +1,10 @@
 #ifndef INDIRECT_ANALYZER_H
 #define INDIRECT_ANALYZER_H
 
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
 #include "ThunkData.h"
 #include "BoundFactData.h"
 #include "CFG.h"

--- a/parseAPI/src/JumpTableFormatPred.h
+++ b/parseAPI/src/JumpTableFormatPred.h
@@ -1,6 +1,8 @@
 #ifndef JUMP_TABLE_FORMAT_PRED_H
 #define JUMP_TABLE_FORMAT_PRED_H
 
+#include <string>
+#include <utility>
 #include "CFG.h"
 #include "slicing.h"
 #include "Edge.h"

--- a/parseAPI/src/JumpTableIndexPred.h
+++ b/parseAPI/src/JumpTableIndexPred.h
@@ -1,6 +1,8 @@
 #ifndef JUMP_TABLE_INDEX_PRED_H
 #define JUMP_TABLE_INDEX_PRED_H
 
+#include <set>
+#include <vector>
 #include "CFG.h"
 #include "slicing.h"
 #include "Edge.h"

--- a/parseAPI/src/LoopAnalyzer.h
+++ b/parseAPI/src/LoopAnalyzer.h
@@ -33,6 +33,7 @@
 
 #include <string>
 #include <set>
+#include <map>
 #include "Annotatable.h"
 #include "CFG.h"
 

--- a/parseAPI/src/ParseData.h
+++ b/parseAPI/src/ParseData.h
@@ -34,6 +34,8 @@
 
 #include <set>
 #include <vector>
+#include <map>
+#include <utility>
 #include <queue>
 
 #include "dyntypes.h"

--- a/parseAPI/src/ParserDetails.h
+++ b/parseAPI/src/ParserDetails.h
@@ -30,6 +30,7 @@
 #ifndef _PARSER_DETAILS_H_
 #define _PARSER_DETAILS_H_
 
+#include <assert.h>
 #include "IA_IAPI.h"
 
 namespace Dyninst {

--- a/parseAPI/src/ProbabilisticParser.h
+++ b/parseAPI/src/ProbabilisticParser.h
@@ -39,6 +39,8 @@
 
 #include "Parser.h"
 
+#include <stdint.h>
+#include <utility>
 #include <string>
 #include <vector>
 #include <set>

--- a/parseAPI/src/SymbolicExpression.h
+++ b/parseAPI/src/SymbolicExpression.h
@@ -4,6 +4,9 @@
 #include "DynAST.h"
 #include "Absloc.h"
 #include "CodeSource.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <utility>
 #include <map>
 using Dyninst::AST;
 using namespace Dyninst;

--- a/parseAPI/src/debug_parse.h
+++ b/parseAPI/src/debug_parse.h
@@ -30,6 +30,7 @@
 #ifndef _PARSEAPI_DEBUG_
 #define _PARSEAPI_DEBUG_
 
+#include <string>
 #include <stdlib.h>
 #include <stdio.h>
 #include <common/h/util.h>

--- a/patchAPI/h/AddrSpace.h
+++ b/patchAPI/h/AddrSpace.h
@@ -33,6 +33,9 @@
 #ifndef PATCHAPI_H_ADDRSPACE_H_
 #define PATCHAPI_H_ADDRSPACE_H_
 
+#include <map>
+#include <stddef.h>
+#include <string>
 #include "PatchCommon.h"
 
 namespace Dyninst {

--- a/patchAPI/h/Command.h
+++ b/patchAPI/h/Command.h
@@ -32,6 +32,7 @@
 #ifndef PATCHAPI_COMMAND_H_
 #define PATCHAPI_COMMAND_H_
 
+#include <list>
 #include "PatchCommon.h"
 
 namespace Dyninst {

--- a/patchAPI/h/Instrumenter.h
+++ b/patchAPI/h/Instrumenter.h
@@ -32,6 +32,7 @@
 #ifndef PATCHAPI_H_INSTRUMENTOR_H_
 #define PATCHAPI_H_INSTRUMENTOR_H_
 
+#include <string>
 #include "PatchCommon.h"
 #include "Point.h"
 #include "AddrSpace.h"

--- a/patchAPI/h/PatchCFG.h
+++ b/patchAPI/h/PatchCFG.h
@@ -32,6 +32,11 @@
 #ifndef _PATCHAPI_DYNINST_CFG_H_
 #define _PATCHAPI_DYNINST_CFG_H_
 
+#include <assert.h>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
 #include "CFG.h"
 #include "PatchCommon.h"
 #include "PatchObject.h"

--- a/patchAPI/h/PatchCallback.h
+++ b/patchAPI/h/PatchCallback.h
@@ -36,6 +36,7 @@
 #if !defined(_PATCH_CALLBACK_H_)
 #define _PATCH_CALLBACK_H_
 
+#include <utility>
 #include <vector>
 #include "util.h"
 

--- a/patchAPI/h/PatchCommon.h
+++ b/patchAPI/h/PatchCommon.h
@@ -31,6 +31,10 @@
 #define PATCHAPI_H_COMMON_H_
 
 // C++
+#include <string>
+#include <string.h>
+#include <utility>
+#include <vector>
 #include <list>
 #include <set>
 #include <map>

--- a/patchAPI/h/PatchMgr.h
+++ b/patchAPI/h/PatchMgr.h
@@ -34,6 +34,8 @@
 
 
 
+#include <utility>
+#include <vector>
 #include "PatchCommon.h"
 #include "Point.h"
 #include "Instrumenter.h"

--- a/patchAPI/h/PatchModifier.h
+++ b/patchAPI/h/PatchModifier.h
@@ -31,6 +31,8 @@
 #ifndef _PATCH_MODIFIER_H_
 #define _PATCH_MODIFIER_H_
 
+#include <set>
+#include <vector>
 #include "dyntypes.h"
 
 // A collection of methods for user-triggered modification of a PatchAPI CFG,

--- a/patchAPI/h/PatchObject.h
+++ b/patchAPI/h/PatchObject.h
@@ -32,6 +32,9 @@
 #ifndef PATCHAPI_H_DYNINST_OBJECT_H_
 #define PATCHAPI_H_DYNINST_OBJECT_H_
 
+#include <map>
+#include <string>
+#include <vector>
 #include "PatchCommon.h"
 #include "CFGMaker.h"
 

--- a/patchAPI/h/Point.h
+++ b/patchAPI/h/Point.h
@@ -32,6 +32,9 @@
 #ifndef PATCHAPI_H_POINT_H_
 #define PATCHAPI_H_POINT_H_
 
+#include <list>
+#include <map>
+#include <stddef.h>
 #include "PatchCommon.h"
 #include "Snippet.h"
 #include "util.h"

--- a/proccontrol/h/Event.h
+++ b/proccontrol/h/Event.h
@@ -32,6 +32,8 @@
 
 #include <string>
 #include <set>
+#include <stddef.h>
+#include <vector>
 #include "dyntypes.h"
 #include "MachSyscall.h"
 #include "EventType.h"

--- a/proccontrol/h/EventType.h
+++ b/proccontrol/h/EventType.h
@@ -30,6 +30,7 @@
 #if !defined(EVENTTYPE_H_)
 #define EVENTTYPE_H_
 
+#include <string>
 #include "util.h"
 
 namespace Dyninst {

--- a/proccontrol/h/Generator.h
+++ b/proccontrol/h/Generator.h
@@ -40,6 +40,7 @@
 #include <set>
 #include <map>
 #include <string>
+#include <vector>
 
 struct GeneratorMTInternals;
 class int_process;

--- a/proccontrol/h/Handler.h
+++ b/proccontrol/h/Handler.h
@@ -33,6 +33,7 @@
 #include "Event.h"
 #include "util.h"
 
+#include <string>
 #include <set>
 #include <vector>
 

--- a/proccontrol/h/PCProcess.h
+++ b/proccontrol/h/PCProcess.h
@@ -36,6 +36,8 @@
 #include <map>
 #include <set>
 #include <iterator>
+#include <stddef.h>
+#include <utility>
 
 #include "dyntypes.h"
 #include "dyn_regs.h"

--- a/proccontrol/h/PlatFeatures.h
+++ b/proccontrol/h/PlatFeatures.h
@@ -34,6 +34,8 @@
 #include <list>
 #include <vector>
 #include <string>
+#include <map>
+#include <set>
 
 #if !defined(PLATFEATURES_H_)
 #define PLATFEATURES_H_

--- a/proccontrol/h/ProcessSet.h
+++ b/proccontrol/h/ProcessSet.h
@@ -33,6 +33,10 @@
 
 #include <string>
 #include <map>
+#include <set>
+#include <stddef.h>
+#include <utility>
+#include <vector>
 
 #include "dyntypes.h"
 #include "PCProcess.h"

--- a/proccontrol/src/DecoderWindows.h
+++ b/proccontrol/src/DecoderWindows.h
@@ -30,6 +30,8 @@
 #if !defined(DECODER_WINDOWS_H)
 #define DECODER_WINDOWS_H
 
+#include <string>
+#include <vector>
 #include "Decoder.h"
 #include "Event.h"
 #include "int_process.h"

--- a/proccontrol/src/GeneratorWindows.h
+++ b/proccontrol/src/GeneratorWindows.h
@@ -35,6 +35,7 @@
 #include "int_process.h"
 #include <sys/types.h>
 #include <vector>
+#include <map>
 #include <deque>
 
 

--- a/proccontrol/src/arm_process.h
+++ b/proccontrol/src/arm_process.h
@@ -31,6 +31,8 @@
 #if !defined(arm_process_h_)
 #define arm_process_h_
 
+#include <set>
+#include <string>
 #include <map>
 #include <vector>
 #include "int_process.h"

--- a/proccontrol/src/freebsd.h
+++ b/proccontrol/src/freebsd.h
@@ -30,6 +30,11 @@
 #if !defined(FREEBSD_H_)
 #define FREEBSD_H_
 
+#include <map>
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <vector>
 #include "Generator.h"
 #include "Event.h"
 #include "Decoder.h"

--- a/proccontrol/src/int_event.h
+++ b/proccontrol/src/int_event.h
@@ -35,6 +35,9 @@
 #endif
 #include "response.h"
 #include "resp.h"
+#include <stddef.h>
+#include <string>
+#include <vector>
 #include <set>
 
 namespace Dyninst {

--- a/proccontrol/src/int_handler.h
+++ b/proccontrol/src/int_handler.h
@@ -30,6 +30,7 @@
 
 #include "Handler.h"
 #include "PCProcess.h"
+#include <set>
 #include <map>
 #include <vector>
 

--- a/proccontrol/src/int_process.h
+++ b/proccontrol/src/int_process.h
@@ -43,6 +43,8 @@
 #include "common/h/SymReader.h"
 #include "common/src/dthread.h"
 
+#include <assert.h>
+#include <string>
 #include <vector>
 #include <map>
 #include <list>

--- a/proccontrol/src/int_thread_db.h
+++ b/proccontrol/src/int_thread_db.h
@@ -56,6 +56,8 @@ extern "C" {
 #include "proc_service_wrapper.h"
 }
 
+#include <stddef.h>
+#include <utility>
 #include <map>
 #include <set>
 #include <vector>

--- a/proccontrol/src/irpc.h
+++ b/proccontrol/src/irpc.h
@@ -31,6 +31,7 @@
 #if !defined(IRPC_H_)
 #define IRPC_H_
 
+#include <vector>
 #include <map>
 #include <list>
 #include <set>

--- a/proccontrol/src/linux.h
+++ b/proccontrol/src/linux.h
@@ -49,6 +49,10 @@
 #include "processplat.h"
 
 #include "common/src/dthread.h"
+#include <map>
+#include <stddef.h>
+#include <string>
+#include <vector>
 #include <sys/types.h>
 #include <sys/ptrace.h>
 

--- a/proccontrol/src/loadLibrary/codegen.h
+++ b/proccontrol/src/loadLibrary/codegen.h
@@ -6,6 +6,9 @@
 #if !defined(_INJECTOR_CODEGEN_H_)
 #define _INJECTOR_CODEGEN_H_
 
+#include <map>
+#include <string>
+#include <vector>
 #include "PCProcess.h"
 #include "Buffer.h"
 

--- a/proccontrol/src/loadLibrary/injector.h
+++ b/proccontrol/src/loadLibrary/injector.h
@@ -3,6 +3,7 @@
 #if !defined(_INJECTOR_H_)
 #define _INJECTOR_H_
 
+#include <string>
 #include "PCProcess.h"
 
 namespace Dyninst {

--- a/proccontrol/src/memcache.h
+++ b/proccontrol/src/memcache.h
@@ -33,6 +33,7 @@
 
 #include "common/h/dyntypes.h"
 #include "response.h"
+#include <vector>
 #include <set>
 #include <map>
 

--- a/proccontrol/src/mmapalloc.h
+++ b/proccontrol/src/mmapalloc.h
@@ -31,6 +31,9 @@
 #if !defined(MMAPALLOC_H_)
 #define MMAPALLOC_H_
 
+#include <map>
+#include <string>
+#include <vector>
 #include "int_process.h"
 
 /**

--- a/proccontrol/src/ppc_process.h
+++ b/proccontrol/src/ppc_process.h
@@ -31,6 +31,9 @@
 #if !defined(ppc_process_h_)
 #define ppc_process_h_
 
+#include <set>
+#include <string>
+#include <vector>
 #include <map>
 #include "int_process.h"
 

--- a/proccontrol/src/proc_service_wrapper.h
+++ b/proccontrol/src/proc_service_wrapper.h
@@ -42,6 +42,7 @@
 
 
 /* The definitions in this file must correspond to those in the debugger.  */
+#include <stddef.h>
 #include <sys/procfs.h>
 
 /* Functions in this interface return one of these status codes.  */

--- a/proccontrol/src/processplat.h
+++ b/proccontrol/src/processplat.h
@@ -31,6 +31,12 @@
 #if !defined(PROCESSPLAT_H_)
 #define PROCESSPLAT_H_
 
+#include <map>
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <utility>
+#include <vector>
 #include "int_process.h"
 #include "resp.h"
 

--- a/proccontrol/src/resp.h
+++ b/proccontrol/src/resp.h
@@ -35,6 +35,7 @@
 #include "int_process.h"
 #include <map>
 #include <string>
+#include <vector>
 
 /**
  * The Resp class is a second implementation of the response

--- a/proccontrol/src/response.h
+++ b/proccontrol/src/response.h
@@ -33,6 +33,7 @@
 
 #include "Event.h"
 #include "common/src/dthread.h"
+#include <string>
 #include <map>
 #include <vector>
 

--- a/proccontrol/src/sysv.h
+++ b/proccontrol/src/sysv.h
@@ -31,6 +31,10 @@
 #if !defined(SYSV_H_)
 #define SYSV_H_
 
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
 #include "common/h/ProcReader.h"
 #include "int_process.h"
 #include "processplat.h"

--- a/proccontrol/src/unix.h
+++ b/proccontrol/src/unix.h
@@ -31,6 +31,10 @@
 #if !defined(UNIX_H_)
 #define UNIX_H_
 
+#include <map>
+#include <stddef.h>
+#include <string>
+#include <vector>
 #include "int_process.h"
 
 /**

--- a/proccontrol/src/windows_process.h
+++ b/proccontrol/src/windows_process.h
@@ -31,6 +31,12 @@
 #if !defined(WINDOWS_PROCESS_H)
 #define WINDOWS_PROCESS_H
 
+#include <assert.h>
+#include <map>
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <vector>
 #include "x86_process.h"
 #include "common/src/IntervalTree.h"
 

--- a/proccontrol/src/windows_thread.h
+++ b/proccontrol/src/windows_thread.h
@@ -30,6 +30,8 @@
 #if !defined(WINDOWS_THREAD_H)
 #define WINDOWS_THREAD_H
 
+#include <string>
+#include <vector>
 #include "int_process.h"
 
 #if !defined(TF_BIT)

--- a/proccontrol/src/x86_process.h
+++ b/proccontrol/src/x86_process.h
@@ -32,6 +32,11 @@
 #if !defined(x86_process_h_)
 #define x86_process_h_
 
+#include <map>
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <vector>
 #include "int_process.h"
 #include "common/h/dyn_regs.h"
 

--- a/stackwalk/h/basetypes.h
+++ b/stackwalk/h/basetypes.h
@@ -34,6 +34,7 @@
 #include "dyntypes.h"
 #include "dyn_regs.h"
 #include "SymReader.h"
+#include <string>
 #include <sstream>
 #include <iostream>
 

--- a/stackwalk/h/frame.h
+++ b/stackwalk/h/frame.h
@@ -35,6 +35,7 @@
 #include "Annotatable.h"
 #include <string>
 #include <set>
+#include <vector>
 
 class StackCallback;
 

--- a/stackwalk/h/framestepper.h
+++ b/stackwalk/h/framestepper.h
@@ -33,6 +33,7 @@
 
 #include "basetypes.h"
 #include "procstate.h"
+#include <utility>
 #include <vector>
 
 namespace Dyninst {

--- a/stackwalk/h/local_var.h
+++ b/stackwalk/h/local_var.h
@@ -30,6 +30,7 @@
 #if !defined (local_var_h_)
 #define local_var_h_
 
+#include <string.h>
 #include <vector>
 #include "Symbol.h"
 #include "Symtab.h"

--- a/stackwalk/h/procstate.h
+++ b/stackwalk/h/procstate.h
@@ -43,6 +43,9 @@
 #include <map>
 #include <queue>
 #include <string>
+#include <set>
+#include <stddef.h>
+#include <utility>
 
 namespace Dyninst {
 namespace Stackwalker {

--- a/stackwalk/h/walker.h
+++ b/stackwalk/h/walker.h
@@ -34,6 +34,7 @@
 #include "basetypes.h"
 #include "PCProcess.h"
 #include <vector>
+#include <set>
 #include <list>
 #include <string>
 #include <utility>

--- a/stackwalk/src/aarch64-swk.h
+++ b/stackwalk/src/aarch64-swk.h
@@ -1,6 +1,7 @@
 #ifndef aarch64_swk_h_
 #define aarch64_swk_h_
 
+#include <map>
 #include "stackwalk/h/steppergroup.h"
 #include "stackwalk/h/framestepper.h"
 

--- a/stackwalk/src/analysis_stepper.h
+++ b/stackwalk/src/analysis_stepper.h
@@ -37,6 +37,10 @@
 #include "SymReader.h"
 
 #include <string>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
 
 namespace Dyninst {
 namespace ParseAPI {

--- a/stackwalk/src/libstate.h
+++ b/stackwalk/src/libstate.h
@@ -35,6 +35,10 @@
 #include "common/h/SymReader.h"
 #include "stackwalk/h/procstate.h"
 #include "common/src/addrtranslate.h"
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 #include <set>
 
 namespace Dyninst {

--- a/stackwalk/src/linux-swk.h
+++ b/stackwalk/src/linux-swk.h
@@ -31,6 +31,7 @@
 #ifndef LINUX_SWK_H
 #define LINUX_SWK_H
 
+#include <string>
 #include "common/h/dyntypes.h"
 #include "common/h/SymReader.h"
 

--- a/stackwalk/src/sw.h
+++ b/stackwalk/src/sw.h
@@ -32,6 +32,9 @@
 #define SW_INTERNAL_H_
 
 #include <set>
+#include <map>
+#include <utility>
+#include <vector>
 #include "common/src/addrRange.h"
 #include "stackwalk/h/framestepper.h"
 #include "stackwalk/h/procstate.h"

--- a/stackwalk/src/x86-swk.h
+++ b/stackwalk/src/x86-swk.h
@@ -31,6 +31,7 @@
 #ifndef x86_swk_h_
 #define x86_swk_h_
 
+#include <map>
 #include "stackwalk/h/steppergroup.h"
 #include "stackwalk/h/framestepper.h"
 #include "common/h/dyntypes.h"

--- a/symlite/h/SymLite-elf.h
+++ b/symlite/h/SymLite-elf.h
@@ -31,6 +31,7 @@
 #include "SymReader.h"
 #include "Elf_X.h"
 
+#include <string>
 #include <map>
 
 namespace Dyninst {

--- a/symtabAPI/h/AddrLookup.h
+++ b/symtabAPI/h/AddrLookup.h
@@ -32,6 +32,8 @@
 #define __AddrLookup_H__
 
 #include "Annotatable.h"
+#include <string>
+#include <vector>
 #include <map>
 
 namespace Dyninst {

--- a/symtabAPI/h/Aggregate.h
+++ b/symtabAPI/h/Aggregate.h
@@ -39,6 +39,8 @@
 #if !defined(_Aggregate_h_)
 #define _Aggregate_h_
 
+#include <string>
+#include <vector>
 #include <iostream>
 #include "Annotatable.h"
 #include <boost/iterator/transform_iterator.hpp>

--- a/symtabAPI/h/Archive.h
+++ b/symtabAPI/h/Archive.h
@@ -30,6 +30,11 @@
 
 #ifndef __ARCHIVE_H__
 #define __ARCHIVE_H__
+
+#include <map>
+#include <stddef.h>
+#include <string>
+#include <vector>
  
 class MappedFile;
 

--- a/symtabAPI/h/Collections.h
+++ b/symtabAPI/h/Collections.h
@@ -31,6 +31,10 @@
 #ifndef _Collections_h_
 #define _Collections_h_
 
+#include <stddef.h>
+#include <string>
+#include <utility>
+#include <vector>
 #include "concurrent.h"
 #include "Type.h"
 #include "Variable.h"

--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -36,6 +36,11 @@
 #if !defined(_Function_h_)
 #define _Function_h_
 
+#include <iosfwd>
+#include <stddef.h>
+#include <string>
+#include <utility>
+#include <vector>
 #include "Annotatable.h"
 #include "Aggregate.h"
 #include "Variable.h"

--- a/symtabAPI/h/LineInformation.h
+++ b/symtabAPI/h/LineInformation.h
@@ -31,6 +31,9 @@
 #if ! defined( LINE_INFORMATION_H )
 #define LINE_INFORMATION_H
 
+#include <string>
+#include <utility>
+#include <vector>
 #include "symutil.h"
 #include "RangeLookup.h"
 #include "Annotatable.h"

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -31,6 +31,11 @@
 #ifndef __MODULE__H__
 #define __MODULE__H__
 
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <utility>
+#include <vector>
 #include "symutil.h"
 #include "Symbol.h"
 

--- a/symtabAPI/h/RangeLookup.h
+++ b/symtabAPI/h/RangeLookup.h
@@ -31,6 +31,8 @@
 #if ! defined( RANGE_LOOKUP_H )
 #define RANGE_LOOKUP_H
 
+#include <ostream>
+#include <utility>
 #include <map>
 #include <vector>
 #include <list>

--- a/symtabAPI/h/Region.h
+++ b/symtabAPI/h/Region.h
@@ -30,6 +30,9 @@
 
 #ifndef __REGION__H__ 
 #define __REGION__H__
+#include <iosfwd>
+#include <string>
+#include <vector>
 #include "symutil.h"
 #include "Annotatable.h"
 

--- a/symtabAPI/h/StringTable.h
+++ b/symtabAPI/h/StringTable.h
@@ -5,6 +5,9 @@
 #ifndef DYNINST_STRINGTABLE_H
 #define DYNINST_STRINGTABLE_H
 
+#include <ostream>
+#include <stddef.h>
+#include <string>
 #include "concurrent.h"
 #include <boost/shared_ptr.hpp>
 #include <boost/multi_index_container.hpp>

--- a/symtabAPI/h/Symbol.h
+++ b/symtabAPI/h/Symbol.h
@@ -43,6 +43,9 @@
 
 #include "symutil.h"
 #include "Annotatable.h"
+#include <iosfwd>
+#include <string>
+#include <vector>
 #include <boost/shared_ptr.hpp>
 
 #ifndef CASE_RETURN_STR

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -31,6 +31,12 @@
 #ifndef __SYMTAB_H__
 #define __SYMTAB_H__
 
+#include <iosfwd>
+#include <map>
+#include <stddef.h>
+#include <utility>
+#include <string>
+#include <vector>
 #include <set>
 
 #include "Symbol.h"

--- a/symtabAPI/h/SymtabReader.h
+++ b/symtabAPI/h/SymtabReader.h
@@ -34,6 +34,7 @@
 #include "SymReader.h"
 #include <string>
 #include <vector>
+#include <map>
 //Some components (StackwalkerAPI, ProcControlAPI) use a SymReader (defined in dyn_util/h)
 // to read symbols rather than a straight dependency on SymtabAPI.  A component can
 // either define its own SymReader (as ProcControlAPI does) or it can use SymtabAPI as

--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -31,6 +31,10 @@
 #ifndef __Type_h__
 #define __Type_h__
 
+#include <assert.h>
+#include <stddef.h>
+#include <string>
+#include <utility>
 #include "Annotatable.h"
 #include "symutil.h"
 #include "concurrent.h"

--- a/symtabAPI/h/Variable.h
+++ b/symtabAPI/h/Variable.h
@@ -31,6 +31,9 @@
 #if !defined(_Variable_h_)
 #define _Variable_h_
 
+#include <ostream>
+#include <string>
+#include <vector>
 #include "Annotatable.h"
 #include "Symtab.h"
 #include "Aggregate.h"

--- a/symtabAPI/src/LinkMap.h
+++ b/symtabAPI/src/LinkMap.h
@@ -36,6 +36,8 @@
 #include "Symbol.h"
 #include "Function.h"
 
+#include <string>
+#include <utility>
 #include <deque>
 #include <map>
 #include <vector>

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -43,6 +43,12 @@
 #include "dwarfHandle.h"
 #endif
 
+#include <assert.h>
+#include <ostream>
+#include <map>
+#include <stddef.h>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 #include "headers.h"
 #include "Types.h"

--- a/symtabAPI/src/Object-nt.h
+++ b/symtabAPI/src/Object-nt.h
@@ -45,6 +45,9 @@
 ************************************************************************/
 
 #include "common/src/Types.h"
+#include <map>
+#include <set>
+#include <utility>
 #include <vector>
 #include <string>
 #include <algorithm>

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -42,6 +42,8 @@
 ************************************************************************/
 
 // trace data streams
+#include <iosfwd>
+#include <utility>
 #include <string>
 #include <vector>
 

--- a/symtabAPI/src/Type-mem.h
+++ b/symtabAPI/src/Type-mem.h
@@ -33,6 +33,9 @@
 
 #include "symtabAPI/h/Type.h"
 #include "boost/static_assert.hpp"
+#include <assert.h>
+#include <string>
+#include <string.h>
 #include <utility>
 
 using namespace Dyninst;

--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -8,6 +8,9 @@
 #include "elf.h"
 #include "libelf.h"
 #include "elfutils/libdw.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <utility>
 #include <stack>
 #include <vector>
 #include <string>

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -36,6 +36,11 @@
 #include "Elf_X.h"
 #include <iostream>
 
+#include <map>
+#include <set>
+#include <stddef.h>
+#include <string>
+#include <utility>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/symtabAPI/src/emitElfStatic.h
+++ b/symtabAPI/src/emitElfStatic.h
@@ -38,6 +38,8 @@
 #include "LinkMap.h"
 #include "Object.h"
 
+#include <string>
+#include <utility>
 #include <deque>
 #include <map>
 #include <vector>


### PR DESCRIPTION
- update dyninst header files to directly include the standard header file defining symbols from the standard C++ library that are used by the dyninst header file; in some instances, the code relied on symbols being defined via an unrelated include file indirectly including the necessary header file leading to fragile code

- minor other cleanups:  remove unnecessary header files, remove definitions of names that are defined in a standard header file

Fixes #1442