### PR TITLE
Fix EM_AMDGPU to use RELA as Region Type

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -281,6 +281,7 @@ static Region::RegionType getRelTypeByElfMachine(Elf_X *localHdr) {
         case EM_X86_64:
         case EM_IA_64:
         case EM_AARCH64:
+        case EM_AMDGPU:
             ret = Region::RT_RELA;
             break;
         default:


### PR DESCRIPTION
According to the llvm page
https://llvm.org/docs/AMDGPUUsage.html#relocation-records AMDGPU backend generates Elf64_Rela records.

This fix added the case for EM_AMDGPU to
static Region::RegionType getRelTypeByElfMachine
such that it uses RELA instead of the default REL type.