### PR TITLE
Explicitly delete unusable special member functions in Symtab

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -126,6 +126,13 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    Symtab(unsigned char *mem_image, size_t image_size, 
                         const std::string &name, bool defensive_binary, bool &err);
 
+   ~Symtab();
+
+   Symtab(Symtab const&) = delete;
+   Symtab& operator=(Symtab const&) = delete;
+   Symtab(Symtab&&) = delete;
+   Symtab& operator=(Symtab&&) = delete;
+
    typedef enum {
       NotDefensive,
       Defensive} def_t; 
@@ -407,8 +414,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    static SymtabError getLastSymtabError();
    static void setSymtabError(SymtabError new_err);
    static std::string printError(SymtabError serr);
-
-   ~Symtab();
 
    bool delSymbol(Symbol *sym) { return deleteSymbol(sym); }
    bool deleteSymbol(Symbol *sym); 


### PR DESCRIPTION
Because there is a user-defined destructor, the compiler will not generate the special member functions (e.g., copy assignment operator). However, we explicitly delete them here to signal that this class is not copyable or movable.  The destructor is also moved to the top of the class to be next to the other special member functions.