### PR TITLE
Make Symtab::getContainingInlinedFunction lazy parsing threadsafe

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -38,6 +38,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <mutex>
 
 #include "Symbol.h"
 #include "Module.h"
@@ -648,6 +649,8 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool isDefensiveBinary_{false};
 
    FuncRangeLookup *func_lookup{};
+   std::once_flag funcRangesAreParsed;
+
     ModRangeLookup *mod_lookup_{};
 
    //Don't use obj_private, use getObject() instead.

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -826,9 +826,8 @@ bool Symtab::getContainingFunction(Offset offset, Function* &func)
 
 bool Symtab::getContainingInlinedFunction(Offset offset, FunctionBase* &func)
 {   
-   if (!func_lookup)
-      parseFunctionRanges();
-   assert(func_lookup);
+   // Lazily parse the function ranges, but ensure we only do it once.
+   std::call_once(funcRangesAreParsed, [this](){ this->parseFunctionRanges(); });
    
    set<FuncRange *> ranges;
    int num_found = func_lookup->find(offset, ranges);


### PR DESCRIPTION
This fix does not address the thread safety issues in Symtab::parseFunctionRanges. That function is still thread unsafe and will require separate modifications.

@jmellorcrummey @mwkrentel This should allow you to remove the need to explicitly call `parseFunctionRanges` before calling `findModuleByOffset`. It does not fix #1446. That will be a separate PR.