### PR TITLE
Remove lazy initialization of IBSTrees in Symtab

### DIFF
--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -46,6 +46,7 @@
 #include "Variable.h"
 #include "IBSTree.h"
 #include "concurrent.h"
+#include "VariableLocation.h"
 
 SYMTAB_EXPORT std::ostream &operator<<(std::ostream &os, const Dyninst::SymtabAPI::Function &);
 

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -43,7 +43,7 @@
 #include "Symbol.h"
 #include "Module.h"
 #include "Region.h"
-
+#include "Function.h"
 #include "Annotatable.h"
 #include "ProcReader.h"
 #include "IBSTree.h"
@@ -92,11 +92,8 @@ class Object;
 class localVar;
 class relocationEntry;
 class Type;
-class FunctionBase;
-class FuncRange;
 
 typedef IBSTree< ModRange > ModRangeLookup;
-typedef IBSTree<FuncRange> FuncRangeLookup;
 typedef Dyninst::ProcessReader MemRegReader;
 
 class SYMTAB_EXPORT Symtab : public LookupInterface,

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -645,7 +645,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool isStaticBinary_{false};
    bool isDefensiveBinary_{false};
 
-   FuncRangeLookup *func_lookup{};
+   FuncRangeLookup func_lookup{};
    std::once_flag funcRangesAreParsed;
 
     ModRangeLookup mod_lookup_{};

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -651,7 +651,8 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    FuncRangeLookup *func_lookup{};
    std::once_flag funcRangesAreParsed;
 
-    ModRangeLookup *mod_lookup_{};
+    ModRangeLookup mod_lookup_{};
+
 
    //Don't use obj_private, use getObject() instead.
  public:

--- a/symtabAPI/h/Variable.h
+++ b/symtabAPI/h/Variable.h
@@ -39,6 +39,7 @@
 #include "Aggregate.h"
 #include "dyn_regs.h"
 #include "VariableLocation.h"
+#include "Type.h"
 
 namespace Dyninst {
 namespace SymtabAPI {

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -723,13 +723,13 @@ bool Symtab::addFunctionRange(FunctionBase *func, Dyninst::Offset next_start)
       FuncRange &range = *i;
       if (range.low() == sym_low && range.high() == sym_high)
          found_sym_range = true;      
-      func_lookup->insert(&range);
+      func_lookup.insert(&range);
    }
 
    //Add symbol range to func_lookup, if present and not already added
    if (!found_sym_range && sym_low && sym_high) {
       FuncRange *frange = new FuncRange(sym_low, sym_high - sym_low, func);      
-      func_lookup->insert(frange);
+      func_lookup.insert(frange);
    }
 
    //Recursively add inlined functions
@@ -743,8 +743,6 @@ bool Symtab::addFunctionRange(FunctionBase *func, Dyninst::Offset next_start)
 bool Symtab::parseFunctionRanges()
 {
    parseTypesNow();
-   assert(!func_lookup);
-   func_lookup = new FuncRangeLookup();
 
    if (everyFunction.size() && !sorted_everyFunction)
    {
@@ -830,7 +828,7 @@ bool Symtab::getContainingInlinedFunction(Offset offset, FunctionBase* &func)
    std::call_once(funcRangesAreParsed, [this](){ this->parseFunctionRanges(); });
    
    set<FuncRange *> ranges;
-   int num_found = func_lookup->find(offset, ranges);
+   int num_found = func_lookup.find(offset, ranges);
    if (num_found == 0) {
       func = NULL;
       return false;

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -1470,7 +1470,6 @@ Symtab::~Symtab()
    }
 
     delete func_lookup;
-    delete mod_lookup_;
 
    // Make sure to free the underlying Object as it doesn't have a factory
    // open method
@@ -2864,16 +2863,13 @@ void Symtab::rebase(Offset loadOff)
 }
 
 ModRangeLookup *Symtab::mod_lookup() {
-    if(!mod_lookup_) mod_lookup_ = new ModRangeLookup;
-    return mod_lookup_;
+    return &mod_lookup_;
 
 }
 
 
 void Symtab::dumpModRanges() {
-  if (mod_lookup_) {
-    mod_lookup_->PrintPreorder();
-  }
+    mod_lookup_.PrintPreorder();
 }
 
 void Symtab::dumpFuncRanges() {

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -1469,8 +1469,6 @@ Symtab::~Symtab()
          allSymtabs.erase(allSymtabs.begin()+i);
    }
 
-    delete func_lookup;
-
    // Make sure to free the underlying Object as it doesn't have a factory
    // open method
    delete obj_private;
@@ -2873,7 +2871,5 @@ void Symtab::dumpModRanges() {
 }
 
 void Symtab::dumpFuncRanges() {
-  if (func_lookup) {
-    func_lookup->PrintPreorder();
-  }
+    func_lookup.PrintPreorder();
 }


### PR DESCRIPTION
The IBSTree type is threadsafe, but the lazy initialization of them is not. Generally, we don't expect users to use these directly in a multithreaded context (e.g., via `mod_lookup()`). However, it is possible for users to indirectly access them through `getContainingInlinedFunction` or `findModuleByOffset`. At this time, an empty `IBSTree` occupies about 300 bytes of the total ~8.5kB of a `Symtab` object.

This works toward fixing #1446.