### PR TITLE
modernize InstructionAPI::Operand class

### DIFF
--- a/instructionAPI/h/Operand.h
+++ b/instructionAPI/h/Operand.h
@@ -60,44 +60,15 @@ namespace Dyninst
     {
     public:
         typedef boost::shared_ptr<Operand> Ptr;
-    Operand() noexcept : m_isRead(false), m_isWritten(false), m_isImplicit(false), m_isTruePredicate(false), m_isFalsePredicate(false) {}
       /// \brief Create an operand from a %Expression and flags describing whether the %ValueComputation
       /// is read, written or both.
       /// \param val Reference-counted pointer to the %Expression that will be contained in the %Operand being constructed
       /// \param read True if this operand is read
       /// \param written True if this operand is written
-      Operand(Expression::Ptr val, bool read, bool written) : 
-          op_value(val), m_isRead(read), m_isWritten(written), m_isImplicit(false), m_isTruePredicate(false), m_isFalsePredicate(false) {}
-      Operand(Expression::Ptr val, bool read, bool written, bool implicit) : 
-          op_value(val), m_isRead(read), m_isWritten(written), m_isImplicit(implicit), m_isTruePredicate(false), m_isFalsePredicate(false) {}
       // An instruction can be true predicated, false predicated, or not predicated at all
-      Operand(Expression::Ptr val, bool read, bool written, bool implicit,
-              bool trueP, bool falseP):
+      Operand(Expression::Ptr val = {}, bool read = false, bool written = false, bool implicit = false,
+              bool trueP = false, bool falseP = false):
           op_value(val), m_isRead(read), m_isWritten(written), m_isImplicit(implicit), m_isTruePredicate(trueP), m_isFalsePredicate(falseP) {}
-
-      virtual ~Operand()
-      {
-	    op_value.reset();
-      }
-
-      Operand(const Operand& o) noexcept :
-        op_value(o.op_value), m_isRead(o.m_isRead), 
-        m_isWritten(o.m_isWritten), m_isImplicit(o.m_isImplicit),
-        m_isTruePredicate(o.m_isTruePredicate), m_isFalsePredicate(o.m_isFalsePredicate)
-      {
-      }
-
-      const Operand& operator=(const Operand& rhs)
-      {
-          op_value = rhs.op_value;
-          m_isRead = rhs.m_isRead;
-          m_isWritten = rhs.m_isWritten;
-          m_isImplicit = rhs.m_isImplicit;
-          m_isTruePredicate = rhs.m_isTruePredicate;
-          m_isFalsePredicate = rhs.m_isFalsePredicate;
-          return *this;
-      }
-      
 
       /// \brief Get the registers read by this operand
       /// \param regsRead Has the registers read inserted into it
@@ -142,14 +113,14 @@ namespace Dyninst
       INSTRUCTION_EXPORT Expression::Ptr getValue() const;
       
     private:
-      Expression::Ptr op_value;
-      bool m_isRead;
-      bool m_isWritten;
-      bool m_isImplicit;
+      Expression::Ptr op_value{};
+      bool m_isRead{};
+      bool m_isWritten{};
+      bool m_isImplicit{};
 
       // Used for GPU instructions with predicates
-      bool m_isTruePredicate;
-      bool m_isFalsePredicate;
+      bool m_isTruePredicate{};
+      bool m_isFalsePredicate{};
     };
   }
 }


### PR DESCRIPTION
- eliminate all but one of the constructors by using default parameters

- remove destructor (unnecessarily virtual, and reset a member shared_ptr), copy ctor, and copy assignment declarations to allow the compiler to generate default versions that are equivalent or better than the hand written versions

- add default member initializers for all members