### PR TITLE
fix x86_64 ret instruction formatting

### DIFF
--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -300,16 +300,14 @@ namespace Dyninst
 
 
       typedef boost::shared_ptr<Instruction> Ptr;
-	public:
+	private:
 	  //Should be private, but we're working around some compilers mis-using the 'friend' declaration.
-      INSTRUCTION_EXPORT void appendOperand(Expression::Ptr e, bool isRead, bool isWritten) const;
-      INSTRUCTION_EXPORT void appendOperand(Expression::Ptr e, bool isRead, bool isWritten, bool isImplicit) const;
-      INSTRUCTION_EXPORT void appendOperand(Expression::Ptr e, bool isRead, bool isWritten, bool isImplicit, bool trueP, bool falseP) const;
+      INSTRUCTION_EXPORT void appendOperand(Expression::Ptr e, bool isRead, bool isWritten, bool isImplicit = false, bool trueP = false, bool falseP = false) const;
 
     private:
       void updateSize(const unsigned int new_size) {m_size = new_size;}
       void decodeOperands() const;
-      void addSuccessor(Expression::Ptr e, bool isCall, bool isIndirect, bool isConditional, bool isFallthrough) const;
+      void addSuccessor(Expression::Ptr e, bool isCall, bool isIndirect, bool isConditional, bool isFallthrough, bool isImplicit = false) const;
       void copyRaw(size_t size, const unsigned char* raw);
       Expression::Ptr makeReturnExpression() const;
       mutable std::list<Operand> m_Operands;

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -624,21 +624,12 @@ namespace Dyninst
                 bool isCall, 
                 bool isIndirect, 
                 bool isConditional, 
-                bool isFallthrough) const
+                bool isFallthrough,
+		bool isImplicit) const
         {
             CFT c(e, isCall, isIndirect, isConditional, isFallthrough);
             m_Successors.push_back(c);
-            if (!isFallthrough) appendOperand(e, true, false);
-        }
-        void Instruction::appendOperand(Expression::Ptr e, bool isRead, bool isWritten) const
-        {
-            m_Operands.push_back(Operand(e, isRead, isWritten));
-        }
-
-        void Instruction::appendOperand(Expression::Ptr e, 
-                bool isRead, bool isWritten, bool isImplicit) const
-        {
-            m_Operands.push_back(Operand(e, isRead, isWritten, isImplicit));
+            if (!isFallthrough) appendOperand(e, true, false, isImplicit);
         }
 
         void Instruction::appendOperand(Expression::Ptr e, 

--- a/instructionAPI/src/InstructionDecoder-x86.C
+++ b/instructionAPI/src/InstructionDecoder-x86.C
@@ -1855,7 +1855,7 @@ namespace Dyninst
             decodedInstruction->getEntry()->getID() == e_ret_far) {
            Expression::Ptr ret_addr = makeDereferenceExpression(makeRegisterExpression(is64BitMode ? x86_64::rsp : x86::esp),
                                                                 is64BitMode ? u64 : u32);
-           insn_to_complete->addSuccessor(ret_addr, false, true, false, false);
+           insn_to_complete->addSuccessor(ret_addr, false, true, false, false, true);
 	    }
         if (insn_to_complete->getOperation().getID() == e_endbr32 ||
             insn_to_complete->getOperation().getID() == e_endbr64) {


### PR DESCRIPTION
The ret instruction formats incorrectly with an operand of '(%rsp)'.  The operand should have been flagged as implicit so it is not included in the output.

- eliminate all but one overloaded Instruction::appendOperand` using default parameters

- add isImplicit parameter defaulting to false to Instruction::addSuccessor

- add isImplicit to the ret instruction's addSuccessor call to set the ret_addr (which adds the operand to the Instruction object)

Fixes #1458 