### PR TITLE
Remove Object::dwarf_parse_aranges

### DIFF
--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -437,7 +437,6 @@ private:
     
     LineInformation* li_for_object;
     LineInformation* parseLineInfoForObject(StringTablePtr strings);
-    bool dwarf_parse_aranges(::Dwarf *dbg, std::set<Dwarf_Off>& dies_seen);
 
   void parseDwarfTypes(Symtab *obj);
 


### PR DESCRIPTION
It's usage was removed by 4be991a7 in 2021.

I just happened to notice this while doing some call tree tracing.