### PR TITLE
improve intel instruction & operand formatting

### DIFF
--- a/instructionAPI/src/ArchSpecificFormatters.C
+++ b/instructionAPI/src/ArchSpecificFormatters.C
@@ -252,6 +252,8 @@ std::string x86Formatter::getInstructionString(std::vector<std::string> operands
 {
     std::string s;
     bool oneOperandAdded{false};
+
+    // append the operands in reverse order to convert from Intel to AT&T syntax order
     for (auto i = operands.crbegin(); i != operands.crend(); ++i)  {
 	if (oneOperandAdded)  {
 	    s += ',';
@@ -259,6 +261,7 @@ std::string x86Formatter::getInstructionString(std::vector<std::string> operands
 	s += *i;
 	oneOperandAdded = true;
     }
+
     return s;
 }
 

--- a/instructionAPI/src/Operand.C
+++ b/instructionAPI/src/Operand.C
@@ -138,7 +138,12 @@ namespace Dyninst
                     return string(hex);
                 }
             }
-            return op_value->format(arch);
+            auto s = op_value->format(arch);
+            if (!s.compare(0, 2, "##"))  {
+                s.replace(0, 2, "0x0(");	// fix-up ##X to indirection syntax 0x0(X)
+                s += ')';
+            }
+            return s;
         }
 
         INSTRUCTION_EXPORT Expression::Ptr Operand::getValue() const


### PR DESCRIPTION
This fixes three issues when formatting an x86_64 instruction or its operands:

1) Fix the order of operands when formatting the instruction to be the
   AT&T syntax order.  If the instruction had three or more operands.
   Conversion from the internal (Intel) order rotated right by 1 instead
   of reversing the operands.
Fixes #1459

2) Eliminate special treatment of register %kN as the first operand as
   mask registers in Instruction::format as Operand::format already
   formats these as masks (enclosed in braces) and not all uses of mask
   registers are as a mask.
Fixes #1461

3) Fix Operand::format to produce the correct disassembly operand
   string.  The formatting of the internal Expression needs to be done
   for some indirect values.  This was done in the Instruction::format
   instead of directly in Operand::format
Fixes #1460

Methods changed:

* x86Formatter::getInstructionString - fixes 1, 2, 3
* Operand::format - fixes 3
* x86Formatter::formatRegister - cleanup, remove malloc that could leak