### PR TITLE
modernize ArchSpecificFormatter classes

### DIFF
--- a/instructionAPI/h/ArchSpecificFormatters.h
+++ b/instructionAPI/h/ArchSpecificFormatters.h
@@ -41,11 +41,11 @@ namespace Dyninst {
 
         class ArchSpecificFormatter {
         public:
-            virtual std::string getInstructionString(const std::vector <std::string>&);
-            virtual std::string formatImmediate(const std::string&) = 0;
-            virtual std::string formatDeref(const std::string&) = 0;
-            virtual std::string formatRegister(const std::string&) = 0;
-            virtual std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&);
+            virtual std::string getInstructionString(const std::vector <std::string>&) const;
+            virtual std::string formatImmediate(const std::string&) const = 0;
+            virtual std::string formatDeref(const std::string&)  const= 0;
+            virtual std::string formatRegister(const std::string&)  const= 0;
+            virtual std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) const;
             virtual ~ArchSpecificFormatter() = default;
 	    ArchSpecificFormatter& operator=(const ArchSpecificFormatter&) = default;
             static INSTRUCTION_EXPORT ArchSpecificFormatter& getFormatter(Dyninst::Architecture a);
@@ -56,10 +56,10 @@ namespace Dyninst {
         public:
             PPCFormatter();
 
-            std::string formatImmediate(const std::string&) override;
-            std::string formatDeref(const std::string&) override;
-            std::string formatRegister(const std::string&) override;
-            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) override;
+            std::string formatImmediate(const std::string&) const override;
+            std::string formatDeref(const std::string&) const override;
+            std::string formatRegister(const std::string&) const override;
+            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) const override;
 
         };
 
@@ -67,10 +67,10 @@ namespace Dyninst {
         public:
             ArmFormatter();
 
-            std::string formatImmediate(const std::string&) override;
-            std::string formatDeref(const std::string&) override;
-            std::string formatRegister(const std::string&) override;
-            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) override;
+            std::string formatImmediate(const std::string&) const override;
+            std::string formatDeref(const std::string&) const override;
+            std::string formatRegister(const std::string&) const override;
+            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) const override;
 
         private:
             std::map<std::string, std::string> binaryFuncModifier;
@@ -80,10 +80,10 @@ namespace Dyninst {
         public:
             AmdgpuFormatter();
 
-            std::string formatImmediate(const std::string&) override;
-            std::string formatDeref(const std::string&) override;
-            std::string formatRegister(const std::string&) override;
-            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) override;
+            std::string formatImmediate(const std::string&) const override;
+            std::string formatDeref(const std::string&) const override;
+            std::string formatRegister(const std::string&) const override;
+            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) const override;
 
         private:
             std::map<std::string, std::string> binaryFuncModifier;
@@ -94,11 +94,11 @@ namespace Dyninst {
         public:
             x86Formatter();
 
-            std::string getInstructionString(const std::vector <std::string>&) override;
-            std::string formatImmediate(const std::string&) override;
-            std::string formatDeref(const std::string&) override;
-            std::string formatRegister(const std::string&) override;
-            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) override;
+            std::string getInstructionString(const std::vector <std::string>&) const override;
+            std::string formatImmediate(const std::string&) const override;
+            std::string formatDeref(const std::string&) const override;
+            std::string formatRegister(const std::string&) const override;
+            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) const override;
         };
 
     }

--- a/instructionAPI/h/ArchSpecificFormatters.h
+++ b/instructionAPI/h/ArchSpecificFormatters.h
@@ -41,11 +41,11 @@ namespace Dyninst {
 
         class ArchSpecificFormatter {
         public:
-            virtual std::string getInstructionString(std::vector <std::string>) = 0;
-            virtual std::string formatImmediate(std::string) = 0;
-            virtual std::string formatDeref(std::string) = 0;
-            virtual std::string formatRegister(std::string) = 0;
-            virtual std::string formatBinaryFunc(std::string, std::string, std::string);
+            virtual std::string getInstructionString(const std::vector <std::string>&);
+            virtual std::string formatImmediate(const std::string&) = 0;
+            virtual std::string formatDeref(const std::string&) = 0;
+            virtual std::string formatRegister(const std::string&) = 0;
+            virtual std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&);
             virtual ~ArchSpecificFormatter() = default;
 	    ArchSpecificFormatter& operator=(const ArchSpecificFormatter&) = default;
             static INSTRUCTION_EXPORT ArchSpecificFormatter& getFormatter(Dyninst::Architecture a);
@@ -56,11 +56,10 @@ namespace Dyninst {
         public:
             PPCFormatter();
 
-            virtual std::string getInstructionString(std::vector <std::string>);
-            virtual std::string formatImmediate(std::string);
-            virtual std::string formatDeref(std::string);
-            virtual std::string formatRegister(std::string);
-            virtual std::string formatBinaryFunc(std::string, std::string, std::string);
+            std::string formatImmediate(const std::string&) override;
+            std::string formatDeref(const std::string&) override;
+            std::string formatRegister(const std::string&) override;
+            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) override;
 
         };
 
@@ -68,11 +67,10 @@ namespace Dyninst {
         public:
             ArmFormatter();
 
-            virtual std::string getInstructionString(std::vector <std::string>);
-            virtual std::string formatImmediate(std::string);
-            virtual std::string formatDeref(std::string);
-            virtual std::string formatRegister(std::string);
-            virtual std::string formatBinaryFunc(std::string, std::string, std::string);
+            std::string formatImmediate(const std::string&) override;
+            std::string formatDeref(const std::string&) override;
+            std::string formatRegister(const std::string&) override;
+            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) override;
 
         private:
             std::map<std::string, std::string> binaryFuncModifier;
@@ -82,11 +80,10 @@ namespace Dyninst {
         public:
             AmdgpuFormatter();
 
-            virtual std::string getInstructionString(std::vector <std::string>);
-            virtual std::string formatImmediate(std::string);
-            virtual std::string formatDeref(std::string);
-            virtual std::string formatRegister(std::string);
-            virtual std::string formatBinaryFunc(std::string, std::string, std::string);
+            std::string formatImmediate(const std::string&) override;
+            std::string formatDeref(const std::string&) override;
+            std::string formatRegister(const std::string&) override;
+            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) override;
 
         private:
             std::map<std::string, std::string> binaryFuncModifier;
@@ -97,11 +94,11 @@ namespace Dyninst {
         public:
             x86Formatter();
 
-            virtual std::string getInstructionString(std::vector <std::string>);
-            virtual std::string formatImmediate(std::string);
-            virtual std::string formatDeref(std::string);
-            virtual std::string formatRegister(std::string);
-            virtual std::string formatBinaryFunc(std::string, std::string, std::string);
+            std::string getInstructionString(const std::vector <std::string>&) override;
+            std::string formatImmediate(const std::string&) override;
+            std::string formatDeref(const std::string&) override;
+            std::string formatRegister(const std::string&) override;
+            std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) override;
         };
 
     }

--- a/instructionAPI/src/ArchSpecificFormatters.C
+++ b/instructionAPI/src/ArchSpecificFormatters.C
@@ -16,7 +16,7 @@ using namespace Dyninst::InstructionAPI;
 
 ///////// Base Formatter
 
-std::string ArchSpecificFormatter::getInstructionString(const std::vector<std::string> &operands)
+std::string ArchSpecificFormatter::getInstructionString(const std::vector<std::string> &operands) const
 {
     std::string s;
     bool oneOperandAdded{false};
@@ -34,7 +34,7 @@ std::string ArchSpecificFormatter::getInstructionString(const std::vector<std::s
     return s;
 }
 
-std::string ArchSpecificFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) {
+std::string ArchSpecificFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) const  {
     // if(isAdd())
     // {
     return left + " " + func + " " + right;
@@ -48,14 +48,14 @@ std::string ArchSpecificFormatter::formatBinaryFunc(const std::string &left, con
 PPCFormatter::PPCFormatter() {
 }
 
-std::string PPCFormatter::formatImmediate(const std::string &evalString) {
+std::string PPCFormatter::formatImmediate(const std::string &evalString) const  {
     size_t endPos;
     long long long_val = stoll(evalString, &endPos, 16);
     signed short val = static_cast<signed short>(long_val);
     return std::to_string(val);
 }
 
-std::string PPCFormatter::formatRegister(const std::string &regName) {
+std::string PPCFormatter::formatRegister(const std::string &regName) const  {
     if (regName == "ppc64::pc"  || 
         regName == "ppc64::ctr" || 
         regName == "ppc64::lr"  ||
@@ -73,7 +73,7 @@ std::string PPCFormatter::formatRegister(const std::string &regName) {
     return ret;
 }
 
-std::string PPCFormatter::formatDeref(const std::string &addrString) {
+std::string PPCFormatter::formatDeref(const std::string &addrString) const  {
     size_t commaPos = addrString.find(",");
     if (commaPos == std::string::npos || commaPos > addrString.length() - 2) {
         return "(" + addrString + ")";
@@ -83,7 +83,7 @@ std::string PPCFormatter::formatDeref(const std::string &addrString) {
     return offset + "(" + base + ")";
 }
 
-std::string PPCFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) {
+std::string PPCFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) const  {
     if (left == "") {
         return right;
     }
@@ -99,11 +99,11 @@ ArmFormatter::ArmFormatter() {
     binaryFuncModifier["<<"] = "lsl";
 }
 
-std::string ArmFormatter::formatImmediate(const std::string &evalString) {
+std::string ArmFormatter::formatImmediate(const std::string &evalString) const  {
     return "0x" + evalString;
 }
 
-std::string ArmFormatter::formatRegister(const std::string &regName) {
+std::string ArmFormatter::formatRegister(const std::string &regName) const  {
     std::string::size_type substr = regName.rfind(':');
     std::string ret = regName;
 
@@ -115,7 +115,7 @@ std::string ArmFormatter::formatRegister(const std::string &regName) {
     return ret;
 }
 
-std::string ArmFormatter::formatDeref(const std::string &addrString) {
+std::string ArmFormatter::formatDeref(const std::string &addrString) const  {
     std::string out;
     size_t pluspos = addrString.find("+");
 
@@ -132,9 +132,9 @@ std::string ArmFormatter::formatDeref(const std::string &addrString) {
     return out;
 }
 
-std::string ArmFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) {
+std::string ArmFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) const  {
     if(binaryFuncModifier.count(func) > 0)
-	    return left + ", " + binaryFuncModifier[func] + " " + right;
+	    return left + ", " + binaryFuncModifier.at(func) + " " + right;
     /*else if(left == "PC")
 	    return right;*/
     else
@@ -147,17 +147,17 @@ AmdgpuFormatter::AmdgpuFormatter() {
     binaryFuncModifier["<<"] = "lsl";
 }
 
-std::string AmdgpuFormatter::formatImmediate(const std::string &evalString) {
+std::string AmdgpuFormatter::formatImmediate(const std::string &evalString) const  {
     return "0x" + evalString;
 }
 
-std::string AmdgpuFormatter::formatRegister(const std::string &regName) {
+std::string AmdgpuFormatter::formatRegister(const std::string &regName) const  {
     std::string ret = regName;
     for(auto &c : ret ) c = ::toupper(c);
     return ret;
 }
 
-std::string AmdgpuFormatter::formatDeref(const std::string &addrString) {
+std::string AmdgpuFormatter::formatDeref(const std::string &addrString) const  {
     std::string out;
     size_t pluspos = addrString.find("+");
 
@@ -174,9 +174,9 @@ std::string AmdgpuFormatter::formatDeref(const std::string &addrString) {
     return out;
 }
 
-std::string AmdgpuFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) {
+std::string AmdgpuFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) const  {
     if(binaryFuncModifier.count(func) > 0)
-	    return "("+left + ", " + binaryFuncModifier[func] + " " + right+")";
+	    return "("+left + ", " + binaryFuncModifier.at(func) + " " + right+")";
     /*else if(left == "PC")
 	    return right;*/
     else
@@ -191,12 +191,12 @@ x86Formatter::x86Formatter()
 
 }
 
-std::string x86Formatter::formatImmediate(const std::string &evalString)
+std::string x86Formatter::formatImmediate(const std::string &evalString) const
 {
 	return "$0x" + evalString;
 }
 
-std::string x86Formatter::formatRegister(const std::string &regName)
+std::string x86Formatter::formatRegister(const std::string &regName) const
 {
     std::string outReg{'%'};
 
@@ -214,7 +214,7 @@ std::string x86Formatter::formatRegister(const std::string &regName)
     return outReg;
 }
 
-std::string x86Formatter::formatDeref(const std::string &addrString)
+std::string x86Formatter::formatDeref(const std::string &addrString) const
 {
     // fprintf(stderr, "Must format dereference: %s\n", addrString.c_str());
 
@@ -224,7 +224,7 @@ std::string x86Formatter::formatDeref(const std::string &addrString)
     else return addrString;
 }
 
-std::string x86Formatter::getInstructionString(const std::vector<std::string> &operands)
+std::string x86Formatter::getInstructionString(const std::vector<std::string> &operands) const
 {
     std::string s;
     bool oneOperandAdded{false};
@@ -241,7 +241,7 @@ std::string x86Formatter::getInstructionString(const std::vector<std::string> &o
     return s;
 }
 
-std::string x86Formatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right)
+std::string x86Formatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) const
 {
     // fprintf(stderr, "left: %s  func: %s  right: %s\n", left.c_str(), func.c_str(), right.c_str());
 

--- a/instructionAPI/src/ArchSpecificFormatters.C
+++ b/instructionAPI/src/ArchSpecificFormatters.C
@@ -16,7 +16,25 @@ using namespace Dyninst::InstructionAPI;
 
 ///////// Base Formatter
 
-std::string ArchSpecificFormatter::formatBinaryFunc(std::string left, std::string func, std::string right) {
+std::string ArchSpecificFormatter::getInstructionString(const std::vector<std::string> &operands)
+{
+    std::string s;
+    bool oneOperandAdded{false};
+
+    for (auto const &op: operands) {
+        if (!op.empty()) {
+	    if (oneOperandAdded)  {
+		s += ", ";
+	    }
+            s += op;
+	    oneOperandAdded = true;
+        }
+    }
+
+    return s;
+}
+
+std::string ArchSpecificFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) {
     // if(isAdd())
     // {
     return left + " " + func + " " + right;
@@ -30,14 +48,14 @@ std::string ArchSpecificFormatter::formatBinaryFunc(std::string left, std::strin
 PPCFormatter::PPCFormatter() {
 }
 
-std::string PPCFormatter::formatImmediate(std::string evalString) {
+std::string PPCFormatter::formatImmediate(const std::string &evalString) {
     size_t endPos;
     long long long_val = stoll(evalString, &endPos, 16);
     signed short val = static_cast<signed short>(long_val);
     return std::to_string(val);
 }
 
-std::string PPCFormatter::formatRegister(std::string regName) {
+std::string PPCFormatter::formatRegister(const std::string &regName) {
     if (regName == "ppc64::pc"  || 
         regName == "ppc64::ctr" || 
         regName == "ppc64::lr"  ||
@@ -55,7 +73,7 @@ std::string PPCFormatter::formatRegister(std::string regName) {
     return ret;
 }
 
-std::string PPCFormatter::formatDeref(std::string addrString) {
+std::string PPCFormatter::formatDeref(const std::string &addrString) {
     size_t commaPos = addrString.find(",");
     if (commaPos == std::string::npos || commaPos > addrString.length() - 2) {
         return "(" + addrString + ")";
@@ -65,22 +83,7 @@ std::string PPCFormatter::formatDeref(std::string addrString) {
     return offset + "(" + base + ")";
 }
 
-std::string PPCFormatter::getInstructionString(std::vector<std::string> operands) {
-    std::string out;
-
-    for(std::vector<std::string>::iterator itr = operands.begin(); itr != operands.end(); itr++) {
-        if (*itr != "") {
-            out += *itr;
-            if(itr != operands.end() - 1) {
-                out += ", ";
-            }
-        }
-    }
-
-    return out;
-}
-
-std::string PPCFormatter::formatBinaryFunc(std::string left, std::string func, std::string right) {
+std::string PPCFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) {
     if (left == "") {
         return right;
     }
@@ -96,11 +99,11 @@ ArmFormatter::ArmFormatter() {
     binaryFuncModifier["<<"] = "lsl";
 }
 
-std::string ArmFormatter::formatImmediate(std::string evalString) {
+std::string ArmFormatter::formatImmediate(const std::string &evalString) {
     return "0x" + evalString;
 }
 
-std::string ArmFormatter::formatRegister(std::string regName) {
+std::string ArmFormatter::formatRegister(const std::string &regName) {
     std::string::size_type substr = regName.rfind(':');
     std::string ret = regName;
 
@@ -112,7 +115,7 @@ std::string ArmFormatter::formatRegister(std::string regName) {
     return ret;
 }
 
-std::string ArmFormatter::formatDeref(std::string addrString) {
+std::string ArmFormatter::formatDeref(const std::string &addrString) {
     std::string out;
     size_t pluspos = addrString.find("+");
 
@@ -129,19 +132,7 @@ std::string ArmFormatter::formatDeref(std::string addrString) {
     return out;
 }
 
-std::string ArmFormatter::getInstructionString(std::vector<std::string> operands) {
-    std::string out;
-
-    for(std::vector<std::string>::iterator itr = operands.begin(); itr != operands.end(); itr++) {
-        out += *itr;
-        if(itr != operands.end() - 1)
-            out += ", ";
-    }
-
-    return out;
-}
-
-std::string ArmFormatter::formatBinaryFunc(std::string left, std::string func, std::string right) {
+std::string ArmFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) {
     if(binaryFuncModifier.count(func) > 0)
 	    return left + ", " + binaryFuncModifier[func] + " " + right;
     /*else if(left == "PC")
@@ -156,17 +147,17 @@ AmdgpuFormatter::AmdgpuFormatter() {
     binaryFuncModifier["<<"] = "lsl";
 }
 
-std::string AmdgpuFormatter::formatImmediate(std::string evalString) {
+std::string AmdgpuFormatter::formatImmediate(const std::string &evalString) {
     return "0x" + evalString;
 }
 
-std::string AmdgpuFormatter::formatRegister(std::string regName) {
+std::string AmdgpuFormatter::formatRegister(const std::string &regName) {
     std::string ret = regName;
     for(auto &c : ret ) c = ::toupper(c);
     return ret;
 }
 
-std::string AmdgpuFormatter::formatDeref(std::string addrString) {
+std::string AmdgpuFormatter::formatDeref(const std::string &addrString) {
     std::string out;
     size_t pluspos = addrString.find("+");
 
@@ -183,22 +174,7 @@ std::string AmdgpuFormatter::formatDeref(std::string addrString) {
     return out;
 }
 
-std::string AmdgpuFormatter::getInstructionString(std::vector<std::string> operands) {
-    std::string out;
-    bool printed = false;
-    for(std::vector<std::string>::iterator itr = operands.begin(); itr != operands.end(); itr++) {
-        if (*itr == "")
-            continue;
-        if(printed)
-            out += ", ";
-        out += *itr;
-        printed = true;
-    }
-
-    return out;
-}
-
-std::string AmdgpuFormatter::formatBinaryFunc(std::string left, std::string func, std::string right) {
+std::string AmdgpuFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) {
     if(binaryFuncModifier.count(func) > 0)
 	    return "("+left + ", " + binaryFuncModifier[func] + " " + right+")";
     /*else if(left == "PC")
@@ -215,12 +191,12 @@ x86Formatter::x86Formatter()
 
 }
 
-std::string x86Formatter::formatImmediate(std::string evalString) 
+std::string x86Formatter::formatImmediate(const std::string &evalString)
 {
 	return "$0x" + evalString;
 }
 
-std::string x86Formatter::formatRegister(std::string regName) 
+std::string x86Formatter::formatRegister(const std::string &regName)
 {
     std::string outReg{'%'};
 
@@ -238,7 +214,7 @@ std::string x86Formatter::formatRegister(std::string regName)
     return outReg;
 }
 
-std::string x86Formatter::formatDeref(std::string addrString) 
+std::string x86Formatter::formatDeref(const std::string &addrString)
 {
     // fprintf(stderr, "Must format dereference: %s\n", addrString.c_str());
 
@@ -248,7 +224,7 @@ std::string x86Formatter::formatDeref(std::string addrString)
     else return addrString;
 }
 
-std::string x86Formatter::getInstructionString(std::vector<std::string> operands) 
+std::string x86Formatter::getInstructionString(const std::vector<std::string> &operands)
 {
     std::string s;
     bool oneOperandAdded{false};
@@ -265,7 +241,7 @@ std::string x86Formatter::getInstructionString(std::vector<std::string> operands
     return s;
 }
 
-std::string x86Formatter::formatBinaryFunc(std::string left, std::string func, std::string right)
+std::string x86Formatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right)
 {
     // fprintf(stderr, "left: %s  func: %s  right: %s\n", left.c_str(), func.c_str(), right.c_str());
 

--- a/instructionAPI/src/ArchSpecificFormatters.C
+++ b/instructionAPI/src/ArchSpecificFormatters.C
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <boost/algorithm/string/join.hpp>
 
 using namespace Dyninst::InstructionAPI;
 
@@ -18,20 +19,8 @@ using namespace Dyninst::InstructionAPI;
 
 std::string ArchSpecificFormatter::getInstructionString(const std::vector<std::string> &operands) const
 {
-    std::string s;
-    bool oneOperandAdded{false};
-
-    for (auto const &op: operands) {
-        if (!op.empty()) {
-	    if (oneOperandAdded)  {
-		s += ", ";
-	    }
-            s += op;
-	    oneOperandAdded = true;
-        }
-    }
-
-    return s;
+    // non-x86_64 operand formatter:  join non-empty operands strings with ", "
+    return boost::algorithm::join_if(operands, ", ", [](const std::string &op){return !op.empty();});
 }
 
 std::string ArchSpecificFormatter::formatBinaryFunc(const std::string &left, const std::string &func, const std::string &right) const  {


### PR DESCRIPTION
- pass string and vector parameters by const reference instead of by value for performance

- add ArchSpecificFormatter::getInstructionString and remove the overridden versions in the non-x86_64 as they were functionally the same, but not identically written

- remove virtual and add override to overridden methods