### PR TITLE
add getDisplayOrderedOperands interface

### DIFF
--- a/instructionAPI/h/ArchSpecificFormatters.h
+++ b/instructionAPI/h/ArchSpecificFormatters.h
@@ -46,8 +46,9 @@ namespace Dyninst {
             virtual std::string formatDeref(const std::string&)  const= 0;
             virtual std::string formatRegister(const std::string&)  const= 0;
             virtual std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) const;
+            virtual bool        operandPrintOrderReversed() const;
             virtual ~ArchSpecificFormatter() = default;
-	    ArchSpecificFormatter& operator=(const ArchSpecificFormatter&) = default;
+            ArchSpecificFormatter& operator=(const ArchSpecificFormatter&) = default;
             static INSTRUCTION_EXPORT ArchSpecificFormatter& getFormatter(Dyninst::Architecture a);
 
         };
@@ -99,6 +100,7 @@ namespace Dyninst {
             std::string formatDeref(const std::string&) const override;
             std::string formatRegister(const std::string&) const override;
             std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) const override;
+            bool        operandPrintOrderReversed() const override;
         };
 
     }

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -145,6 +145,9 @@ namespace Dyninst
       /// in the same order that they were decoded.
       INSTRUCTION_EXPORT void getOperands(std::vector<Operand>& operands) const;
 
+      /// Returns a vector of non-implicit operands in printed order
+      INSTRUCTION_EXPORT std::vector<Operand> getDisplayOrderedOperands() const;
+
       /// The \c getOperand method returns the operand at position \c index, or
       /// an empty operand if \c index does not correspond to a valid operand in this
       /// instruction.

--- a/instructionAPI/src/ArchSpecificFormatters.C
+++ b/instructionAPI/src/ArchSpecificFormatters.C
@@ -30,6 +30,11 @@ std::string ArchSpecificFormatter::formatBinaryFunc(const std::string &left, con
     // } else retVal << "NOT VALID FOR AT&T";
 }
 
+bool ArchSpecificFormatter::operandPrintOrderReversed() const
+{
+    return false;
+}
+
 ///////////////////////////
 
 ///////// Formatter for PowerPC
@@ -302,6 +307,11 @@ std::string x86Formatter::formatBinaryFunc(const std::string &left, const std::s
 
     // fprintf(stderr, "Retval: %s\n", retval.c_str());
     return retval;
+}
+
+bool x86Formatter::operandPrintOrderReversed() const
+{
+    return true;
 }
 
 ///////////////////////////

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -47,6 +47,7 @@
 #include <iomanip>
 #include <set>
 #include <functional>
+#include <algorithm>
 
 #include "common/src/arch-x86.h"
 #include "dyninstversion.h"
@@ -237,6 +238,23 @@ namespace Dyninst
 
             DECODE_OPERANDS();
             std::copy(m_Operands.begin(), m_Operands.end(), std::back_inserter(operands));
+        }
+
+        INSTRUCTION_EXPORT std::vector<Operand> Instruction::getDisplayOrderedOperands() const
+        {
+            DECODE_OPERANDS();
+
+            std::vector<Operand> operands;
+            auto operandsInserter{std::back_inserter(operands)};
+            auto isNotImplicitPred = [](const Operand & x){return !x.isImplicit();};
+
+            if (formatter->operandPrintOrderReversed())  {
+                copy_if(m_Operands.crbegin(), m_Operands.crend(), operandsInserter, isNotImplicitPred);
+            }  else  {
+                copy_if(m_Operands.cbegin(), m_Operands.cend(), operandsInserter, isNotImplicitPred);
+            }
+
+            return operands;
         }
 
         INSTRUCTION_EXPORT Operand Instruction::getOperand(int index) const


### PR DESCRIPTION
Add method Instruction::getDisplayOrderedOperands to return the operands that are displayed (non implicit operands) when formatting an instruction for disassembly.  Returns a vector of Operands in display order.

These operands can be inspected and formatted to produce a disassembly string with annotations.