### PR TITLE
do not export Instruction::appendOperand

### DIFF
--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -303,14 +303,12 @@ namespace Dyninst
 
 
       typedef boost::shared_ptr<Instruction> Ptr;
-	private:
-	  //Should be private, but we're working around some compilers mis-using the 'friend' declaration.
-      INSTRUCTION_EXPORT void appendOperand(Expression::Ptr e, bool isRead, bool isWritten, bool isImplicit = false, bool trueP = false, bool falseP = false) const;
 
     private:
       void updateSize(const unsigned int new_size) {m_size = new_size;}
       void decodeOperands() const;
       void addSuccessor(Expression::Ptr e, bool isCall, bool isIndirect, bool isConditional, bool isFallthrough, bool isImplicit = false) const;
+      void appendOperand(Expression::Ptr e, bool isRead, bool isWritten, bool isImplicit = false, bool trueP = false, bool falseP = false) const;
       void copyRaw(size_t size, const unsigned char* raw);
       Expression::Ptr makeReturnExpression() const;
       mutable std::list<Operand> m_Operands;


### PR DESCRIPTION
- do not export since it is now private, and should not have been used
  externally (comment said it was to work around old compiler issue).

- cleanup method order and remove comment

Suggested in https://github.com/dyninst/dyninst/pull/1457#discussion_r1273826614