### PR TITLE
Do not decode operands for invalid opcodes

### DIFF
--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -124,6 +124,7 @@ namespace Dyninst
 
         void Instruction::decodeOperands() const
         {
+        if (!m_Valid) return;
             //m_Operands.reserve(5);
             InstructionDecoder dec(ptr(), size(), arch_decoded_from);
             dec.doDelayedDecode(this);


### PR DESCRIPTION
This was originally part of #638.