### PR TITLE
add support for EM_INTELGT

### DIFF
--- a/dwarf/src/dwarfHandle.C
+++ b/dwarf/src/dwarfHandle.C
@@ -223,6 +223,9 @@ bool DwarfHandle::init_dbg()
         case EM_INTEL_GEN9:
             arch = Arch_intelGen9;
             break;
+        case EM_INTELGT:
+            arch = Arch_intelGen9; // temporary for compatibility
+            break;
         default:
             assert(0 && "Unsupported archiecture in ELF file.");
             return false;

--- a/elf/h/Elf_X.h
+++ b/elf/h/Elf_X.h
@@ -48,6 +48,10 @@
 #define EM_INTEL_GEN9		182	/* INTEL GEN9 */
 #endif
 
+#ifndef EM_INTELGT
+#define EM_INTELGT		205	/* INTEL Graphics Technology */
+#endif
+
 namespace Dyninst {
 
 // Forward declarations

--- a/elf/src/Elf_X.C
+++ b/elf/src/Elf_X.C
@@ -1820,6 +1820,8 @@ Dyninst::Architecture Elf_X::getArch() const
             return Dyninst::Arch_cuda;
         case EM_INTEL_GEN9:
             return Dyninst::Arch_intelGen9;
+        case EM_INTELGT:
+            return Dyninst::Arch_intelGen9;
         case EM_ARM:
             return Dyninst::Arch_aarch32;
         case EM_AARCH64:


### PR DESCRIPTION
Add minimal support to parse Intel's new ZeBinaries.

It's unclear at this time how we should treat Intel's XE Gen12/Tiger Lake binaries, so we just treat them as Gen9 (Ponte Vecchio) for now.