### PR TITLE
Fix AMDGPU register formatting

### DIFF
--- a/instructionAPI/h/ArchSpecificFormatters.h
+++ b/instructionAPI/h/ArchSpecificFormatters.h
@@ -85,7 +85,9 @@ namespace Dyninst {
             std::string formatDeref(const std::string&) const override;
             std::string formatRegister(const std::string&) const override;
             std::string formatBinaryFunc(const std::string&, const std::string&, const std::string&) const override;
-
+            // Helper function for formatting consecutive registers that are displayed as a single operand
+            // Called when architecture is passed to Instruction.format.
+            static std::string formatRegister(MachRegister m_Reg, uint32_t num_elements, unsigned m_Low , unsigned m_High );
         private:
             std::map<std::string, std::string> binaryFuncModifier;
         };

--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.C
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.C
@@ -180,11 +180,11 @@ namespace Dyninst {
         Expression::Ptr InstructionDecoder_amdgpu_gfx908::decodeOPR_WAITCNT(uint64_t input){
 		    return Immediate::makeImmediate(Result(s16, input));
         }
-        Expression::Ptr InstructionDecoder_amdgpu_gfx908::makeRegisterExpression(MachRegister registerID, uint32_t ){
+        Expression::Ptr InstructionDecoder_amdgpu_gfx908::makeRegisterExpression(MachRegister registerID, uint32_t num_elements){
             if(registerID == amdgpu_gfx908::src_literal){
                 return Immediate::makeImmediate(Result(u32,decodeOPR_LITERAL()));
             }
-            return InstructionDecoderImpl::makeRegisterExpression(registerID);
+            return InstructionDecoderImpl::makeRegisterExpression(registerID,num_elements);
         }
         Expression::Ptr InstructionDecoder_amdgpu_gfx908::makeRegisterExpression(MachRegister registerID, uint32_t low, uint32_t high ){
             if(registerID == amdgpu_gfx908::src_literal){
@@ -212,11 +212,6 @@ namespace Dyninst {
 			isBranch = false;
 			isConditional = false;
 			isModifyPC =false;
-			isSMEM = false;
-			isLoad = false ;
-			isStore =false;
-			isBuffer =false ;
-			isScratch = false;
 			insn = insn_high = insn_long = 0;
 			useImm = false;
 			isCall = false;

--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
@@ -216,21 +216,9 @@ namespace Dyninst {
             uint32_t imm_at_64{};
             uint32_t imm_at_96{};
 
-            bool setSCC{};
-
-#define IS_LD_ST() (isLoad || isStore )
-
-            bool isSMEM{}; // this is set when using smem instruction
-            bool isLoad{}; // this is set when a smem instruction is load, will set number of elements that are loaded at the same time
-            bool isStore{}; // similar to isLoad, but for store instructions
-            bool isBuffer{}; //
-            bool isScratch{};
-
             bool isBranch{}; // this is set for all branch instructions,
             bool isConditional{}; // this is set for all conditional branch instruction, will set branchCond
             bool isCall{}; // this is a call function
-
-
 
             // this is set for instructions that directly modify pc
             // namely s_setpc and s_swappc
@@ -269,14 +257,6 @@ namespace Dyninst {
                     }
 
                 }
-
-            void setSMEM() {isSMEM = true;}
-
-
-
-            void setScratch() {isScratch = true;}
-
-            void setBuffer() {isBuffer = true;}
 
             typedef struct buffer_resource_desc{
                 unsigned long long base_address;

--- a/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.C
+++ b/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.C
@@ -181,11 +181,11 @@ namespace Dyninst {
         Expression::Ptr InstructionDecoder_amdgpu_gfx90a::decodeOPR_WAITCNT(uint64_t input){
             return Immediate::makeImmediate(Result(s16, input));
         }
-        Expression::Ptr InstructionDecoder_amdgpu_gfx90a::makeRegisterExpression(MachRegister registerID, uint32_t ){
+        Expression::Ptr InstructionDecoder_amdgpu_gfx90a::makeRegisterExpression(MachRegister registerID, uint32_t num_elements){
             if(registerID == amdgpu_gfx90a::src_literal){
                 return Immediate::makeImmediate(Result(u32,decodeOPR_LITERAL()));
             }
-            return InstructionDecoderImpl::makeRegisterExpression(registerID);
+            return InstructionDecoderImpl::makeRegisterExpression(registerID,num_elements);
         }
         Expression::Ptr InstructionDecoder_amdgpu_gfx90a::makeRegisterExpression(MachRegister registerID, uint32_t low, uint32_t high ){
             if(registerID == amdgpu_gfx90a::src_literal){
@@ -210,15 +210,9 @@ namespace Dyninst {
         void InstructionDecoder_amdgpu_gfx90a::reset(){
             immLen = 0;
             insn_size = 0;
-            num_elements =1;
             isBranch = false;
             isConditional = false;
             isModifyPC =false;
-            isSMEM = false;
-            isLoad = false ;
-            isStore =false;
-            isBuffer =false ;
-            isScratch = false;
             insn = insn_high = insn_long = 0;
             useImm = false;
             isCall = false;

--- a/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.h
+++ b/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.h
@@ -218,17 +218,6 @@ namespace Dyninst {
             uint32_t imm_at_64{};
             uint32_t imm_at_96{};
 
-            bool setSCC{};
-
-#define IS_LD_ST() (isLoad || isStore )
-
-            unsigned int num_elements{1};  // the number of elements that will be load or store by each instruction
-            bool isSMEM{}; // this is set when using smem instruction
-            bool isLoad{}; // this is set when a smem instruction is load, will set number of elements that are loaded at the same time
-            bool isStore{}; // similar to isLoad, but for store instructions
-            bool isBuffer{}; //
-            bool isScratch{};
-
             bool isBranch{}; // this is set for all branch instructions,
             bool isConditional{}; // this is set for all conditional branch instruction, will set branchCond
             bool isCall{}; // this is a call function
@@ -272,20 +261,6 @@ namespace Dyninst {
                     }
 
                 }
-
-            void setSMEM() {isSMEM = true;}
-
-
-
-            template<unsigned int num_elements>
-                void setLoad(){isLoad = true; this->num_elements = num_elements; }
-
-            template<unsigned int num_elements>
-                void setStore() {isStore = true;this->num_elements = num_elements;}
-
-            void setScratch() {isScratch = true;}
-
-            void setBuffer() {isBuffer = true;}
 
             typedef struct buffer_resource_desc{
                 unsigned long long base_address;

--- a/instructionAPI/src/Register.C
+++ b/instructionAPI/src/Register.C
@@ -90,10 +90,10 @@ namespace Dyninst
       return m_Reg;
     }
 
-    std::string RegisterAST::format(Architecture arch, formatStyle f) const
+    std::string RegisterAST::format(Architecture arch, formatStyle) const
     {
         if(arch == Arch_amdgpu_vega || arch == Arch_amdgpu_gfx908 || arch == Arch_amdgpu_gfx90a){
-            return RegisterAST::format(f);
+            return AmdgpuFormatter::formatRegister(m_Reg,m_num_elements,m_Low,m_High);
         }
         return ArchSpecificFormatter::getFormatter(arch).formatRegister(m_Reg.name());
     }
@@ -105,69 +105,6 @@ namespace Dyninst
         if(substr != std::string::npos)
         {
             name = name.substr(substr + 2, name.length());
-        }
-        if( m_num_elements ==0 ){
-            return "";
-        }else if ( m_num_elements > 1){
-            uint32_t id = m_Reg & 0xff ;
-            uint32_t regClass = m_Reg.regClass();
- 
-            uint32_t  size = m_num_elements;
-
-DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_LOGICAL_OP
-
-            if(regClass == amdgpu_gfx908::SGPR || regClass == amdgpu_gfx90a::SGPR || regClass == amdgpu_vega::SGPR){
-                return "S["+to_string(id) + ":" + to_string(id+size-1)+"]";
-            }
-
-            if(regClass == amdgpu_gfx908::VGPR || regClass == amdgpu_gfx90a::VGPR || regClass == amdgpu_vega::VGPR){
-                return "V["+to_string(id) + ":" + to_string(id+size-1)+"]";
-            }
-
-            if(regClass == amdgpu_gfx908::ACC_VGPR || regClass == amdgpu_gfx90a::ACC_VGPR){
-                return "ACC["+to_string(id) + ":" + to_string(id+size-1)+"]";
-            }
-
-DYNINST_DIAGNOSTIC_END_SUPPRESS_LOGICAL_OP
-
-            if(m_Reg == amdgpu_gfx908::vcc_lo || m_Reg == amdgpu_gfx90a::vcc_lo || m_Reg == amdgpu_vega::vcc_lo)
-                return "VCC";
-            if(m_Reg == amdgpu_gfx908::exec_lo || m_Reg == amdgpu_gfx90a::exec_lo || m_Reg == amdgpu_vega::exec_lo)
-                return "EXEC";
-
-       
-        }else if ( m_High -m_Low > 32 && m_Reg.size()*8 != m_High - m_Low){
-
-        // Size of base register * 8 != m_High - mLow ( in bits) when we it is a register vector
-            uint32_t id = m_Reg & 0xff ;
-            uint32_t regClass = m_Reg.regClass();
-            uint32_t size = (m_High - m_Low ) / 32;
-
-            // Suppress warning (for compilers where it is a false positive)
-            // The values of the two *::SGPR constants are identical, as
-            // are the two *::VGPR constants
-DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_LOGICAL_OP
-
-            if(regClass == amdgpu_gfx908::SGPR || regClass == amdgpu_gfx90a::SGPR || regClass == amdgpu_vega::SGPR){
-                return "S["+to_string(id) + ":" + to_string(id+size-1)+"]";
-            }
-
-            if(regClass == amdgpu_gfx908::VGPR || regClass == amdgpu_gfx90a::VGPR || regClass == amdgpu_vega::VGPR){
-                return "V["+to_string(id) + ":" + to_string(id+size-1)+"]";
-            }
-
-            if(regClass == amdgpu_gfx908::ACC_VGPR || regClass == amdgpu_gfx90a::ACC_VGPR){
-                return "ACC["+to_string(id) + ":" + to_string(id+size-1)+"]";
-            }
-
-DYNINST_DIAGNOSTIC_END_SUPPRESS_LOGICAL_OP
-
-            if(m_Reg == amdgpu_gfx908::vcc_lo || m_Reg == amdgpu_gfx90a::vcc_lo || m_Reg == amdgpu_vega::vcc_lo)
-                return "VCC";
-            if(m_Reg == amdgpu_gfx908::exec_lo || m_Reg == amdgpu_gfx90a::exec_lo || m_Reg == amdgpu_vega::exec_lo)
-                return "EXEC";
-
-            name +=  "["+to_string(m_Low)+":"+to_string(m_High)+"]";
         }
         /* we have moved to AT&T syntax (lowercase registers) */
         for(char &c : name) c = std::toupper(c);


### PR DESCRIPTION
Fix missing parameter for makeRegisterExpression
During one of the PRs that targets compiler warning,
the num_elements parameter to makeRegisterExpression is omitted,
resulting in all register operands are displayed separately,
whether they should be displayed as a group or not.

In addition to adding the parameter, certern unused helper functions
and fields of InstructionDecoder-amdgpu-gfx*** has been removed
to avoid shadowing of variable names.
(Note that this change isn't applied to vega as we don't have ISA-XML for it.)

Also, the logic for handling this type of formatting is extracted out of Register.C
into a helper function in ArchitectureSpecificFormatter.C


