### PR TITLE
Don't include compiler-specific headers

### DIFF
--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -26,7 +26,6 @@
 
 //Concurrent Hash Map
 #include "concurrent.h"
-#include <bits/stdc++.h>
 
 namespace Dyninst {
 	namespace SymtabAPI {


### PR DESCRIPTION
Including anything in <bits/*> is not portable. Also, the contents of this header were never used.

Stan Cox (scox@redhat.com) reported:

It's not included as the first thing in the file, which means it can't use the precompiled version of that header
(https://gcc.gnu.org/onlinedocs/gcc/Precompiled-Headers.html) and therefore it's just including the entire C++ standard library, which is going to be much slower than just including the right headers.

@stanfordcox 