### PR TITLE
Remove Symtab::forceFullLineInfoParse

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -272,7 +272,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
          unsigned int lineNo, unsigned int lineOffset = 0);
    void setTruncateLinePaths(bool value);
    bool getTruncateLinePaths();
-   void forceFullLineInfoParse();
    
    /***** Type Information *****/
    virtual bool findType(boost::shared_ptr<Type>& type, std::string name);


### PR DESCRIPTION
It was added by 1867619517b3 in 2015, but was never implemented.