### PR TITLE
Remove unused Object::find_symbol in Object-elf

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2165,30 +2165,6 @@ dyn_scnp, Elf_X_Data &symdata,
 #endif
 }
 
-#if defined(cap_dwarf)
-
-string Object::find_symbol(string name) {
-    string name2;
-
-    // pass #1: unmodified
-    name2 = name;
-    if (symbols_.contains(name2)) return name2;
-
-    // pass #2: leading underscore (C)
-    name2 = "_" + name;
-    if (symbols_.contains(name2)) return name2;
-
-    // pass #3: trailing underscore (Fortran)
-    name2 = name + "_";
-    if (symbols_.contains(name2))
-        return name2;
-
-    return "";
-}
-
-#endif
-
-
 /********************************************************
  *
  * For object files only....

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -483,10 +483,6 @@ private:
                          std::vector<ExceptionBlock> &catch_addrs);
   // Line info: CUs to skip
   std::set<std::string> modules_parsed_for_line_info;
-#if defined(cap_dwarf)
-  std::string find_symbol(std::string name);
-
-#endif
 
  public:
   struct DbgAddrConversion_t {


### PR DESCRIPTION
Its usage was removed by 9de709ec5 in 2016.