### PR TITLE
Remove Symtab::updateIndices

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -438,7 +438,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool addSymbolToIndices(Symbol *&sym, bool undefined);
    bool addSymbolToAggregates(const Symbol *sym);
    bool doNotAggregate(const Symbol *sym);
-   bool updateIndices(Symbol *sym, std::string newName, NameType nameType);
 
 
    void setModuleLanguages(dyn_hash_map<std::string, supportedLanguages> *mod_langs);

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -795,27 +795,6 @@ bool Symtab::doNotAggregate(const Symbol* sym) {
     return false;
 }
 
-/* Add the new name to the appropriate symbol index */
-
-bool Symtab::updateIndices(Symbol * /*sym*/, std::string /*newName*/, NameType /*nameType*/) {
-
-#if 0
-     if (nameType & mangledName) {
-        // Add this symbol under the given name (as mangled)
-        symsByMangledName[newName].push_back(sym);
-    }
-    if (nameType & prettyName) {
-        // Add this symbol under the given name (as pretty)
-        symsByPrettyName[newName].push_back(sym);
-    }
-    if (nameType & typedName) {
-        // Add this symbol under the given name (as typed)
-        symsByTypedName[newName].push_back(sym);
-    }
-#endif
-    return true;
-}
-
 //  setModuleLanguages is only called after modules have been defined.
 //  it attempts to set each module's language, information which is needed
 //  before names can be demangled.


### PR DESCRIPTION
Its usage was removed by cabbe58ff in 2015. It's a private function, so there are no API/ABI issues in removing it.