### PR TITLE
Remove Module::setName

### DIFF
--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -154,7 +154,6 @@ namespace Dyninst{
 
 			const std::string &fileName() const;
 			const std::string &fullName() const;
-			bool setName(std::string newName);
 
 			supportedLanguages language() const;
 			void setLanguage(supportedLanguages lang);

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -453,13 +453,6 @@ bool Module::operator==(Module &mod)
          );
 }
 
-bool Module::setName(std::string newName)
-{
-   fullName_ = newName;
-   fileName_ = extract_pathname_tail(fullName_);
-   return true;
-}
-
 void Module::setLanguage(supportedLanguages lang)
 {
    language_ = lang;


### PR DESCRIPTION
This is never called internally. The filename corresponding to the module is a class invariant. It makes no sense to make it mutable. This member function is not documented.