### PR TITLE
Remove declaration of Object::load_shared_object

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2419,7 +2419,6 @@ Object::Object(MappedFile *mf_, bool, void (*err_func)(const char *),
     dwarf = DwarfHandle::createDwarfHandle(mf_->pathname(), elfHdr);
 
     if (elfHdr->e_type() == ET_DYN) {
-//        load_shared_object(alloc_syms);
         load_object(alloc_syms);
     } else if (elfHdr->e_type() == ET_REL || elfHdr->e_type() == ET_EXEC) {
         load_object(alloc_syms);

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -441,7 +441,6 @@ private:
   void parseDwarfTypes(Symtab *obj);
 
   void load_object(bool);
-  void load_shared_object(bool);
 
   // initialize relocation_table_ from .rel[a].plt section entries 
   bool get_relocation_entries(Elf_X_Shdr *&rel_plt_scnp,


### PR DESCRIPTION
Its definition was removed by 758aa226 in 2016.