### PR TITLE
Make MappedFile::mapped_files threadsafe

### DIFF
--- a/common/src/MappedFile.h
+++ b/common/src/MappedFile.h
@@ -36,8 +36,6 @@
 #include "Types.h"
 
 class MappedFile {
-     static dyn_hash_map<std::string, MappedFile *> mapped_files;
-
    public:
       COMMON_EXPORT static MappedFile *createMappedFile(std::string fullpath_);
       COMMON_EXPORT static MappedFile *createMappedFile(void *map_loc, unsigned long size_, const std::string &name);


### PR DESCRIPTION
Currently, a MappedFile is created from a constructor in either the Symtab or Archive classes. In both cases, a user is allowed to invoke them in parallel (although only one thread may enter the constructor), but the cache here is not threadsafe.