### PR TITLE
Make Symtab::parseTypesNow thread-safe

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -629,8 +629,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool getExplicitSymtabRefs(std::set<Symtab *> &refs);
    std::set<Symtab *> explicitSymtabRefs_{};
 
-   //type info valid flag
-   bool isTypeInfoValid_{false};
+   std::once_flag types_parsed;
 
    //Relocation sections
    bool hasRel_{false};

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -2617,11 +2617,7 @@ const Object *Symtab::getObject() const
 
 void Symtab::parseTypesNow()
 {
-   if (isTypeInfoValid_)
-      return;
-   isTypeInfoValid_ = true;
-
-   parseTypes();
+   std::call_once(this->types_parsed, [this](){ this->parseTypes(); });
 }
 
 SYMTAB_EXPORT Offset Symtab::getElfDynamicOffset()


### PR DESCRIPTION
There are many places where this is called without a user realizing it. If they were to call any of those functions in parallel, type parsing would break.