### PR TITLE
Fix responsibility inversion in Module::finalizeRanges

### DIFF
--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -135,6 +135,7 @@ namespace Dyninst{
 		typedef Statement LineNoTuple;
 #define MODULE_ANNOTATABLE_CLASS AnnotatableSparse
 
+		typedef Dyninst::SimpleInterval<Offset, Module*> ModRange;
 		class SYMTAB_EXPORT Module : public LookupInterface
 		{
 			friend class Symtab;
@@ -257,10 +258,8 @@ namespace Dyninst{
 
 			bool setLineInfo(Dyninst::SymtabAPI::LineInformation *lineInfo);
 			void addRange(Dyninst::Address low, Dyninst::Address high);
-			bool hasRanges() const { return !ranges.empty() || ranges_finalized; }
+			bool hasRanges() const { return !ranges.empty(); }
 			void addDebugInfo(Module::DebugInfoT info);
-
-			void finalizeRanges();
 
 		private:
             bool objectLevelLineInfo;
@@ -276,15 +275,12 @@ namespace Dyninst{
 			Offset addr_;                      // starting address of module
 			Symtab *exec_;
 			std::set<AddressRange > ranges;
+			std::vector<ModRange*> finalizeRanges();
 
 			StringTablePtr strings_;
 		public:
 			StringTablePtr & getStrings() ;
 
-		private:
-			bool ranges_finalized;
-
-			void finalizeOneRange(Address ext_s, Address ext_e) const;
 		};
 		template <typename OS>
 		OS& operator<<(OS& os, const Module& m)
@@ -298,8 +294,6 @@ namespace Dyninst{
 			os << m->fileName() << ": " << m->addr();
 			return os;
 		}
-
-		typedef Dyninst::SimpleInterval<Offset, Module*> ModRange;
 
 		inline bool operator==(Offset off, const ModRange& r) {
 			return (r.low() <= off) && (off < r.high());

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -570,7 +570,9 @@ bool Symtab::fixSymModules(std::vector<Symbol *> &raw_syms)
     }
     for (auto i = indexed_modules.begin(); i != indexed_modules.end(); ++i)
     {
-        (*i)->finalizeRanges();
+        for(auto *m : (*i)->finalizeRanges()) {
+            mod_lookup_.insert(m);
+        }
     }
 
 //    const std::vector<std::pair<std::string, Offset> > &mods = obj->modules_;
@@ -850,7 +852,9 @@ void Symtab::createDefaultModule() {
                      this);
     mod->addRange(imageOffset_, imageLen_ + imageOffset_);
     indexed_modules.push_back(mod);
-    mod->finalizeRanges();
+    for(auto *m : mod->finalizeRanges()) {
+      mod_lookup_.insert(m);
+    }
 }
 
 
@@ -1827,7 +1831,9 @@ void Symtab::parseTypes()
     for (auto i = indexed_modules.begin(); i != indexed_modules.end(); ++i)
    {
        (*i)->setModuleTypes(typeCollection::getModTypeCollection((*i)));
-       (*i)->finalizeRanges();
+       for(auto *m : (*i)->finalizeRanges()) {
+	 mod_lookup_.insert(m);
+       }
    }
 
    //  optionally we might want to clear the static data struct in typeCollection


### PR DESCRIPTION
A Module shouldn't modify the Symtab object to which it belongs. It knows what ranges belong to it (see
Object::fix_global_symbol_modules_static_dwarf), so it can munge them into a collection of `ModRange`s.

The `ranges_finalized` member was never needed as the only place it was set was in `finalizeRanges` which is the only place where `ranges` was emptied.