### PR TITLE
Remove FunctionBase::setReturnType(Type*)

### DIFF
--- a/symtabAPI/doc/API/Symtab/Function.tex
+++ b/symtabAPI/doc/API/Symtab/Function.tex
@@ -108,12 +108,3 @@ bool findLocalVariable(vector<localVar *> &vars,
 This method returns a list of local variables within a function that have name \code{name}. \code{vars} contains the list of variables found.
 Returns \code{true} on success and \code{false} on failure.
 }
-
-
-
-\begin{apient}
-bool setReturnType(Type *type)
-\end{apient}
-\apidesc{
-Sets the return type of a function to \code{type}.
-}

--- a/symtabAPI/doc/API/Symtab/FunctionBase.tex
+++ b/symtabAPI/doc/API/Symtab/FunctionBase.tex
@@ -95,15 +95,6 @@ This method returns a list of local variables within a function that have name \
 Returns \code{true} on success and \code{false} on failure.
 }
 
-
-
-\begin{apient}
-bool setReturnType(Type *type)
-\end{apient}
-\apidesc{
-Sets the return type of a function to \code{type}.
-}
-
 \begin{apient}
 FunctionBase* getInlinedParent()
 \end{apient}

--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -126,7 +126,6 @@ class SYMTAB_EXPORT FunctionBase
    bool addLocalVar(localVar *);
    bool addParam(localVar *);
    bool	setReturnType(boost::shared_ptr<Type>);
-   bool	setReturnType(Type* t) { return setReturnType(t->reshare()); }
 
    virtual Offset getOffset() const = 0;
    virtual unsigned getSize() const = 0;


### PR DESCRIPTION
This is never called from within Dyninst and should never be called by a user.