### PR TITLE
Fix inverted logic  in DwarfDyninst::is_cudie

### DIFF
--- a/dwarf/h/dwarf_cu_info.hpp
+++ b/dwarf/h/dwarf_cu_info.hpp
@@ -12,8 +12,8 @@ namespace Dyninst { namespace DwarfDyninst {
   inline bool is_typecu(Dwarf_Die die) { return dwarf_tag(&die) == DW_TAG_type_unit; }
 
   inline bool is_cudie(Dwarf_Die die) {
-    // If there is an inner CU attribute, then it's not a CU
-    if (die.cu)
+    // If there is not an inner CU attribute, then it's not a CU
+    if (!die.cu)
       return false;
 
     // These are best guess. Ideally, we'd like to interrogate


### PR DESCRIPTION
If a DIE is a CU, then it contains a reference to its Dwarf_CU.

Introduced by 71f2e14d3 (PR1499).