### PR TITLE
Don't check for existing return type when parsing DWARF subprogram

### DIFF
--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -2724,10 +2724,8 @@ void DwarfWalker::setFuncReturnType() {
     dwarf_printf("(0x%lx) In setFuncReturnType().\n", id());
    boost::shared_ptr<Type> returnType;
    boost::unique_lock<dyn_mutex> l(curFunc()->ret_lock);
-   if (!curFunc()->getReturnType(Type::share)) {
       getReturnType(false, returnType);
       if (returnType)
          curFunc()->setReturnType(returnType);
-   }
 }
 


### PR DESCRIPTION
Since 8b400af5, functions are guaranteed to only be parsed once, so the return type can never be set before the call here. Checking the return type circularly invokes Symtab::parseTypesNow which deadlocks since 7f1e24d.