### PR TITLE
Parse all DWARF source files in DwarfWalker::buildSrcFiles

### DIFF
--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -311,7 +311,7 @@ bool DwarfWalker::buildSrcFiles(::Dwarf * /*dbg*/, Dwarf_Die entry, StringTableP
     auto comp_dir = Dyninst::DwarfDyninst::cu_name(entry);
 
     // store all file sources found by libdw
-    for (unsigned i = 1; i < cnt; ++i) {
+    for (unsigned i = 0; i < cnt; ++i) {
         auto filename = dwarf_filesrc(df, i, NULL, NULL);
         if(!filename) continue;
         srcFiles->emplace_back(DwarfDyninst::detail::absolute_path(filename, comp_dir),"");


### PR DESCRIPTION
From 2.6.4.16 of the DWARF5 standard

	Prior to DWARF Version 5, the current compilation file name was not
	represented in the file_names field. In DWARF Version 5, the current
	compilation file name is explicitly present and has index 0. This is
	needed to support the common practice of stripping all but the line
	number sections (.debug_line and .debug_line_str) from an executable.

However, libdw takes care of this in `dwarf_getsrcfiles`.

Fixes a major bug where we produce no function parameter information
when there is only one CU in a binary because
DwarfWalker::parseFormalParam requires line information.

Fixes #1156