### PR TITLE
Remove DwarfWalker::version member variable

### DIFF
--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -90,7 +90,6 @@ DwarfWalker::DwarfWalker(Symtab *symtab, ::Dwarf *dbg, std::shared_ptr<ParsedFun
    modLow(0),
    modHigh(0),
    cu_header_length(0),
-   version(0),
    abbrev_offset(0),
    addr_size(0),
    offset_size(0),

--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -230,7 +230,6 @@ public:
             is_mangled_name_(o.is_mangled_name_),
             modLow(o.modLow), modHigh(o.modHigh),
             cu_header_length(o.cu_header_length),
-            version(o.version),
             abbrev_offset(o.abbrev_offset),
             addr_size(o.addr_size),
             offset_size(o.offset_size),
@@ -398,7 +397,6 @@ private:
     Address modLow;
     Address modHigh;
     size_t  cu_header_length;
-    Dwarf_Half version;
     Dwarf_Word abbrev_offset;
     uint8_t /*Dwarf_Half*/ addr_size;
     uint8_t /*Dwarf_Half*/ offset_size;


### PR DESCRIPTION
It was added by 49df4377c in 2012, but never used.