### PR TITLE
Hide implementations of complex data structures in SymtabAPI::Symtab

### DIFF
--- a/symtabAPI/CMakeLists.txt
+++ b/symtabAPI/CMakeLists.txt
@@ -31,7 +31,9 @@ set(_private_headers
     src/Object-elf.h
     src/Object.h
     src/Object-nt.h
-    src/Type-mem.h)
+    src/Type-mem.h
+    src/indexed_symbols.hpp
+    src/symtab_impl.hpp)
 
 set(_sources
     src/AddrLookup.C

--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -44,7 +44,6 @@
 #include "Annotatable.h"
 #include "Aggregate.h"
 #include "Variable.h"
-#include "IBSTree.h"
 #include "concurrent.h"
 #include "VariableLocation.h"
 
@@ -77,7 +76,6 @@ class SYMTAB_EXPORT FuncRange {
    typedef Dyninst::Offset type;
 };
 
-typedef IBSTree<FuncRange> FuncRangeLookup;
 typedef std::vector<FuncRange> FuncRangeCollection;
 typedef std::vector<FunctionBase *> InlineCollection;
 typedef std::vector<FuncRange> FuncRangeCollection;

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -51,8 +51,6 @@
 
 #include "dyninstversion.h"
 
-#include "concurrent.h"
-
 #include "boost/shared_ptr.hpp"
 
 class MappedFile;

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -532,8 +532,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
    // Similar for Variables
    std::vector<Variable *> everyVariable{};
-   using VarsByOffsetMap = dyn_c_hash_map<Offset, std::vector<Variable *> >;
-   VarsByOffsetMap varsByOffset{};
 
    std::vector<relocationEntry > relocation_table_{};
    std::vector<ExceptionBlock *> excpBlocks{};

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -552,9 +552,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool isStaticBinary_{false};
    bool isDefensiveBinary_{false};
 
-   FuncRangeLookup func_lookup{};
-
-
    //Don't use obj_private, use getObject() instead.
  public:
    Object *getObject();

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -46,7 +46,6 @@
 #include "Function.h"
 #include "Annotatable.h"
 #include "ProcReader.h"
-#include "IBSTree.h"
 #include "Type.h"
 
 #include "dyninstversion.h"
@@ -75,7 +74,6 @@ class relocationEntry;
 class Type;
 struct symtab_impl;
 
-typedef IBSTree< ModRange > ModRangeLookup;
 typedef Dyninst::ProcessReader MemRegReader;
 
 class SYMTAB_EXPORT Symtab : public LookupInterface,
@@ -556,14 +554,11 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
    FuncRangeLookup func_lookup{};
 
-    ModRangeLookup mod_lookup_{};
-
 
    //Don't use obj_private, use getObject() instead.
  public:
    Object *getObject();
    const Object *getObject() const;
-   ModRangeLookup* mod_lookup();
    void dumpModRanges();
    void dumpFuncRanges();
 

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -529,9 +529,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    // We also need per-Aggregate indices
    bool sorted_everyFunction{false};
    std::vector<Function *> everyFunction{};
-   // Since Functions are unique by address we require this structure to
-   // efficiently track them.
-   dyn_c_hash_map <Offset, Function *> funcsByOffset{};
 
    // Similar for Variables
    std::vector<Variable *> everyVariable{};

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -55,23 +55,6 @@
 #include "concurrent.h"
 
 #include "boost/shared_ptr.hpp"
-#include "boost/multi_index_container.hpp"
-#include <boost/multi_index/member.hpp>
-#include <boost/multi_index/mem_fun.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/identity.hpp>
-#include <boost/multi_index/random_access_index.hpp>
-using boost::multi_index_container;
-using boost::multi_index::indexed_by;
-using boost::multi_index::ordered_unique;
-using boost::multi_index::ordered_non_unique;
-using boost::multi_index::hashed_non_unique;
-
-using boost::multi_index::identity;
-using boost::multi_index::tag;
-using boost::multi_index::const_mem_fun;
-using boost::multi_index::member;
 
 class MappedFile;
 
@@ -555,18 +538,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    std::vector<Variable *> everyVariable{};
    using VarsByOffsetMap = dyn_c_hash_map<Offset, std::vector<Variable *> >;
    VarsByOffsetMap varsByOffset{};
-
-    dyn_mutex im_lock{};
-    boost::multi_index_container<Module*,
-            boost::multi_index::indexed_by<
-                    boost::multi_index::random_access<>,
-                    boost::multi_index::ordered_unique<boost::multi_index::identity<Module*> >,
-                    boost::multi_index::ordered_non_unique<
-                            boost::multi_index::const_mem_fun<Module, const std::string&, &Module::fileName> >
-                    >
-            >
-            indexed_modules{};
-
 
    std::vector<relocationEntry > relocation_table_{};
    std::vector<ExceptionBlock *> excpBlocks{};

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -92,7 +92,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    friend class Object;
 
    // Hide implementation details that are complex or add large dependencies
-   std::unique_ptr<symtab_impl> impl;
+   const std::unique_ptr<symtab_impl> impl;
 
  public:
 

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -38,7 +38,6 @@
 #include <string>
 #include <vector>
 #include <set>
-#include <mutex>
 #include <memory>
 
 #include "Symbol.h"
@@ -550,8 +549,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    // This set represents Symtabs referenced by a new external Symbol
    bool getExplicitSymtabRefs(std::set<Symtab *> &refs);
    std::set<Symtab *> explicitSymtabRefs_{};
-
-   std::once_flag types_parsed;
 
    //Relocation sections
    bool hasRel_{false};

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -565,7 +565,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool isDefensiveBinary_{false};
 
    FuncRangeLookup func_lookup{};
-   std::once_flag funcRangesAreParsed;
 
     ModRangeLookup mod_lookup_{};
 

--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -121,13 +121,13 @@ bool Symtab::deleteVariable(Variable *var) {
 
     // remove variable from varsByOffset
     {
-        VarsByOffsetMap::accessor a;
-        bool found = !varsByOffset.find(a, var->getOffset());
+        decltype(impl->varsByOffset)::accessor a;
+        bool found = !impl->varsByOffset.find(a, var->getOffset());
         if (found)  {
-            VarsByOffsetMap::mapped_type &vars = a->second;
+            decltype(impl->varsByOffset)::mapped_type &vars = a->second;
             vars.erase(std::remove(vars.begin(), vars.end(), var), vars.end());
             if (vars.empty())  {
-                varsByOffset.erase(a);
+                impl->varsByOffset.erase(a);
             }
         }
     }
@@ -204,19 +204,19 @@ bool Symtab::changeAggregateOffset(Aggregate *agg, Offset oldOffset, Offset newO
         }
     }
     if (var) {
-        VarsByOffsetMap::accessor a;
-        bool found = !varsByOffset.find(a, oldOffset);
-        VarsByOffsetMap::mapped_type &vars = a->second;
+        decltype(impl->varsByOffset)::accessor a;
+        bool found = !impl->varsByOffset.find(a, oldOffset);
+        decltype(impl->varsByOffset)::mapped_type &vars = a->second;
         if (found)  {
             vars.erase(std::remove(vars.begin(), vars.end(), var), vars.end());
             if (vars.empty())  {
-                varsByOffset.erase(a);
+                impl->varsByOffset.erase(a);
             }
         }  else  {
             assert(0);
         }
 
-        found = !varsByOffset.insert(a, newOffset);
+        found = !impl->varsByOffset.insert(a, newOffset);
         if (found)  {
             found = false;
             for (auto v: vars)  {

--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -109,7 +109,7 @@ bool Symtab::deleteFunction(Function *func) {
         }
     }
 */
-    funcsByOffset.erase(func->getOffset());
+    impl->funcsByOffset.erase(func->getOffset());
 
     // Now handle the Aggregate stuff
     return deleteAggregate(func);
@@ -198,8 +198,8 @@ bool Symtab::changeAggregateOffset(Aggregate *agg, Offset oldOffset, Offset newO
     Variable *var = dynamic_cast<Variable *>(agg);
 
     if (func) {
-        funcsByOffset.erase(oldOffset);
-        if (!funcsByOffset.insert({newOffset, func})) {
+        impl->funcsByOffset.erase(oldOffset);
+        if (!impl->funcsByOffset.insert({newOffset, func})) {
             // Already someone there... odd, so don't do anything.
         }
     }

--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -308,7 +308,7 @@ Function *Symtab::createFunction(std::string name,
     }
 
     // Check to see if we contain this module...
-    if(indexed_modules.get<1>().find(mod) == indexed_modules.get<1>().end()) return NULL;
+    if(impl->indexed_modules.get<1>().find(mod) == impl->indexed_modules.get<1>().end()) return NULL;
 //
 //    bool found = false;
 //    for (unsigned i = 0; i < indexed_modules.size(); i++) {
@@ -356,7 +356,7 @@ Variable *Symtab::createVariable(std::string name,
         mod = getDefaultModule();
     }
     // Check to see if we contain this module...
-    if(indexed_modules.get<1>().find(mod) == indexed_modules.get<1>().end()) return NULL;
+    if(impl->indexed_modules.get<1>().find(mod) == impl->indexed_modules.get<1>().end()) return NULL;
 //
 //    bool found = false;
 //    for (unsigned i = 0; i < indexed_modules.size(); i++) {

--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -43,7 +43,7 @@
 #include "Collections.h"
 #include "Function.h"
 #include "Variable.h"
-
+#include "symtab_impl.hpp"
 #include "symtabAPI/src/Object.h"
 
 #include "boost/tuple/tuple.hpp"
@@ -148,8 +148,8 @@ bool Symtab::deleteAggregate(Aggregate *agg) {
 }
 
 bool Symtab::deleteSymbolFromIndices(Symbol *sym) {
-  everyDefinedSymbol.erase(sym);
-  undefDynSyms.erase(sym);
+  impl->everyDefinedSymbol.erase(sym);
+  impl->undefDynSyms.erase(sym);
   return true;
 }
 
@@ -172,17 +172,17 @@ bool Symtab::changeSymbolOffset(Symbol *sym, Offset newOffset) {
     // the aggregate, and make a new aggregate.
   {
     indexed_symbols::master_t::accessor a;
-    if (!everyDefinedSymbol.master.find(a, sym))  {
+    if (!impl->everyDefinedSymbol.master.find(a, sym))  {
         assert(!"everyDefinedSymbol.master.find(a, sym)");
     }
 
     indexed_symbols::by_offset_t::accessor oa;
-    if (!everyDefinedSymbol.by_offset.find(oa, sym->offset_))  {
+    if (!impl->everyDefinedSymbol.by_offset.find(oa, sym->offset_))  {
         assert(!"everyDefinedSymbol.by_offset.find(oa, sym->offset_)");
     }
     auto &syms = oa->second;
     syms.erase(std::remove(syms.begin(), syms.end(), sym), syms.end());
-    everyDefinedSymbol.by_offset.insert(oa, newOffset);
+    impl->everyDefinedSymbol.by_offset.insert(oa, newOffset);
     oa->second.push_back(sym);
 
     a->second = newOffset;

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -713,13 +713,13 @@ bool Symtab::addFunctionRange(FunctionBase *func, Dyninst::Offset next_start)
       FuncRange &range = *i;
       if (range.low() == sym_low && range.high() == sym_high)
          found_sym_range = true;      
-      func_lookup.insert(&range);
+      impl->func_lookup.insert(&range);
    }
 
    //Add symbol range to func_lookup, if present and not already added
    if (!found_sym_range && sym_low && sym_high) {
       FuncRange *frange = new FuncRange(sym_low, sym_high - sym_low, func);      
-      func_lookup.insert(frange);
+      impl->func_lookup.insert(frange);
    }
 
    //Recursively add inlined functions
@@ -818,7 +818,7 @@ bool Symtab::getContainingInlinedFunction(Offset offset, FunctionBase* &func)
    std::call_once(impl->funcRangesAreParsed, [this](){ this->parseFunctionRanges(); });
    
    set<FuncRange *> ranges;
-   int num_found = func_lookup.find(offset, ranges);
+   int num_found = impl->func_lookup.find(offset, ranges);
    if (num_found == 0) {
       func = NULL;
       return false;

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -364,7 +364,7 @@ bool Symtab::findModuleByOffset(Module *&ret, Offset off)
 {
     dyn_mutex::unique_lock l(impl->im_lock);
     std::set<ModRange*> mods;
-    mod_lookup()->find(off, mods);
+    impl->mod_lookup_.find(off, mods);
     if(!mods.empty())
     {
         ret = (*mods.begin())->id();
@@ -377,7 +377,7 @@ bool Symtab::findModuleByOffset(std::set<Module *>&ret, Offset off)
     dyn_mutex::unique_lock l(impl->im_lock);
     std::set<ModRange*> mods;
     ret.clear();
-    mod_lookup()->find(off, mods);
+    impl->mod_lookup_.find(off, mods);
     for(auto i = mods.begin();
             i != mods.end();
             ++i)

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -245,7 +245,7 @@ bool Symtab::findFuncByEntryOffset(Function *&ret, const Offset entry)
      */
     {
         dyn_c_hash_map<Offset,Function*>::const_accessor ca;
-        if (funcsByOffset.find(ca, entry)) {
+        if (impl->funcsByOffset.find(ca, entry)) {
             ret = ca->second;
             return true;
         }

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -815,7 +815,7 @@ bool Symtab::getContainingFunction(Offset offset, Function* &func)
 bool Symtab::getContainingInlinedFunction(Offset offset, FunctionBase* &func)
 {   
    // Lazily parse the function ranges, but ensure we only do it once.
-   std::call_once(funcRangesAreParsed, [this](){ this->parseFunctionRanges(); });
+   std::call_once(impl->funcRangesAreParsed, [this](){ this->parseFunctionRanges(); });
    
    set<FuncRange *> ranges;
    int num_found = func_lookup.find(offset, ranges);

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -349,10 +349,10 @@ bool Symtab::getAllVariables(std::vector<Variable *> &ret)
 
 bool Symtab::getAllModules(std::vector<Module *> &ret)
 {
-    dyn_mutex::unique_lock l(im_lock);
-    if (indexed_modules.size() >0 )
+    dyn_mutex::unique_lock l(impl->im_lock);
+    if (impl->indexed_modules.size() >0 )
     {
-        std::copy(indexed_modules.begin(), indexed_modules.end(), std::back_inserter(ret));
+        std::copy(impl->indexed_modules.begin(), impl->indexed_modules.end(), std::back_inserter(ret));
         return true;
     }	
 
@@ -362,7 +362,7 @@ bool Symtab::getAllModules(std::vector<Module *> &ret)
 
 bool Symtab::findModuleByOffset(Module *&ret, Offset off)
 {
-    dyn_mutex::unique_lock l(im_lock);
+    dyn_mutex::unique_lock l(impl->im_lock);
     std::set<ModRange*> mods;
     mod_lookup()->find(off, mods);
     if(!mods.empty())
@@ -374,7 +374,7 @@ bool Symtab::findModuleByOffset(Module *&ret, Offset off)
 
 bool Symtab::findModuleByOffset(std::set<Module *>&ret, Offset off)
 {
-    dyn_mutex::unique_lock l(im_lock);
+    dyn_mutex::unique_lock l(impl->im_lock);
     std::set<ModRange*> mods;
     ret.clear();
     mod_lookup()->find(off, mods);
@@ -389,10 +389,10 @@ bool Symtab::findModuleByOffset(std::set<Module *>&ret, Offset off)
 
 bool Symtab::findModuleByName(Module *&ret, const std::string name)
 {
-   dyn_mutex::unique_lock l(im_lock);
-   auto loc = indexed_modules.get<2>().find(name);
+   dyn_mutex::unique_lock l(impl->im_lock);
+   auto loc = impl->indexed_modules.get<2>().find(name);
 
-   if (loc != indexed_modules.get<2>().end())
+   if (loc != impl->indexed_modules.get<2>().end())
    {
       ret = *(loc);
       return true;
@@ -854,9 +854,9 @@ bool Symtab::getContainingInlinedFunction(Offset offset, FunctionBase* &func)
 }
 
 Module *Symtab::getDefaultModule() {
-    dyn_mutex::unique_lock l(im_lock);
-    if(indexed_modules.empty()) createDefaultModule();
-    return indexed_modules[0];
+    dyn_mutex::unique_lock l(impl->im_lock);
+    if(impl->indexed_modules.empty()) createDefaultModule();
+    return impl->indexed_modules[0];
 }
 
 unsigned Function::getSymbolSize() const {

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -303,8 +303,8 @@ bool Symtab::findVariablesByOffset(std::vector<Variable *> &ret, const Offset of
      * relocatable files -- this discrepancy applies here as well.
      */
     {
-        VarsByOffsetMap::const_accessor ca;
-        if (varsByOffset.find(ca, offset)) {
+        decltype(impl->varsByOffset)::const_accessor ca;
+        if (impl->varsByOffset.find(ca, offset)) {
             ret = ca->second;
             return true;
         }

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -637,9 +637,9 @@ bool Symtab::addSymbolToAggregates(const Symbol *sym_tmp)
         Variable *var = NULL;
         bool found = false;
         {
-            VarsByOffsetMap::accessor a;
-            found = !varsByOffset.insert(a, sym->getOffset());
-            VarsByOffsetMap::mapped_type &vars = a->second;
+            decltype(impl->varsByOffset)::accessor a;
+            found = !impl->varsByOffset.insert(a, sym->getOffset());
+            decltype(impl->varsByOffset)::mapped_type &vars = a->second;
             if (found)  {
                 found = false;
                 for (auto v: vars)  {
@@ -1336,7 +1336,7 @@ Symtab::~Symtab()
    }
 
    everyVariable.clear();
-   varsByOffset.clear();
+   impl->varsByOffset.clear();
 
     for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
    {

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -498,7 +498,7 @@ bool Symtab::fixSymModules(std::vector<Symbol *> &raw_syms)
     if (!obj) {
        return false;
     }
-    for (auto i = indexed_modules.begin(); i != indexed_modules.end(); ++i)
+    for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
     {
         for(auto *m : (*i)->finalizeRanges()) {
             mod_lookup_.insert(m);
@@ -738,7 +738,7 @@ void Symtab::setModuleLanguages(dyn_hash_map<std::string, supportedLanguages> *m
    Module *currmod = NULL;
    //int dump = 0;
 
-    for (auto i = indexed_modules.begin(); i != indexed_modules.end(); ++i)
+    for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
    {
       currmod = (*i);
       supportedLanguages currLang;
@@ -775,13 +775,13 @@ void Symtab::setModuleLanguages(dyn_hash_map<std::string, supportedLanguages> *m
 }
 
 void Symtab::createDefaultModule() {
-    assert(indexed_modules.empty());
+    assert(impl->indexed_modules.empty());
     Module *mod = new Module(lang_Unknown,
                      imageOffset_,
                      file(),
                      this);
     mod->addRange(imageOffset_, imageLen_ + imageOffset_);
-    indexed_modules.push_back(mod);
+    impl->indexed_modules.push_back(mod);
     for(auto *m : mod->finalizeRanges()) {
       mod_lookup_.insert(m);
     }
@@ -792,7 +792,7 @@ void Symtab::createDefaultModule() {
 Module *Symtab::getOrCreateModule(const std::string &modName, 
                                   const Offset modAddr)
 {
-    if(indexed_modules.empty()) {
+    if(impl->indexed_modules.empty()) {
         createDefaultModule();
     }
 
@@ -840,13 +840,13 @@ Module *Symtab::newModule(const std::string &name, const Offset addr, supportedL
     ret = new Module(lang, addr, fullNm, this);
     assert(ret);
 
-   if (indexed_modules.get<2>().end() != indexed_modules.get<2>().find(ret->fileName()))
+    if (impl->indexed_modules.get<2>().end() != impl->indexed_modules.get<2>().find(ret->fileName()))
     {
        create_printf("%s[%d]:  WARN:  LEAK?  already have module with name %s\n", 
              FILE__, __LINE__, ret->fileName().c_str());
     }
 
-    indexed_modules.push_back(ret);
+    impl->indexed_modules.push_back(ret);
     
     return (ret);
 }
@@ -1338,11 +1338,11 @@ Symtab::~Symtab()
    everyVariable.clear();
    varsByOffset.clear();
 
-    for (auto i = indexed_modules.begin(); i != indexed_modules.end(); ++i)
+    for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
    {
       delete (*i);
    }
-   indexed_modules.clear();
+   impl->indexed_modules.clear();
 
    for (unsigned i=0;i<excpBlocks.size();i++)
       delete excpBlocks[i];
@@ -1621,7 +1621,7 @@ SYMTAB_EXPORT bool Symtab::getAddressRanges(std::vector<AddressRange > &ranges,
    parseLineInformation();
    
    /* Iteratate over the modules, looking for ranges in each. */
-    for (auto i = indexed_modules.begin(); i != indexed_modules.end(); ++i)
+    for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
    {
        StringTablePtr s = (*i)->getStrings();
        boost::unique_lock<dyn_mutex> l(s->lock);
@@ -1740,7 +1740,7 @@ void Symtab::parseTypes()
 	}
     linkedFile->parseTypeInfo();
 
-    for (auto i = indexed_modules.begin(); i != indexed_modules.end(); ++i)
+    for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
    {
        (*i)->setModuleTypes(typeCollection::getModTypeCollection((*i)));
        for(auto *m : (*i)->finalizeRanges()) {
@@ -1779,10 +1779,10 @@ SYMTAB_EXPORT bool Symtab::findType(boost::shared_ptr<Type> &type, std::string n
 {
    parseTypesNow();
 
-   if (indexed_modules.empty())
+   if (impl->indexed_modules.empty())
       return false;
 
-   for (auto i = indexed_modules.begin(); i != indexed_modules.end(); ++i)
+   for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
    {
 	   typeCollection *tc = (*i)->getModuleTypes();
 	   if (!tc) continue;
@@ -1801,12 +1801,12 @@ SYMTAB_EXPORT boost::shared_ptr<Type> Symtab::findType(unsigned type_id, Type::d
 	boost::shared_ptr<Type> t;
    parseTypesNow();
 
-   if (indexed_modules.empty())
+   if (impl->indexed_modules.empty())
    {
       return NULL;
    }
 
-   for (auto i = indexed_modules.begin(); i != indexed_modules.end(); ++i)
+   for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
    {
 	   typeCollection *tc = (*i)->getModuleTypes();
 	   if (!tc) continue;
@@ -1838,7 +1838,7 @@ SYMTAB_EXPORT bool Symtab::findVariableType(boost::shared_ptr<Type>& type, std::
 {
    parseTypesNow();
     type = NULL;
-   for (auto i = indexed_modules.begin(); i != indexed_modules.end(); ++i)
+   for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
    {
 	   typeCollection *tc = (*i)->getModuleTypes();
 	   if (!tc) continue;

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -501,7 +501,7 @@ bool Symtab::fixSymModules(std::vector<Symbol *> &raw_syms)
     for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
     {
         for(auto *m : (*i)->finalizeRanges()) {
-            mod_lookup_.insert(m);
+            impl->mod_lookup_.insert(m);
         }
     }
 
@@ -783,7 +783,7 @@ void Symtab::createDefaultModule() {
     mod->addRange(imageOffset_, imageLen_ + imageOffset_);
     impl->indexed_modules.push_back(mod);
     for(auto *m : mod->finalizeRanges()) {
-      mod_lookup_.insert(m);
+	impl->mod_lookup_.insert(m);
     }
 }
 
@@ -1744,7 +1744,7 @@ void Symtab::parseTypes()
    {
        (*i)->setModuleTypes(typeCollection::getModTypeCollection((*i)));
        for(auto *m : (*i)->finalizeRanges()) {
-	 mod_lookup_.insert(m);
+	   impl->mod_lookup_.insert(m);
        }
    }
 
@@ -2706,14 +2706,8 @@ void Symtab::rebase(Offset loadOff)
 	load_address_ = loadOff;
 }
 
-ModRangeLookup *Symtab::mod_lookup() {
-    return &mod_lookup_;
-
-}
-
-
 void Symtab::dumpModRanges() {
-    mod_lookup_.PrintPreorder();
+    impl->mod_lookup_.PrintPreorder();
 }
 
 void Symtab::dumpFuncRanges() {

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -2494,7 +2494,7 @@ const Object *Symtab::getObject() const
 
 void Symtab::parseTypesNow()
 {
-   std::call_once(this->types_parsed, [this](){ this->parseTypes(); });
+   std::call_once(this->impl->types_parsed, [this](){ this->parseTypes(); });
 }
 
 SYMTAB_EXPORT Offset Symtab::getElfDynamicOffset()

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -2711,5 +2711,5 @@ void Symtab::dumpModRanges() {
 }
 
 void Symtab::dumpFuncRanges() {
-    func_lookup.PrintPreorder();
+    impl->func_lookup.PrintPreorder();
 }

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -596,7 +596,7 @@ bool Symtab::addSymbolToAggregates(const Symbol *sym_tmp)
         bool found = false;
         {
             dyn_c_hash_map<Offset,Function*>::accessor a;
-            found = !funcsByOffset.insert(a, sym->getOffset());
+            found = !impl->funcsByOffset.insert(a, sym->getOffset());
             if(found) func = a->second;
             else {
             // Create a new function
@@ -1328,7 +1328,7 @@ Symtab::~Symtab()
    }
 
    everyFunction.clear();
-   funcsByOffset.clear();
+   impl->funcsByOffset.clear();
 
    for (unsigned i = 0; i < everyVariable.size(); i++) 
    {

--- a/symtabAPI/src/indexed_symbols.hpp
+++ b/symtabAPI/src/indexed_symbols.hpp
@@ -1,0 +1,130 @@
+#ifndef INDEXED_SYMBOLS_HPP
+#define INDEXED_SYMBOLS_HPP
+
+#include "Symbol.h"
+#include "concurrent.h"
+#include <iterator>
+#include <utility>
+#include <vector>
+
+namespace st = Dyninst::SymtabAPI;
+
+struct indexed_symbols {
+  typedef Dyninst::dyn_c_hash_map<st::Symbol *, Dyninst::Offset> master_t;
+  typedef std::vector<st::Symbol *> symvec_t;
+  typedef Dyninst::dyn_c_hash_map<Offset, symvec_t> by_offset_t;
+  typedef Dyninst::dyn_c_hash_map<std::string, symvec_t> by_name_t;
+
+  master_t master;
+  by_offset_t by_offset;
+  by_name_t by_mangled;
+  by_name_t by_pretty;
+  by_name_t by_typed;
+
+  // Only inserts if not present. Returns whether it inserted.
+  // Operations on the indexed_symbols compound table.
+  bool insert(st::Symbol *s) {
+    Offset o = s->getOffset();
+    master_t::accessor a;
+    if (master.insert(a, std::make_pair(s, o))) {
+      {
+        by_offset_t::accessor oa;
+        by_offset.insert(oa, o);
+        oa->second.push_back(s);
+      }
+      {
+        by_name_t::accessor ma;
+        by_mangled.insert(ma, s->getMangledName());
+        ma->second.push_back(s);
+      }
+      {
+        by_name_t::accessor pa;
+        by_pretty.insert(pa, s->getPrettyName());
+        pa->second.push_back(s);
+      }
+      {
+        by_name_t::accessor ta;
+        by_typed.insert(ta, s->getTypedName());
+        ta->second.push_back(s);
+      }
+
+      return true;
+    }
+    return false;
+  }
+
+  // Clears the table. Do not use in parallel.
+  void clear() {
+    master.clear();
+    by_offset.clear();
+    by_mangled.clear();
+    by_pretty.clear();
+    by_typed.clear();
+  }
+
+  // Erases Symbols from the table. Do not use in parallel.
+  void erase(st::Symbol *s) {
+    if (master.erase(s)) {
+      {
+        by_offset_t::accessor oa;
+        if (!by_offset.find(oa, s->getOffset())) {
+          assert(!"by_offset.find(oa, s->getOffset())");
+        }
+        std::remove(oa->second.begin(), oa->second.end(), s);
+      }
+      {
+        by_name_t::accessor ma;
+        if (!by_mangled.find(ma, s->getMangledName())) {
+          assert(!"by_mangled.find(ma, s->getMangledName())");
+        }
+        std::remove(ma->second.begin(), ma->second.end(), s);
+      }
+      {
+        by_name_t::accessor pa;
+        if (!by_pretty.find(pa, s->getPrettyName())) {
+          assert(!"by_pretty.find(pa, s->getPrettyName())");
+        }
+        std::remove(pa->second.begin(), pa->second.end(), s);
+      }
+      {
+        by_name_t::accessor ta;
+        if (!by_typed.find(ta, s->getTypedName())) {
+          assert(!"by_typed.find(ta, s->getTypedName())");
+        }
+        std::remove(ta->second.begin(), ta->second.end(), s);
+      }
+    }
+  }
+
+  // Iterator for the symbols. Do not use in parallel.
+  class iterator {
+    master_t::iterator m;
+
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = st::Symbol *;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
+    iterator(master_t::iterator i) : m(i) {}
+    bool operator==(const iterator &x) const { return m == x.m; }
+    bool operator!=(const iterator &x) const { return !operator==(x); }
+    st::Symbol *const &operator*() const { return m->first; }
+    st::Symbol *const *operator->() const { return &operator*(); }
+    iterator &operator++() {
+      ++m;
+      return *this;
+    }
+    iterator operator++(int) {
+      iterator old(m);
+      operator++();
+      return old;
+    }
+  };
+
+  iterator begin() { return iterator(master.begin()); }
+  iterator end() { return iterator(master.end()); }
+};
+
+#endif

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -42,6 +42,9 @@ namespace Dyninst { namespace SymtabAPI {
 
     using ModRangeLookup = IBSTree<ModRange>;
     ModRangeLookup mod_lookup_{};
+
+    using FuncRangeLookup = IBSTree<FuncRange>;
+    FuncRangeLookup func_lookup{};
   };
 
 }}

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -6,8 +6,8 @@
 #include "concurrent.h"
 #include "indexed_symbols.hpp"
 
-#include <string>
 #include <mutex>
+#include <string>
 
 #include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -36,7 +36,7 @@ namespace Dyninst { namespace SymtabAPI {
     // efficiently track them.
     dyn_c_hash_map<Offset, Function *> funcsByOffset{};
 
-    using VarsByOffsetMap = dyn_c_hash_map<Offset, std::vector<Variable *> >;
+    using VarsByOffsetMap = dyn_c_hash_map<Offset, std::vector<Variable *>>;
     VarsByOffsetMap varsByOffset{};
   };
 

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -29,6 +29,7 @@ namespace Dyninst { namespace SymtabAPI {
         indexed_modules{};
 
     std::once_flag funcRangesAreParsed;
+    std::once_flag types_parsed;
   };
 
 }}

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -6,6 +6,7 @@
 #include "indexed_symbols.hpp"
 
 #include <string>
+#include <mutex>
 
 #include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -26,6 +27,8 @@ namespace Dyninst { namespace SymtabAPI {
                       boost::multi_index::ordered_non_unique<boost::multi_index::const_mem_fun<
                           Module, const std::string &, &Module::fileName>>>>
         indexed_modules{};
+
+    std::once_flag funcRangesAreParsed;
   };
 
 }}

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -30,6 +30,10 @@ namespace Dyninst { namespace SymtabAPI {
 
     std::once_flag funcRangesAreParsed;
     std::once_flag types_parsed;
+
+    // Since Functions are unique by address, we require this structure to
+    // efficiently track them.
+    dyn_c_hash_map<Offset, Function *> funcsByOffset{};
   };
 
 }}

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -1,6 +1,7 @@
 #ifndef SYMTAB_IMPL_HPP
 #define SYMTAB_IMPL_HPP
 
+#include "IBSTree.h"
 #include "Module.h"
 #include "Variable.h"
 #include "concurrent.h"
@@ -38,6 +39,9 @@ namespace Dyninst { namespace SymtabAPI {
 
     using VarsByOffsetMap = dyn_c_hash_map<Offset, std::vector<Variable *>>;
     VarsByOffsetMap varsByOffset{};
+
+    using ModRangeLookup = IBSTree<ModRange>;
+    ModRangeLookup mod_lookup_{};
   };
 
 }}

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -2,6 +2,7 @@
 #define SYMTAB_IMPL_HPP
 
 #include "Module.h"
+#include "Variable.h"
 #include "concurrent.h"
 #include "indexed_symbols.hpp"
 
@@ -34,6 +35,9 @@ namespace Dyninst { namespace SymtabAPI {
     // Since Functions are unique by address, we require this structure to
     // efficiently track them.
     dyn_c_hash_map<Offset, Function *> funcsByOffset{};
+
+    using VarsByOffsetMap = dyn_c_hash_map<Offset, std::vector<Variable *> >;
+    VarsByOffsetMap varsByOffset{};
   };
 
 }}

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -1,0 +1,15 @@
+#ifndef SYMTAB_IMPL_HPP
+#define SYMTAB_IMPL_HPP
+
+#include "indexed_symbols.hpp"
+
+namespace Dyninst { namespace SymtabAPI {
+
+  struct symtab_impl final {
+    indexed_symbols everyDefinedSymbol{};
+    indexed_symbols undefDynSyms{};
+  };
+
+}}
+
+#endif

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -7,13 +7,12 @@
 #include "concurrent.h"
 #include "indexed_symbols.hpp"
 
-#include <mutex>
-#include <string>
-
 #include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index_container.hpp>
+#include <mutex>
+#include <string>
 
 namespace Dyninst { namespace SymtabAPI {
 

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -1,13 +1,31 @@
 #ifndef SYMTAB_IMPL_HPP
 #define SYMTAB_IMPL_HPP
 
+#include "Module.h"
+#include "concurrent.h"
 #include "indexed_symbols.hpp"
+
+#include <string>
+
+#include <boost/multi_index/mem_fun.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/random_access_index.hpp>
+#include <boost/multi_index_container.hpp>
 
 namespace Dyninst { namespace SymtabAPI {
 
   struct symtab_impl final {
     indexed_symbols everyDefinedSymbol{};
     indexed_symbols undefDynSyms{};
+
+    Dyninst::dyn_mutex im_lock{};
+    boost::multi_index_container<
+        Module *, boost::multi_index::indexed_by<
+                      boost::multi_index::random_access<>,
+                      boost::multi_index::ordered_unique<boost::multi_index::identity<Module *>>,
+                      boost::multi_index::ordered_non_unique<boost::multi_index::const_mem_fun<
+                          Module, const std::string &, &Module::fileName>>>>
+        indexed_modules{};
   };
 
 }}


### PR DESCRIPTION
This allows us to more easily modify the parallelism around the big tables (e.g., `indexed_modules`) without bumping the ABI around, meaning we don't have to wait until a major release to make those changes. This also removes internal details like `concurrent.h` which puts TBB into the pubic API and the multiple Boost headers needed for `multi_index`.

Although `ModRangeLookup* mod_lookup();` was a public member, it was never documented, and should never be called by a user. I'm not considering this an API-breaking change.