### PR TITLE
Make a default module a class invariant in Symtab

### DIFF
--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -854,9 +854,7 @@ bool Symtab::getContainingInlinedFunction(Offset offset, FunctionBase* &func)
 }
 
 Module *Symtab::getDefaultModule() {
-    dyn_mutex::unique_lock l(impl->im_lock);
-    if(impl->indexed_modules.empty()) createDefaultModule();
-    return impl->indexed_modules[0];
+    return impl->default_module;
 }
 
 unsigned Function::getSymbolSize() const {

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -307,6 +307,7 @@ SYMTAB_EXPORT bool Symtab::isBigEndianDataEncoding() const
 SYMTAB_EXPORT Symtab::Symtab(MappedFile *mf_) : Symtab()
 {
 		mf = mf_;
+  createDefaultModule();
 }
 
 SYMTAB_EXPORT Symtab::Symtab() :
@@ -498,6 +499,11 @@ bool Symtab::fixSymModules(std::vector<Symbol *> &raw_syms)
     if (!obj) {
        return false;
     }
+
+    if(!impl->default_module) {
+	createDefaultModule();
+    }
+
     for (auto i = impl->indexed_modules.begin(); i != impl->indexed_modules.end(); ++i)
     {
         for(auto *m : (*i)->finalizeRanges()) {
@@ -780,12 +786,12 @@ void Symtab::setModuleLanguages(dyn_hash_map<std::string, supportedLanguages> *m
 }
 
 void Symtab::createDefaultModule() {
-    assert(impl->indexed_modules.empty());
     Module *mod = new Module(lang_Unknown,
                      imageOffset_,
                      file(),
                      this);
     mod->addRange(imageOffset_, imageLen_ + imageOffset_);
+    impl->default_module = mod;
     impl->indexed_modules.push_back(mod);
     for(auto *m : mod->finalizeRanges()) {
 	impl->mod_lookup_.insert(m);
@@ -797,10 +803,6 @@ void Symtab::createDefaultModule() {
 Module *Symtab::getOrCreateModule(const std::string &modName, 
                                   const Offset modAddr)
 {
-    if(impl->indexed_modules.empty()) {
-        createDefaultModule();
-    }
-
    Module *fm = NULL;
    if (findModuleByName(fm, modName))
    {

--- a/symtabAPI/src/symtab_impl.hpp
+++ b/symtabAPI/src/symtab_impl.hpp
@@ -44,6 +44,8 @@ namespace Dyninst { namespace SymtabAPI {
 
     using FuncRangeLookup = IBSTree<FuncRange>;
     FuncRangeLookup func_lookup{};
+
+    Module* default_module{};
   };
 
 }}


### PR DESCRIPTION
This simplifies the handling of modules and ensures a default always exists. Creation must happen after the MappedFile has been created (`Symtab::file()` checks that one has been created), but before the symbols are assigned to a Module.