### PR TITLE
Add new Symtab interface for accessing modules by offset

### DIFF
--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -1697,10 +1697,9 @@ parse_func *image::addFunction(Address functionEntryAddr, const char *fName)
      }
      region = *(regions.begin()); // XXX pick one, throwing up hands. 
 
-     std::set<Module*> st_mod;
-     linkedFile->findModuleByOffset(st_mod, functionEntryAddr);
+     auto *m = linkedFile->findModuleByOffset(functionEntryAddr);
      
-     pdmodule *mod = getOrCreateModule(*(st_mod.begin()));
+     pdmodule *mod = getOrCreateModule(m);
 
      // copy or create function name
      char funcName[32];

--- a/symtabAPI/doc/API/Symtab/Symtab.tex
+++ b/symtabAPI/doc/API/Symtab/Symtab.tex
@@ -163,14 +163,6 @@ This method searches for a module with name \code{name}. If the module exists re
 }
 
 \begin{apient}
-bool findModuleByOffset(Module *&ret,
-                        Offset offset)
-\end{apient}
-\apidesc{
-This method searches for a module that starts at offset \code{offset}. If the module exists returns \code{true} with \code{ret} set to the module handle; otherwise returns \code{false} with \code{ret} set to \code{NULL}.
-}
-
-\begin{apient}
 Module* findModuleByOffset(Offset offset) const
 \end{apient}
 \apidesc{

--- a/symtabAPI/doc/API/Symtab/Symtab.tex
+++ b/symtabAPI/doc/API/Symtab/Symtab.tex
@@ -171,6 +171,13 @@ This method searches for a module that starts at offset \code{offset}. If the mo
 }
 
 \begin{apient}
+Module* findModuleByOffset(Offset offset) const
+\end{apient}
+\apidesc{
+Returns the module starting at \code{offset}; \code{nullptr}, if not found.
+}
+
+\begin{apient}
 bool getAllModules(vector<module *> &ret)
 \end{apient}
 \apidesc{

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -187,7 +187,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    // Module
 
    bool getAllModules(std::vector<Module *>&ret);
-   bool findModuleByOffset(std::set<Module *>& ret, Offset off);
    /*[[deprecated]]*/ bool findModuleByOffset(Module *& ret, Offset off);
    Module* findModuleByOffset(Offset offset) const;
    bool findModuleByName(Module *&ret, const std::string name);

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -189,6 +189,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool getAllModules(std::vector<Module *>&ret);
    bool findModuleByOffset(std::set<Module *>& ret, Offset off);
    bool findModuleByOffset(Module *& ret, Offset off);
+   Module* findModuleByOffset(Offset offset) const;
    bool findModuleByName(Module *&ret, const std::string name);
    Module *getDefaultModule() const;
 

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -188,7 +188,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
    bool getAllModules(std::vector<Module *>&ret);
    bool findModuleByOffset(std::set<Module *>& ret, Offset off);
-   bool findModuleByOffset(Module *& ret, Offset off);
+   /*[[deprecated]]*/ bool findModuleByOffset(Module *& ret, Offset off);
    Module* findModuleByOffset(Offset offset) const;
    bool findModuleByName(Module *&ret, const std::string name);
    Module *getDefaultModule() const;

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3698,13 +3698,8 @@ void Object::parseLineInfoForAddr(Offset addr_to_find) {
     Dwarf **dbg_ptr = dwarf->line_dbg();
     if (!dbg_ptr)
         return;
-    std::set<Module *> mod_for_offset;
-    associated_symtab->findModuleByOffset(mod_for_offset, addr_to_find);
-    for (auto mod = mod_for_offset.begin();
-         mod != mod_for_offset.end();
-         ++mod) {
-        (*mod)->parseLineInformation();
-    }
+    auto *m = associated_symtab->findModuleByOffset(addr_to_find);
+    if(m) m->parseLineInformation();
     // no mod for offset means no line info for sure if we've parsed all ranges...
 }
 

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -365,20 +365,6 @@ Module* Symtab::findModuleByOffset(Offset offset) const {
   return impl->modules.find(offset);
 }
 
-bool Symtab::findModuleByOffset(std::set<Module *>&ret, Offset off)
-{
-    std::set<ModRange*> mods;
-    ret.clear();
-    impl->mod_lookup_.find(off, mods);
-    for(auto i = mods.begin();
-            i != mods.end();
-            ++i)
-    {
-        ret.insert((*i)->id());
-    }
-    return !ret.empty();
-}
-
 bool Symtab::findModuleByName(Module *&ret, const std::string name)
 {
    auto const& mods = impl->modules.find(name);

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -357,13 +357,8 @@ bool Symtab::getAllModules(std::vector<Module *> &ret)
 
 bool Symtab::findModuleByOffset(Module *&ret, Offset off)
 {
-    std::set<ModRange*> mods;
-    impl->mod_lookup_.find(off, mods);
-    if(!mods.empty())
-    {
-        ret = (*mods.begin())->id();
-    }
-    return !mods.empty();
+   ret = findModuleByOffset(off);
+   return ret != nullptr;
 }
 
 Module* Symtab::findModuleByOffset(Offset offset) const {

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -366,6 +366,10 @@ bool Symtab::findModuleByOffset(Module *&ret, Offset off)
     return !mods.empty();
 }
 
+Module* Symtab::findModuleByOffset(Offset offset) const {
+  return impl->modules.find(offset);
+}
+
 bool Symtab::findModuleByOffset(std::set<Module *>&ret, Offset off)
 {
     std::set<ModRange*> mods;

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -1651,14 +1651,11 @@ SYMTAB_EXPORT bool Symtab::getAddressRanges(std::vector<AddressRange > &ranges,
 SYMTAB_EXPORT bool Symtab::getSourceLines(std::vector<Statement::Ptr> &lines, Offset addressInRange)
 {
    unsigned int originalSize = lines.size();
-    std::set<Module*> mods_for_offset;
-    findModuleByOffset(mods_for_offset, addressInRange);
-    for(auto i = mods_for_offset.begin();
-            i != mods_for_offset.end();
-            ++i)
-    {
-        (*i)->getSourceLines(lines, addressInRange);
-    }
+    Module* m = findModuleByOffset(addressInRange);
+
+    if(!m) return false;
+
+    m->getSourceLines(lines, addressInRange);
 
    if ( lines.size() != originalSize )
       return true;


### PR DESCRIPTION
- Add findModuleByOffset(Offset)

- Deprecate findModuleByOffset(Module *&, Offset)
    It is replaced by findModuleByOffset(Offset).

- Remove findModuleByOffset(std::set<Module *>&, Offset)
    It was never documented and makes no sense as offsets are unique
    within a module (i.e., DWARF CU). Dyninst uses a separate
    Symtab instance for each object file in an archive, as well.
