### PR TITLE
Remove DwarfWalker::setModuleFromName

### DIFF
--- a/symtabAPI/src/dwarfWalker.h
+++ b/symtabAPI/src/dwarfWalker.h
@@ -170,7 +170,6 @@ public:
     {
         return symtab()->file();
     }
-    virtual void setModuleFromName(std::string moduleName);
     virtual Dyninst::Architecture getArchitecture() const
     {
         return symtab()->getArchitecture();


### PR DESCRIPTION
It's replaced with the updated Symtab::findModuleByOffset. Finding by name was always unnecessary as we know the offset of the current DIE.

This is a step toward removing the broken Symtab::findModuleByName.