### PR TITLE
Mark SymtabAPI::Function::removeSymbol as 'override'

### DIFF
--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -168,7 +168,7 @@ class SYMTAB_EXPORT FunctionBase
    virtual ~Function();
 
    /* Symbol management */
-   bool removeSymbol(Symbol *sym);
+   bool removeSymbol(Symbol *sym) override;
 
    /***** IA64-Specific Frame Pointer Information *****/
    bool  setFramePtrRegnum(int regnum);


### PR DESCRIPTION
This was detected by -Winconsistent-missing-override enabled by default in clang-15.