### PR TITLE
Add findModulesByName(std::string const&)

### DIFF
--- a/symtabAPI/doc/API/Symtab/Symtab.tex
+++ b/symtabAPI/doc/API/Symtab/Symtab.tex
@@ -163,6 +163,13 @@ This method searches for a module with name \code{name}. If the module exists re
 }
 
 \begin{apient}
+std::vector<Module*> findModulesByName(std::string const& name) const
+\end{apient}
+\apidesc{
+Retrieve all modules with name \code{name}.
+}
+
+\begin{apient}
 Module* findModuleByOffset(Offset offset) const
 \end{apient}
 \apidesc{

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -190,6 +190,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    /*[[deprecated]]*/ bool findModuleByOffset(Module *& ret, Offset off);
    Module* findModuleByOffset(Offset offset) const;
    bool findModuleByName(Module *&ret, const std::string name);
+   std::vector<Module*> findModulesByName(std::string const& name) const;
    Module *getDefaultModule() const;
 
    // Region

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -375,6 +375,10 @@ bool Symtab::findModuleByName(Module *&ret, const std::string name)
    return false;
 }
 
+std::vector<Module*> Symtab::findModulesByName(std::string const& name) const {
+  return impl->modules.find(name);
+}
+
 bool Symtab::getAllRegions(std::vector<Region *>&ret)
 {
    if (regions_.size() > 0)


### PR DESCRIPTION
This will eventually replace `findModuleByName(Module *&ret, const std::string name)`.