### PR TITLE
Create unique name for unnamed partial DWARF DIEs

### DIFF
--- a/dwarf/CMakeLists.txt
+++ b/dwarf/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT DYNINST_OS_UNIX)
 endif()
 
 set(_public_headers h/dwarfExprParser.h h/dwarfFrameParser.h h/dwarfHandle.h
-                    h/dwarfResult.h)
+                    h/dwarfResult.h h/dwarf_unit_info.h)
 
 set(_sources src/dwarfResult.C src/dwarfExprParser.C src/dwarfFrameParser.C
              src/dwarfHandle.C src/dwarf_subrange.cpp)

--- a/dwarf/h/dwarf_cu_info.h
+++ b/dwarf/h/dwarf_cu_info.h
@@ -32,18 +32,12 @@
 #define DWARFDYNINST_DWARF_CU_INFO_HPP
 
 #include "dwarf_names.h"
+#include "dwarf_unit_info.h"
 #include <dwarf.h>
 #include <elfutils/libdw.h>
 #include <string>
 
 namespace Dyninst { namespace DwarfDyninst {
-
-  // We purposefully don't include DW_TAG_skeleton_unit here as
-  // libdw should merge those into a single CU for us.
-  inline bool is_full_unit(Dwarf_Die die) { return dwarf_tag(&die) == DW_TAG_compile_unit; }
-  inline bool is_partial_unit(Dwarf_Die die) { return dwarf_tag(&die) == DW_TAG_partial_unit; }
-  inline bool is_type_unit(Dwarf_Die die) { return dwarf_tag(&die) == DW_TAG_type_unit; }
-  inline bool is_imported_unit(Dwarf_Die die) { return dwarf_tag(&die) == DW_TAG_imported_unit; }
 
   inline bool is_cudie(Dwarf_Die die) {
     // If there is not an inner CU attribute, then it's not a CU

--- a/dwarf/h/dwarf_names.h
+++ b/dwarf/h/dwarf_names.h
@@ -36,6 +36,7 @@
 #include <iomanip>
 #include <string>
 #include <sstream>
+#include "dwarf_unit_info.h"
 
 namespace Dyninst { namespace DwarfDyninst {
 
@@ -127,11 +128,10 @@ namespace Dyninst { namespace DwarfDyninst {
 
     auto name = detail::die_name(die);
 
-    // There is no standard for naming artificial DIEs, so we just
-    // append the DIE's location to it. For C++ member functions,
-    // compilers will sometimes add a DW_AT_name called 'this', and
-    // we don't want to mangle that.
-    if (name.empty() && is_artificial_die(die)) {
+    // For artificial DIEs or partial units, append the DIE's location to its name (if any).
+    // For C++ member functions, compilers will sometimes add a DW_AT_name called 'this',
+    // and we don't want to mangle that.
+    if (name.empty() && (is_artificial_die(die) || is_partial_unit(die))) {
       name += "(" + detail::die_offset(die) + ")";
       return name;
     }

--- a/dwarf/h/dwarf_unit_info.h
+++ b/dwarf/h/dwarf_unit_info.h
@@ -1,0 +1,43 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DWARF_UNIT_INFO_H
+#define DWARF_UNIT_INFO_H
+
+namespace Dyninst { namespace DwarfDyninst {
+  // We purposefully don't include DW_TAG_skeleton_unit here as
+  // libdw should merge those into a single CU for us.
+  inline bool is_full_unit(Dwarf_Die die) { return dwarf_tag(&die) == DW_TAG_compile_unit; }
+  inline bool is_partial_unit(Dwarf_Die die) { return dwarf_tag(&die) == DW_TAG_partial_unit; }
+  inline bool is_type_unit(Dwarf_Die die) { return dwarf_tag(&die) == DW_TAG_type_unit; }
+  inline bool is_imported_unit(Dwarf_Die die) { return dwarf_tag(&die) == DW_TAG_imported_unit; }
+}}
+
+#endif


### PR DESCRIPTION
This also refactors the unit type checks out of dwarf_cu_info.h into dwarf_unit_info.h.

This fixes the crashes found by @bigtrak on Fedora. The root cause there is that their system libraries are assembled as a collection of DW_TAG_partial_units instead of DW_TAG_compilation_units. This is likely due to them using split and compressed DWARF (at least its a recommended idiom for that case).