### PR TITLE
warning fix:  improve logical-op handling

### DIFF
--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -2366,15 +2366,10 @@ bool shouldSaveReg(registerSlot *reg, baseTramp *inst, bool saveFlags)
    if (saveFlags) {
       // Saving flags takes up EAX/RAX, and so if they're live they must
       // be saved even if we don't explicitly use them
-#if !defined(__GNUC__) || __GNUC__ >= 10
+      DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_LOGICAL_OP
       if (reg->number == REGNUM_EAX ||
           reg->number == REGNUM_RAX) return true;
-#else
-      // eliminate warning with gcc < 10 about duplicate logical or clauses
-      // since REGNUM_EAX is a macro that with value 0 and REGNUM_RAX is an
-      // enum that has a value 0
-      if (reg->number == REGNUM_EAX) return true;
-#endif
+      DYNINST_DIAGNOSTIC_END_SUPPRESS_LOGICAL_OP
    }
    if (inst && inst->validOptimizationInfo() && !inst->definedRegs[reg->encoding()]) {
       regalloc_printf("\t Base tramp instance doesn't have reg %u (num %u) defined; concluding don't save\n",


### PR DESCRIPTION
- use DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_LOGICAL_OP and END macros to suppress logical-op warning