### PR TITLE
GithubCI: add testing on Fedora-39

### DIFF
--- a/.github/workflows/dev-containers.yaml
+++ b/.github/workflows/dev-containers.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04", "ubuntu-22.04"]
+        os: ["ubuntu-20.04", "ubuntu-22.04", "fedora-39"]
     runs-on: ubuntu-latest
     name: Update dev containers
     steps:

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-         os: ['ubuntu-20.04']
+         os: ['ubuntu-20.04', 'fedora-39']
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/dyninst/amd64/${{ matrix.os }}-base:latest

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -27,3 +27,4 @@ RUN yum update -y &&   \
       libdwarf-devel   \
       libstdc++-static \
       tbb-devel
+      

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -1,0 +1,29 @@
+ARG version
+FROM fedora:${version}
+
+#####################################################
+#
+# Base container for a Fedora environment
+#
+#   The dependencies are purposefully unversioned
+#   so that the distribution-default ones are used.
+#
+#####################################################
+
+LABEL maintainer="@hainest"
+
+ENV TZ=America/Chicago
+
+RUN yum update -y &&   \
+    yum install -y     \
+      binutils-devel   \
+      boost-devel      \
+      cmake            \
+      elfutils-devel   \
+      gcc              \
+      g++              \
+      git              \
+      glibc-static     \
+      libdwarf-devel   \
+      libstdc++-static \
+      tbb-devel


### PR DESCRIPTION
This uses gcc-13. Clang won't work because the only available libomp is for clang-17, but the highest installable version of clang is 15.