### PR TITLE
Remove Module::findFunctionByEntryOffset

### DIFF
--- a/symtabAPI/doc/API/Symtab/Module.tex
+++ b/symtabAPI/doc/API/Symtab/Module.tex
@@ -35,16 +35,6 @@ exec & Symtab * & Symtab object that contains the module. \\
 \subsubsection{Function, Variable, Symbol lookup}
 
 \begin{apient}
-bool findFunctionByEntryOffset(Function *&ret,
-                               const Offset offset)
-\end{apient}
-\apidesc{
-This method returns the \code{Function} object that begins at \code{offset}. Returns \code{true} on
-success and \code{false} if there is no matching function. The error value is set to
-\code{No\_Such\_Function}.
-}
-
-\begin{apient}
 typedef enum {
     mangledName,
     prettyName,

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -183,7 +183,11 @@ namespace Dyninst{
 
 			// Function based methods
 			bool getAllFunctions(std::vector<Function *>&ret);
-			bool findFunctionByEntryOffset(Function *&ret, const Offset offset);
+
+			bool findFunctionsByName(std::vector<Function *> &ret, const std::string& name,
+									 NameType nameType = anyName,
+									 bool isRegex = false,
+									 bool checkCase = true);
 
 			// Variable based methods
 			bool findVariablesByOffset(std::vector<Variable *> &ret, const Offset offset);


### PR DESCRIPTION
This was added by c848409ec in 2009, but never implemented. It looks like this was copy/pasted from the earliest Symtab rewrite.