### PR TITLE
Remove Module::findFunctionsByName

### DIFF
--- a/symtabAPI/doc/API/Symtab/Module.tex
+++ b/symtabAPI/doc/API/Symtab/Module.tex
@@ -54,19 +54,6 @@ typedef enum {
 \end{apient}
 
 \begin{apient}
-bool findFunctionsByName(vector<Function> &ret,
-                         const string name,
-                         Symtab::NameType nameType = anyName,
-                         bool isRegex = false,
-                         bool checkCase = true)
-\end{apient}
-\apidesc{
-This method finds and returns a vector of \code{Functions} whose names match the given pattern. The \code{nameType} parameter determines which names are searched: mangled, pretty, typed, or any. If the \code{isRegex} flag is set a regular expression match is performed with the symbol names. \code{checkCase} is applicable only if \code{isRegex} has been set. This indicates if the case be considered while performing regular expression matching. \code{ret} contains the list of matching \code{Function}s, if any.
-Returns \code{true} if it finds functions that match the given name, otherwise returns
-\code{false}. The error value is set to \code{No\_Such\_Function}.
-}
-
-\begin{apient}
 bool getAllFunctions(vector<Function *> &ret)
 \end{apient}
 \apidesc{

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -184,10 +184,6 @@ namespace Dyninst{
 			// Function based methods
 			bool getAllFunctions(std::vector<Function *>&ret);
 			bool findFunctionByEntryOffset(Function *&ret, const Offset offset);
-			bool findFunctionsByName(std::vector<Function *> &ret, const std::string& name,
-									 NameType nameType = anyName,
-									 bool isRegex = false,
-									 bool checkCase = true);
 
 			// Variable based methods
 			bool findVariablesByOffset(std::vector<Variable *> &ret, const Offset offset);


### PR DESCRIPTION
This was added by c848409 in 2009, but never implemented. It looks like this was copy/pasted from the earliest Symtab rewrite.