### PR TITLE
Remove Symtab::findModuleByName(Module *&, std::string)

### DIFF
--- a/symtabAPI/doc/3-Examples.tex
+++ b/symtabAPI/doc/3-Examples.tex
@@ -56,16 +56,14 @@ New symbols, functions, and variables can be created and added to the library at
 using namespace Dyninst;
 using namespace SymtabAPI;
 
-//Module for the symbol
-Module *mod;
-
 // obj represents a handle to a parsed object file.
-obj->findModuleByName(mod, "/path/to/foo.c");
+for(auto *m : obj->findModulesByName("/path/to/foo.c")) {
 
-// Create a new function symbol
-Variable *newVar = mod->createVariable("newIntVar",  // Name of new variable
+  // Create a new function symbol
+  Variable *newVar = m->createVariable("newIntVar",  // Name of new variable
                                        0x12345,      // Offset from data section
                                        sizeof(int)); // Size of symbol 
+}
 \end{lstlisting}
 
 SymtabAPI gives the ability to query type information present in the object file. Also, new user defined types can be added to SymtabAPI. The following example shows both how to query type information after an object file is successfully parsed and also add a new structure type.

--- a/symtabAPI/doc/API/LineInfo/Iterating.tex
+++ b/symtabAPI/doc/API/LineInfo/Iterating.tex
@@ -11,19 +11,20 @@ using namespace SymtabAPI;
 Module *mod;
 
 //Find the module \lq foo\rq within the object.
-obj->findModuleByName(mod, "foo");
+for(auto *m : findModulesByName("foo")) {
 
-// Get the Line Information for module foo.
-LineInformation *info = mod->getLineInformation();
-
-//Iterate over the line information
-LineInformation::const_iterator iter;
-for( iter = info->begin(); iter != info->end(); iter++)
-{
-// First component represents the address range for the line
-const std::pair<Offset, Offset> addrRange = iter->first;
-
-//Second component gives information about the line itself.
-LineNoTuple lt = iter->second;
+  // Get the Line Information for module foo.
+  LineInformation *info = m->getLineInformation();
+  
+  //Iterate over the line information
+  LineInformation::const_iterator iter;
+  for( iter = info->begin(); iter != info->end(); iter++)
+  {
+  // First component represents the address range for the line
+  const std::pair<Offset, Offset> addrRange = iter->first;
+  
+  //Second component gives information about the line itself.
+  LineNoTuple lt = iter->second;
+  }
 }
 \end{lstlisting}

--- a/symtabAPI/doc/API/Symtab/Symtab.tex
+++ b/symtabAPI/doc/API/Symtab/Symtab.tex
@@ -155,14 +155,6 @@ Returns the default module, a collection of all functions, variables, and symbol
 }
 
 \begin{apient}
-bool findModuleByName(Module *&ret,
-                      const string name)
-\end{apient}
-\apidesc{
-This method searches for a module with name \code{name}. If the module exists returns \code{true} with \code{ret} set to the module handle; otherwise returns \code{false} with \code{ret} set to \code{NULL}.
-}
-
-\begin{apient}
 std::vector<Module*> findModulesByName(std::string const& name) const
 \end{apient}
 \apidesc{

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -189,7 +189,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool getAllModules(std::vector<Module *>&ret);
    DYNINST_DEPRECATED("Use findModulesByOffset(Offset)") bool findModuleByOffset(Module *& ret, Offset off);
    Module* findModuleByOffset(Offset offset) const;
-   bool findModuleByName(Module *&ret, const std::string name);
    std::vector<Module*> findModulesByName(std::string const& name) const;
    Module *getDefaultModule() const;
 

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -365,16 +365,6 @@ Module* Symtab::findModuleByOffset(Offset offset) const {
   return impl->modules.find(offset);
 }
 
-bool Symtab::findModuleByName(Module *&ret, const std::string name)
-{
-   auto const& mods = impl->modules.find(name);
-   if(mods.size()) {
-       ret = mods[0];
-       return true;
-   }
-   return false;
-}
-
 std::vector<Module*> Symtab::findModulesByName(std::string const& name) const {
   return impl->modules.find(name);
 }

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -803,8 +803,9 @@ void Symtab::createDefaultModule() {
 Module *Symtab::getOrCreateModule(const std::string &modName, 
                                   const Offset modAddr)
 {
-   Module *fm = NULL;
-   if (findModuleByName(fm, modName))
+   Module *fm = findModuleByOffset(modAddr);
+
+   if (fm)
    {
        if(modAddr && (modAddr < fm->addr()))
        {
@@ -827,13 +828,6 @@ Module *Symtab::getOrCreateModule(const std::string &modName,
 Module *Symtab::newModule(const std::string &name, const Offset addr, supportedLanguages lang)
 {
     Module *ret = NULL;
-    // modules can be defined several times in C++ due to templates and
-    //   in-line member functions.
-
-    if (findModuleByName(ret, name)) 
-    {
-        return(ret);
-    }
 
     //parsing_printf("=== image, creating new pdmodule %s, addr 0x%x\n",
     //				name.c_str(), addr);


### PR DESCRIPTION
This can't be merged until after https://github.com/dyninst/examples/pull/40.

A Symtab::Module is a one-to-one mapping to a DWARF compilation unit
(CU). In DWARF4, we consider a CU to be an entry in the .debug_info
section with the tag DW_TAG_compile_unit. In DWARF5, we also include
entries with the tag DW_TAG_partial_unit as they can contain symbol
definitions; we assume libdw will merge all other split unit types for
us.

The name of a module is the DW_AT_name of the containing DIE. This is
either the full path name of the source file used to create the CU or
the relative path of the same with respect to the DW_AT_comp_dir. We
ensure that the module's name is always an absolute path.

Modules have never been required to have unique names. That is, many
modules can share the same name. The following demonstrates this case:

```
test.c
------
 #ifdef FUNC1
  void func1(){}
 #endif
 #ifdef FUNC2
  void func2(){}
 #endif

$ gcc -g -c -DFUNC1 -o func1.o test.c
$ gcc -g -c -DFUNC2 -o func2.o test.c
$ gcc -g -fPIC -shared func1.o func2.o -o libfunc.so
$ readelf --debug-dump=info libfunc.so | grep -A 6 DW_TAG_compile_unit
 <0><c>: Abbrev Number: 1 (DW_TAG_compile_unit)
    <d>   DW_AT_producer    : <redacted>
    <11>   DW_AT_language    : 29	(C11)
    <12>   DW_AT_name        : test.c
    <16>   DW_AT_comp_dir    : /path/to/test
    <1a>   DW_AT_low_pc      : 0x10f9
    <22>   DW_AT_high_pc     : 0x1104

 <0><55>: Abbrev Number: 1 (DW_TAG_compile_unit)
    <56>   DW_AT_producer    : <redacted>
    <5a>   DW_AT_language    : 29	(C11)
    <5b>   DW_AT_name        : test.c
    <5f>   DW_AT_comp_dir    : /path/to/test
    <63>   DW_AT_low_pc      : 0x1104
    <6b>   DW_AT_high_pc     : 0x110F
```

Because the two CUs have the same name, Dyninst throws away the contents
of the second one because this function would return the first. It is
also possible (and likely) that the two CUs have different line maps and
location lists. These, too, are discarded. Although unlikely, it is
legal for a compiler to emit CUs with overlapping PC range values. This
means the only way to uniquely identify a module is by its offset in
the .debug_info section.