### PR TITLE
Remove Symtab::changeSymbolOffset

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -423,7 +423,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    // Change the type of a symbol after the fact
    bool changeType(Symbol *sym, Symbol::SymbolType oldType);
 
-   bool changeSymbolOffset(Symbol *sym, Offset newOffset);
    bool deleteSymbolFromIndices(Symbol *sym);
 
    bool changeAggregateOffset(Aggregate *agg, Offset oldOffset, Offset newOffset);

--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -163,36 +163,6 @@ bool Symtab::deleteSymbol(Symbol *sym)
     return result;
 }
 
-bool Symtab::changeSymbolOffset(Symbol *sym, Offset newOffset) {
-    // If we aren't part of an aggregate, change the symbol offset
-    // and update symsByOffset.
-    // If we are part of an aggregate and the only symbol element,
-    // do that and update funcsByOffset or varsByOffset.
-    // If we are and not the only symbol, do 1), remove from 
-    // the aggregate, and make a new aggregate.
-  {
-    indexed_symbols::master_t::accessor a;
-    if (!impl->everyDefinedSymbol.master.find(a, sym))  {
-        assert(!"everyDefinedSymbol.master.find(a, sym)");
-    }
-
-    indexed_symbols::by_offset_t::accessor oa;
-    if (!impl->everyDefinedSymbol.by_offset.find(oa, sym->offset_))  {
-        assert(!"everyDefinedSymbol.by_offset.find(oa, sym->offset_)");
-    }
-    auto &syms = oa->second;
-    syms.erase(std::remove(syms.begin(), syms.end(), sym), syms.end());
-    impl->everyDefinedSymbol.by_offset.insert(oa, newOffset);
-    oa->second.push_back(sym);
-
-    a->second = newOffset;
-    sym->offset_ = newOffset;
-  }
-
-  if (sym->aggregate_ == NULL) return true;
-  else return sym->aggregate_->changeSymbolOffset(sym);
-}
-
 bool Symtab::changeAggregateOffset(Aggregate *agg, Offset oldOffset, Offset newOffset) {
     Function *func = dynamic_cast<Function *>(agg);
     Variable *var = dynamic_cast<Variable *>(agg);


### PR DESCRIPTION
It is never used. Not a breaking change as it's private.

I have left the function of the same name in Aggregate because it's protected, there is a virtual dtor, and that class is accessible by users. It's possible that someone is using it.