### PR TITLE
fix gcc 6's broken __has_x_attribute

### DIFF
--- a/common/h/compiler_annotations.h
+++ b/common/h/compiler_annotations.h
@@ -31,6 +31,33 @@
 #ifndef COMPILER_ANNOTATIONS_H
 #define COMPILER_ANNOTATIONS_H
 
+
+/***********************************************************************
+ *
+ * INTERNAL HELPER MACROS
+ *
+ * Determine if compiler supports __has_cpp_attrribute and __has_c_attribute,
+ * and check if the attribute can be used without warning giving the language
+ * version the attribute was introduced (clang and gcc <=6 report true but warn
+ * if attribute is used).  The DYNSINT_STD_FOR_VER_HAS_X_ATTRIBUTES parameter
+ * is the minumum version of the language that the attribute was introduced.
+ */
+#if defined(__cplusplus) && defined(__has_cpp_attribute)
+    #define DYNINST_HAS_HAS_CPP_ATTRIBUTE               1
+    #define DYNINST_STD_FOR_VER_HAS_CPP_ATTRIBUTE(minV) (__GNUC__ > 6 || __cplusplus >= (minV))
+#else
+    #define DYNINST_HAS_HAS_CPP_ATTRIBUTE               0
+    #define DYNINST_STD_FOR_VER_HAS_CPP_ATTRIBUTE(minV) 0
+#endif
+#if defined(__STDC_VERSION__) && defined(__has_c_attribute)
+    #define DYNINST_HAS_HAS_C_ATTRIBUTE                 1
+    #define DYNINST_STD_FOR_VER_HAS_C_ATTRIBUTE(minV)   (__GNUC__ > 6 || __STDC_VERSION__ >= (minV))
+#else
+    #define DYNINST_HAS_HAS_C_ATTRIBUTE                 0
+    #define DYNINST_STD_FOR_VER_HAS_C_ATTRIBUTE(minV)   0
+#endif
+
+
 /***********************************************************************
  *
  * DYNINST_FALLTHROUGH
@@ -52,19 +79,19 @@
  *    }
  */
 
-#if defined(__cplusplus) && defined(__has_cpp_attribute)
-    #if __has_cpp_attribute(fallthrough) && !(__clang__ && __cplusplus < 201703L)
+#if DYNINST_HAS_HAS_CPP_ATTRIBUTE
+    #if __has_cpp_attribute(fallthrough) && DYNINST_STD_FOR_VER_HAS_CPP_ATTRIBUTE(201703)
         #define DYNINST_FALLTHROUGH [[fallthrough]]
     #elif __has_cpp_attribute(gcc::fallthrough)
         #define DYNINST_FALLTHROUGH [[gcc::fallthrough]]
     #elif __has_cpp_attribute(clang::fallthrough)
         #define DYNINST_FALLTHROUGH [[clang::fallthrough]]
     #endif
-#elif !defined(__cplusplus) && defined(__has_c_attribute)
-    #if __has_c_attribute(fallthrough) && !(__clang__ && __STDC_VERSION__ < 202311L)
+#elif DYNINST_HAS_HAS_C_ATTRIBUTE
+    #if __has_c_attribute(fallthrough) && DYNINST_STD_FOR_VER_HAS_C_ATTRIBUTE(202311L)
         #define DYNINST_FALLTHROUGH [[fallthrough]]
     #elif __STDC_VERSION__ >= 202311L
-	// scoped attribute names are only valid in C 23 or later
+	// scoped attribute names not valid in C until C23 (:: is not a token)
 	#if __has_c_attribute(gcc::fallthrough)
 	    #define DYNINST_FALLTHROUGH [[gcc::fallthrough]]
 	#elif __has_c_attribute(clang::fallthrough)
@@ -77,7 +104,7 @@
     #if __has_attribute(fallthrough)
         #define DYNINST_FALLTHROUGH __attribute__((fallthrough))
     #elif __cplusplus || __STDC_VERSION__ >= 202311L
-	// scoped attribute names are only valid in C++, or C 23 or later
+	// scoped attribute names not valid in C until C23 (:: is not a token)
 	#if __has_attribute(gcc::fallthrough)
 	    #define DYNINST_FALLTHROUGH __attribute__((gcc::fallthrough))
 	#elif __has_attribute(clang::fallthrough)
@@ -106,11 +133,11 @@
  *   DYNINST_DEPRECRATED("Use NewFoo") int Foo();
  */
 
-#if defined(__cplusplus) && defined(__has_cpp_attribute) && !(__clang__ && __cplusplus < 201402L)
+#if DYNINST_HAS_HAS_CPP_ATTRIBUTE && DYNINST_STD_FOR_VER_HAS_CPP_ATTRIBUTE(201402L)
     #if __has_cpp_attribute(deprecated)
         #define DYNINST_DEPRECATED(msg) [[deprecated(msg)]]
     #endif
-#elif !defined(__cplusplus) && defined(__has_c_attribute) && !(__clang__ && __STDC_VERSION__ >= 202311L)
+#elif DYNINST_HAS_HAS_C_ATTRIBUTE && DYNINST_STD_FOR_VER_HAS_C_ATTRIBUTE(202311L)
     #if __has_c_attribute(deprecated)
         #define DYNINST_DEPRECATED(msg) [[deprecated(msg)]]
     #endif


### PR DESCRIPTION
- gcc 6's __has_c_attribute and __has_cpp_attribute return true if an attribute is supported as a non-standard extension, but if used produces a warning if the language standard is earlier than the attribute's standardization; treat gcc 6 like clang and only allow if the language standard is after the introduction.

- refactor the conditional compilation tests into common macros