### PR TITLE
Add Symtab::getContainingModule(Offset)

### DIFF
--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -1697,7 +1697,7 @@ parse_func *image::addFunction(Address functionEntryAddr, const char *fName)
      }
      region = *(regions.begin()); // XXX pick one, throwing up hands. 
 
-     auto *m = linkedFile->findModuleByOffset(functionEntryAddr);
+     auto *m = linkedFile->getContainingModule(functionEntryAddr);
      
      pdmodule *mod = getOrCreateModule(m);
 

--- a/symtabAPI/doc/API/Symtab/Symtab.tex
+++ b/symtabAPI/doc/API/Symtab/Symtab.tex
@@ -169,6 +169,14 @@ Returns the module starting at \code{offset}; \code{nullptr}, if not found.
 }
 
 \begin{apient}
+Module* getContainingModule(Offset offset) const
+\end{apient}
+\apidesc{
+Returns the module with PC ranges that contain \code{offset}; \code{nullptr}, if not found.
+By contrast \code{findModuleByOffset}, finds a module \it{starting} at \code{offset}.
+}
+
+\begin{apient}
 bool getAllModules(vector<module *> &ret)
 \end{apient}
 \apidesc{

--- a/symtabAPI/doc/API/Symtab/Symtab.tex
+++ b/symtabAPI/doc/API/Symtab/Symtab.tex
@@ -173,7 +173,8 @@ Module* getContainingModule(Offset offset) const
 \end{apient}
 \apidesc{
 Returns the module with PC ranges that contain \code{offset}; \code{nullptr}, if not found.
-By contrast \code{findModuleByOffset}, finds a module \it{starting} at \code{offset}.
+The default module will be returned if and only if it is the only module present. By contrast,
+\code{findModuleByOffset}, finds a module \it{starting} at \code{offset}.
 }
 
 \begin{apient}

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -191,6 +191,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    Module* findModuleByOffset(Offset offset) const;
    std::vector<Module*> findModulesByName(std::string const& name) const;
    Module *getDefaultModule() const;
+   Module* getContainingModule(Offset offset) const;
 
    // Region
 

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3697,7 +3697,7 @@ void Object::parseLineInfoForAddr(Offset addr_to_find) {
     Dwarf **dbg_ptr = dwarf->line_dbg();
     if (!dbg_ptr)
         return;
-    auto *m = associated_symtab->findModuleByOffset(addr_to_find);
+    auto *m = associated_symtab->getContainingModule(addr_to_find);
     if(m) m->parseLineInformation();
     // no mod for offset means no line info for sure if we've parsed all ranges...
 }

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -369,6 +369,10 @@ std::vector<Module*> Symtab::findModulesByName(std::string const& name) const {
   return impl->modules.find(name);
 }
 
+Module* Symtab::getContainingModule(Offset offset) const {
+  return impl->getContainingModule(offset);
+}
+
 bool Symtab::getAllRegions(std::vector<Region *>&ret)
 {
    if (regions_.size() > 0)

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -562,7 +562,7 @@ bool Symtab::createAggregates()
  
 bool Symtab::fixSymModule(Symbol *&sym) 
 {
-    Module* mod = findModuleByOffset(sym->getOffset());
+    Module* mod = getContainingModule(sym->getOffset());
     if(!mod) mod = getDefaultModule();
     sym->setModule(mod);
     return true;


### PR DESCRIPTION
Returns the module with PC ranges that contain a given offset (really address). By contrast, findModuleByOffset(Offset) finds a module starting at the given offset.

This is the correct replacement for `Symtab::findModuleByOffset(std::set<Module *>&, Offset)` removed in #1545.