### PR TITLE
Use Symtab::getContainingModule instead of Symtab::findModuleByOffset

### DIFF
--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -803,7 +803,7 @@ void Symtab::createDefaultModule() {
 Module *Symtab::getOrCreateModule(const std::string &modName, 
                                   const Offset modAddr)
 {
-   Module *fm = findModuleByOffset(modAddr);
+   Module *fm = getContainingModule(modAddr);
 
    if (fm) return fm;
 
@@ -1609,7 +1609,7 @@ SYMTAB_EXPORT bool Symtab::getAddressRanges(std::vector<AddressRange > &ranges,
 SYMTAB_EXPORT bool Symtab::getSourceLines(std::vector<Statement::Ptr> &lines, Offset addressInRange)
 {
    unsigned int originalSize = lines.size();
-    Module* m = findModuleByOffset(addressInRange);
+    Module* m = getContainingModule(addressInRange);
 
     if(!m) return false;
 


### PR DESCRIPTION
This should have been part of ddd2315b5.

I have no idea how these were left out of #1571. I distinctly remember fixing them.