### PR TITLE
Deprecate mapped_module::truncateLineFilenames

### DIFF
--- a/dyninstAPI/h/BPatch.h
+++ b/dyninstAPI/h/BPatch.h
@@ -44,6 +44,7 @@
 #include <string>
 
 #include "dyninstversion.h"
+#include "compiler_diagnostics.h"
 
 class BPatch_typeCollection;
 class BPatch_libInfo;
@@ -479,7 +480,8 @@ public:
     //  Turn on/off line info truncating
     
 
-    void truncateLineInfoFilenames(bool x);
+    DYNINST_DEPRECATED("Does nothing")
+    void truncateLineInfoFilenames(bool);
 
     //  BPatch::setTrampRecursive:
     //  Turn on/off recursive trampolines

--- a/dyninstAPI/src/BPatch.C
+++ b/dyninstAPI/src/BPatch.C
@@ -1851,11 +1851,7 @@ int BPatch::getNotificationFD() {
 #endif
 }
 
-/* If true, we return just filenames when the user asks for line info
-   otherwise, we return filename plus path information. */
-void BPatch::truncateLineInfoFilenames(bool newval) {
-   mapped_module::truncateLineFilenames = newval;
-}
+void BPatch::truncateLineInfoFilenames(bool) {}
 
 void BPatch::getBPatchVersion(int &major, int &minor, int &subminor) 
 {

--- a/dyninstAPI/src/mapped_module.C
+++ b/dyninstAPI/src/mapped_module.C
@@ -40,8 +40,6 @@
 #include <iomanip>
 #include <string>
 
-bool mapped_module::truncateLineFilenames = true;
-
 const std::vector<func_instance *> &mapped_module::getAllFunctions() 
 {
    std::vector<parse_func *> pdfuncs;

--- a/dyninstAPI/src/mapped_module.h
+++ b/dyninstAPI/src/mapped_module.h
@@ -117,7 +117,6 @@ class mapped_module {
       
       void remove(func_instance *func);
 
-      static bool truncateLineFilenames;
       unsigned int getFuncVectorSize() { return everyUniqueFunction.size(); }
 
    private:


### PR DESCRIPTION
It's never used.