### PR TITLE
Remove DWARFisms from Symtab::Module

### DIFF
--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -83,9 +83,6 @@ namespace Dyninst { namespace SymtabAPI {
     bool isShared() const;
     ~Module();
 
-    std::string getCompDir();
-    std::string getCompDir(Module::DebugInfoT &); // For internal use
-
     // Symbol output methods
     virtual bool findSymbol(std::vector<Symbol *> &ret, const std::string &name,
                             Symbol::SymbolType sType = Symbol::ST_UNKNOWN,

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -40,9 +40,6 @@
 #include <stddef.h>
 #include <string>
 #include <vector>
-#if defined(cap_dwarf)
-#include "elfutils/libdw.h"
-#endif
 #include <boost/shared_ptr.hpp>
 
 namespace Dyninst { namespace SymtabAPI {
@@ -60,12 +57,6 @@ namespace Dyninst { namespace SymtabAPI {
     friend class Symtab;
 
   public:
-#if defined(cap_dwarf)
-    typedef Dwarf_Die DebugInfoT;
-#else
-    typedef void *DebugInfoT;
-#endif
-
     Module();
     Module(supportedLanguages lang, Offset adr, std::string fullNm, Symtab *img);
     Module(const Module &mod);
@@ -171,15 +162,12 @@ namespace Dyninst { namespace SymtabAPI {
 
     bool hasRanges() const { return !ranges.empty(); }
 
-    void addDebugInfo(Module::DebugInfoT info);
-
     StringTablePtr &getStrings();
 
   private:
     bool objectLevelLineInfo;
     Dyninst::SymtabAPI::LineInformation *lineInfo_;
     typeCollection *typeInfo_;
-    dyn_c_queue<Module::DebugInfoT> info_;
 
     std::string fileName_; // full path to file
     std::string compDir_;

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -60,35 +60,6 @@ using namespace std;
 
 static SymtabError serr;
 
-string Module::getCompDir(Module::DebugInfoT& cu)
-{
-    if(!compDir_.empty()) return compDir_;
-
-#if defined(cap_dwarf)
-    if(!dwarf_hasattr(&cu, DW_AT_comp_dir))
-    {
-        return "";
-    }
-
-    Dwarf_Attribute attr;
-    auto comp_dir = dwarf_formstring( dwarf_attr(&cu, DW_AT_comp_dir, &attr) );
-    compDir_ = std::string( comp_dir ? comp_dir : "" );
-    return compDir_;
-
-#else
-    // TODO Implement this for non-dwarf format
-    return compDir_;
-#endif
-}
-
-string Module::getCompDir()
-{
-    if(!compDir_.empty()) return compDir_;
-
-    return "";
-}
-
-
 bool Module::findSymbol(std::vector<Symbol *> &found,
                         const std::string& name,
                         Symbol::SymbolType sType, 
@@ -216,9 +187,6 @@ LineInformation *Module::parseLineInformation() {
             do {
                 exec()->getObject()->parseLineInfoForCU(cu2, lineInfo_);
             } while(info_.try_pop(cu2));
-
-            // Make sure to call getCompDir so its stored and ready.
-            getCompDir(cu);
         }
 
         // Work queue has now been emptied.
@@ -343,7 +311,6 @@ Module::Module() :
    lineInfo_(NULL),
    typeInfo_(NULL),
    fileName_(""),
-   compDir_(""),
    language_(lang_Unknown),
    addr_(0),
    exec_(NULL),
@@ -358,7 +325,6 @@ Module::Module(const Module &mod) :
    typeInfo_(mod.typeInfo_),
    info_(mod.info_),
    fileName_(mod.fileName_),
-   compDir_(mod.compDir_),
    language_(mod.language_),
    addr_(mod.addr_),
    exec_(mod.exec_),

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2244,8 +2244,6 @@ bool Object::fix_global_symbol_modules_static_dwarf() {
                 }
             }
         }
-        #pragma omp critical
-        m->addDebugInfo(cu_die);
         DwarfWalker::buildSrcFiles(dbg, cu_die, m->getStrings());
         // dies_seen.insert(cu_die_off);
     }
@@ -3189,8 +3187,14 @@ const char *Object::interpreter_name() const {
     return interpreter_name_;
 }
 
-void Object::parseLineInfoForCU(Dwarf_Die cuDIE, LineInformation* li_for_module)
+void Object::parseLineInfoForCU(Offset offset_, LineInformation* li_for_module)
 {
+    Dwarf_Die cuDIE{};
+    if(!dwarf_addrdie(*dwarf->type_dbg(), offset_, &cuDIE)) {
+        lineinfo_printf("No CU at offset 0x%zx: %s\n", offset_, dwarf_errmsg(dwarf_errno()));
+        return;
+    }
+
     /* Acquire this CU's source lines. */
     Dwarf_Lines *lineBuffer;
     Dwarf_Attribute attr2;

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -417,7 +417,7 @@ public:
   bool hasDebugInfo();
 
 private:
-    void parseLineInfoForCU(Module::DebugInfoT cuDIE, LineInformation* li);
+    void parseLineInfoForCU(Offset offset, LineInformation* li);
     void recordLine(
        Region *debug_str,
        open_statement &saved_statement,

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -145,7 +145,7 @@ protected:
     // explicitly protected
     SYMTAB_EXPORT AObject(MappedFile *, void (*err_func)(const char *), Symtab*);
 friend class Module;
-    virtual void parseLineInfoForCU(Module::DebugInfoT , LineInformation* ) { }
+    virtual void parseLineInfoForCU(Offset , LineInformation* ) { }
 
     MappedFile *mf;
 


### PR DESCRIPTION
There is no need to store the CU DIE from which a Module instance is
derived. The address of the CU can be used to reconstitute the
entry in the .debug_info section using dwarf_addrdie.

Because Module.h is part of the public API for Dyninst, this also
removes the transitive dependency on libdw.