### PR TITLE
Remove MODULE_ANNOTATABLE_CLASS

### DIFF
--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -52,8 +52,6 @@ namespace Dyninst { namespace SymtabAPI {
   class localVar;
   class Symtab;
 
-#define MODULE_ANNOTATABLE_CLASS AnnotatableSparse
-
   typedef Dyninst::SimpleInterval<Offset, Module *> ModRange;
 
   class SYMTAB_EXPORT Module : public LookupInterface {


### PR DESCRIPTION
This is never used and Module doesn't inherit from AnnotatableSparse.