### PR TITLE
Remove Module::findFunctionByEntryOffset

### DIFF
--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -97,10 +97,6 @@ namespace Dyninst { namespace SymtabAPI {
     // Function based methods
     bool getAllFunctions(std::vector<Function *> &ret);
 
-    bool findFunctionsByName(std::vector<Function *> &ret, const std::string &name,
-                             NameType nameType = anyName, bool isRegex = false,
-                             bool checkCase = true);
-
     // Variable based methods
     bool findVariablesByOffset(std::vector<Variable *> &ret, const Offset offset);
     bool findVariablesByName(std::vector<Variable *> &ret, const std::string &name,


### PR DESCRIPTION
This was originally done in d2d48213a, but was accidentally reverted in 1c5f4966b.