### PR TITLE
Replace getAllFunctions

### DIFF
--- a/symtabAPI/doc/API/Symtab/Module.tex
+++ b/symtabAPI/doc/API/Symtab/Module.tex
@@ -47,8 +47,7 @@ typedef enum {
 bool getAllFunctions(vector<Function *> &ret)
 \end{apient}
 \apidesc{
-This method returns all functions in the object file. Returns \code{true} on success
-and \code{false} if there are no modules. The error value is set to \code{No\_Such\_Function}.
+Returns all functions located within the PC address ranges covered by this module.
 }
 
 \begin{apient}

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -81,7 +81,7 @@ namespace Dyninst { namespace SymtabAPI {
     virtual bool getAllSymbols(std::vector<Symbol *> &ret);
 
     // Function based methods
-    bool getAllFunctions(std::vector<Function *> &ret);
+    std::vector<Function*> getAllFunctions() const;
 
     // Variable based methods
     bool findVariablesByOffset(std::vector<Variable *> &ret, const Offset offset);

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -46,6 +46,7 @@
 #include "common/src/pathName.h"
 #include "Object.h"
 #include <boost/foreach.hpp>
+#include <algorithm>
 
 #if defined(cap_dwarf)
 #include "dwarfWalker.h"
@@ -359,9 +360,16 @@ bool Module::getAllSymbolsByType(std::vector<Symbol *> &found, Symbol::SymbolTyp
    return false;
 }
 
-bool Module::getAllFunctions(std::vector<Function *> &ret)
+std::vector<Function*> Module::getAllFunctions() const
 {
-    return exec()->getAllFunctions(ret);
+    auto const& all_funcs = exec()->getAllFunctionsRef();
+    std::vector<Function*> funcs;
+    std::copy_if(all_funcs.begin(), all_funcs.end(), std::back_inserter(funcs),
+	[this] (Function *f) {
+	  return f->getModule() == this;
+        }
+    );
+    return funcs;
 }
 
 bool Module::operator==(Module &mod) 


### PR DESCRIPTION
The documented meaning did not match the implementation. This fixes that and breaks the interface so that users are forced to see the change rather than being surprised by it. It also makes it consistent with the other 'find' members like findSymbol and findLocalVariable.