### PR TITLE
Fix line information parsing for CUs with no aranges

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3190,8 +3190,8 @@ const char *Object::interpreter_name() const {
 void Object::parseLineInfoForCU(Offset offset_, LineInformation* li_for_module)
 {
     Dwarf_Die cuDIE{};
-    if(!dwarf_addrdie(*dwarf->type_dbg(), offset_, &cuDIE)) {
-        lineinfo_printf("No CU at offset 0x%zx: %s\n", offset_, dwarf_errmsg(dwarf_errno()));
+    if(!DwarfDyninst::find_cu(*dwarf->type_dbg(), offset_, &cuDIE)) {
+        lineinfo_printf("No CU found at offset 0x%zx: %s\n", offset_, dwarf_errmsg(dwarf_errno()));
         return;
     }
 


### PR DESCRIPTION
As of libdw 0.189, `dwarf_addrdie` assumes the presence of .debug_aranges. For compilers that do not emit one, or emit an invalid one (e.g., gtpin binaries), then manually search through all of the CUs to find a match.