### PR TITLE
Remove mapped_module::getAddrFromLine

### DIFF
--- a/dyninstAPI/src/mapped_module.h
+++ b/dyninstAPI/src/mapped_module.h
@@ -104,13 +104,6 @@ class mapped_module {
 
       std::string processDirectories(const std::string &fn) const;
 
-      // Given a line in the module, get the set of addresses that it maps
-      // to. Calls the internal getAddrFromLine and then adds the base
-      // address to the returned list of offsets.
-      bool getAddrFromLine(unsigned lineNum,
-            std::vector<Address> &addresses,
-            bool exactMatch);
-
       void addFunction(func_instance *func);
       void addVariable(int_variable *var);
       int_variable* createVariable(std::string name, Address offset, int size);


### PR DESCRIPTION
It was introduced in 2005 by 5731bd02a, but never implemented.