### PR TITLE
Remove BPatch_flowGraph::getLoopMinMaxSourceLines

### DIFF
--- a/dyninstAPI/src/BPatch_flowGraph.C
+++ b/dyninstAPI/src/BPatch_flowGraph.C
@@ -588,32 +588,6 @@ void BPatch_flowGraph::fillPostDominatorInfo()
 }
 
 
-// return a pair of the min and max source lines for this loop
-pdpair<u_short, u_short>
-getLoopMinMaxSourceLines(BPatch_loop * loop)
-{
-  BPatch_Vector<BPatch_basicBlock*> blocks;
-  loop->getLoopBasicBlocks(blocks);
-
-  BPatch_Vector<u_short> lines;
-
-  for (u_int j = 0; j < blocks.size (); j++) {
-    BPatch_Vector<BPatch_sourceBlock*> sourceBlocks;
-    blocks[j]->getSourceBlocks(sourceBlocks);
-
-    for (u_int k = 0; k < sourceBlocks.size (); k++) {
-      BPatch_Vector<u_short> sourceLines;
-      sourceBlocks[k]->getSourceLines(sourceLines);
-      for (u_int l = 0; l < sourceLines.size(); l++)
-        lines.push_back(sourceLines[l]);
-    }
-  }
-
-  pdpair<u_short, u_short> mm = min_max_pdpair<u_short>(lines);
-  return mm;
-}
-
-
 BPatch_loopTreeNode *BPatch_flowGraph::getLoopTree()
 {
   if (loopRoot == NULL) {
@@ -633,9 +607,6 @@ BPatch_loop *BPatch_flowGraph::findLoop(const char *name)
 void BPatch_flowGraph::dfsPrintLoops(BPatch_loopTreeNode *n)
 {
   if (n->loop != NULL) {
-    //    pdpair<u_short, u_short> mm = getLoopMinMaxSourceLines(n->loop);
-    //  printf("%s (source %d-%d)\n", n->name(), mm.first, mm.second);
-
     printf("%s %s\n", n->name(),ll_func()->prettyName().c_str());
   }
 


### PR DESCRIPTION
Its usage was removed by f531f7261 in 2011.