### PR TITLE
Remove FunctionBase::ranges_lock

### DIFF
--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -142,7 +142,6 @@ class SYMTAB_EXPORT FunctionBase
    InlineCollection inlines;
    FunctionBase *inline_parent;
 
-   dyn_mutex ranges_lock;
    FuncRangeCollection ranges;
    std::vector<VariableLocation> frameBase_;
    dyn_mutex frameBaseLock_;

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -724,7 +724,6 @@ bool DwarfWalker::parseSubprogram(DwarfWalker::inline_t func_type) {
 }
 
 void DwarfWalker::setRanges(FunctionBase *func) {
-   dyn_mutex::unique_lock l(func->ranges_lock);
    if(func->ranges.empty()) {
 	   Address last_low = 0, last_high = 0;
 	   for (auto i = ranges_begin(); i != ranges_end(); i++) {


### PR DESCRIPTION
It's only ever used in DwarfWalker::setRanges, and that is only ever called from DwarfWalker::parseSubprogram which is now correctly guarded (as of 8b400af59b).