### PR TITLE
Remove redundant declaration of SymtabAPI::FuncRangeCollection

### DIFF
--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -77,7 +77,6 @@ class SYMTAB_EXPORT FuncRange {
 
 typedef std::vector<FuncRange> FuncRangeCollection;
 typedef std::vector<FunctionBase *> InlineCollection;
-typedef std::vector<FuncRange> FuncRangeCollection;
 
 class SYMTAB_EXPORT FunctionBase
 {


### PR DESCRIPTION
It was added by 5ed068167 in 2013.