### PR TITLE
Remove Symtab(MappedFile*)

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -100,7 +100,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    /***** Public Member Functions *****/
    public:
    static void version(int& major, int& minor, int& maintenance);
-   Symtab(MappedFile *);
 
    Symtab();
 

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -304,12 +304,6 @@ SYMTAB_EXPORT bool Symtab::isBigEndianDataEncoding() const
    return obj_private->isBigEndianDataEncoding();
 }
 
-SYMTAB_EXPORT Symtab::Symtab(MappedFile *mf_) : Symtab()
-{
-		mf = mf_;
-  createDefaultModule();
-}
-
 SYMTAB_EXPORT Symtab::Symtab() :
    LookupInterface(),
    AnnotatableSparse(),


### PR DESCRIPTION
It's never used. MappedFile is also an opaque type here, so users could never have used it. This makes it not an ABI/API-breaking change.