### PR TITLE
Remove Symtab::exportXML,exportBin,importBin

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -125,9 +125,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    static Symtab *findOpenSymtab(std::string filename);
    static bool closeSymtab(Symtab *);
 
-    bool exportXML(std::string filename);
-   bool exportBin(std::string filename);
-   static Symtab *importBin(std::string filename);
    bool getRegValueAtFrame(Address pc, 
                                      Dyninst::MachRegister reg, 
                                      Dyninst::MachRegisterVal &reg_result,

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -1331,21 +1331,6 @@ Symtab::~Symtab()
 
 }	
 
-bool Symtab::exportXML(string)
-{
-   return false;
-}
-
-bool Symtab::exportBin(string) 
-{
-   return false;
-}
-
-Symtab *Symtab::importBin(std::string)
-{
-   return NULL;
-}
-
 bool Symtab::openFile(Symtab *&obj, void *mem_image, size_t size, 
                       std::string name, def_t def_bin)
 {


### PR DESCRIPTION
These were part of the serialization interface and should have been removed by f4ee3410b.