### PR TITLE
Remove MachRegister(int, char const*) overload

### DIFF
--- a/common/h/registers/MachRegister.h
+++ b/common/h/registers/MachRegister.h
@@ -52,7 +52,6 @@ namespace Dyninst {
   public:
     MachRegister();
     explicit MachRegister(signed int r);
-    explicit MachRegister(signed int r, const char* n);
     explicit MachRegister(signed int r, std::string n);
 
     MachRegister getBaseRegister() const;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -19,10 +19,6 @@ namespace Dyninst {
 
   MachRegister::MachRegister(signed int r) : reg(r) {}
 
-  MachRegister::MachRegister(signed int r, const char* n) : reg(r) {
-    (*names())[r] = std::string(n);
-  }
-
   MachRegister::MachRegister(signed int r, std::string n) : reg(r) { (*names())[r] = n; }
 
   unsigned int MachRegister::regClass() const { return reg & 0x00ff0000; }


### PR DESCRIPTION
It makes no sense to have this and the std::string version when they do the same thing.