### PR TITLE
Remove Symtab::getSymbolByIndex

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -393,8 +393,6 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
    bool delSymbol(Symbol *sym) { return deleteSymbol(sym); }
    bool deleteSymbol(Symbol *sym); 
 
-   Symbol *getSymbolByIndex(unsigned);
-
    /***** Private Member Functions *****/
    private:
 


### PR DESCRIPTION
It was added by 3a7f5df6 in 2009, but never implemented.