### PR TITLE
Remove extraneous variables in Symbol.C

### DIFF
--- a/symtabAPI/src/Symbol.C
+++ b/symtabAPI/src/Symbol.C
@@ -273,10 +273,7 @@ std::ostream& Dyninst::SymtabAPI::operator<< (ostream &os, const Symbol &s)
                   << " }";
 }
 
-     Offset tryStart_;
-	       unsigned trySize_;
-		         Offset catchStart_;
-				       bool hasTry_;
+
 
 ostream & Dyninst::SymtabAPI::operator<< (ostream &s, const ExceptionBlock &eb) 
 {


### PR DESCRIPTION
These were added by c848409ec in 2009, but never used.