### PR TITLE
Remove useless assert in binaryEdit::writeFile

### DIFF
--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -667,7 +667,6 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       // Symtab::emit(std::string filename)
         
       // First, text
-      assert(symObj);
       
       
       // And now we generate the new binary


### PR DESCRIPTION
The variable is used before the assert.