### PR TITLE
Remove code protected by USE_ADDRESS_MAPS

### DIFF
--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -41,8 +41,6 @@
 
 using namespace Dyninst::SymtabAPI;
 
-// #define USE_ADDRESS_MAPS
-
 // Reading and writing get somewhat interesting. We are building
 // a false address space - that of the "inferior" binary we're editing. 
 // However, that address space doesn't exist - and so we must overlay
@@ -696,11 +694,6 @@ Address BinaryEdit::maxAllocedAddr() {
 bool BinaryEdit::inferiorMallocStatic(unsigned size) {
     // Should be set by now
     assert(highWaterMark_ != 0);
-
-#if defined(USE_ADDRESS_MAPS)
-    void *buf = malloc(size);
-    if (!buf) return false;
-#endif
     
     Address newStart = highWaterMark_;
 


### PR DESCRIPTION
The usage of the variables it protects was removed by 399a10ea in 2007.