### PR TITLE
Fix astOperatorNode semantics

### DIFF
--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -1592,7 +1592,6 @@ bool AstOperatorNode::generateCode_phase2(codeGen &gen, bool noCost,
                break;
             }
             case operandType::RegOffset: {
-               assert(loperand);
                assert(loperand->operand());
 
                // load the address reg + addr into dest

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -1300,7 +1300,7 @@ bool AstOperatorNode::generateOptimizedAssignment(codeGen &, int, bool)
 bool AstOperatorNode::generateCode_phase2(codeGen &gen, bool noCost,
                                           Address &retAddr,
                                           Register &retReg) {
-   if(!(loperand && roperand)) { return false; }
+   if(!loperand) { return false; }
 
    retAddr = ADDR_NULL; // We won't be setting this...
    // retReg may have a value or be the (register) equivalent of NULL.
@@ -1330,8 +1330,8 @@ bool AstOperatorNode::generateCode_phase2(codeGen &gen, bool noCost,
          break;
       }
       case ifOp: {
+         if(!roperand) { return false; }
          // This ast cannot be shared because it doesn't return a register
-
          if (!loperand->generateCode_phase2(gen, noCost, addr, src1)) ERROR_RETURN;
          REGISTER_CHECK(src1);
          codeBufIndex_t ifIndex= gen.getIndex();
@@ -1481,6 +1481,7 @@ bool AstOperatorNode::generateCode_phase2(codeGen &gen, bool noCost,
          break;
       }
       case whileOp: {
+        if(!roperand) { return false; }
         codeBufIndex_t top = gen.getIndex(); 
 
         // BEGIN from ifOp       
@@ -1627,6 +1628,7 @@ bool AstOperatorNode::generateCode_phase2(codeGen &gen, bool noCost,
          break;
       }
       case storeOp: {
+        if(!roperand) { return false; }
 	bool result = generateOptimizedAssignment(gen, size, noCost);
          if (result)
             break;
@@ -1745,7 +1747,7 @@ bool AstOperatorNode::generateCode_phase2(codeGen &gen, bool noCost,
          break;
       }
       case storeIndirOp: {
-
+        if(!roperand) { return false; }
          if (!roperand->generateCode_phase2(gen, noCost, addr, src1)) ERROR_RETURN;
          if (!loperand->generateCode_phase2(gen, noCost, addr, src2)) ERROR_RETURN;
          REGISTER_CHECK(src1);
@@ -1778,6 +1780,7 @@ bool AstOperatorNode::generateCode_phase2(codeGen &gen, bool noCost,
       case geOp:
       default:
       {
+         if(!roperand) { return false; }
          bool signedOp = IsSignedOperation(loperand->getType(), roperand->getType());
          src1 = Null_Register;
          right_dest = Null_Register;

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -2456,11 +2456,11 @@ void AstNode::print() const {
         fprintf(stderr," %s", (char *)oValue);
       } else if (oType == operandType::DataIndir) {
 	fprintf(stderr," @[");
-        loperand->print();
+        if(loperand) loperand->print();
 	fprintf(stderr,"]");
       } else if (oType == operandType::DataReg) {
 	fprintf(stderr," reg%d ",(int)(Address)oValue);
-        loperand->print();
+	if(loperand) loperand->print();
       } else if (oType == operandType::Param || oType == operandType::ParamAtCall || oType == operandType::ParamAtEntry) {
 	fprintf(stderr," param[%d]", (int)(Address) oValue);
       } else if (oType == operandType::ReturnVal) {

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -1784,14 +1784,11 @@ bool AstOperatorNode::generateCode_phase2(codeGen &gen, bool noCost,
          bool signedOp = IsSignedOperation(loperand->getType(), roperand->getType());
          src1 = Null_Register;
          right_dest = Null_Register;
-         if (loperand) {
             if (!loperand->generateCode_phase2(gen,
                                                noCost, addr, src1)) ERROR_RETURN;
             REGISTER_CHECK(src1);
-         }
 
-         if (roperand &&
-             (roperand->getoType() == operandType::Constant) &&
+         if ((roperand->getoType() == operandType::Constant) &&
              doNotOverflow((int64_t)roperand->getOValue())) {
             if (retReg == REG_NULL) {
                retReg = allocateAndKeep(gen, noCost);
@@ -1810,10 +1807,8 @@ bool AstOperatorNode::generateCode_phase2(codeGen &gen, bool noCost,
             roperand->decUseCount(gen);
          }
          else {
-            if (roperand) {
                if (!roperand->generateCode_phase2(gen, noCost, addr, right_dest)) ERROR_RETURN;
                REGISTER_CHECK(right_dest);
-            }
             if (retReg == REG_NULL) {
                retReg = allocateAndKeep(gen, noCost);
             }

--- a/dyninstAPI/src/ast.h
+++ b/dyninstAPI/src/ast.h
@@ -572,7 +572,6 @@ class AstOperatorNode : public AstNode {
 
     bool generateOptimizedAssignment(codeGen &gen, int size, bool noCost);
 
-    AstOperatorNode() {}
     opCode op{};
     AstNodePtr loperand;
     AstNodePtr roperand;

--- a/dyninstAPI/src/ast.h
+++ b/dyninstAPI/src/ast.h
@@ -534,6 +534,12 @@ class AstOperatorNode : public AstNode {
  public:
 
     AstOperatorNode(opCode opC, AstNodePtr l, AstNodePtr r = AstNodePtr(), AstNodePtr e = AstNodePtr());
+    
+    ~AstOperatorNode() {
+        //printf("at ~AstOperatorode()\n");
+        //debugPrint();
+    }
+
 
    virtual std::string format(std::string indent);
     virtual int costHelper(enum CostStyleType costStyle) const;	
@@ -566,6 +572,7 @@ class AstOperatorNode : public AstNode {
 
     bool generateOptimizedAssignment(codeGen &gen, int size, bool noCost);
 
+    AstOperatorNode() {}
     opCode op{};
     AstNodePtr loperand;
     AstNodePtr roperand;

--- a/dyninstAPI/src/ast.h
+++ b/dyninstAPI/src/ast.h
@@ -534,12 +534,6 @@ class AstOperatorNode : public AstNode {
  public:
 
     AstOperatorNode(opCode opC, AstNodePtr l, AstNodePtr r = AstNodePtr(), AstNodePtr e = AstNodePtr());
-    
-    ~AstOperatorNode() {
-        //printf("at ~AstOperatorode()\n");
-        //debugPrint();
-    }
-
 
    virtual std::string format(std::string indent);
     virtual int costHelper(enum CostStyleType costStyle) const;	


### PR DESCRIPTION
The lack of consistent checking of empty pointers was fixed by #1609, but those changes broke the semantics of the class. This reverts those changes and fixes the pointer checks more directly.