### PR TITLE
Deprecate Symtab::getOrCreateModule

### DIFF
--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -38,6 +38,7 @@
 #include "os.h"
 #include "instPoint.h"
 #include "function.h"
+#include "Object.h"
 
 using namespace Dyninst::SymtabAPI;
 
@@ -585,8 +586,12 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       }
       
       std::vector<Symbol *> newSyms;
-      buildDyninstSymbols(newSyms, newSec, symObj->getOrCreateModule("dyninstInst",
-                                                                     lowWaterMark_));
+      auto *mod = symObj->getContainingModule(lowWaterMark_);
+      if(!mod) {
+	  mod = new Module(lang_Unknown, lowWaterMark_, "dyninstInst", symObj);
+	  symObj->getObject()->addModule(mod);
+      }
+      buildDyninstSymbols(newSyms, newSec, mod);
       for (unsigned i = 0; i < newSyms.size(); i++) {
          symObj->addSymbol(newSyms[i]);
       }

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -429,8 +429,8 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
 
    bool canBeShared();
-   Module *getOrCreateModule(const std::string &modName, 
-                                           const Offset modAddr);
+   DYNINST_DEPRECATED("Use getContainingModule")
+   Module *getOrCreateModule(const std::string &modName, const Offset modAddr);
    bool parseFunctionRanges();
 
    //Only valid on ELF formats

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -441,6 +441,7 @@ class SYMTAB_EXPORT Symtab : public LookupInterface,
 
  private:
    void createDefaultModule();
+   void addModule(Module *m);
    
    //bool buildFunctionLists(std::vector <Symbol *> &raw_funcs);
    //void enterFunctionInTables(Symbol *func, bool wasSymtab);

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3051,6 +3051,10 @@ ObjectType Object::objType() const {
     return obj_type_;
 }
 
+void Object::addModule(SymtabAPI::Module* m) {
+  associated_symtab->addModule(m);
+}
+
 void Object::getModuleLanguageInfo(dyn_hash_map<string, supportedLanguages> *mod_langs) {
     string working_module;
     string mod_string;

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -53,7 +53,7 @@
 #include "headers.h"
 #include "MappedFile.h"
 #include "IntervalTree.h"
-
+#include "Module.h"
 #include <elf.h>
 #include <libelf.h>
 #include <string>
@@ -166,8 +166,8 @@ public:
   bool hasDwarfInfo() const { return dwarvenDebugInfo; }
   void getModuleLanguageInfo(dyn_hash_map<std::string, supportedLanguages> *mod_langs);
   void parseFileLineInfo();
-  
   void parseTypeInfo();
+  void addModule(SymtabAPI::Module* m) override;
 
   bool needs_function_binding() const override { return (plt_addr_ > 0); }
   bool get_func_binding_table(std::vector<relocationEntry> &fbt) const override;

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -49,6 +49,7 @@
 
 #include "Symbol.h"
 #include "Symtab.h"
+#include "Module.h"
 #include "LineInformation.h"
 #include "common/src/headers.h"
 #include "common/src/MappedFile.h"
@@ -140,6 +141,7 @@ public:
     // Only implemented for ELF right now
     SYMTAB_EXPORT virtual void getSegmentsSymReader(std::vector<SymSegment> &) {}
 	SYMTAB_EXPORT virtual void rebase(Offset) {}
+    virtual void addModule(SymtabAPI::Module *) {}
 protected:
     SYMTAB_EXPORT virtual ~AObject();
     // explicitly protected

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -786,14 +786,14 @@ void Symtab::createDefaultModule() {
                      this);
     mod->addRange(imageOffset_, imageLen_ + imageOffset_);
     impl->default_module = mod;
-    impl->modules.insert(mod);
-    for(auto *m : mod->finalizeRanges()) {
-	impl->mod_lookup_.insert(m);
-    }
+    addModule(mod);
 }
 
-void Symtab::addModule(Module *m) {
-  impl->modules.insert(m);
+void Symtab::addModule(Module *mod) {
+  impl->modules.insert(mod);
+  for(auto *m : mod->finalizeRanges()) {
+    impl->mod_lookup_.insert(m);
+  }
 }
 
 Module *Symtab::getOrCreateModule(const std::string &modName, 
@@ -807,9 +807,8 @@ Module *Symtab::getOrCreateModule(const std::string &modName,
 	          FILE__, __LINE__, modName.c_str(), modAddr);
 
     Module *mod = new Module(lang_Unknown, modAddr, modName, this);
+    addModule(mod);
 
-    impl->modules.insert(mod);
-    
     return mod;
 }
 

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -792,7 +792,9 @@ void Symtab::createDefaultModule() {
     }
 }
 
-
+void Symtab::addModule(Module *m) {
+  impl->modules.insert(m);
+}
 
 Module *Symtab::getOrCreateModule(const std::string &modName, 
                                   const Offset modAddr)

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -498,13 +498,6 @@ bool Symtab::fixSymModules(std::vector<Symbol *> &raw_syms)
 	createDefaultModule();
     }
 
-    for (auto *m : impl->modules)
-    {
-        for(auto *mr : m->finalizeRanges()) {
-            impl->mod_lookup_.insert(mr);
-        }
-    }
-
 //    const std::vector<std::pair<std::string, Offset> > &mods = obj->modules_;
 //    for (unsigned i=0; i< mods.size(); i++) {
 //       getOrCreateModule(mods[i].first, mods[i].second);


### PR DESCRIPTION
There are several problems here:

1) Users shouldn't be creating modules

2) When created, the returned module must be "fixed up" before it's
useful. There's no need for that when one could be properly constructed
at the callsite inside Dyninst.

3) It violates the Single Responsibility Principle