### PR TITLE
Construct a Module from the CU's offset not its PC

### DIFF
--- a/dwarf/h/dwarf_cu_info.h
+++ b/dwarf/h/dwarf_cu_info.h
@@ -97,6 +97,12 @@ namespace Dyninst { namespace DwarfDyninst {
    *
    */
   inline Dwarf_Die *find_cu(Dwarf *dbg, Dwarf_Addr addr, Dwarf_Die *result) {
+    // The .debug_info DIE offset is the starting address for modules.
+    if(dwarf_offdie(dbg, addr, result)) {
+      return result;
+    }
+
+    // Search for the given address (assumes .debug_aranges is present)
     Dwarf_Die cuDIE{};
     if (dwarf_addrdie(dbg, addr, &cuDIE)) {
       *result = cuDIE;

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2193,7 +2193,7 @@ bool Object::fix_global_symbol_modules_static_dwarf() {
 
         dwarf_printf("Locating ranges for module '%s' at offset 0x%zx\n", modname.c_str(), loc);
         std::vector<AddressRange> mod_ranges = DwarfWalker::getDieRanges(cu_die);
-        auto *m = associated_symtab->getContainingModule(loc);
+        auto *m = associated_symtab->findModuleByOffset(loc);
         if(!m) {
           m = new SymtabAPI::Module(lang_Unknown, loc, modname, associated_symtab);
         }

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2189,17 +2189,13 @@ bool Object::fix_global_symbol_modules_static_dwarf() {
 
         std::string modname = DwarfDyninst::cu_name(cu_die);
 
-        Address tempModLow;
-        Address modLow = 0;
-        if (DwarfWalker::findConstant(DW_AT_low_pc, tempModLow, &cu_die, dbg)) {
-            convertDebugOffset(tempModLow, modLow);
-        }
+        auto const loc = dwarf_dieoffset(&cu_die);
 
-        dwarf_printf("Locating ranges for module '%s' at offset 0x%zx\n", modname.c_str(), modLow);
+        dwarf_printf("Locating ranges for module '%s' at offset 0x%zx\n", modname.c_str(), loc);
         std::vector<AddressRange> mod_ranges = DwarfWalker::getDieRanges(cu_die);
-        auto *m = associated_symtab->getContainingModule(modLow);
+        auto *m = associated_symtab->getContainingModule(loc);
         if(!m) {
-          m = new SymtabAPI::Module(lang_Unknown, modLow, modname, associated_symtab);
+          m = new SymtabAPI::Module(lang_Unknown, loc, modname, associated_symtab);
         }
         dwarf_printf("Adding %zu ranges to '%s'\n", mod_ranges.size(), m->fileName().c_str());
         for (auto r = mod_ranges.begin(); r != mod_ranges.end(); ++r)

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -262,12 +262,12 @@ bool DwarfWalker::parseModule(Dwarf_Die moduleDIE, Module *&fixUnknownMod) {
 
     // Find the Symtab Module corresponding to this CU
     mod() = [this]() {
-      SymtabAPI::Module* m = symtab()->findModuleByOffset(modLow);
+      SymtabAPI::Module* m = symtab()->findModuleByOffset(offset());
       if(m) return m;
       return symtab()->getDefaultModule();
     }();
 
-    dwarf_printf("Mapped to Symtab module %p from '%s' at offset %zx\n", (void*)mod(), mod()->fileName().c_str(), modLow);
+    dwarf_printf("Mapped to Symtab module %p from '%s' at offset %zx\n", (void*)mod(), mod()->fileName().c_str(), offset());
 
     if(!fixUnknownMod){
       fixUnknownMod = mod();


### PR DESCRIPTION
The PC value can be non-unique across CUs. For example, they can all be 0x0 for a PIE binary. The offset of the CU is unique as it's the location inside of the .debug_info table.

Fixes #1625