### PR TITLE
Clean up and improve documentation of x86_64 registers

### DIFF
--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -137,6 +137,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int VM    = 0x11;       // Virtual-8086 Mode
   const signed int AC    = 0x12;       // Alignment Check/Access Control
   const signed int VIF   = 0x13;       // Virtual Interrupt Flag
+  const signed int VIP   = 0x14;       // Virtual Interrupt Pending
   /* Flags 22-63 are reserved */
 
   //          (      name,     ID | alias |   cat |        arch,     arch)
@@ -231,6 +232,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(        vm,     VM |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ac,     AC |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(       vif,    VIF |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       vip,    VIP |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ds, BASEDS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        es, BASEES |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        fs, BASEFS |  FULL |   SEG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -62,15 +62,15 @@ namespace Dyninst { namespace x86_64 {
    *   registers that are historically referred to by name (e.g., AL is
    *   the lower 8 bits of EAX).
    */
-  const signed int L_REG  = 0x00000100; // 8-bit, first byte
-  const signed int H_REG  = 0x00000200; // 8-bit, second byte
-  const signed int W_REG  = 0x00000300; // 16-bit, first word
-  const signed int D_REG  = 0x00000F00; // 32 bit, first double word
   const signed int FULL   = 0x00000000; // 64 bits
-  const signed int MMS    = 0x00000500; // 64-bit MMX and 3DNow!
-  const signed int OCT    = 0x00000600; // 128-bit SSE, FC16, XOP, AVX, and FMA3/4
-  const signed int FPDBL  = 0x00000700; // 80-bit x87 FPU
-  const signed int BIT    = 0x00000800; // 1-bit EFLAGS
+  const signed int BIT    = 0x00000100; // 1-bit EFLAGS
+  const signed int L_REG  = 0x00000200; // 8-bit, first byte
+  const signed int H_REG  = 0x00000300; // 8-bit, second byte
+  const signed int W_REG  = 0x00000400; // 16-bit, first word
+  const signed int D_REG  = 0x00000500; // 32 bit, first double word
+  const signed int FPDBL  = 0x00000600; // 80-bit x87 FPU
+  const signed int MMS    = 0x00000700; // 64-bit MMX and 3DNow!
+  const signed int OCT    = 0x00000800; // 128-bit SSE, FC16, XOP, AVX, and FMA3/4
   const signed int YMMS   = 0x00000900; // 256-bit SSE, AVX2, FMA3/4
   const signed int ZMMS   = 0x00000A00; // 512-bit AVX-512/AVX10
   const signed int GPR    = 0x00010000;

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -85,6 +85,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int CTL    = 0x000A0000;
   const signed int DBG    = 0x000B0000;
   const signed int TST    = 0x000C0000;
+  const signed int X87    = 0x000D0000;  // x87 FPU Registers
   const signed int FLAGS  = 0x00000000;
   const signed int BASEA  = 0x0;
   const signed int BASEC  = 0x1;
@@ -343,14 +344,14 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(       tr5,    0x5 |  FULL |   TST | Arch_x86_64, "x86_64");
   DEF_REGISTER(       tr6,    0x6 |  FULL |   TST | Arch_x86_64, "x86_64");
   DEF_REGISTER(       tr7,    0x7 |  FULL |   TST | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st0,    0x0 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st1,    0x1 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st2,    0x2 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st3,    0x3 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st4,    0x4 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st5,    0x5 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st6,    0x6 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st7,    0x7 | FPDBL |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st0,    0x0 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st1,    0x1 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st2,    0x2 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st3,    0x3 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st4,    0x4 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st5,    0x5 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st6,    0x6 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st7,    0x7 | FPDBL |   X87 | Arch_x86_64, "x86_64");
 
 }}
 

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -88,6 +88,8 @@ namespace Dyninst { namespace x86_64 {
   const signed int YMM    = 0x000B0000;  // YMM0-YMM7 Registers from AVX2/FMA
   const signed int ZMM    = 0x000C0000;  // ZMM0-ZMM7 Registers from AVX-512
   const signed int KMASK  = 0x000D0000;  // K0-K7 opmask Registers from AVX-512
+
+  /* Base IDs for aliased GPRs */
   const signed int BASEA  = 0x0;
   const signed int BASEC  = 0x1;
   const signed int BASED  = 0x2;

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -122,6 +122,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int PF    = x86::PF;    // Parity Flag
   const signed int FLAG3 = x86::FLAG3; // Reserved
   const signed int AF    = x86::AF;    // Auxiliary Carry Flag
+  const signed int FLAG5 = x86::FLAG5; // Reserved
   const signed int ZF    = x86::ZF;    // Zero Flag
   const signed int SF    = x86::SF;    // Sign Flag
   const signed int TF    = x86::TF;    // Trap Flag
@@ -208,6 +209,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(        pf,     PF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(     flag3,  FLAG3 |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        af,     AF |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     flag5,  FLAG5 |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        zf,     ZF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        sf,     SF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        tf,     TF |   BIT |  FLAG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -51,19 +51,27 @@ namespace Dyninst { namespace x86_64 {
    *  public interface, and may change.
    **/
 
-  const signed int L_REG = 0x00000100; // 8-bit, first byte
-  const signed int H_REG = 0x00000200; // 8-bit, second byte
-  const signed int W_REG = 0x00000300; // 16 bit, first work
-  const signed int D_REG = 0x00000F00; // 32 bit, first double word
-
-  // MachRegister::getBaseRegister clears the bit field for size,
-  // so the full register size has to be 0
-  const signed int FULL   = 0x00000000;  // 64 bits
-  const signed int OCT    = 0x00000600;  // 128 bits
-  const signed int FPDBL  = 0x00000700;  // 80 bits
-  const signed int BIT    = 0x00000800;  // 1 bit
-  const signed int YMMS   = 0x00000900;  // YMM are 256 bits
-  const signed int ZMMS   = 0x00000A00;  // ZMM are 512 bits
+  /* Register lengths
+   *
+   * NOTE:
+   *
+   *   MachRegister::getBaseRegister clears the bit field for size, so
+   *   the full register size has to be represented as 0x0.
+   *
+   *   The {L,H,W}_REG sizes represent the aliased portions of the GPR
+   *   registers that are historically referred to by name (e.g., AL is
+   *   the lower 8 bits of EAX).
+   */
+  const signed int L_REG  = 0x00000100; // 8-bit, first byte
+  const signed int H_REG  = 0x00000200; // 8-bit, second byte
+  const signed int W_REG  = 0x00000300; // 16-bit, first word
+  const signed int D_REG  = 0x00000F00; // 32 bit, first double word
+  const signed int FULL   = 0x00000000; // 64 bits
+  const signed int OCT    = 0x00000600; // 128-bit SSE, FC16, XOP, AVX, and FMA3/4
+  const signed int FPDBL  = 0x00000700; // 80-bit x87 FPU
+  const signed int BIT    = 0x00000800; // 1-bit EFLAGS
+  const signed int YMMS   = 0x00000900; // 256-bit SSE, AVX2, FMA3/4
+  const signed int ZMMS   = 0x00000A00; // 512-bit AVX-512/AVX10
   const signed int GPR    = 0x00010000;
   const signed int SEG    = 0x00020000;
   const signed int FLAG   = 0x00030000;

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -139,75 +139,76 @@ namespace Dyninst { namespace x86_64 {
    */
   //          (      name,     ID | alias |   cat |        arch,     arch)
   DEF_REGISTER(       rax,  BASEA |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       rcx,  BASEC |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       rdx,  BASED |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       rbx,  BASEB |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       rsp, BASESP |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       rbp, BASEBP |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       rsi, BASESI |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       rdi, BASEDI |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        r8,  BASE8 |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        r9,  BASE9 |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       r10, BASE10 |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       r11, BASE11 |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       r12, BASE12 |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       r13, BASE13 |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       r14, BASE14 |  FULL |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       r15, BASE15 |  FULL |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       eax,  BASEA | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        ax,  BASEA | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ah,  BASEA | H_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(        al,  BASEA | L_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        ax,  BASEA | W_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       eax,  BASEA | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       rcx,  BASEC |  FULL |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       ecx,  BASEC | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        cx,  BASEC | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ch,  BASEC | H_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(        cl,  BASEC | L_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        cx,  BASEC | W_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       ecx,  BASEC | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       rdx,  BASED |  FULL |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       edx,  BASED | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        dx,  BASED | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(        dh,  BASED | H_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(        dl,  BASED | L_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        dx,  BASED | W_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       edx,  BASED | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       rbx,  BASEB |  FULL |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       ebx,  BASEB | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        bx,  BASEB | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(        bh,  BASEB | H_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(        bl,  BASEB | L_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        bx,  BASEB | W_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       ebx,  BASEB | D_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       spl, BASESP | L_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        sp, BASESP | W_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       rsp, BASESP |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       esp, BASESP | D_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       bpl, BASEBP | L_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        bp, BASEBP | W_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        sp, BASESP | W_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       spl, BASESP | L_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       rbp, BASEBP |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       ebp, BASEBP | D_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       dil, BASEDI | L_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        di, BASEDI | W_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       edi, BASEDI | D_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       sil, BASESI | L_REG |   GPR | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        si, BASESI | W_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        bp, BASEBP | W_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       bpl, BASEBP | L_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       rsi, BASESI |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       esi, BASESI | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        si, BASESI | W_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       sil, BASESI | L_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       rdi, BASEDI |  FULL |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       edi, BASEDI | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        di, BASEDI | W_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       dil, BASEDI | L_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        r8,  BASE8 |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       r8b,  BASE8 | L_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       r8w,  BASE8 | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       r8d,  BASE8 | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        r9,  BASE9 |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       r9b,  BASE9 | L_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       r9w,  BASE9 | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       r9d,  BASE9 | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       r10, BASE10 |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r10b, BASE10 | L_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r10w, BASE10 | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r10d, BASE10 | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       r11, BASE11 |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r11b, BASE11 | L_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r11w, BASE11 | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r11d, BASE11 | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       r12, BASE12 |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r12b, BASE12 | L_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r12w, BASE12 | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r12d, BASE12 | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       r13, BASE13 |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r13b, BASE13 | L_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r13w, BASE13 | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r13d, BASE13 | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       r14, BASE14 |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r14b, BASE14 | L_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r14w, BASE14 | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r14d, BASE14 | D_REG |   GPR | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       r15, BASE15 |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r15b, BASE15 | L_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r15w, BASE15 | W_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(      r15d, BASE15 | D_REG |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       rip,   0x10 |  FULL |         Arch_x86_64, "x86_64");
   DEF_REGISTER(       eip,   0x10 | D_REG |         Arch_x86_64, "x86_64");
+
   DEF_REGISTER(     flags,  FLAGS |  FULL |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        cf,     CF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(     flag1,  FLAG1 |   BIT |  FLAG | Arch_x86_64, "x86_64");
@@ -231,23 +232,50 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(       vif,    VIF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(       vip,    VIP |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(       id,      ID |   BIT |  FLAG | Arch_x86_64, "x86_64");
+
   DEF_REGISTER(        ds, BASEDS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        es, BASEES |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        fs, BASEFS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        gs, BASEGS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        cs, BASECS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ss, BASESS |  FULL |   SEG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      orax,    0x0 |  FULL |  MISC | Arch_x86_64, "x86_64");
-  DEF_REGISTER(    fsbase,    0x1 |  FULL |  MISC | Arch_x86_64, "x86_64");
-  DEF_REGISTER(    gsbase,    0x2 |  FULL |  MISC | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k0,   0x00 | KMSKS | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k1,   0x01 | KMSKS | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k2,   0x02 | KMSKS | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k3,   0x03 | KMSKS | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k4,   0x04 | KMSKS | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k5,   0x05 | KMSKS | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k6,   0x06 | KMSKS | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k7,   0x07 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+
+  DEF_REGISTER(       cr0,    0x0 |  FULL |   CTL | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       cr1,    0x1 |  FULL |   CTL | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       cr2,    0x2 |  FULL |   CTL | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       cr3,    0x3 |  FULL |   CTL | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       cr4,    0x4 |  FULL |   CTL | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       cr5,    0x5 |  FULL |   CTL | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       cr6,    0x6 |  FULL |   CTL | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       cr7,    0x7 |  FULL |   CTL | Arch_x86_64, "x86_64");
+
+  DEF_REGISTER(       dr0,    0x0 |  FULL |   DBG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       dr1,    0x1 |  FULL |   DBG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       dr2,    0x2 |  FULL |   DBG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       dr3,    0x3 |  FULL |   DBG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       dr4,    0x4 |  FULL |   DBG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       dr5,    0x5 |  FULL |   DBG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       dr6,    0x6 |  FULL |   DBG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       dr7,    0x7 |  FULL |   DBG | Arch_x86_64, "x86_64");
+
+  DEF_REGISTER(       st0,    0x0 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st1,    0x1 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st2,    0x2 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st3,    0x3 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st4,    0x4 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st5,    0x5 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st6,    0x6 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       st7,    0x7 | FPDBL |   X87 | Arch_x86_64, "x86_64");
+
+  DEF_REGISTER(       mm0,    0x0 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm1,    0x1 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm2,    0x2 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm3,    0x3 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm4,    0x4 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm5,    0x5 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm6,    0x6 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm7,    0x7 |   MMS |   MMX | Arch_x86_64, "x86_64");
+
   DEF_REGISTER(      xmm0,   0x00 |  XMMS |   XMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      xmm1,   0x01 |  XMMS |   XMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      xmm2,   0x02 |  XMMS |   XMM | Arch_x86_64, "x86_64");
@@ -280,6 +308,10 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(     xmm29,   0x1D |  XMMS |   XMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(     xmm30,   0x1E |  XMMS |   XMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(     xmm31,   0x1F |  XMMS |   XMM | Arch_x86_64, "x86_64");
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
   DEF_REGISTER(      ymm0,   0x00 |  YMMS |   YMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      ymm1,   0x01 |  YMMS |   YMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      ymm2,   0x02 |  YMMS |   YMM | Arch_x86_64, "x86_64");
@@ -312,6 +344,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(     ymm29,   0x1D |  YMMS |   YMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(     ymm30,   0x1E |  YMMS |   YMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(     ymm31,   0x1F |  YMMS |   YMM | Arch_x86_64, "x86_64");
+
   DEF_REGISTER(      zmm0,   0x00 |  ZMMS |   ZMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      zmm1,   0x01 |  ZMMS |   ZMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      zmm2,   0x02 |  ZMMS |   ZMM | Arch_x86_64, "x86_64");
@@ -344,30 +377,21 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(     zmm29,   0x1D |  ZMMS |   ZMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(     zmm30,   0x1E |  ZMMS |   ZMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(     zmm31,   0x1F |  ZMMS |   ZMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm0,    0x0 |   MMS |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm1,    0x1 |   MMS |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm2,    0x2 |   MMS |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm3,    0x3 |   MMS |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm4,    0x4 |   MMS |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm5,    0x5 |   MMS |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm6,    0x6 |   MMS |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm7,    0x7 |   MMS |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       cr0,    0x0 |  FULL |   CTL | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       cr1,    0x1 |  FULL |   CTL | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       cr2,    0x2 |  FULL |   CTL | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       cr3,    0x3 |  FULL |   CTL | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       cr4,    0x4 |  FULL |   CTL | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       cr5,    0x5 |  FULL |   CTL | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       cr6,    0x6 |  FULL |   CTL | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       cr7,    0x7 |  FULL |   CTL | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       dr0,    0x0 |  FULL |   DBG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       dr1,    0x1 |  FULL |   DBG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       dr2,    0x2 |  FULL |   DBG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       dr3,    0x3 |  FULL |   DBG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       dr4,    0x4 |  FULL |   DBG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       dr5,    0x5 |  FULL |   DBG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       dr6,    0x6 |  FULL |   DBG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       dr7,    0x7 |  FULL |   DBG | Arch_x86_64, "x86_64");
+
+  DEF_REGISTER(        k0,   0x00 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k1,   0x01 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k2,   0x02 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k3,   0x03 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k4,   0x04 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k5,   0x05 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k6,   0x06 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k7,   0x07 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+
+
+  /* Pseudo-registers for internal use only */
+  DEF_REGISTER(      orax,    0x0 |  FULL |  MISC | Arch_x86_64, "x86_64");
+  DEF_REGISTER(    fsbase,    0x1 |  FULL |  MISC | Arch_x86_64, "x86_64");
+  DEF_REGISTER(    gsbase,    0x2 |  FULL |  MISC | Arch_x86_64, "x86_64");
   DEF_REGISTER(       tr0,    0x0 |  FULL |   TST | Arch_x86_64, "x86_64");
   DEF_REGISTER(       tr1,    0x1 |  FULL |   TST | Arch_x86_64, "x86_64");
   DEF_REGISTER(       tr2,    0x2 |  FULL |   TST | Arch_x86_64, "x86_64");
@@ -376,14 +400,6 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(       tr5,    0x5 |  FULL |   TST | Arch_x86_64, "x86_64");
   DEF_REGISTER(       tr6,    0x6 |  FULL |   TST | Arch_x86_64, "x86_64");
   DEF_REGISTER(       tr7,    0x7 |  FULL |   TST | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st0,    0x0 | FPDBL |   X87 | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st1,    0x1 | FPDBL |   X87 | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st2,    0x2 | FPDBL |   X87 | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st3,    0x3 | FPDBL |   X87 | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st4,    0x4 | FPDBL |   X87 | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st5,    0x5 | FPDBL |   X87 | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st6,    0x6 | FPDBL |   X87 | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       st7,    0x7 | FPDBL |   X87 | Arch_x86_64, "x86_64");
 
 }}
 

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -132,6 +132,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int FLAGC = x86::FLAGC; // I/O Privilege Level (bits 12 and 13)
   const signed int FLAGD = x86::FLAGD; // I/O Privilege Level (bits 12 and 13)
   const signed int NT    = x86::NT;    // Nested Task
+  const signed int FLAGF = x86::FLAGF; // Reserved
   const signed int RF    = x86::RF;    // Resume Flag
 
   //          (      name,     ID | alias |   cat |        arch,     arch)
@@ -221,6 +222,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(     flagc,  FLAGC |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(     flagd,  FLAGD |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(       nt_,     NT |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     flagf,  FLAGF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        rf,     RF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ds, BASEDS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        es, BASEES |  FULL |   SEG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -129,6 +129,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int IF    = x86::IF;    // Interrupt Enable Flag
   const signed int DF    = x86::DF;    // Direction Flag
   const signed int OF    = x86::OF;    // Overflow Flag
+  const signed int FLAGC = x86::FLAGC; // I/O Privilege Level (bits 12 and 13)
   const signed int NT    = x86::NT;    // Nested Task
   const signed int RF    = x86::RF;    // Resume Flag
 
@@ -216,6 +217,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(       if_,     IF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        df,     DF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        of,     OF |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     flagc,  FLAGC |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(       nt_,     NT |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        rf,     RF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ds, BASEDS |  FULL |   SEG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -138,6 +138,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int AC    = 0x12;       // Alignment Check/Access Control
   const signed int VIF   = 0x13;       // Virtual Interrupt Flag
   const signed int VIP   = 0x14;       // Virtual Interrupt Pending
+  const signed int ID    = 0x15;       // ID Flag
   /* Flags 22-63 are reserved */
 
   //          (      name,     ID | alias |   cat |        arch,     arch)
@@ -233,6 +234,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(        ac,     AC |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(       vif,    VIF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(       vip,    VIP |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       id,      ID |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ds, BASEDS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        es, BASEES |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        fs, BASEFS |  FULL |   SEG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -116,7 +116,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int BASECS = 0x4; // Code Segment register
   const signed int BASEES = 0x5; // Extended data Segment register
 
-  /* Base IDs for each bit in EFLAGS */
+  /* Base IDs for each bit in RFLAGS */
   const signed int CF    = x86::CF;    // Carry Flag
   const signed int FLAG1 = x86::FLAG1; // Reserved
   const signed int PF    = x86::PF;    // Parity Flag
@@ -134,6 +134,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int NT    = x86::NT;    // Nested Task
   const signed int FLAGF = x86::FLAGF; // Reserved
   const signed int RF    = x86::RF;    // Resume Flag
+  /* Flags 22-63 are reserved */
 
   //          (      name,     ID | alias |   cat |        arch,     arch)
   DEF_REGISTER(       rax,  BASEA |  FULL |   GPR | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -88,7 +88,6 @@ namespace Dyninst { namespace x86_64 {
   const signed int YMM    = 0x000B0000;  // YMM0-YMM7 Registers from AVX2/FMA
   const signed int ZMM    = 0x000C0000;  // ZMM0-ZMM7 Registers from AVX-512
   const signed int KMASK  = 0x000D0000;  // K0-K7 opmask Registers from AVX-512
-  const signed int FLAGS  = 0x00000000;  // RFLAGS Register
   const signed int BASEA  = 0x0;
   const signed int BASEC  = 0x1;
   const signed int BASED  = 0x2;
@@ -105,6 +104,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int BASE13 = 0xd;
   const signed int BASE14 = 0xe;
   const signed int BASE15 = 0xf;
+  const signed int FLAGS  = 0x00000000;  // RFLAGS Register
 
   const signed int CF = x86::CF;
   const signed int PF = x86::PF;

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -108,17 +108,18 @@ namespace Dyninst { namespace x86_64 {
   const signed int BASE15 = 0xf;
   const signed int FLAGS  = 0x00000000;  // RFLAGS Register
 
-  const signed int CF = x86::CF;
-  const signed int PF = x86::PF;
-  const signed int AF = x86::AF;
-  const signed int ZF = x86::ZF;
-  const signed int SF = x86::SF;
-  const signed int TF = x86::TF;
-  const signed int IF = x86::IF;
-  const signed int DF = x86::DF;
-  const signed int OF = x86::OF;
-  const signed int NT = x86::NT;
-  const signed int RF = x86::RF;
+  /* Base IDs for each bit in EFLAGS */
+  const signed int CF = x86::CF; // Carry Flag
+  const signed int PF = x86::PF; // Parity Flag
+  const signed int AF = x86::AF; // Auxiliary Carry Flag
+  const signed int ZF = x86::ZF; // Zero Flag
+  const signed int SF = x86::SF; // Sign Flag
+  const signed int TF = x86::TF; // Trap Flag
+  const signed int IF = x86::IF; // Interrupt Enable Flag
+  const signed int DF = x86::DF; // Direction Flag
+  const signed int OF = x86::OF; // Overflow Flag
+  const signed int NT = x86::NT; // Nested Task
+  const signed int RF = x86::RF; // Resume Flag
 
   //          (      name,     ID | alias |   cat |        arch,     arch)
   DEF_REGISTER(       rax,  BASEA |  FULL |   GPR | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -73,20 +73,22 @@ namespace Dyninst { namespace x86_64 {
   const signed int OCT    = 0x00000800; // 128-bit SSE, FC16, XOP, AVX, and FMA3/4
   const signed int YMMS   = 0x00000900; // 256-bit SSE, AVX2, FMA3/4
   const signed int ZMMS   = 0x00000A00; // 512-bit AVX-512/AVX10
-  const signed int GPR    = 0x00010000;
-  const signed int SEG    = 0x00020000;
-  const signed int FLAG   = 0x00030000;
-  const signed int MISC   = 0x00040000;
-  const signed int KMASK  = 0x00050000;
-  const signed int XMM    = 0x00060000;
-  const signed int YMM    = 0x00070000;
-  const signed int ZMM    = 0x00080000;
-  const signed int MMX    = 0x00090000;
-  const signed int CTL    = 0x000A0000;
-  const signed int DBG    = 0x000B0000;
-  const signed int TST    = 0x000C0000;
+
+  /* Register Categories */
+  const signed int GPR    = 0x00010000;  // General-Purpose Registers
+  const signed int SEG    = 0x00020000;  // Segment Registers
+  const signed int FLAG   = 0x00030000;  // EFLAGS Register
+  const signed int MISC   = 0x00040000;  // Internal ProcControlAPI Register
+  const signed int KMASK  = 0x00050000;  // K0-K7 opmask Registers from AVX-512
+  const signed int XMM    = 0x00060000;  // XMM0-XMM7 Registers from SSE
+  const signed int YMM    = 0x00070000;  // YMM0-YMM7 Registers from AVX2/FMA
+  const signed int ZMM    = 0x00080000;  // ZMM0-ZMM7 Registers from AVX-512
+  const signed int MMX    = 0x00090000;  // MM0-MM7 Registers
+  const signed int CTL    = 0x000A0000;  // Control Registers CR0-CR7
+  const signed int DBG    = 0x000B0000;  // Debug Registers DR0-DR7
+  const signed int TST    = 0x000C0000;  // Internal InstructionAPI Registers
   const signed int X87    = 0x000D0000;  // x87 FPU Registers
-  const signed int FLAGS  = 0x00000000;
+  const signed int FLAGS  = 0x00000000;  // RFLAGS Register
   const signed int BASEA  = 0x0;
   const signed int BASEC  = 0x1;
   const signed int BASED  = 0x2;

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -135,6 +135,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int FLAGF = x86::FLAGF; // Reserved
   const signed int RF    = x86::RF;    // Resume Flag
   const signed int VM    = 0x11;       // Virtual-8086 Mode
+  const signed int AC    = 0x12;       // Alignment Check/Access Control
   /* Flags 22-63 are reserved */
 
   //          (      name,     ID | alias |   cat |        arch,     arch)
@@ -227,6 +228,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(     flagf,  FLAGF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        rf,     RF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        vm,     VM |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        ac,     AC |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ds, BASEDS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        es, BASEES |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        fs, BASEFS |  FULL |   SEG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -136,6 +136,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int RF    = x86::RF;    // Resume Flag
   const signed int VM    = 0x11;       // Virtual-8086 Mode
   const signed int AC    = 0x12;       // Alignment Check/Access Control
+  const signed int VIF   = 0x13;       // Virtual Interrupt Flag
   /* Flags 22-63 are reserved */
 
   //          (      name,     ID | alias |   cat |        arch,     arch)
@@ -229,6 +230,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(        rf,     RF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        vm,     VM |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ac,     AC |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       vif,    VIF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ds, BASEDS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        es, BASEES |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        fs, BASEFS |  FULL |   SEG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -308,10 +308,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(     xmm29,   0x1D |  XMMS |   XMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(     xmm30,   0x1E |  XMMS |   XMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(     xmm31,   0x1F |  XMMS |   XMM | Arch_x86_64, "x86_64");
-<<<<<<< Updated upstream
-=======
 
->>>>>>> Stashed changes
   DEF_REGISTER(      ymm0,   0x00 |  YMMS |   YMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      ymm1,   0x01 |  YMMS |   YMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      ymm2,   0x02 |  YMMS |   YMM | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -117,17 +117,18 @@ namespace Dyninst { namespace x86_64 {
   const signed int BASEES = 0x5; // Extended data Segment register
 
   /* Base IDs for each bit in EFLAGS */
-  const signed int CF = x86::CF; // Carry Flag
-  const signed int PF = x86::PF; // Parity Flag
-  const signed int AF = x86::AF; // Auxiliary Carry Flag
-  const signed int ZF = x86::ZF; // Zero Flag
-  const signed int SF = x86::SF; // Sign Flag
-  const signed int TF = x86::TF; // Trap Flag
-  const signed int IF = x86::IF; // Interrupt Enable Flag
-  const signed int DF = x86::DF; // Direction Flag
-  const signed int OF = x86::OF; // Overflow Flag
-  const signed int NT = x86::NT; // Nested Task
-  const signed int RF = x86::RF; // Resume Flag
+  const signed int CF    = x86::CF;    // Carry Flag
+  const signed int FLAG1 = x86::FLAG1; // Reserved
+  const signed int PF    = x86::PF;    // Parity Flag
+  const signed int AF    = x86::AF;    // Auxiliary Carry Flag
+  const signed int ZF    = x86::ZF;    // Zero Flag
+  const signed int SF    = x86::SF;    // Sign Flag
+  const signed int TF    = x86::TF;    // Trap Flag
+  const signed int IF    = x86::IF;    // Interrupt Enable Flag
+  const signed int DF    = x86::DF;    // Direction Flag
+  const signed int OF    = x86::OF;    // Overflow Flag
+  const signed int NT    = x86::NT;    // Nested Task
+  const signed int RF    = x86::RF;    // Resume Flag
 
   //          (      name,     ID | alias |   cat |        arch,     arch)
   DEF_REGISTER(       rax,  BASEA |  FULL |   GPR | Arch_x86_64, "x86_64");
@@ -202,6 +203,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(       eip,   0x10 | D_REG |         Arch_x86_64, "x86_64");
   DEF_REGISTER(     flags,  FLAGS |  FULL |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        cf,     CF |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     flag1,  FLAG1 |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        pf,     PF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        af,     AF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        zf,     ZF |   BIT |  FLAG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -123,11 +123,11 @@ namespace Dyninst { namespace x86_64 {
   const signed int NT    = x86::NT;    // Nested Task
   const signed int FLAGF = x86::FLAGF; // Reserved
   const signed int RF    = x86::RF;    // Resume Flag
-  const signed int VM    = 0x11;       // Virtual-8086 Mode
-  const signed int AC    = 0x12;       // Alignment Check/Access Control
-  const signed int VIF   = 0x13;       // Virtual Interrupt Flag
-  const signed int VIP   = 0x14;       // Virtual Interrupt Pending
-  const signed int ID    = 0x15;       // ID Flag
+  const signed int VM    = x86::VM;    // Virtual-8086 Mode
+  const signed int AC    = x86::AC;    // Alignment Check/Access Control
+  const signed int VIF   = x86::VIF;   // Virtual Interrupt Flag
+  const signed int VIP   = x86::VIP;   // Virtual Interrupt Pending
+  const signed int ID    = x86::ID;    // ID Flag
   /* Flags 22-63 are reserved */
 
   /* Format of constants:

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -106,7 +106,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int BASE13 = 0xd;
   const signed int BASE14 = 0xe;
   const signed int BASE15 = 0xf;
-  const signed int FLAGS  = 0x00000000;  // RFLAGS Register
+  const signed int FLAGS  = 0x0;  // RFLAGS Register
 
   /* Base IDs for each bit in EFLAGS */
   const signed int CF = x86::CF; // Carry Flag

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -120,6 +120,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int CF    = x86::CF;    // Carry Flag
   const signed int FLAG1 = x86::FLAG1; // Reserved
   const signed int PF    = x86::PF;    // Parity Flag
+  const signed int FLAG3 = x86::FLAG3; // Reserved
   const signed int AF    = x86::AF;    // Auxiliary Carry Flag
   const signed int ZF    = x86::ZF;    // Zero Flag
   const signed int SF    = x86::SF;    // Sign Flag
@@ -205,6 +206,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(        cf,     CF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(     flag1,  FLAG1 |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        pf,     PF |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     flag3,  FLAG3 |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        af,     AF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        zf,     ZF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        sf,     SF |   BIT |  FLAG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -134,6 +134,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int NT    = x86::NT;    // Nested Task
   const signed int FLAGF = x86::FLAGF; // Reserved
   const signed int RF    = x86::RF;    // Resume Flag
+  const signed int VM    = 0x11;       // Virtual-8086 Mode
   /* Flags 22-63 are reserved */
 
   //          (      name,     ID | alias |   cat |        arch,     arch)
@@ -225,6 +226,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(       nt_,     NT |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(     flagf,  FLAGF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        rf,     RF |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        vm,     VM |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ds, BASEDS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        es, BASEES |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        fs, BASEFS |  FULL |   SEG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -39,18 +39,6 @@
 
 namespace Dyninst { namespace x86_64 {
 
-  /**
-   * For interpreting constants:
-   *  Lowest 16 bits (0x000000ff) is base register ID
-   *  Next 16 bits (0x0000ff00) is the aliasing and subrange ID-
-   *    used on x86/x86_64 to distinguish between things like EAX and AH
-   *  Next 16 bits (0x00ff0000) are the register category, GPR/FPR/MMX/...
-   *  Top 16 bits (0xff000000) are the architecture.
-   *
-   *  These values/layout are not guaranteed to remain the same as part of the
-   *  public interface, and may change.
-   **/
-
   /* Register lengths
    *
    * NOTE:
@@ -141,6 +129,13 @@ namespace Dyninst { namespace x86_64 {
   const signed int ID    = 0x15;       // ID Flag
   /* Flags 22-63 are reserved */
 
+  /* Format of constants:
+   *  [0x000000ff] Lower 16 bits are base register ID
+   *  [0x0000ff00] Next 16 bits are the aliasing and subrange ID used to distinguish
+   *               between whole and aliased registers like EAX and AH.
+   *  [0x00ff0000] Next 16 bits are the register category, GPR, FLAG, etc.
+   *  [0xff000000] Upper 16 bits are the architecture.
+   */
   //          (      name,     ID | alias |   cat |        arch,     arch)
   DEF_REGISTER(       rax,  BASEA |  FULL |   GPR | Arch_x86_64, "x86_64");
   DEF_REGISTER(       rcx,  BASEC |  FULL |   GPR | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -61,6 +61,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int OCT    = 0x00000800; // 128-bit SSE, FC16, XOP, AVX, and FMA3/4
   const signed int YMMS   = 0x00000900; // 256-bit SSE, AVX2, FMA3/4
   const signed int ZMMS   = 0x00000A00; // 512-bit AVX-512/AVX10
+  const signed int KMSKS  = 0x00000B00;  // 64-bit mask from AVX-512/AVX10
 
   /* Register Categories */
   const signed int GPR    = 0x00010000;  // General-Purpose Registers
@@ -239,14 +240,14 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(      orax,    0x0 |  FULL |  MISC | Arch_x86_64, "x86_64");
   DEF_REGISTER(    fsbase,    0x1 |  FULL |  MISC | Arch_x86_64, "x86_64");
   DEF_REGISTER(    gsbase,    0x2 |  FULL |  MISC | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k0,   0x00 |   OCT | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k1,   0x01 |   OCT | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k2,   0x02 |   OCT | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k3,   0x03 |   OCT | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k4,   0x04 |   OCT | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k5,   0x05 |   OCT | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k6,   0x06 |   OCT | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        k7,   0x07 |   OCT | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k0,   0x00 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k1,   0x01 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k2,   0x02 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k3,   0x03 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k4,   0x04 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k5,   0x05 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k6,   0x06 | KMSKS | KMASK | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        k7,   0x07 | KMSKS | KMASK | Arch_x86_64, "x86_64");
   DEF_REGISTER(      xmm0,   0x00 |   OCT |   XMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      xmm1,   0x01 |   OCT |   XMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      xmm2,   0x02 |   OCT |   XMM | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -67,6 +67,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int W_REG  = 0x00000300; // 16-bit, first word
   const signed int D_REG  = 0x00000F00; // 32 bit, first double word
   const signed int FULL   = 0x00000000; // 64 bits
+  const signed int MMS    = 0x00000500; // 64-bit MMX and 3DNow!
   const signed int OCT    = 0x00000600; // 128-bit SSE, FC16, XOP, AVX, and FMA3/4
   const signed int FPDBL  = 0x00000700; // 80-bit x87 FPU
   const signed int BIT    = 0x00000800; // 1-bit EFLAGS
@@ -310,14 +311,14 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(     zmm29,   0x1D |  ZMMS |   ZMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(     zmm30,   0x1E |  ZMMS |   ZMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(     zmm31,   0x1F |  ZMMS |   ZMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm0,    0x0 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm1,    0x1 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm2,    0x2 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm3,    0x3 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm4,    0x4 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm5,    0x5 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm6,    0x6 | FPDBL |   MMX | Arch_x86_64, "x86_64");
-  DEF_REGISTER(       mm7,    0x7 | FPDBL |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm0,    0x0 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm1,    0x1 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm2,    0x2 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm3,    0x3 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm4,    0x4 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm5,    0x5 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm6,    0x6 |   MMS |   MMX | Arch_x86_64, "x86_64");
+  DEF_REGISTER(       mm7,    0x7 |   MMS |   MMX | Arch_x86_64, "x86_64");
   DEF_REGISTER(       cr0,    0x0 |  FULL |   CTL | Arch_x86_64, "x86_64");
   DEF_REGISTER(       cr1,    0x1 |  FULL |   CTL | Arch_x86_64, "x86_64");
   DEF_REGISTER(       cr2,    0x2 |  FULL |   CTL | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -130,6 +130,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int DF    = x86::DF;    // Direction Flag
   const signed int OF    = x86::OF;    // Overflow Flag
   const signed int FLAGC = x86::FLAGC; // I/O Privilege Level (bits 12 and 13)
+  const signed int FLAGD = x86::FLAGD; // I/O Privilege Level (bits 12 and 13)
   const signed int NT    = x86::NT;    // Nested Task
   const signed int RF    = x86::RF;    // Resume Flag
 
@@ -218,6 +219,7 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(        df,     DF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        of,     OF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(     flagc,  FLAGC |   BIT |  FLAG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     flagd,  FLAGD |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(       nt_,     NT |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        rf,     RF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        ds, BASEDS |  FULL |   SEG | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -58,7 +58,7 @@ namespace Dyninst { namespace x86_64 {
   const signed int D_REG  = 0x00000500; // 32 bit, first double word
   const signed int FPDBL  = 0x00000600; // 80-bit x87 FPU
   const signed int MMS    = 0x00000700; // 64-bit MMX and 3DNow!
-  const signed int OCT    = 0x00000800; // 128-bit SSE, FC16, XOP, AVX, and FMA3/4
+  const signed int XMMS   = 0x00000800; // 128-bit SSE, FC16, XOP, AVX, and FMA3/4
   const signed int YMMS   = 0x00000900; // 256-bit SSE, AVX2, FMA3/4
   const signed int ZMMS   = 0x00000A00; // 512-bit AVX-512/AVX10
   const signed int KMSKS  = 0x00000B00;  // 64-bit mask from AVX-512/AVX10
@@ -248,38 +248,38 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(        k5,   0x05 | KMSKS | KMASK | Arch_x86_64, "x86_64");
   DEF_REGISTER(        k6,   0x06 | KMSKS | KMASK | Arch_x86_64, "x86_64");
   DEF_REGISTER(        k7,   0x07 | KMSKS | KMASK | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      xmm0,   0x00 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      xmm1,   0x01 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      xmm2,   0x02 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      xmm3,   0x03 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      xmm4,   0x04 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      xmm5,   0x05 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      xmm6,   0x06 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      xmm7,   0x07 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      xmm8,   0x08 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(      xmm9,   0x09 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm10,   0x0A |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm11,   0x0B |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm12,   0x0C |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm13,   0x0D |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm14,   0x0E |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm15,   0x0F |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm16,   0x10 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm17,   0x11 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm18,   0x12 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm19,   0x13 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm20,   0x14 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm21,   0x15 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm22,   0x16 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm23,   0x17 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm24,   0x18 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm25,   0x19 |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm26,   0x1A |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm27,   0x1B |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm28,   0x1C |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm29,   0x1D |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm30,   0x1E |   OCT |   XMM | Arch_x86_64, "x86_64");
-  DEF_REGISTER(     xmm31,   0x1F |   OCT |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(      xmm0,   0x00 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(      xmm1,   0x01 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(      xmm2,   0x02 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(      xmm3,   0x03 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(      xmm4,   0x04 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(      xmm5,   0x05 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(      xmm6,   0x06 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(      xmm7,   0x07 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(      xmm8,   0x08 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(      xmm9,   0x09 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm10,   0x0A |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm11,   0x0B |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm12,   0x0C |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm13,   0x0D |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm14,   0x0E |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm15,   0x0F |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm16,   0x10 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm17,   0x11 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm18,   0x12 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm19,   0x13 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm20,   0x14 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm21,   0x15 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm22,   0x16 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm23,   0x17 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm24,   0x18 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm25,   0x19 |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm26,   0x1A |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm27,   0x1B |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm28,   0x1C |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm29,   0x1D |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm30,   0x1E |  XMMS |   XMM | Arch_x86_64, "x86_64");
+  DEF_REGISTER(     xmm31,   0x1F |  XMMS |   XMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      ymm0,   0x00 |  YMMS |   YMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      ymm1,   0x01 |  YMMS |   YMM | Arch_x86_64, "x86_64");
   DEF_REGISTER(      ymm2,   0x02 |  YMMS |   YMM | Arch_x86_64, "x86_64");

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -73,9 +73,9 @@ namespace Dyninst { namespace x86_64 {
   const signed int TST    = 0x00070000;  // Internal InstructionAPI Registers
   const signed int X87    = 0x00080000;  // x87 FPU Registers
   const signed int MMX    = 0x00090000;  // MM0-MM7 Registers
-  const signed int XMM    = 0x000A0000;  // XMM0-XMM7 Registers from SSE
-  const signed int YMM    = 0x000B0000;  // YMM0-YMM7 Registers from AVX2/FMA
-  const signed int ZMM    = 0x000C0000;  // ZMM0-ZMM7 Registers from AVX-512
+  const signed int XMM    = 0x000A0000;  // XMM0-XMM15 Registers from SSE (XMM0-XMM31 for AVX-512)
+  const signed int YMM    = 0x000B0000;  // YMM0-YMM15 Registers from AVX2/FMA (YMM0-YMM31 for AVX-512)
+  const signed int ZMM    = 0x000C0000;  // ZMM0-ZMM31 Registers from AVX-512
   const signed int KMASK  = 0x000D0000;  // K0-K7 opmask Registers from AVX-512
 
   /* Base IDs for aliased GPRs */

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -77,17 +77,17 @@ namespace Dyninst { namespace x86_64 {
   /* Register Categories */
   const signed int GPR    = 0x00010000;  // General-Purpose Registers
   const signed int SEG    = 0x00020000;  // Segment Registers
-  const signed int FLAG   = 0x00030000;  // EFLAGS Register
+  const signed int FLAG   = 0x00030000;  // RFLAGS Register
   const signed int MISC   = 0x00040000;  // Internal ProcControlAPI Register
-  const signed int KMASK  = 0x00050000;  // K0-K7 opmask Registers from AVX-512
-  const signed int XMM    = 0x00060000;  // XMM0-XMM7 Registers from SSE
-  const signed int YMM    = 0x00070000;  // YMM0-YMM7 Registers from AVX2/FMA
-  const signed int ZMM    = 0x00080000;  // ZMM0-ZMM7 Registers from AVX-512
+  const signed int CTL    = 0x00050000;  // Control Registers CR0-CR7
+  const signed int DBG    = 0x00060000;  // Debug Registers DR0-DR7
+  const signed int TST    = 0x00070000;  // Internal InstructionAPI Registers
+  const signed int X87    = 0x00080000;  // x87 FPU Registers
   const signed int MMX    = 0x00090000;  // MM0-MM7 Registers
-  const signed int CTL    = 0x000A0000;  // Control Registers CR0-CR7
-  const signed int DBG    = 0x000B0000;  // Debug Registers DR0-DR7
-  const signed int TST    = 0x000C0000;  // Internal InstructionAPI Registers
-  const signed int X87    = 0x000D0000;  // x87 FPU Registers
+  const signed int XMM    = 0x000A0000;  // XMM0-XMM7 Registers from SSE
+  const signed int YMM    = 0x000B0000;  // YMM0-YMM7 Registers from AVX2/FMA
+  const signed int ZMM    = 0x000C0000;  // ZMM0-ZMM7 Registers from AVX-512
+  const signed int KMASK  = 0x000D0000;  // K0-K7 opmask Registers from AVX-512
   const signed int FLAGS  = 0x00000000;  // RFLAGS Register
   const signed int BASEA  = 0x0;
   const signed int BASEC  = 0x1;

--- a/common/h/registers/x86_64_regs.h
+++ b/common/h/registers/x86_64_regs.h
@@ -90,23 +90,31 @@ namespace Dyninst { namespace x86_64 {
   const signed int KMASK  = 0x000D0000;  // K0-K7 opmask Registers from AVX-512
 
   /* Base IDs for aliased GPRs */
-  const signed int BASEA  = 0x0;
-  const signed int BASEC  = 0x1;
-  const signed int BASED  = 0x2;
-  const signed int BASEB  = 0x3;
-  const signed int BASESP = 0x4;
-  const signed int BASEBP = 0x5;
-  const signed int BASESI = 0x6;
-  const signed int BASEDI = 0x7;
-  const signed int BASE8  = 0x8;
-  const signed int BASE9  = 0x9;
-  const signed int BASE10 = 0xa;
-  const signed int BASE11 = 0xb;
-  const signed int BASE12 = 0xc;
-  const signed int BASE13 = 0xd;
-  const signed int BASE14 = 0xe;
-  const signed int BASE15 = 0xf;
-  const signed int FLAGS  = 0x0;  // RFLAGS Register
+  const signed int FLAGS  = 0x00;  // RFLAGS Register
+  const signed int BASEA  = 0x00;
+  const signed int BASEC  = 0x01;
+  const signed int BASED  = 0x02;
+  const signed int BASEB  = 0x03;
+  const signed int BASESP = 0x04;
+  const signed int BASEBP = 0x05;
+  const signed int BASESI = 0x06;
+  const signed int BASEDI = 0x07;
+  const signed int BASE8  = 0x08;
+  const signed int BASE9  = 0x09;
+  const signed int BASE10 = 0x0A;
+  const signed int BASE11 = 0x0B;
+  const signed int BASE12 = 0x0C;
+  const signed int BASE13 = 0x0D;
+  const signed int BASE14 = 0x0E;
+  const signed int BASE15 = 0x0F;
+
+  /* Base IDs for memory segment registers */
+  const signed int BASEDS = 0x0; // Data Segment register
+  const signed int BASESS = 0x1; // Stack Segment register
+  const signed int BASEFS = 0x2; // F Segment register
+  const signed int BASEGS = 0x3; // G Segment register
+  const signed int BASECS = 0x4; // Code Segment register
+  const signed int BASEES = 0x5; // Extended data Segment register
 
   /* Base IDs for each bit in EFLAGS */
   const signed int CF = x86::CF; // Carry Flag
@@ -204,12 +212,12 @@ namespace Dyninst { namespace x86_64 {
   DEF_REGISTER(        of,     OF |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(       nt_,     NT |   BIT |  FLAG | Arch_x86_64, "x86_64");
   DEF_REGISTER(        rf,     RF |   BIT |  FLAG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        ds,    0x0 |  FULL |   SEG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        es,    0x1 |  FULL |   SEG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        fs,    0x2 |  FULL |   SEG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        gs,    0x3 |  FULL |   SEG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        cs,    0x4 |  FULL |   SEG | Arch_x86_64, "x86_64");
-  DEF_REGISTER(        ss,    0x5 |  FULL |   SEG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        ds, BASEDS |  FULL |   SEG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        es, BASEES |  FULL |   SEG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        fs, BASEFS |  FULL |   SEG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        gs, BASEGS |  FULL |   SEG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        cs, BASECS |  FULL |   SEG | Arch_x86_64, "x86_64");
+  DEF_REGISTER(        ss, BASESS |  FULL |   SEG | Arch_x86_64, "x86_64");
   DEF_REGISTER(      orax,    0x0 |  FULL |  MISC | Arch_x86_64, "x86_64");
   DEF_REGISTER(    fsbase,    0x1 |  FULL |  MISC | Arch_x86_64, "x86_64");
   DEF_REGISTER(    gsbase,    0x2 |  FULL |  MISC | Arch_x86_64, "x86_64");

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -52,6 +52,8 @@ namespace Dyninst {
           return x86_64::flags;
         else if(category == x86_64::MMX)
           return x86_64::st0;
+        else if(category == x86_64::XMM)
+          return x86_64::ymm0;
         else
           return *this;
       case Arch_ppc32:

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -818,6 +818,7 @@ namespace Dyninst {
               case x86_64::AC: n = x86_flag_ac; break;
               case x86_64::VIF: n = x86_flag_vif; break;
               case x86_64::VIP: n = x86_flag_vip; break;
+              case x86_64::ID: n = x86_flag_id; break;
               default:
                 c = -1;
                 return;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -816,6 +816,7 @@ namespace Dyninst {
               case x86_64::VM: n = x86_flag_vm; break;
               case x86_64::RF: n = x86_flag_rf; break;
               case x86_64::AC: n = x86_flag_ac; break;
+              case x86_64::VIF: n = x86_flag_vif; break;
               default:
                 c = -1;
                 return;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -50,6 +50,8 @@ namespace Dyninst {
           return MachRegister(reg & 0xfffff0ff);
         else if(category == x86_64::FLAG)
           return x86_64::flags;
+        else if(category == x86_64::MMX)
+          return x86_64::st0;
         else
           return *this;
       case Arch_ppc32:

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -126,20 +126,17 @@ namespace Dyninst {
         break;
       case Arch_x86_64:
         switch(reg & 0x0000ff00) {
-          case x86_64::L_REG: // L_REG
-          case x86_64::H_REG: // H_REG
-            return 1;
-          case x86_64::W_REG: // W_REG
-            return 2;
-          case x86_64::FULL: // FULL
-            return 8;
+          case x86_64::L_REG:
+          case x86_64::H_REG: return 1;
+          case x86_64::W_REG: return 2;
           case x86_64::D_REG: return 4;
+          case x86_64::FULL: return 8;
+          case x86_64::MMS: return 8;
           case x86_64::OCT: return 16;
           case x86_64::FPDBL: return 10;
           case x86_64::BIT: return 0;
           case x86_64::YMMS: return 32;
           case x86_64::ZMMS: return 64;
-          case x86_64::MMS: return 8;
           default:
             return 0;  // Xiaozhu: return 0 as an indication of parsing junk.
         }

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -785,12 +785,12 @@ namespace Dyninst {
           case x86_64::SEG:
             c = x86_regclass_segment;
             switch(baseID) {
-              case 0x0: n = x86_segreg_ds; break;
-              case 0x1: n = x86_segreg_es; break;
-              case 0x2: n = x86_segreg_fs; break;
-              case 0x3: n = x86_segreg_gs; break;
-              case 0x4: n = x86_segreg_cs; break;
-              case 0x5: n = x86_segreg_ss; break;
+              case x86_64::BASEDS: n = x86_segreg_ds; break;
+              case x86_64::BASEES: n = x86_segreg_es; break;
+              case x86_64::BASEFS: n = x86_segreg_fs; break;
+              case x86_64::BASEGS: n = x86_segreg_gs; break;
+              case x86_64::BASECS: n = x86_segreg_cs; break;
+              case x86_64::BASESS: n = x86_segreg_ss; break;
               default: n = 0; break;
             }
             break;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -132,7 +132,7 @@ namespace Dyninst {
           case x86_64::D_REG: return 4;
           case x86_64::FULL: return 8;
           case x86_64::MMS: return 8;
-          case x86_64::OCT: return 16;
+          case x86_64::XMMS: return 16;
           case x86_64::FPDBL: return 10;
           case x86_64::BIT: return 0;
           case x86_64::YMMS: return 32;
@@ -1008,7 +1008,7 @@ namespace Dyninst {
       case Arch_x86_64:
         switch(subrange) {
           case x86_64::FULL:
-          case x86_64::OCT:
+          case x86_64::XMMS:
           case x86_64::MMS:
           case x86_64::KMSKS:
           case x86_64::FPDBL: p = x86_regpos_qword; break;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -813,6 +813,7 @@ namespace Dyninst {
               case x86_64::FLAGD: n = x86_flag_iopl1; break;
               case x86_64::FLAGF: n = x86_flag_15; break;
               case x86_64::VM: n = x86_flag_vm; break;
+              case x86_64::RF: n = x86_flag_rf; break;
               default:
                 c = -1;
                 return;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -1011,6 +1011,8 @@ namespace Dyninst {
           case x86_64::XMMS:
           case x86_64::MMS:
           case x86_64::KMSKS:
+          case x86_64::YMMS:
+          case x86_64::ZMMS:
           case x86_64::FPDBL: p = x86_regpos_qword; break;
           case x86_64::H_REG: p = x86_regpos_high_byte; break;
           case x86_64::L_REG: p = x86_regpos_low_byte; break;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -54,6 +54,8 @@ namespace Dyninst {
           return x86_64::st0;
         else if(category == x86_64::XMM)
           return x86_64::ymm0;
+        else if(category == x86_64::YMM)
+          return x86_64::zmm0;
         else
           return *this;
       case Arch_ppc32:

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -139,6 +139,7 @@ namespace Dyninst {
           case x86_64::BIT: return 0;
           case x86_64::YMMS: return 32;
           case x86_64::ZMMS: return 64;
+          case x86_64::MMS: return 8;
           default:
             return 0;  // Xiaozhu: return 0 as an indication of parsing junk.
         }
@@ -993,7 +994,8 @@ namespace Dyninst {
       case Arch_x86_64:
         switch(subrange) {
           case x86::FULL:
-          case x86::XMMS:
+          case x86::OCT:
+          case x86_64::MMS:
           case x86::FPDBL: p = x86_regpos_qword; break;
           case x86::H_REG: p = x86_regpos_high_byte; break;
           case x86::L_REG: p = x86_regpos_low_byte; break;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -809,6 +809,7 @@ namespace Dyninst {
               case x86_64::IF: n = x86_flag_if; break;
               case x86_64::DF: n = x86_flag_df; break;
               case x86_64::OF: n = x86_flag_of; break;
+              case x86_64::FLAGC: n = x86_flag_iopl0; break;
               default:
                 c = -1;
                 return;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -47,7 +47,7 @@ namespace Dyninst {
           return *this;
       case Arch_x86_64:
         if(category == x86_64::GPR)
-          return MachRegister(reg & 0xfffff0ff);
+          return MachRegister(reg & 0xffff00ff);
         else if(category == x86_64::FLAG)
           return x86_64::flags;
         else if(category == x86_64::MMX)

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -811,6 +811,7 @@ namespace Dyninst {
               case x86_64::OF: n = x86_flag_of; break;
               case x86_64::FLAGC: n = x86_flag_iopl0; break;
               case x86_64::FLAGD: n = x86_flag_iopl1; break;
+              case x86_64::NT: n = x86_flag_nt; break;
               case x86_64::FLAGF: n = x86_flag_15; break;
               case x86_64::VM: n = x86_flag_vm; break;
               case x86_64::RF: n = x86_flag_rf; break;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -798,6 +798,7 @@ namespace Dyninst {
             c = x86_regclass_flags;
             switch(baseID) {
               case x86_64::CF: n = x86_flag_cf; break;
+              case x86_64::FLAG1: n = x86_flag_1; break;
               case x86_64::PF: n = x86_flag_pf; break;
               case x86_64::AF: n = x86_flag_af; break;
               case x86_64::ZF: n = x86_flag_zf; break;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -137,6 +137,7 @@ namespace Dyninst {
           case x86_64::BIT: return 0;
           case x86_64::YMMS: return 32;
           case x86_64::ZMMS: return 64;
+          case x86_64::KMSKS: return 8;
           default:
             return 0;  // Xiaozhu: return 0 as an indication of parsing junk.
         }
@@ -1009,6 +1010,7 @@ namespace Dyninst {
           case x86_64::FULL:
           case x86_64::OCT:
           case x86_64::MMS:
+          case x86_64::KMSKS:
           case x86_64::FPDBL: p = x86_regpos_qword; break;
           case x86_64::H_REG: p = x86_regpos_high_byte; break;
           case x86_64::L_REG: p = x86_regpos_low_byte; break;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -51,11 +51,14 @@ namespace Dyninst {
         else if(category == x86_64::FLAG)
           return x86_64::flags;
         else if(category == x86_64::MMX)
-          return x86_64::st0;
+          // Keep the register number, but change the category to X87 (e.g., MMX1 -> st1).
+          return MachRegister((reg & ~0x00ff0000) | x86_64::X87);
         else if(category == x86_64::XMM)
-          return x86_64::ymm0;
+            // Keep the register number, but change the category to ZMM (e.g., XMM1 -> ZMM1).
+	    return MachRegister((reg & ~0x00ff0000) | x86_64::ZMM);
         else if(category == x86_64::YMM)
-          return x86_64::zmm0;
+            // Keep the register number, but change the category to ZMM (e.g., YMM1 -> ZMM1).
+	    return MachRegister((reg & ~0x00ff0000) | x86_64::ZMM);
         else
           return *this;
       case Arch_ppc32:

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -833,6 +833,10 @@ namespace Dyninst {
             c = x86_regclass_mm;
             n = baseID;
             break;
+          case x86_64::X87:
+            c = x86_regclass_st_top;
+            n = baseID;
+            break;
           case x86_64::CTL:
             c = x86_regclass_cr;
             n = baseID;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -810,6 +810,7 @@ namespace Dyninst {
               case x86_64::DF: n = x86_flag_df; break;
               case x86_64::OF: n = x86_flag_of; break;
               case x86_64::FLAGC: n = x86_flag_iopl0; break;
+              case x86_64::FLAGD: n = x86_flag_iopl1; break;
               default:
                 c = -1;
                 return;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -802,6 +802,7 @@ namespace Dyninst {
               case x86_64::PF: n = x86_flag_pf; break;
               case x86_64::FLAG3: n = x86_flag_3; break;
               case x86_64::AF: n = x86_flag_af; break;
+              case x86_64::FLAG5: n = x86_flag_5; break;
               case x86_64::ZF: n = x86_flag_zf; break;
               case x86_64::SF: n = x86_flag_sf; break;
               case x86_64::TF: n = x86_flag_tf; break;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -983,7 +983,6 @@ namespace Dyninst {
           case x86::L_REG: p = x86_regpos_low_byte; break;
           case x86::W_REG: p = x86_regpos_word; break;
           case x86::FULL:
-          case x86_64::D_REG: p = x86_regpos_dword; break;
           case x86::BIT: p = x86_regpos_all; break;
           default:
               common_parsing_printf("Unknown subrange value '%d' for Arch_x86\n", subrange);
@@ -993,15 +992,15 @@ namespace Dyninst {
 
       case Arch_x86_64:
         switch(subrange) {
-          case x86::FULL:
-          case x86::OCT:
+          case x86_64::FULL:
+          case x86_64::OCT:
           case x86_64::MMS:
-          case x86::FPDBL: p = x86_regpos_qword; break;
-          case x86::H_REG: p = x86_regpos_high_byte; break;
-          case x86::L_REG: p = x86_regpos_low_byte; break;
-          case x86::W_REG: p = x86_regpos_word; break;
+          case x86_64::FPDBL: p = x86_regpos_qword; break;
+          case x86_64::H_REG: p = x86_regpos_high_byte; break;
+          case x86_64::L_REG: p = x86_regpos_low_byte; break;
+          case x86_64::W_REG: p = x86_regpos_word; break;
           case x86_64::D_REG: p = x86_regpos_dword; break;
-          case x86::BIT: p = x86_regpos_all; break;
+          case x86_64::BIT: p = x86_regpos_all; break;
           default:
               common_parsing_printf("Unknown subrange value '%d' for Arch_x86_64\n", subrange);
               break;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -817,6 +817,7 @@ namespace Dyninst {
               case x86_64::RF: n = x86_flag_rf; break;
               case x86_64::AC: n = x86_flag_ac; break;
               case x86_64::VIF: n = x86_flag_vif; break;
+              case x86_64::VIP: n = x86_flag_vip; break;
               default:
                 c = -1;
                 return;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -812,6 +812,7 @@ namespace Dyninst {
               case x86_64::FLAGC: n = x86_flag_iopl0; break;
               case x86_64::FLAGD: n = x86_flag_iopl1; break;
               case x86_64::FLAGF: n = x86_flag_15; break;
+              case x86_64::VM: n = x86_flag_vm; break;
               default:
                 c = -1;
                 return;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -811,6 +811,7 @@ namespace Dyninst {
               case x86_64::OF: n = x86_flag_of; break;
               case x86_64::FLAGC: n = x86_flag_iopl0; break;
               case x86_64::FLAGD: n = x86_flag_iopl1; break;
+              case x86_64::FLAGF: n = x86_flag_15; break;
               default:
                 c = -1;
                 return;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -815,6 +815,7 @@ namespace Dyninst {
               case x86_64::FLAGF: n = x86_flag_15; break;
               case x86_64::VM: n = x86_flag_vm; break;
               case x86_64::RF: n = x86_flag_rf; break;
+              case x86_64::AC: n = x86_flag_ac; break;
               default:
                 c = -1;
                 return;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -800,6 +800,7 @@ namespace Dyninst {
               case x86_64::CF: n = x86_flag_cf; break;
               case x86_64::FLAG1: n = x86_flag_1; break;
               case x86_64::PF: n = x86_flag_pf; break;
+              case x86_64::FLAG3: n = x86_flag_3; break;
               case x86_64::AF: n = x86_flag_af; break;
               case x86_64::ZF: n = x86_flag_zf; break;
               case x86_64::SF: n = x86_flag_sf; break;

--- a/dataflowAPI/src/SymEvalPolicy.C
+++ b/dataflowAPI/src/SymEvalPolicy.C
@@ -456,6 +456,8 @@ Absloc SymEvalPolicy_64::convert(X86Flag f)
          return Absloc(x86_64::flag1);
       case x86_flag_pf:
          return Absloc(x86_64::pf);
+      case x86_flag_3:
+         return Absloc(x86_64::flag3);
       case x86_flag_af:
          return Absloc(x86_64::af);
       case x86_flag_zf:

--- a/dataflowAPI/src/SymEvalPolicy.C
+++ b/dataflowAPI/src/SymEvalPolicy.C
@@ -460,6 +460,8 @@ Absloc SymEvalPolicy_64::convert(X86Flag f)
          return Absloc(x86_64::flag3);
       case x86_flag_af:
          return Absloc(x86_64::af);
+      case x86_flag_5:
+         return Absloc(x86_64::flag5);
       case x86_flag_zf:
          return Absloc(x86_64::zf);
       case x86_flag_sf:

--- a/dataflowAPI/src/SymEvalPolicy.C
+++ b/dataflowAPI/src/SymEvalPolicy.C
@@ -476,6 +476,8 @@ Absloc SymEvalPolicy_64::convert(X86Flag f)
          return Absloc(x86_64::of);
       case x86_flag_iopl0:
          return Absloc(x86_64::FLAGC);
+      case x86_flag_iopl1:
+         return Absloc(x86_64::FLAGD);
       case x86_flag_nt:
          return Absloc(x86_64::nt_);
       default:

--- a/dataflowAPI/src/SymEvalPolicy.C
+++ b/dataflowAPI/src/SymEvalPolicy.C
@@ -480,6 +480,8 @@ Absloc SymEvalPolicy_64::convert(X86Flag f)
          return Absloc(x86_64::FLAGD);
       case x86_flag_nt:
          return Absloc(x86_64::nt_);
+      case x86_flag_15:
+         return Absloc(x86_64::FLAGF);
       default:
          assert(0);
          return Absloc();

--- a/dataflowAPI/src/SymEvalPolicy.C
+++ b/dataflowAPI/src/SymEvalPolicy.C
@@ -452,6 +452,8 @@ Absloc SymEvalPolicy_64::convert(X86Flag f)
    switch (f) {
       case x86_flag_cf:
          return Absloc(x86_64::cf);
+      case x86_flag_1:
+         return Absloc(x86_64::flag1);
       case x86_flag_pf:
          return Absloc(x86_64::pf);
       case x86_flag_af:

--- a/dataflowAPI/src/SymEvalPolicy.C
+++ b/dataflowAPI/src/SymEvalPolicy.C
@@ -474,6 +474,8 @@ Absloc SymEvalPolicy_64::convert(X86Flag f)
          return Absloc(x86_64::df);
       case x86_flag_of:
          return Absloc(x86_64::of);
+      case x86_flag_iopl0:
+         return Absloc(x86_64::FLAGC);
       case x86_flag_nt:
          return Absloc(x86_64::nt_);
       default:


### PR DESCRIPTION
The values for the RFLAGS fields VM..ID will get updated to the x86 ones after #1629 is merged.