### PR TITLE
Remove MachineRegister::getSubRegValue

### DIFF
--- a/common/h/registers/MachRegister.h
+++ b/common/h/registers/MachRegister.h
@@ -51,7 +51,6 @@ namespace Dyninst {
     MachRegister getBaseRegister() const;
     Architecture getArchitecture() const;
     bool isValid() const;
-    MachRegisterVal getSubRegValue(const MachRegister& subreg, MachRegisterVal& orig) const;
 
     std::string const& name() const;
     unsigned int size() const;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -85,22 +85,6 @@ namespace Dyninst {
 
   bool MachRegister::isValid() const { return (reg != InvalidReg.reg); }
 
-  MachRegisterVal MachRegister::getSubRegValue(const MachRegister& subreg,
-                                               MachRegisterVal& orig) const {
-    if(subreg.reg == reg || getArchitecture() == Arch_ppc32 || getArchitecture() == Arch_ppc64)
-      return orig;
-
-    assert(subreg.getBaseRegister() == getBaseRegister());
-    switch((subreg.reg & 0x00000f00) >> 8) {
-      case 0x0: return orig;
-      case 0x1: return (orig & 0xff);
-      case 0x2: return (orig & 0xff00) >> 8;
-      case 0x3: return (orig & 0xffff);
-      case 0xf: return (orig & 0xffffffff);
-      default: assert(0); return orig;
-    }
-  }
-
   std::string const& MachRegister::name() const {
     auto iter = names.find(reg);
     if(iter != names.end()) {


### PR DESCRIPTION
It was added by efa87d1f4d in 2010, but never documented or used.