### PR TITLE
Set new CMake policy for upper-case <NAME>_ROOT variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ if(CMAKE_VERSION VERSION_EQUAL "3.19.0")
 endif()
 
 # find_package() uses upper-case <PACKAGENAME>_ROOT variables.
-cmake_policy(SET CMP0144 NEW)
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW)
+endif()
 
 set(DYNINST_MAJOR_VERSION 12)
 set(DYNINST_MINOR_VERSION 3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ if(CMAKE_VERSION VERSION_EQUAL "3.19.0")
   message(FATAL_ERROR "Dyninst cannot use CMake version 3.19.0")
 endif()
 
+# find_package() uses upper-case <PACKAGENAME>_ROOT variables.
+cmake_policy(SET CMP0144 NEW)
+
 set(DYNINST_MAJOR_VERSION 12)
 set(DYNINST_MINOR_VERSION 3)
 set(DYNINST_PATCH_VERSION 0)


### PR DESCRIPTION
In CMake 3.27 and above the find_package(<PackageName>) command now searches prefixes specified by the upper-case <PACKAGENAME>_ROOT CMake variable and the <PACKAGENAME>_ROOT environment variable in addition to the case-preserved <PackageName>_ROOT and <PackageName>_ROOT variables used since policy CMP0074. This policy provides compatibility with projects that have not been updated to avoid using <PACKAGENAME>_ROOT variables for other purposes.

The OLD behavior for this policy is to ignore <PACKAGENAME>_ROOT variables if the original <PackageName> has lower-case characters. The NEW behavior for this policy is to use <PACKAGENAME>_ROOT variables.