### PR TITLE
Fix register check in LivenessAnalyzer::isMMX

### DIFF
--- a/dataflowAPI/src/liveness.C
+++ b/dataflowAPI/src/liveness.C
@@ -625,10 +625,10 @@ void LivenessAnalyzer::clean(Function *func){
 bool LivenessAnalyzer::isMMX(MachRegister machReg){
 	auto const arch = machReg.getArchitecture();
 	if (arch == Arch_x86) {
-		return (machReg.val() & 0x00ff0000) == x86::MMX;
+		return machReg.regClass() == x86::MMX;
 	}
 	if (arch == Arch_x86_64) {
-		return (machReg.val() & 0x00ff0000) == x86_64::MMX;
+		return machReg.regClass() == x86_64::MMX;
 	}
 	return false;
 }

--- a/dataflowAPI/src/liveness.C
+++ b/dataflowAPI/src/liveness.C
@@ -625,10 +625,10 @@ void LivenessAnalyzer::clean(Function *func){
 bool LivenessAnalyzer::isMMX(MachRegister machReg){
 	auto const arch = machReg.getArchitecture();
 	if (arch == Arch_x86) {
-		return (machReg.val() & x86::MMX) == x86::MMX;
+		return (machReg.val() & 0x00ff0000) == x86::MMX;
 	}
 	if (arch == Arch_x86_64) {
-		return (machReg.val() & x86_64::MMX) == x86_64::MMX;
+		return (machReg.val() & 0x00ff0000) == x86_64::MMX;
 	}
 	return false;
 }

--- a/dataflowAPI/src/liveness.C
+++ b/dataflowAPI/src/liveness.C
@@ -623,9 +623,12 @@ void LivenessAnalyzer::clean(Function *func){
 }
 
 bool LivenessAnalyzer::isMMX(MachRegister machReg){
-	if ((machReg.val() & Arch_x86) == Arch_x86 || (machReg.val() & Arch_x86_64) == Arch_x86_64){
-		assert( ((machReg.val() & x86::MMX) == x86::MMX) == ((machReg.val() & x86_64::MMX) == x86_64::MMX) );
+	auto const arch = machReg.getArchitecture();
+	if (arch == Arch_x86) {
 		return (machReg.val() & x86::MMX) == x86::MMX;
+	}
+	if (arch == Arch_x86_64) {
+		return (machReg.val() & x86_64::MMX) == x86_64::MMX;
 	}
 	return false;
 }


### PR DESCRIPTION
There is no requirement that the two values for MMX be the same between the two architectures.