### PR TITLE
Write to stderr in ParseAPI::parsing_printf

### DIFF
--- a/parseAPI/src/debug_parse.C
+++ b/parseAPI/src/debug_parse.C
@@ -74,7 +74,14 @@ int Dyninst::ParseAPI::parsing_printf_int(const char *format, ...)
       int v{};
       #pragma omp critical
       {
-        v = vfprintf(stderr, msg.c_str(), va);
+#ifdef __clang__
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
+        v = vprintf(msg.c_str(), va);
+#ifdef __clang__
+        #pragma clang diagnostic pop
+#endif
         fflush(stdout);
       }
       return v;

--- a/parseAPI/src/debug_parse.C
+++ b/parseAPI/src/debug_parse.C
@@ -82,7 +82,7 @@ int Dyninst::ParseAPI::parsing_printf_int(const char *format, ...)
 #ifdef __clang__
         #pragma clang diagnostic pop
 #endif
-        fflush(stdout);
+        fflush(stderr);
       }
       return v;
     }();

--- a/parseAPI/src/debug_parse.C
+++ b/parseAPI/src/debug_parse.C
@@ -65,8 +65,6 @@ int Dyninst::ParseAPI::parsing_printf_int(const char *format, ...)
       return 0;
     }();
 
-    auto msg = "[thread " + std::to_string(id) + "] " + std::string(format);
-
     va_list va;
     va_start(va,format);
 
@@ -74,14 +72,8 @@ int Dyninst::ParseAPI::parsing_printf_int(const char *format, ...)
       int v{};
       #pragma omp critical
       {
-#ifdef __clang__
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
-        v = vfprintf(stderr, msg.c_str(), va);
-#ifdef __clang__
-        #pragma clang diagnostic pop
-#endif
+        v = fprintf(stderr, "[thread %d] ", id);
+        v &= vfprintf(stderr, format, va);
         fflush(stderr);
       }
       return v;

--- a/parseAPI/src/debug_parse.C
+++ b/parseAPI/src/debug_parse.C
@@ -73,7 +73,9 @@ int Dyninst::ParseAPI::parsing_printf_int(const char *format, ...)
       #pragma omp critical
       {
         v = fprintf(stderr, "[thread %d] ", id);
-        v &= vfprintf(stderr, format, va);
+        if(v >= 0) {
+          v = vfprintf(stderr, format, va);
+        }
         fflush(stderr);
       }
       return v;

--- a/parseAPI/src/debug_parse.C
+++ b/parseAPI/src/debug_parse.C
@@ -78,7 +78,7 @@ int Dyninst::ParseAPI::parsing_printf_int(const char *format, ...)
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Wformat-nonliteral"
 #endif
-        v = vprintf(msg.c_str(), va);
+        v = vfprintf(stderr, msg.c_str(), va);
 #ifdef __clang__
         #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
Using a per-thread file here is cumbersome. Including the thread id in the message and synchronizing vprintf makes this work for multiple threads.