### PR TITLE
Github CI: Pass '-y' to apt when removing libomp

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
       # Clang doesn't allow for multiple libomp installations
       - name: Clean libomp install
         if: ${{ inputs.is-clang }}
-        run: apt remove --purge "libomp*"
+        run: apt remove --purge -y "libomp*"
         
       - name: Install C compiler (${{ inputs.c-compiler }})
         run: |


### PR DESCRIPTION
Should have been part of 39899e55bf.