### PR TITLE
Suppress -Wframe-larger-than in power_opcode_table in clang-1{3,7}

### DIFF
--- a/cmake/DyninstWarnings.cmake
+++ b/cmake/DyninstWarnings.cmake
@@ -163,7 +163,7 @@ if(HAS_CPP_FLAG_Wframe_larger_than AND NOT DYNINST_DISABLE_DIAGNOSTIC_SUPPRESSIO
       set(nonDebugMaxFrameSizeOverrideFinalizeOperands 30000)
     endif()
   elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-    if(${CMAKE_CXX_COMPILER_VERSION} MATCHES "^1[4-6](\.|$)")
+    if(${CMAKE_CXX_COMPILER_VERSION} MATCHES "^1[3-7](\.|$)")
       set(debugMaxFrameSizeOverridePowerOpcodeTable 40000)
     else()
       set(debugMaxFrameSizeOverridePowerOpcodeTable 30000)


### PR DESCRIPTION
Debug builds with clang-13 now have stack frame consumption of 37512 bytes. I think this is due to upstream patch version bumps in Ubuntu.