### PR TITLE
GithubCI: don't fail fast for PR tests

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       packages: read
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
          os: ['ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-23.04', 'ubuntu-23.10', 'ubuntu-24.04', 'fedora-37', 'fedora-38', 'fedora-39']
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
     permissions:
       packages: read
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
          os: ['ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-23.04', 'ubuntu-23.10', 'ubuntu-24.04']
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will make re-running the failed actions cheaper.