### PR TITLE
GithubCI: only build hpctoolkit@develop

### DIFF
--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         consumer: [
-          "hpctoolkit",
+          "hpctoolkit@develop",
           "must+stackwalker~backward~tsan"
 #           extrae+dyninst    - not yet tested, may not support dyninst >10.0.0
 #           omnitrace         - Needs updated cmake


### PR DESCRIPTION
Building the HEAD of dynininst against the last release of HPCToolkit is a good idea for tracking breaking changes, but it ultimately produced more noise than signal. Making sure that HPCToolkit's latest source will compile with Dyninst's latest source is likely a better measure.