### PR TITLE
Improve support of different ways to implement syscall

### DIFF
--- a/instructionAPI/src/InstructionCategories.C
+++ b/instructionAPI/src/InstructionCategories.C
@@ -113,6 +113,7 @@ namespace Dyninst
       case e_sysenter:
 	return c_SysEnterInsn;
       case e_syscall:
+      case e_int:
     return c_SyscallInsn;
           default:
 	return c_NoCategory;

--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -500,7 +500,7 @@ bool IA_IAPI::isCall() const
 
 bool IA_IAPI::isInterruptOrSyscall() const
 {
-    return (isInterrupt() && isSyscall());
+    return (isInterrupt() || isSyscall());
 }
 
 bool IA_IAPI::isSyscall() const
@@ -943,4 +943,26 @@ InstrumentableLevel IA_IAPI::getInstLevel(Function * context, unsigned int num_i
           return NORMAL;
           }*/
     return ret;
+}
+
+bool IA_IAPI::isSyscall(const Instruction &insn, Architecture arch)
+{
+    switch (arch) {
+        case Arch_x86:
+        case Arch_x86_64:
+            return IA_x86::isSyscall(insn);
+        case Arch_ppc32:
+        case Arch_ppc64:
+            return IA_power::isSyscall(insn);
+        case Arch_aarch64:
+            return IA_aarch64::isSyscall(insn);
+        case Arch_amdgpu_gfx908:
+        case Arch_amdgpu_gfx90a:
+        case Arch_amdgpu_gfx940:
+            return IA_amdgpu::isSyscall(insn);
+
+        default:
+            assert(!"unimplemented architecture");
+    }
+    return false;
 }

--- a/parseAPI/src/IA_IAPI.h
+++ b/parseAPI/src/IA_IAPI.h
@@ -117,6 +117,8 @@ class IA_IAPI : public InstructionAdapter {
         virtual bool isBranch() const;
         virtual bool isInterruptOrSyscall() const;
         virtual bool isSyscall() const;
+        static bool isSyscall(const Dyninst::InstructionAPI::Instruction &) { return false; }
+        static bool isSyscall(const Dyninst::InstructionAPI::Instruction &insn, Dyninst::Architecture arch);
         virtual bool isInterrupt() const;
         virtual bool isCall() const;
         virtual bool isReturnAddrSave(Address &ret_addr) const = 0;

--- a/parseAPI/src/IA_aarch64.C
+++ b/parseAPI/src/IA_aarch64.C
@@ -273,3 +273,8 @@ bool IA_aarch64::isNopJump() const
 {
     return false;
 }
+
+bool IA_aarch64::isSyscall(const Instruction &insn)
+{
+    return (insn.getOperation().getID() == aarch64_op_svc);
+}

--- a/parseAPI/src/IA_aarch64.h
+++ b/parseAPI/src/IA_aarch64.h
@@ -65,6 +65,8 @@ class IA_aarch64 : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+    static bool isSyscall(const Dyninst::InstructionAPI::Instruction &insn);
+    using IA_IAPI::isSyscall;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_power.C
+++ b/parseAPI/src/IA_power.C
@@ -528,4 +528,7 @@ bool IA_power::isNopJump() const
     return false;
 }
 
-
+bool IA_power::isSyscall(const Instruction &insn)
+{
+    return (insn.getOperation().getID() == power_op_sc);
+}

--- a/parseAPI/src/IA_power.h
+++ b/parseAPI/src/IA_power.h
@@ -101,6 +101,8 @@ class IA_power : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+    static bool isSyscall(const Dyninst::InstructionAPI::Instruction &insn);
+    using IA_IAPI::isSyscall;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_x86.h
+++ b/parseAPI/src/IA_x86.h
@@ -66,6 +66,8 @@ class IA_x86 : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+    static bool isSyscall(const Dyninst::InstructionAPI::Instruction &insn);
+    using IA_IAPI::isSyscall;
 };
 
 }

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -1498,7 +1498,7 @@ Parser::parse_frame_one_iteration(ParseFrame &frame, bool recursive) {
                 InstructionAPI::Instruction prevInsn = prev->second;
                 bool is_nonret = false;
 
-                if (prevInsn.getOperation().getID() == e_syscall) {
+                if (InstructionAdapter_t::isSyscall(prevInsn, func->obj()->cs()->getArch())) {
                     Address src = edge->src()->lastInsnAddr();
 
 


### PR DESCRIPTION
Dyninst supports different architectures, yet in Parser.C system calls are detected by explicitly comparing instruction to e_syscall, which is an x86_64 instruction. The result was a segmentation fault on 32-bit code like this:

```
_start:
    mov     $0, %ebx
    mov     $1, %eax
    int     $0x80
```

This change aims at moving architecture-specific parts of syscall detection to architecture-specific files and using generalized interface in common code.

This code doesn't handle e_sysenter because it is not listed in `man 2 syscall` and I'm not sure what the convention regarding it is.