### PR TITLE
Add CodeObject::parse overloads to accept multiple targets

### DIFF
--- a/parseAPI/h/CodeObject.h
+++ b/parseAPI/h/CodeObject.h
@@ -82,9 +82,11 @@ class CodeObject {
     
     // `exact-target' parsing; optinally recursive
     PARSER_EXPORT void parse(Address target, bool recursive);
+    PARSER_EXPORT void parse(const std::vector<Address> &targets, bool recursive);
 
     // `even-more-exact-target' parsing; optinally recursive
     PARSER_EXPORT void parse(CodeRegion *cr, Address target, bool recursive);
+    PARSER_EXPORT void parse(const std::vector<std::pair<Address, CodeRegion *>> &targets, bool recursive);
 
     // parses new edges in already parsed functions
 	struct NewEdgeToParse {

--- a/parseAPI/src/CodeObject.C
+++ b/parseAPI/src/CodeObject.C
@@ -207,6 +207,24 @@ CodeObject::parse(CodeRegion *cr, Address target, bool recursive) {
 }
 
 void
+CodeObject::parse(const std::vector<Address> &targets, bool recursive) {
+    if(!parser) {
+        fprintf(stderr,"FATAL: internal parser undefined\n");
+        return;
+    }
+    parser->parse_at(targets, recursive, ONDEMAND);
+}
+
+void
+CodeObject::parse(const std::vector<std::pair<Address, CodeRegion *>> &targets, bool recursive) {
+    if(!parser) {
+        fprintf(stderr,"FATAL: internal parser undefined\n");
+        return;
+    }
+    parser->parse_at(targets, recursive, ONDEMAND);
+}
+
+void
 CodeObject::parseGaps(CodeRegion *cr, GapParsingType type /* PreambleMatching 0 */) {
     if(!parser) {
         fprintf(stderr,"FATAL: internal parser undefined\n");

--- a/parseAPI/src/Parser.h
+++ b/parseAPI/src/Parser.h
@@ -149,6 +149,10 @@ namespace Dyninst {
 
             void parse_at(Address addr, bool recursive, FuncSource src);
 
+            void parse_at(const std::vector<Address> &addrs, bool recursive, FuncSource src);
+
+            void parse_at(const std::vector<std::pair<Address, CodeRegion *>> &addrs, bool recursive, FuncSource src);
+
             void parse_edges(vector<ParseWorkElem *> &work_elems);
 
             CFGFactory &factory() const { return _cfgfact; }


### PR DESCRIPTION
Parser::parse_at takes only one target at a time. This has two repercussions:

* It can't take full advantage of parallel parsing when there are multiple targets in need of it.
* It still enters and exits OMP parallel loop. This operation has its own performance overhead that depends on the host system (number of processors and OMP configuration). This overhead can be very significant.

This change introduces Parser::parse_vec that takes a vector of targets and parses them in parallel.

When there are significant number of parse_at calls, performance gains from migrating to parse_vec can be huge. Parsing what initial parse() missed in libLLVM-12.so.1 with parse_at took nearly 20 minutes on 4-core hyper-threaded CPU. Doing the same with parse_vec took less than 4 minutes. On 128-bit ARM64 server we've seen even bigger gains (from around 40 minutes to less than 3).