### PR TITLE
fix operator<< for Module*

### DIFF
--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -180,7 +180,11 @@ namespace Dyninst { namespace SymtabAPI {
   }
 
   template <typename OS> OS &operator<<(OS &os, Module *m) {
-    os << m->fileName() << ": " << m->addr();
+    if (m)  {
+	os << m->fileName() << ": " << m->addr();
+    }  else  {
+	os << "null";
+    }
     return os;
   }
 


### PR DESCRIPTION
fix nullptr dereference if Module* is nullptr; print "null" instead