### PR TITLE
Fix logic error in IA_IAPI::isInterruptOrSyscall

### DIFF
--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -500,7 +500,7 @@ bool IA_IAPI::isCall() const
 
 bool IA_IAPI::isInterruptOrSyscall() const
 {
-    return (isInterrupt() && isSyscall());
+    return (isInterrupt() || isSyscall());
 }
 
 bool IA_IAPI::isSysEnter() const


### PR DESCRIPTION
This was broken by e7db16f5 in 2010.

Originally part of #1670 