### PR TITLE
Refactor IA_IAPI::isSyscall,isInterrupt into arch-specific files

### DIFF
--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -503,28 +503,6 @@ bool IA_IAPI::isInterruptOrSyscall() const
     return (isInterrupt() && isSyscall());
 }
 
-bool IA_IAPI::isSyscall() const
-{
-    static RegisterAST::Ptr gs(new RegisterAST(x86::gs));
-
-    Instruction ci = curInsn();
-
-    return (((ci.getOperation().getID() == e_call) &&
-                (ci.getOperation().isRead(gs)) &&
-                (ci.getOperand(0).format(ci.getArch()) == "16")) ||
-            (ci.getOperation().getID() == e_syscall) ||
-            (ci.getOperation().getID() == e_int) ||
-            (ci.getOperation().getID() == power_op_sc));
-}
-
-
-bool IA_IAPI::isInterrupt() const
-{
-    Instruction ci = curInsn();
-    return ((ci.getOperation().getID() == e_int) ||
-            (ci.getOperation().getID() == e_int3));
-}
-
 bool IA_IAPI::isSysEnter() const
 {
     Instruction ci = curInsn();

--- a/parseAPI/src/IA_IAPI.h
+++ b/parseAPI/src/IA_IAPI.h
@@ -116,8 +116,8 @@ class IA_IAPI : public InstructionAdapter {
         virtual bool isConditional() const;
         virtual bool isBranch() const;
         virtual bool isInterruptOrSyscall() const;
-        virtual bool isSyscall() const;
-        virtual bool isInterrupt() const;
+        virtual bool isSyscall() const = 0;
+        virtual bool isInterrupt() const = 0;
         virtual bool isCall() const;
         virtual bool isReturnAddrSave(Address &ret_addr) const = 0;
         virtual bool isNopJump() const = 0;

--- a/parseAPI/src/IA_aarch64.C
+++ b/parseAPI/src/IA_aarch64.C
@@ -273,3 +273,11 @@ bool IA_aarch64::isNopJump() const
 {
     return false;
 }
+
+bool IA_aarch64::isSyscall() const {
+  return false;
+}
+
+bool IA_aarch64::isInterrupt() const {
+  return false;
+}

--- a/parseAPI/src/IA_aarch64.h
+++ b/parseAPI/src/IA_aarch64.h
@@ -65,8 +65,8 @@ class IA_aarch64 : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
-  bool isSyscall() const;
-  bool isInterrupt() const;
+	bool isSyscall() const;
+	bool isInterrupt() const;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_aarch64.h
+++ b/parseAPI/src/IA_aarch64.h
@@ -65,6 +65,8 @@ class IA_aarch64 : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+  bool isSyscall() const;
+  bool isInterrupt() const;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_amdgpu.C
+++ b/parseAPI/src/IA_amdgpu.C
@@ -142,3 +142,11 @@ bool IA_amdgpu::isNopJump() const
 {
     return false;
 }
+
+bool IA_amdgpu::isSyscall() const {
+  return false;
+}
+
+bool IA_amdgpu::isInterrupt() const {
+  return false;
+}

--- a/parseAPI/src/IA_amdgpu.h
+++ b/parseAPI/src/IA_amdgpu.h
@@ -65,6 +65,8 @@ class IA_amdgpu : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+  bool isSyscall() const;
+  bool isInterrupt() const;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_amdgpu.h
+++ b/parseAPI/src/IA_amdgpu.h
@@ -65,8 +65,8 @@ class IA_amdgpu : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
-  bool isSyscall() const;
-  bool isInterrupt() const;
+	bool isSyscall() const;
+	bool isInterrupt() const;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_power.C
+++ b/parseAPI/src/IA_power.C
@@ -528,4 +528,11 @@ bool IA_power::isNopJump() const
     return false;
 }
 
+bool IA_power::isSyscall() const {
+  auto const& i = curInsn();
+  return i.getOperation().getID() == power_op_sc;
+}
 
+bool IA_power::isInterrupt() const {
+  return false;
+}

--- a/parseAPI/src/IA_power.h
+++ b/parseAPI/src/IA_power.h
@@ -101,6 +101,8 @@ class IA_power : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+  bool isSyscall() const;
+  bool isInterrupt() const;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_power.h
+++ b/parseAPI/src/IA_power.h
@@ -101,8 +101,8 @@ class IA_power : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
-  bool isSyscall() const;
-  bool isInterrupt() const;
+	bool isSyscall() const;
+	bool isInterrupt() const;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_x86.C
+++ b/parseAPI/src/IA_x86.C
@@ -40,6 +40,7 @@
 #include "bitArray.h"
 //#include "StackTamperVisitor.h"
 #include "instructionAPI/h/Visitor.h"
+#include "registers/x86_regs.h"
 
 #include <deque>
 #include "Register.h"
@@ -772,3 +773,23 @@ bool IA_x86::isLinkerStub() const
     // No need for linker stubs on x86 platforms.
     return false;
 }
+
+bool IA_x86::isInterrupt() const
+{
+    Instruction ci = curInsn();
+    return ((ci.getOperation().getID() == e_int) ||
+            (ci.getOperation().getID() == e_int3));
+}
+
+bool IA_x86::isSyscall() const {
+  static RegisterAST::Ptr gs(new RegisterAST(x86::gs));
+
+  Instruction ci = curInsn();
+
+  return (((ci.getOperation().getID() == e_call) &&
+              (ci.getOperation().isRead(gs)) &&
+              (ci.getOperand(0).format(ci.getArch()) == "16")) ||
+          (ci.getOperation().getID() == e_syscall) ||
+          (ci.getOperation().getID() == e_int));
+}
+

--- a/parseAPI/src/IA_x86.h
+++ b/parseAPI/src/IA_x86.h
@@ -67,7 +67,7 @@ class IA_x86 : public IA_IAPI {
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
 	bool isSyscall() const;
-  bool isInterrupt() const;
+	bool isInterrupt() const;
 };
 
 }

--- a/parseAPI/src/IA_x86.h
+++ b/parseAPI/src/IA_x86.h
@@ -66,6 +66,8 @@ class IA_x86 : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+	bool isSyscall() const;
+  bool isInterrupt() const;
 };
 
 }


### PR DESCRIPTION
This also requires those members be defined for all classes derived from IA_IAPI.

Originally part of #1670