### PR TITLE
Add CMake option to control symbol visibility

### DIFF
--- a/cmake/DyninstLibrarySettings.cmake
+++ b/cmake/DyninstLibrarySettings.cmake
@@ -15,9 +15,19 @@ endif()
 
 set(BUILD_SHARED_LIBS ON)
 
-set(CMAKE_C_VISIBILITY_PRESET hidden)
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+# DYNINST_EXPORT_ALL is a 'hidden' build option
+#  It is intended for use by developers to facilitate
+#  unit testing of internal libraries that don't export
+#  all of their interfaces.
+if(DYNINST_EXPORT_ALL)
+  set(CMAKE_C_VISIBILITY_PRESET default)
+  set(CMAKE_CXX_VISIBILITY_PRESET default)
+  set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
+else()
+  set(CMAKE_C_VISIBILITY_PRESET hidden)
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+endif()
 
 set(DYNINST_INSTALL_BINDIR "bin")
 set(DYNINST_INSTALL_LIBDIR "lib")

--- a/cmake/DyninstLibrarySettings.cmake
+++ b/cmake/DyninstLibrarySettings.cmake
@@ -15,10 +15,6 @@ endif()
 
 set(BUILD_SHARED_LIBS ON)
 
-# DYNINST_EXPORT_ALL is a 'hidden' build option
-#  It is intended for use by developers to facilitate
-#  unit testing of internal libraries that don't export
-#  all of their interfaces.
 if(DYNINST_EXPORT_ALL)
   set(CMAKE_C_VISIBILITY_PRESET default)
   set(CMAKE_CXX_VISIBILITY_PRESET default)

--- a/cmake/DyninstOptions.cmake
+++ b/cmake/DyninstOptions.cmake
@@ -46,3 +46,9 @@ mark_as_advanced(DYNINST_CXXSTDLIB)
 
 option(DYNINST_FORCE_RUNPATH "Require the use of RUNPATH instead of compiler's default"
        OFF)
+
+# This is intended for use by developers to facilitate
+# unit testing of internal libraries that don't export
+# all of their interfaces.
+option(DYNINST_EXPORT_ALL "Export all symbols" OFF)
+mark_as_advanced(DYNINST_EXPORT_ALL)


### PR DESCRIPTION
Currently, all symbols are hidden by default and
then explicitly made visible. This is the behavior we want for publishing Dyninst libraries, but unit testing the internal functionality requires access to these symbols. This option allows that.

It is explicitly not described in DyninstOptions.cmake because it is not intended to be used by regular users.