### PR TITLE
Remove explicit check for system calls in parse_frame_one_iteration

### DIFF
--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -1857,27 +1857,6 @@ Parser::parse_frame_one_iteration(ParseFrame &frame, bool recursive) {
                 if (!set_edge_parsing_status(frame,cur->last(), cur)) break;
                 link_addr(ahPtr->getAddr(), _sink, DIRECT, true, func);
                 break;
-            } else if ( ah->isInterruptOrSyscall() ) {
-                // 5. Raising instructions
-                end_block(cur,ahPtr);
-                if (!set_edge_parsing_status(frame,cur->last(), cur)) break; 
-                ParseAPI::Edge* newedge = link_tempsink(cur, FALLTHROUGH);
-                parsing_printf("[%s:%d] pushing %lx onto worklist\n",
-                        FILE__,__LINE__,curAddr);
-                frame.pushWork(
-                        frame.mkWork(
-                            NULL,
-                            newedge,
-                            ahPtr->getAddr(),
-                            ahPtr->getNextAddr(),
-                            true,
-                            false)
-                        );
-                if (unlikely(func->obj()->defensiveMode())) {
-                    fprintf(stderr,"parsed bluepill insn sysenter or syscall "
-                            "in defensive mode at %lx\n",curAddr);
-                }
-                break;
             } else if (unlikely(func->obj()->defensiveMode())) {
                 if (!_pcb.hasWeirdInsns(func) && ah->isGarbageInsn()) {
                     // add instrumentation at this addr so we can


### PR DESCRIPTION
165f19cd and 091929d6 changed the parsing semantics of system calls such that software interrupts (e.g., `int` on x86) are always interpreted as system calls. The `hasCFT()` check on line 1824 now covers all of the system call cases because it considers those instructions to have a control flow target (CFT).

Its non-use was verified against /usr/libx32/libc.so.6, /usr/lib/i386-linux-gnu/libc.so.6, /usr/lib/x86_64-linux-gnu/libc.so.6, and /usr/lib32/libc.so.6 on Ubuntu 22.04.