### PR TITLE
Remove bitArray SPEC_*_BIT macros

### DIFF
--- a/dataflowAPI/h/bitArray.h
+++ b/dataflowAPI/h/bitArray.h
@@ -36,9 +36,4 @@
 #include <boost/dynamic_bitset.hpp>
 typedef boost::dynamic_bitset<unsigned long, std::allocator<unsigned long> > bitArray;
 
-// Bitarrays for register liveness. This could move to registerSpace...
-#define SPEC_GPR_BIT(x) (x.size() - 3)
-#define SPEC_FPR_BIT(x) (x.size() - 2)
-#define SPEC_SPR_BIT(x) (x.size() - 1)
-#define SPEC_BIT_COUNT 3
 #endif


### PR DESCRIPTION
They were added by 3a70928cc in 2007, but never used.