### PR TITLE
MachRegister: Add interface for collecting and retrieving all registers

### DIFF
--- a/common/h/registers/MachRegister.h
+++ b/common/h/registers/MachRegister.h
@@ -35,6 +35,7 @@
 #include "util.h"
 
 #include <string>
+#include <vector>
 
 namespace Dyninst {
   typedef unsigned long MachRegisterVal;
@@ -87,6 +88,7 @@ namespace Dyninst {
     int getDwarfEnc() const;
 
     static MachRegister getArchReg(unsigned int regNum, Dyninst::Architecture arch);
+    static std::vector<MachRegister> const& getAllRegistersForArch(Dyninst::Architecture);
   };
 }
 

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -8,19 +8,24 @@
 
 #include <cassert>
 #include <unordered_map>
+#include <map>
+#include <vector>
 
 namespace {
   std::unordered_map<signed int, std::string> names;
   const std::string invalid_reg_name{"<INVALID_REG>"};
+  std::map<Dyninst::Architecture, std::vector<Dyninst::MachRegister>> all_regs;
 }
 
 namespace Dyninst {
 
   MachRegister::MachRegister() : reg(0) {}
 
-  MachRegister::MachRegister(signed int r) : reg(r) {}
+  MachRegister::MachRegister(signed int r) : reg(r) {
+    all_regs[getArchitecture()].push_back(*this);
+  }
 
-  MachRegister::MachRegister(signed int r, std::string n) : reg(r) { names.emplace(r, std::move(n)); }
+  MachRegister::MachRegister(signed int r, std::string n) : MachRegister(r) { names.emplace(r, std::move(n)); }
 
   unsigned int MachRegister::regClass() const { return reg & 0x00ff0000; }
 
@@ -2629,4 +2634,7 @@ namespace Dyninst {
     return InvalidReg;
   }
 
+  std::vector<MachRegister> const& getAllRegistersForArch(Dyninst::Architecture arch) {
+    return all_regs[arch];
+  }
 }

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -21,11 +21,12 @@ namespace Dyninst {
 
   MachRegister::MachRegister() : reg(0) {}
 
-  MachRegister::MachRegister(signed int r) : reg(r) {
+  MachRegister::MachRegister(signed int r) : reg(r) {}
+
+  MachRegister::MachRegister(signed int r, std::string n) : MachRegister(r) {
+    names.emplace(r, std::move(n));
     all_regs[getArchitecture()].push_back(*this);
   }
-
-  MachRegister::MachRegister(signed int r, std::string n) : MachRegister(r) { names.emplace(r, std::move(n)); }
 
   unsigned int MachRegister::regClass() const { return reg & 0x00ff0000; }
 


### PR DESCRIPTION
This makes writing ABI rules much simpler. It could also be useful for some power users.

The registers returned are in the order they are declared in common/h/registers/<arch>_regs.h.