### PR TITLE
Do not kill caller-saved registers when slicing backward

### DIFF
--- a/dataflowAPI/src/slicing.C
+++ b/dataflowAPI/src/slicing.C
@@ -1536,7 +1536,8 @@ bool Slicer::kills(AbsRegion const&reg, Assignment::Ptr &assign) {
       ABI* abi = ABI::getABI(b_->obj()->cs()->getAddressWidth());
       int index = abi->getIndex(r);
       if (index >= 0)
-          if (abi->getCallWrittenRegisters()[abi->getIndex(r)] && r != x86_64::r11) return true;
+          // Caller-saved registers are alive
+          if (abi->getCallWrittenRegisters()[abi->getIndex(r)]) return false;
   }
   return reg.contains(assign->out()) || assign->out().contains(reg);
 }


### PR DESCRIPTION
This check was added by 578ff24aa 2017, but the logic is inverted. From the commit message:

  Currently when backward slicing, a absloc that is written by call
  defined by abi will be killed, however, caller saved registers
  can/should survive

It's also unclear why r11 was excluded as it's not saved across function calls (i.e., not callee-saved).

Fixes #1280