### PR TITLE
GithubCI: use verbose output with ctest

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Run tests
         run: |
           cd external-tests/build
-          ctest .
+          ctest -VV --output-on-failure .
 
   clang-build:
     permissions:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -50,4 +50,4 @@ jobs:
       - name: Run unit tests
         run: |
           cd unit-tests/build
-          ctest .
+          ctest -VV --output-on-failure .


### PR DESCRIPTION
This will help with debugging test failures.