### PR TITLE
Fix definition of MachRegister::getAllRegistersForArch

### DIFF
--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -2635,7 +2635,7 @@ namespace Dyninst {
     return InvalidReg;
   }
 
-  std::vector<MachRegister> const& getAllRegistersForArch(Dyninst::Architecture arch) {
+  std::vector<MachRegister> const& MachRegister::getAllRegistersForArch(Dyninst::Architecture arch) {
     return all_regs[arch];
   }
 }


### PR DESCRIPTION
It's defined in the wrong scope, so it's not accessible outside of MachRegister.C.

Introduced by 88ad81c14 in 2024.