### PR TITLE
Rewrite and fix ABI representation and usage

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -6,6 +6,7 @@ configure_file(${PROJECT_SOURCE_DIR}/cmake/dyninstversion.h.in
                ${CMAKE_CURRENT_SOURCE_DIR}/h/dyninstversion.h)
 
 set(_public_headers
+    h/abi.h
     h/Annotatable.h
     h/Architecture.h
     h/Buffer.h
@@ -42,6 +43,7 @@ set(_public_headers
     h/registers/MachRegister.h
     h/registers/ppc32_regs.h
     h/registers/ppc64_regs.h
+    h/registers/registerSet.h
     h/registers/reg_def.h
     h/registers/x86_64_regs.h
     h/registers/x86_regs.h
@@ -53,6 +55,12 @@ set(_public_headers
     )
 
 set(_private_headers
+    src/ABI/aarch64.h
+    src/ABI/architecture.h
+    src/ABI/interface_definition.h
+    src/ABI/ppc64.h
+    src/ABI/x86_64.h
+    src/ABI/x86.h
     src/addrtranslate.h
     src/addrtranslate-sysv.h
     src/arch-aarch64.h
@@ -88,6 +96,7 @@ set(_private_headers
     src/vm_maps.h)
 
 set(_sources
+    src/ABI/ABI.C
     src/pfq-rwlock.C
     src/concurrent.C
     src/Timer.C

--- a/common/h/abi.h
+++ b/common/h/abi.h
@@ -28,47 +28,32 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef DYNINST_ARCHITECTURE_H
-#define DYNINST_ARCHITECTURE_H
+#ifndef DYNINST_COMMON_ABI_H
+#define DYNINST_COMMON_ABI_H
 
-#include <cassert>
+#include "Architecture.h"
+#include "registers/registerSet.h"
+#include <memory>
 
 namespace Dyninst {
 
-  // 0xff000000 is used to encode architecture
-  typedef enum {
-    Arch_none = 0x00000000,
-    Arch_x86 = 0x14000000,
-    Arch_x86_64 = 0x18000000,
-    Arch_ppc32 = 0x24000000,
-    Arch_ppc64 = 0x28000000,
-    Arch_aarch32 = 0x44000000, // for later use
-    Arch_aarch64 = 0x48000000,
-    Arch_cuda = 0x88000000,
-    Arch_amdgpu_gfx908 = 0x94000000, // future support for gfx908
-    Arch_amdgpu_gfx90a = 0x98000000, // future support for gfx90a
-    Arch_amdgpu_gfx940 = 0x9c000000, // future support for gfx940
-    Arch_intelGen9 = 0xb6000000      // same as machine no. retrevied from eu-readelf
-  } Architecture;
-
-  inline unsigned getArchAddressWidth(Architecture arch) {
-    switch(arch) {
-      case Arch_x86:
-      case Arch_ppc32: return 4;
-      case Arch_x86_64:
-      case Arch_ppc64:
-      case Arch_aarch64:
-      case Arch_cuda:
-      case Arch_intelGen9:
-      case Arch_amdgpu_gfx908:
-      case Arch_amdgpu_gfx90a:
-      case Arch_amdgpu_gfx940: return 8;
-      case Arch_none:
-      case Arch_aarch32:
-        return 0;
-    }
-    return 0;
+  namespace abi {
+    struct abi_impl;
   }
+
+  class COMMON_EXPORT ABI {
+    std::unique_ptr<Dyninst::abi::abi_impl> impl{};
+  public:
+    explicit ABI(Dyninst::Architecture a);
+
+  //  const bitArray &getCallReadRegisters() const;
+  //  const bitArray &getCallWrittenRegisters() const;
+  //  const bitArray &getReturnReadRegisters() const;
+  //  const bitArray &getReturnRegisters() const;
+  //  const bitArray &getParameterRegisters() const;
+  //  const bitArray &getSyscallReadRegisters() const;
+  //  const bitArray &getSyscallWrittenRegisters() const;
+  };
 
 }
 

--- a/common/h/registers/registerSet.h
+++ b/common/h/registers/registerSet.h
@@ -1,0 +1,95 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_DATAFLOW_REGISTERSET_H
+#define DYNINST_DATAFLOW_REGISTERSET_H
+
+#include "registers/MachRegister.h"
+#include <unordered_set>
+#include <initializer_list>
+
+namespace Dyninst { namespace abi {
+
+  namespace detail {
+    struct reg_hasher final {
+      std::size_t operator()(Dyninst::MachRegister m) const {
+        return m.val();
+      }
+    };
+  }
+
+  class registerSet final {
+    std::unordered_set<Dyninst::MachRegister, detail::reg_hasher> regs;
+  public:
+    registerSet(std::initializer_list<Dyninst::MachRegister> l) : regs(std::move(l)) {}
+    registerSet() = default;
+
+    bool contains(Dyninst::MachRegister m) const {
+      return regs.find(m) != regs.end();
+    }
+    void insert(MachRegister m) {
+      regs.insert(m);
+    }
+    void remove(MachRegister m) {
+      regs.erase(m);
+    }
+    auto begin() const -> decltype(regs.begin()) {
+      return regs.begin();
+    }
+    auto end() const -> decltype(regs.end()) {
+      return regs.end();
+    }
+    void operator|=(registerSet const& rhs) {
+      for(auto r : rhs) {
+        regs.insert(r);
+      }
+    }
+    registerSet operator|(registerSet const& rhs) const {
+      auto tmp = *this;
+      tmp |= rhs;
+      return tmp;
+    }
+    void operator&=(registerSet const& rhs) {
+      for(auto r : regs) {
+        if(rhs.contains(r)) {
+          regs.erase(r);
+        }
+      }
+    }
+    registerSet operator&(registerSet const& rhs) const {
+      auto tmp = *this;
+      tmp &= rhs;
+      return tmp;
+    }
+  };
+
+}}
+
+#endif

--- a/common/src/ABI/ABI.C
+++ b/common/src/ABI/ABI.C
@@ -28,48 +28,46 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef DYNINST_ARCHITECTURE_H
-#define DYNINST_ARCHITECTURE_H
+#include "abi.h"
+#include "ABI/x86.h"
+#include "ABI/x86_64.h"
+#include "ABI/ppc64.h"
+#include "ABI/aarch64.h"
+#include "registers/registerSet.h"
+#include "ABI/architecture.h"
 
-#include <cassert>
+namespace Dyninst { namespace abi {
 
-namespace Dyninst {
+  struct abi_impl final {
+    Dyninst::abi::architecture machine;
 
-  // 0xff000000 is used to encode architecture
-  typedef enum {
-    Arch_none = 0x00000000,
-    Arch_x86 = 0x14000000,
-    Arch_x86_64 = 0x18000000,
-    Arch_ppc32 = 0x24000000,
-    Arch_ppc64 = 0x28000000,
-    Arch_aarch32 = 0x44000000, // for later use
-    Arch_aarch64 = 0x48000000,
-    Arch_cuda = 0x88000000,
-    Arch_amdgpu_gfx908 = 0x94000000, // future support for gfx908
-    Arch_amdgpu_gfx90a = 0x98000000, // future support for gfx90a
-    Arch_amdgpu_gfx940 = 0x9c000000, // future support for gfx940
-    Arch_intelGen9 = 0xb6000000      // same as machine no. retrevied from eu-readelf
-  } Architecture;
-
-  inline unsigned getArchAddressWidth(Architecture arch) {
-    switch(arch) {
-      case Arch_x86:
-      case Arch_ppc32: return 4;
-      case Arch_x86_64:
-      case Arch_ppc64:
-      case Arch_aarch64:
-      case Arch_cuda:
-      case Arch_intelGen9:
-      case Arch_amdgpu_gfx908:
-      case Arch_amdgpu_gfx90a:
-      case Arch_amdgpu_gfx940: return 8;
-      case Arch_none:
-      case Arch_aarch32:
-        return 0;
+    abi_impl(Dyninst::Architecture a) {
+      switch(a) {
+        case Dyninst::Arch_x86:
+          machine = abi::make_x86();
+          break;
+        case Dyninst::Arch_x86_64:
+          machine = abi::make_x86_64();
+          break;
+        case Dyninst::Arch_ppc64:
+          machine = abi::make_ppc64();
+          break;
+        case Dyninst::Arch_aarch64:
+          machine = abi::make_aarch64();
+          break;
+        case Dyninst::Arch_ppc32:
+        case Dyninst::Arch_aarch32:
+        case Dyninst::Arch_amdgpu_gfx908:
+        case Dyninst::Arch_amdgpu_gfx90a:
+        case Dyninst::Arch_amdgpu_gfx940:
+        case Dyninst::Arch_cuda:
+        case Dyninst::Arch_intelGen9:
+        case Dyninst::Arch_none:
+          break;
+      }
     }
-    return 0;
-  }
+  };
 
-}
+}}
 
-#endif
+Dyninst::ABI::ABI(Dyninst::Architecture a) : impl(new Dyninst::abi::abi_impl(a)) {}

--- a/common/src/ABI/aarch64.h
+++ b/common/src/ABI/aarch64.h
@@ -1,0 +1,232 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_COMMON_AARCH64_ABI_H
+#define DYNINST_COMMON_AARCH64_ABI_H
+
+#include "registers/aarch64_regs.h"
+#include "registers/registerSet.h"
+#include "ABI/architecture.h"
+#include "Architecture.h"
+#include "registers/MachRegister.h"
+
+namespace Dyninst { namespace abi {
+
+/*
+ * Procedure Call Standard for the Arm 64-bit Architecture (AArch64)
+ * April 12 2021
+ *
+ * Chapter 6 The Base Procedure Call Standard
+ */
+
+architecture make_aarch64() {
+  architecture arch;
+  arch.address_width = getArchAddressWidth(Arch_aarch64);
+
+  arch.function.params = {
+    aarch64::x0,  // 32- and 64-bit GPRs
+    aarch64::w0,
+    aarch64::x1,
+    aarch64::w1,
+    aarch64::x2,
+    aarch64::w2,
+    aarch64::x3,
+    aarch64::w3,
+    aarch64::x4,
+    aarch64::w4,
+    aarch64::x5,
+    aarch64::w5,
+    aarch64::x6,
+    aarch64::w6,
+    aarch64::x7,
+    aarch64::w7,
+    aarch64::q0,  // 128-, 64-, and 32-bit SIMD
+    aarch64::d0,
+    aarch64::s0,
+    aarch64::q1,
+    aarch64::d1,
+    aarch64::s1,
+    aarch64::q2,
+    aarch64::d2,
+    aarch64::s2,
+    aarch64::q3,
+    aarch64::d3,
+    aarch64::s3,
+    aarch64::q4,
+    aarch64::d4,
+    aarch64::s4,
+    aarch64::q5,
+    aarch64::d5,
+    aarch64::s5,
+    aarch64::q6,
+    aarch64::d6,
+    aarch64::s6,
+    aarch64::q7,
+    aarch64::d7,
+    aarch64::s7
+  };
+
+  arch.function.returns = {
+    aarch64::x0,  // 32- and 64-bit GPRs
+    aarch64::w0,
+    aarch64::x1,
+    aarch64::w1,
+    aarch64::x2,
+    aarch64::w2,
+    aarch64::x3,
+    aarch64::w3,
+    aarch64::x4,
+    aarch64::w4,
+    aarch64::x5,
+    aarch64::w5,
+    aarch64::x6,
+    aarch64::w6,
+    aarch64::x7,
+    aarch64::w7,
+    aarch64::x8,  // Indirect result location register
+    aarch64::w8,
+    aarch64::q0,  // 128-, 64-, and 32-bit SIMD
+    aarch64::d0,
+    aarch64::s0,
+    aarch64::q1,
+    aarch64::d1,
+    aarch64::s1,
+    aarch64::q2,
+    aarch64::d2,
+    aarch64::s2,
+    aarch64::q3,
+    aarch64::d3,
+    aarch64::s3,
+    aarch64::q4,
+    aarch64::d4,
+    aarch64::s4,
+    aarch64::q5,
+    aarch64::d5,
+    aarch64::s5,
+    aarch64::q6,
+    aarch64::d6,
+    aarch64::s6,
+    aarch64::q7,
+    aarch64::d7,
+    aarch64::s7
+  };
+
+  arch.function.preserved = {
+    // All 64 bits of each value stored in r19-r29 must be preserved, even
+    // when using the ILP32 data model.
+    aarch64::x19,
+    aarch64::w19,
+    aarch64::x20,
+    aarch64::w20,
+    aarch64::x21,
+    aarch64::w21,
+    aarch64::x22,
+    aarch64::w22,
+    aarch64::x23,
+    aarch64::w23,
+    aarch64::x24,
+    aarch64::w24,
+    aarch64::x25,
+    aarch64::w25,
+    aarch64::x26,
+    aarch64::w26,
+    aarch64::x27,
+    aarch64::w27,
+    aarch64::x28,
+    aarch64::w28,
+    aarch64::sp,    // stack pointer
+
+    // 128-, 64-, and 32-bit SIMD
+    // Only the bottom 64 bits of each value stored in v8-v15 need
+    // to be preserved, but we mark the whole register.
+    aarch64::q8,
+    aarch64::d8,
+    aarch64::s8,
+    aarch64::q9,
+    aarch64::d9,
+    aarch64::s9,
+    aarch64::q10,
+    aarch64::d10,
+    aarch64::s10,
+    aarch64::q11,
+    aarch64::d11,
+    aarch64::s11,
+    aarch64::q12,
+    aarch64::d12,
+    aarch64::s12,
+    aarch64::q13,
+    aarch64::d13,
+    aarch64::s13,
+    aarch64::q14,
+    aarch64::d14,
+    aarch64::s14,
+    aarch64::q15,
+    aarch64::d15,
+    aarch64::s15
+  };
+
+  arch.function.globals = {
+    // r16/IP0 and r17/IP1 can be used by call veneers and PLT code, but may
+    // also be a temporary. Conservatively assume they are always used.
+    aarch64::x16,
+    aarch64::w16,
+    aarch64::x17,
+    aarch64::w17,
+
+    /* The Platform Register, if needed; otherwise a temporary register
+     *
+     * Software developers creating platform-independent code are advised to
+     * avoid using r18 if at all possible. It should not be assumed that treating
+     * the register as callee-saved will be sufficient to satisfy the requirements
+     * of the platform.
+     */
+    aarch64::x18,
+    aarch64::w18,
+
+    aarch64::x30, // Link register (LR)
+    aarch64::w30,
+    aarch64::x29, // Frame pointer (FP)
+    aarch64::w29
+
+    // Note: The N, Z, C and V flags are undefined on entry to and return
+    //       from a public interface. We don't need to do anything with them.
+  };
+
+  arch.syscall.params = {};
+  arch.syscall.returns = {};
+  arch.syscall.preserved = {};
+  arch.syscall.globals = {};
+
+  return arch;
+}
+
+}}
+
+#endif

--- a/common/src/ABI/architecture.h
+++ b/common/src/ABI/architecture.h
@@ -28,48 +28,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef DYNINST_ARCHITECTURE_H
-#define DYNINST_ARCHITECTURE_H
+#ifndef DYNINST_COMMON_ABI_ARCHITECTURE_H
+#define DYNINST_COMMON_ABI_ARCHITECTURE_H
 
-#include <cassert>
+#include "registers/registerSet.h"
+#include "ABI/interface_definition.h"
 
-namespace Dyninst {
-
-  // 0xff000000 is used to encode architecture
-  typedef enum {
-    Arch_none = 0x00000000,
-    Arch_x86 = 0x14000000,
-    Arch_x86_64 = 0x18000000,
-    Arch_ppc32 = 0x24000000,
-    Arch_ppc64 = 0x28000000,
-    Arch_aarch32 = 0x44000000, // for later use
-    Arch_aarch64 = 0x48000000,
-    Arch_cuda = 0x88000000,
-    Arch_amdgpu_gfx908 = 0x94000000, // future support for gfx908
-    Arch_amdgpu_gfx90a = 0x98000000, // future support for gfx90a
-    Arch_amdgpu_gfx940 = 0x9c000000, // future support for gfx940
-    Arch_intelGen9 = 0xb6000000      // same as machine no. retrevied from eu-readelf
-  } Architecture;
-
-  inline unsigned getArchAddressWidth(Architecture arch) {
-    switch(arch) {
-      case Arch_x86:
-      case Arch_ppc32: return 4;
-      case Arch_x86_64:
-      case Arch_ppc64:
-      case Arch_aarch64:
-      case Arch_cuda:
-      case Arch_intelGen9:
-      case Arch_amdgpu_gfx908:
-      case Arch_amdgpu_gfx90a:
-      case Arch_amdgpu_gfx940: return 8;
-      case Arch_none:
-      case Arch_aarch32:
-        return 0;
-    }
-    return 0;
-  }
-
-}
+namespace Dyninst { namespace abi {
+  struct architecture {
+    int address_width{};
+    interface_definition function;
+    interface_definition syscall;
+  };
+}}
 
 #endif

--- a/common/src/ABI/interface_definition.h
+++ b/common/src/ABI/interface_definition.h
@@ -28,48 +28,30 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef DYNINST_ARCHITECTURE_H
-#define DYNINST_ARCHITECTURE_H
+#ifndef DYNINST_COMMON_ABI_INTERFACE_DEFINITION_H
+#define DYNINST_COMMON_ABI_INTERFACE_DEFINITION_H
 
-#include <cassert>
+#include "registers/registerSet.h"
 
-namespace Dyninst {
+namespace Dyninst { namespace abi {
 
-  // 0xff000000 is used to encode architecture
-  typedef enum {
-    Arch_none = 0x00000000,
-    Arch_x86 = 0x14000000,
-    Arch_x86_64 = 0x18000000,
-    Arch_ppc32 = 0x24000000,
-    Arch_ppc64 = 0x28000000,
-    Arch_aarch32 = 0x44000000, // for later use
-    Arch_aarch64 = 0x48000000,
-    Arch_cuda = 0x88000000,
-    Arch_amdgpu_gfx908 = 0x94000000, // future support for gfx908
-    Arch_amdgpu_gfx90a = 0x98000000, // future support for gfx90a
-    Arch_amdgpu_gfx940 = 0x9c000000, // future support for gfx940
-    Arch_intelGen9 = 0xb6000000      // same as machine no. retrevied from eu-readelf
-  } Architecture;
+  struct interface_definition {
 
-  inline unsigned getArchAddressWidth(Architecture arch) {
-    switch(arch) {
-      case Arch_x86:
-      case Arch_ppc32: return 4;
-      case Arch_x86_64:
-      case Arch_ppc64:
-      case Arch_aarch64:
-      case Arch_cuda:
-      case Arch_intelGen9:
-      case Arch_amdgpu_gfx908:
-      case Arch_amdgpu_gfx90a:
-      case Arch_amdgpu_gfx940: return 8;
-      case Arch_none:
-      case Arch_aarch32:
-        return 0;
-    }
-    return 0;
-  }
+    // registers used to pass parameters to a function
+    registerSet params;
 
-}
+    // registers used to return parameters from a function
+    registerSet returns;
+
+    // registers whose value is preserved on function return
+    // Also referred to as 'callee-saved' in the ABI docs
+    registerSet preserved;
+
+    // Registers that act as global variable by the ABI/runtime system
+    // that are possibly read & written in the function and are valid after
+    // a function such as `%rsp`, `%rip` and `%fs`.
+    registerSet globals;
+  };
+}}
 
 #endif

--- a/common/src/ABI/ppc64.h
+++ b/common/src/ABI/ppc64.h
@@ -1,0 +1,192 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_COMMON_PPC64_ABI_H
+#define DYNINST_COMMON_PPC64_ABI_H
+
+#include "registers/ppc64_regs.h"
+#include "registers/registerSet.h"
+#include "ABI/architecture.h"
+#include "Architecture.h"
+#include "registers/MachRegister.h"
+
+namespace Dyninst { namespace abi {
+
+/*
+ * OpenPOWER 64-Bit ELF V2 ABI Specification
+ * Version 1.5
+ * December 1, 2020
+ *
+ * Section 2.2 Function Calling Sequence
+ *
+ * While it is recommended that all functions use the standard calling sequence,
+ * the requirements of the standard calling sequence are only applicable to
+ * global functions. Different calling sequences and conventions can be used by
+ * local functions that cannot be reached from other compilation units, if they
+ * comply with the stack back trace requirements. Some tools may not work with
+ * alternate calling sequences and conventions.
+ */
+
+architecture make_ppc64() {
+  architecture arch;
+  arch.address_width = getArchAddressWidth(Arch_ppc64);
+
+  arch.function.params = {
+    ppc64::r3,    // GPRs
+    ppc64::r4,
+    ppc64::r5,
+    ppc64::r6,
+    ppc64::r7,
+    ppc64::r8,
+    ppc64::r9,
+    ppc64::r10,
+    ppc64::fpr1,  // Floating-point registers
+    ppc64::fpr2,
+    ppc64::fpr3,
+    ppc64::fpr4,
+    ppc64::fpr5,
+    ppc64::fpr6,
+    ppc64::fpr7,
+    ppc64::fpr8,
+    ppc64::fpr9,
+    ppc64::fpr10,
+    ppc64::fpr11,
+    ppc64::fpr12,
+    ppc64::fpr13,
+    ppc64::vsr2,  // Vector-scalar registers
+    ppc64::vsr3,
+    ppc64::vsr4,
+    ppc64::vsr5,
+    ppc64::vsr6,
+    ppc64::vsr7,
+    ppc64::vsr8,
+    ppc64::vsr9,
+    ppc64::vsr10,
+    ppc64::vsr11,
+    ppc64::vsr12,
+    ppc64::vsr13,
+  };
+
+  arch.function.returns = {
+    ppc64::r3,    // GPRs
+    ppc64::r4,
+    ppc64::r5,
+    ppc64::r6,
+    ppc64::r7,
+    ppc64::r8,
+    ppc64::r9,
+    ppc64::r10,
+    ppc64::fpr1,  // Floating-point registers
+    ppc64::fpr2,
+    ppc64::fpr3,
+    ppc64::fpr4,
+    ppc64::fpr5,
+    ppc64::fpr6,
+    ppc64::fpr7,
+    ppc64::fpr8,
+    ppc64::fpr9,
+    ppc64::fpr10,
+    ppc64::fpr11,
+    ppc64::fpr12,
+    ppc64::fpr13,
+    ppc64::vsr2,  // Vector-scalar registers
+    ppc64::vsr3,
+    ppc64::vsr4,
+    ppc64::vsr5,
+    ppc64::vsr6,
+    ppc64::vsr7,
+    ppc64::vsr8,
+    ppc64::vsr9,
+    ppc64::vsr10,
+    ppc64::vsr11,
+    ppc64::vsr12,
+    ppc64::vsr13,
+  };
+
+  arch.function.preserved = {
+    ppc64::r1,    // stack pointer
+    ppc64::r2,    // TOC pointer (only saved between calls in same compilation unti)
+    ppc64::cr2,   // Condition register fields
+    ppc64::cr3,
+    ppc64::cr4,
+//    DSCR (ppc64::dsisr?)    // Data stream prefect control
+    ppc64::fpr14, // Floating-point registers for local variables
+    ppc64::fpr15,
+    ppc64::fpr16,
+    ppc64::fpr17,
+    ppc64::fpr18,
+    ppc64::fpr19,
+    ppc64::fpr20,
+    ppc64::fpr21,
+    ppc64::fpr22,
+    ppc64::fpr23,
+    ppc64::fpr24,
+    ppc64::fpr25,
+    ppc64::fpr26,
+    ppc64::fpr27,
+    ppc64::fpr28,
+    ppc64::fpr29,
+    ppc64::fpr30,
+    ppc64::fpr31,
+    ppc64::vsr20, // Vector-scalar registers for local variables
+    ppc64::vsr21,
+    ppc64::vsr22,
+    ppc64::vsr23,
+    ppc64::vsr24,
+    ppc64::vsr25,
+    ppc64::vsr26,
+    ppc64::vsr27,
+    ppc64::vsr28,
+    ppc64::vsr29,
+    ppc64::vsr30,
+    ppc64::vsr31,
+  };
+
+  arch.function.globals = {
+    ppc64::r12,     // Optional use in function linkage
+    ppc64::r13,     // Thread pointer (reserved use)
+//    TAR    // Reserved for system use
+    ppc64::vrsave,  // Reserved for system use
+//    FPSCR see 2.2.2.2 Limited-Access bits
+//    VSCR see 2.2.2.2 Limited-Access bits
+  };
+
+  // https://github.com/torvalds/linux/blob/v6.8/Documentation/arch/powerpc/syscall64-abi.rst
+  arch.syscall.params = {};
+  arch.syscall.returns = {};
+  arch.syscall.preserved = {};
+  arch.syscall.globals = {};
+
+  return arch;
+}
+
+}}
+
+#endif

--- a/common/src/ABI/x86.h
+++ b/common/src/ABI/x86.h
@@ -1,0 +1,128 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_COMMON_X86_ABI_H
+#define DYNINST_COMMON_X86_ABI_H
+
+#include "registers/x86_regs.h"
+#include "ABI/architecture.h"
+
+namespace Dyninst { namespace abi {
+
+/* i386 ABI
+ *
+ * System V Application Binary Interface
+ * Intel386 Architecture Processor Supplement
+ * Version 1.0
+ * February 3, 2015
+ * Section 2.2 Function Calling Sequence
+ */
+architecture make_x86() {
+  architecture arch;
+  arch.address_width = getArchAddressWidth(Arch_x86);
+
+  arch.function.params = {
+    /*
+    * For purposes of parameter passing and function return,
+    * xmmN and ymmN refer to the same register. Only one of
+    * them can be used at the same time.
+    */
+    x86::xmm0,  // __m128
+    x86::xmm1,
+    x86::xmm2,
+    x86::ymm0,  // __m256
+    x86::ymm1,
+    x86::ymm2,
+    x86::mm0,   // __m64
+    x86::mm1,
+    x86::mm2,
+    x86::edx,   // used by fastcall convention
+    x86::ecx    // used by fastcall convention
+  };
+
+  arch.function.returns = {
+    x86::eax,   // ints, pointers, address of struct/union
+    x86::edx,   // upper 32 bits of some 64-bit return types
+    x86::xmm0,  // __m128
+    x86::ymm0,  // __m256
+    x86::mm0,   // __m64
+    x86::st0    // float, double, long double, __float80
+  };
+
+  arch.function.preserved = {
+    x86::ebx,
+    x86::esp,
+    x86::ebp,     // can be used as frame pointer
+    x86::esi,
+    x86::edi,
+    x86::mxcsr,   // only control bits, but we don't break it down
+    x86::fcw      // x87 control word
+  };
+
+  arch.function.globals = {
+    /*
+    * The direction flag DF in the %EFLAGS register must be clear (set to “forward”
+    * direction) on function entry and return. Other user flags have no specified role
+    * in the standard calling sequence and are not preserved across calls.
+    */
+    x86::df,
+    x86::gs,    // Reserved for system (as thread specific data register)
+    x86::ebx    // Used to hold GOT pointer when making calls via PLT
+  };
+
+  /*
+  * Emulated IA32 system calls via `int 0x80` for Linux v4.1
+  *
+  *   https://github.com/torvalds/linux/blob/v4.1/arch/x86/ia32/ia32entry.S#L498
+  *
+  * Support for IA32 system calls was removed in Linux 4.2
+  *
+  *  We only care about parameters here because the caller must save all registers
+  *  except eax, and there are no return values or globals.
+  */
+  arch.syscall.params = {
+    x86::eax,   // system call number
+    x86::ebx,   // arg1
+    x86::ecx,   // arg2
+    x86::edx,   // arg3
+    x86::esi,   // arg4
+    x86::edi,   // arg5
+    x86::ebp    // arg6
+  };
+
+#ifdef os_windows
+#  error "Windows ABI is unimplemented"
+#endif
+
+  return arch;
+  }
+}}
+
+#endif

--- a/common/src/ABI/x86_64.h
+++ b/common/src/ABI/x86_64.h
@@ -1,0 +1,160 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_COMMON_X86_64_ABI_H
+#define DYNINST_COMMON_X86_64_ABI_H
+
+#include "registers/x86_64_regs.h"
+#include "registers/registerSet.h"
+#include "ABI/architecture.h"
+#include "Architecture.h"
+#include "registers/MachRegister.h"
+
+namespace Dyninst { namespace abi {
+
+/*
+ * System V Application Binary Interface
+ * AMD64 Architecture Processor Supplement
+ * (With LP64 and ILP32 Programming Models)
+ * Version 1.0
+ * November 7, 2023
+ *
+ * Section 3.2 Function Calling Sequence
+ * Figure 3.4: Register Usage
+ */
+
+architecture make_x86_64() {
+  architecture arch;
+  arch.address_width = getArchAddressWidth(Arch_x86_64);
+
+  arch.function.params = {
+    x86_64::rax,   // number of vector registers for varargs
+    x86_64::rdi,
+    x86_64::rsi,
+    x86_64::rdx,
+    x86_64::rcx,
+    x86_64::r8,
+    x86_64::r9,
+    x86_64::xmm0,   // __m128
+    x86_64::xmm1,
+    x86_64::xmm2,
+    x86_64::xmm3,
+    x86_64::xmm4,
+    x86_64::xmm5,
+    x86_64::xmm6,
+    x86_64::xmm7,
+    x86_64::ymm0,   // __m256
+    x86_64::ymm1,
+    x86_64::ymm2,
+    x86_64::ymm3,
+    x86_64::ymm4,
+    x86_64::ymm5,
+    x86_64::ymm6,
+    x86_64::ymm7,
+    x86_64::zmm0,   // __m512
+    x86_64::zmm1,
+    x86_64::zmm2,
+    x86_64::zmm3,
+    x86_64::zmm4,
+    x86_64::zmm5,
+    x86_64::zmm6,
+    x86_64::zmm7
+  };
+
+  arch.function.returns = {
+    x86_64::rax,
+    x86_64::rdx,
+    x86_64::xmm0,   // __m128
+    x86_64::xmm1,
+    x86_64::ymm0,   // __m256
+    x86_64::ymm1,
+    x86_64::zmm0,   // __m512
+    x86_64::zmm1,
+    x86_64::st0,    // long double
+    x86_64::st1
+  };
+
+  arch.function.preserved = {
+    x86_64::rbx,
+    x86_64::rsp,
+    x86_64::rbp,    // can be used as frame pointer
+    x86_64::r12,
+    x86_64::r13,
+    x86_64::r14,
+    x86_64::r15,    // optionally used as GOT base pointer
+    x86_64::fs,     // Thread control block
+    x86_64::mxcsr,  // only control bits, but we don't break it down
+    x86_64::fcw     // x87 control word
+  };
+
+  arch.function.globals = {
+    /*
+    * The direction flag DF in the %RFLAGS register must be clear (set to “forward”
+    * direction) on function entry and return. Other user flags have no specified role
+    * in the standard calling sequence and are not preserved across calls.
+    */
+    x86_64::df,
+    x86_64::r10   // Used for passing a function’s static chain pointer
+  };
+
+  /*
+   * A.2 AMD64 Linux Kernel Conventions
+   */
+
+  // User-level applications (UIA) and the kernel interface (KI) use overlapping
+  // sets of registers to pass arguments.
+  arch.syscall.params = {
+    x86_64::rax,  // syscall number
+    x86_64::rdi,  // arg1: UIA, KI
+    x86_64::rsi,  // arg2: UIA, KI
+    x86_64::rdx,  // arg3: UIA, KI
+    x86_64::rcx,  // arg4: UIA
+    x86_64::r10,  // arg4: KI
+    x86_64::r8,   // arg5: UIA, KI
+    x86_64::r9,   // arg6: UIA, KI
+  };
+
+  arch.syscall.returns = {
+    x86_64::rax   // The result of the system-call
+  };
+
+  // The kernel clobbers %rcx and %r11 but preserves all others except %rax.
+  auto const& all_regs = MachRegister::getAllRegistersForArch(Arch_x86_64);
+  for(auto r : all_regs) {
+    arch.syscall.preserved.insert(r);
+  }
+  arch.syscall.preserved.remove(x86_64::rax);
+
+  return arch;
+}
+
+}}
+
+#endif

--- a/parseAPI/CMakeLists.txt
+++ b/parseAPI/CMakeLists.txt
@@ -116,7 +116,9 @@ foreach(t ${parseAPI_TARGETS})
                              PRIVATE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/common/h>")
 
   target_include_directories(
-    ${t} PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/dataflowAPI/h>")
+    ${t} PUBLIC
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/dataflowAPI/h>"
+    )
 
   set_property(TARGET ${t} PROPERTY PUBLIC_HEADER ${parseapi_headers}
                                     ${dataflowapi_headers})


### PR DESCRIPTION
## TODO 

 - [ ] Verify i386

 - [ ] Verify x86_64
   - [ ] Does this fix #609?
   - [ ] Does this fix #712?
   - [ ] Does this fix #775?
   - [ ] Does this fix #724?

 - [ ] Finish aarch64 functions (needs update to aarch64_regs.h)
 - [ ] Add aarch64 system call

 - [ ] Finish ppc64 functions (needs update to ppc64_regs.h)
 - [ ] Add ppc64 system call
   - [ ] Does this fix #1165?

 - [ ] Replace use of ppc32 abi with ppc64 (will fix #1142)

 - [ ] Replace use of old ABI class

 - [ ] Finish removing ppc32 (hasn't been supported since #1145)

Fixes #1135

--------
I've verified that none of our known consumers uses this interface.

| consumer | uses LivenessAnalyzer | uses ABI
| --- | --- | --- |
hpctoolkit | no  | no |
tau        | no  | no |
llnl-stat  | no  | no |
must       | no  | no |
extrae     | no  | no |
systemtap  | yes | no |

systemtap only uses `bool query(ParseAPI::Location, Type, const MachRegister&, bool&)`.
