### PR TITLE
fix hpctoolkit github ci workflow

### DIFF
--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -27,7 +27,7 @@ jobs:
         sudo apt install -y -qq --no-install-recommends build-essential gcc g++ gfortran m4 cmake autoconf python3 git unzip openmpi-bin libopenmpi-dev
         git clone --depth=1 --branch=develop https://github.com/spack/spack
         spack/bin/spack compiler find
-        spack/bin/spack external find --not-buildable cmake python git m4 openmpi gmake
+        spack/bin/spack external find --not-buildable cmake git m4 openmpi gmake
         spack/bin/spack install ${{ matrix.consumer }} ^dyninst@master
 
   systemtap:


### PR DESCRIPTION
have spack use python that it built and intalled instead of the system python, so meson gets installed in the correct path