### PR TITLE
Add MultiRegisterAST to instructionAPI for AMDGPU

### DIFF
--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -267,7 +267,7 @@ public:
         defined = false;
         results.push_back(0);
     }
-    virtual void visit(MultiRegisterAST* r)
+    virtual void visit(MultiRegisterAST* )
     {
         defined = false;
     }

--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -526,11 +526,12 @@ void AssignmentConverter::convert(const Instruction &I,
         //
         std::vector<Operand> operands;
         I.getOperands(operands);
-        assert(operands.size() == 3);
-        RegisterAST::Ptr lowpc_reg  = boost::dynamic_pointer_cast<RegisterAST>(operands[0].getValue());
-        RegisterAST::Ptr highpc_reg = boost::dynamic_pointer_cast<RegisterAST>(operands[1].getValue());
-        AbsRegion lowpc_dst  = AbsRegion(lowpc_reg->getID()) ;
-        AbsRegion highpc_dst = AbsRegion(highpc_reg->getID()) ;
+        assert(operands.size() == 2);
+        MultiRegisterAST::Ptr pc_reg  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
+        const std::vector<RegisterAST::Ptr> & pc_regasts = pc_reg->getRegs();
+        AbsRegion lowpc_dst  = AbsRegion(pc_regasts[0]->getID()) ;
+        AbsRegion highpc_dst = AbsRegion(pc_regasts[1]->getID()) ;
+
 
         //AbsRegion pc = AbsRegion(Absloc::makePC(func->isrc()->getArch()));
         AbsRegion pc = AbsRegion(Absloc(addr));
@@ -565,11 +566,11 @@ void AssignmentConverter::convert(const Instruction &I,
 
         std::vector<Operand> operands;
         I.getOperands(operands);
-        assert(operands.size() == 3);
-        RegisterAST::Ptr lowpc_reg  = boost::dynamic_pointer_cast<RegisterAST>(operands[0].getValue());
-        RegisterAST::Ptr highpc_reg = boost::dynamic_pointer_cast<RegisterAST>(operands[1].getValue());
-        AbsRegion lowpc_src  = AbsRegion(lowpc_reg->getID()) ;
-        AbsRegion highpc_src = AbsRegion(highpc_reg->getID()) ;
+        assert(operands.size() == 2);
+        MultiRegisterAST::Ptr pc_reg  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
+        const std::vector<RegisterAST::Ptr> & pc_regasts = pc_reg->getRegs();
+        AbsRegion lowpc_src  = AbsRegion(pc_regasts[0]->getID()) ;
+        AbsRegion highpc_src = AbsRegion(pc_regasts[1]->getID()) ;
 
         pcA->addInput(lowpc_src);
         pcA->addInput(highpc_src);
@@ -581,12 +582,15 @@ void AssignmentConverter::convert(const Instruction &I,
     case amdgpu_gfx940_op_S_SWAPPC_B64: {
         std::vector<Operand> operands;
         I.getOperands(operands);
-        assert(operands.size() == 6);
+        assert(operands.size() == 4);
 
-        RegisterAST::Ptr new_pc_value_low  = boost::dynamic_pointer_cast<RegisterAST>(operands[2].getValue());
-        RegisterAST::Ptr new_pc_value_high = boost::dynamic_pointer_cast<RegisterAST>(operands[3].getValue());
-        AbsRegion new_pc_reg_low  = AbsRegion(new_pc_value_low->getID()) ;
-        AbsRegion new_pc_reg_high = AbsRegion(new_pc_value_high->getID()) ;
+        MultiRegisterAST::Ptr pc_src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[1].getValue());
+        const std::vector<RegisterAST::Ptr> & pc_src_regasts = pc_src_regs->getRegs();
+        AbsRegion pc_src_low  = AbsRegion(pc_src_regasts[0]->getID()) ;
+        AbsRegion pc_src_hi = AbsRegion(pc_src_regasts[1]->getID()) ;
+
+
+        
         AbsRegion pc = AbsRegion(Absloc::makePC(func->isrc()->getArch()));
 
         Assignment::Ptr pcA = Assignment::makeAssignment(I,
@@ -595,34 +599,33 @@ void AssignmentConverter::convert(const Instruction &I,
                 block,
                 pc);
 
-        pcA->addInput(new_pc_reg_low);
-        pcA->addInput(new_pc_reg_high);
-
-/*
-        RegisterAST::Ptr backup_pc_low  = boost::dynamic_pointer_cast<RegisterAST>(operands[0].getValue());
-        RegisterAST::Ptr backup_pc_high = boost::dynamic_pointer_cast<RegisterAST>(operands[1].getValue());
-        AbsRegion backup_pc_low_reg  = AbsRegion(backup_pc_low->getID()) ;
-        AbsRegion backup_pc_high_reg = AbsRegion(backup_pc_high->getID()) ;
-
-        Assignment::Ptr backup_pc_lowA = Assignment::makeAssignment(I,
-                addr,
-                func,
-                block,
-                backup_pc_low_reg);
-        backup_pc_lowA->addInput(pc);
-
-        Assignment::Ptr backup_pc_highA = Assignment::makeAssignment(I,
-                addr,
-                func,
-                block,
-                backup_pc_high_reg);
-        backup_pc_highA->addInput(pc);
-*/
-
+        pcA->addInput(pc_src_low);
+        pcA->addInput(pc_src_hi);
         assignments.push_back(pcA);
-        //assignments.push_back(backup_pc_lowA);
-        //assignments.push_back(backup_pc_highA);
 
+        MultiRegisterAST::Ptr pc_dst_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
+        const std::vector<RegisterAST::Ptr> & pc_dst_regasts = pc_dst_regs->getRegs();
+        AbsRegion pc_dst_low  = AbsRegion(pc_dst_regasts[0]->getID()) ;
+        AbsRegion pc_dst_hi = AbsRegion(pc_dst_regasts[1]->getID()) ;
+
+
+        Assignment::Ptr pcA_lo = Assignment::makeAssignment(I,
+                addr,
+                func,
+                block,
+                pc_dst_low);
+
+        Assignment::Ptr pcA_hi = Assignment::makeAssignment(I,
+                addr,
+                func,
+                block,
+                pc_dst_hi);
+
+
+        pcA_lo->addInput(pc);
+        pcA_hi->addInput(pc);
+        assignments.push_back(pcA_lo);
+        assignments.push_back(pcA_hi);
 
         break;
     }

--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -269,10 +269,7 @@ public:
     }
     virtual void visit(MultiRegisterAST* r)
     {
-      for (auto my_Reg : r->getRegs() ){
-          visit(my_Reg.get());
-      }
-      // TODO
+        defined = false;
     }
 
     virtual void visit(Dereference* )

--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -34,6 +34,7 @@
 #include "AbslocInterface.h"
 
 #include "Register.h"
+#include "MultiRegister.h"
 // Pile of InstructionAPI includes
 #include "Expression.h"
 #include "Result.h"
@@ -266,6 +267,14 @@ public:
         defined = false;
         results.push_back(0);
     }
+    virtual void visit(MultiRegisterAST* r)
+    {
+      for (auto my_Reg : r->getRegs() ){
+          visit(my_Reg.get());
+      }
+      // TODO
+    }
+
     virtual void visit(Dereference* )
     {
         //defined = false;

--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -37,6 +37,7 @@
 #include <list>
 
 #include "Register.h"
+#include "MultiRegister.h"
 #include "../rose/SgAsmExpression.h"
 
 using namespace Dyninst;
@@ -157,6 +158,14 @@ void ExpressionConversionVisitor::visit(RegisterAST *regast) {
     }
     m_stack.push_front(reg);
     roseExpression = m_stack.front();
+    return;
+}
+
+void ExpressionConversionVisitor::visit(MultiRegisterAST *multiregast) {
+    // has no children
+    for (auto my_Reg : multiregast->getRegs() ){
+        visit(my_Reg.get());
+    }
     return;
 }
 

--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -161,12 +161,9 @@ void ExpressionConversionVisitor::visit(RegisterAST *regast) {
     return;
 }
 
-void ExpressionConversionVisitor::visit(MultiRegisterAST *multiregast) {
-    // has no children
-    for (auto my_Reg : multiregast->getRegs() ){
-        visit(my_Reg.get());
-    }
-    return;
+void ExpressionConversionVisitor::visit(MultiRegisterAST * ) {
+    roseExpression = NULL;
+    assert(0);
 }
 
 void ExpressionConversionVisitor::visit(Dereference *deref) {

--- a/dataflowAPI/src/ExpressionConversionVisitor.h
+++ b/dataflowAPI/src/ExpressionConversionVisitor.h
@@ -69,10 +69,11 @@ namespace Dyninst
       
       DYNINST_EXPORT SgAsmExpression *getRoseExpression() { return roseExpression; }
       
-      DYNINST_EXPORT virtual void visit(InstructionAPI::BinaryFunction *binfunc);
-      DYNINST_EXPORT virtual void visit(InstructionAPI::Immediate *immed);
-      DYNINST_EXPORT virtual void visit(InstructionAPI::RegisterAST *regast);
-      DYNINST_EXPORT virtual void visit(InstructionAPI::Dereference *deref);
+      DATAFLOW_EXPORT virtual void visit(InstructionAPI::BinaryFunction *binfunc);
+      DATAFLOW_EXPORT virtual void visit(InstructionAPI::Immediate *immed);
+      DATAFLOW_EXPORT virtual void visit(InstructionAPI::RegisterAST *regast);
+      DATAFLOW_EXPORT virtual void visit(InstructionAPI::Dereference *deref);
+      DATAFLOW_EXPORT virtual void visit(InstructionAPI::MultiRegisterAST *multiregast);
       
     private:
 

--- a/dataflowAPI/src/ExpressionConversionVisitor.h
+++ b/dataflowAPI/src/ExpressionConversionVisitor.h
@@ -69,11 +69,11 @@ namespace Dyninst
       
       DYNINST_EXPORT SgAsmExpression *getRoseExpression() { return roseExpression; }
       
-      DATAFLOW_EXPORT virtual void visit(InstructionAPI::BinaryFunction *binfunc);
-      DATAFLOW_EXPORT virtual void visit(InstructionAPI::Immediate *immed);
-      DATAFLOW_EXPORT virtual void visit(InstructionAPI::RegisterAST *regast);
-      DATAFLOW_EXPORT virtual void visit(InstructionAPI::Dereference *deref);
-      DATAFLOW_EXPORT virtual void visit(InstructionAPI::MultiRegisterAST *multiregast);
+      DYNINST_EXPORT virtual void visit(InstructionAPI::BinaryFunction *binfunc);
+      DYNINST_EXPORT virtual void visit(InstructionAPI::Immediate *immed);
+      DYNINST_EXPORT virtual void visit(InstructionAPI::RegisterAST *regast);
+      DYNINST_EXPORT virtual void visit(InstructionAPI::Dereference *deref);
+      DYNINST_EXPORT virtual void visit(InstructionAPI::MultiRegisterAST *multiregast);
       
     private:
 

--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -434,13 +434,17 @@ void RoseInsnAMDGPUFactory::massageOperands(const Instruction &insn,
         std::vector<InstructionAPI::Operand> &operands) {
     switch (insn.getOperation().getID()) {
 
+    // SWAPPC has 4 operands, two multiregisters followed by two copies of PC
+    // Breaking up the multiregisters into individual registers 
+    // So we end up getting 6 operands
+    // Similar concept for SETPC and GETPC
     case amdgpu_gfx908_op_S_SWAPPC_B64:
     case amdgpu_gfx90a_op_S_SWAPPC_B64: 
     case amdgpu_gfx940_op_S_SWAPPC_B64: {
         assert(operands.size() == 4);
         operands.reserve(6);
-        operands[5] = operands[3];
         operands[4] = operands[2];
+        operands[5] = operands[3];
         MultiRegisterAST::Ptr src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[1].getValue());
         const std::vector<RegisterAST::Ptr> & src_reg_asts = src_regs->getRegs();
         operands[3] = Operand(src_reg_asts[1]);

--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -437,21 +437,48 @@ void RoseInsnAMDGPUFactory::massageOperands(const Instruction &insn,
     case amdgpu_gfx908_op_S_SWAPPC_B64:
     case amdgpu_gfx90a_op_S_SWAPPC_B64: 
     case amdgpu_gfx940_op_S_SWAPPC_B64: {
-        assert(operands.size() == 6);
+        assert(operands.size() == 4);
+        operands.resize(6);
+        operands[5] = operands[3];
+        operands[4] = operands[2];
+        MultiRegisterAST::Ptr src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[1].getValue());
+        const std::vector<RegisterAST::Ptr> & src_reg_asts = src_regs->getRegs();
+        operands[3] = Operand(src_reg_asts[1]);
+        operands[2] = Operand(src_reg_asts[0]);
+        MultiRegisterAST::Ptr dst_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
+        const std::vector<RegisterAST::Ptr> & dst_reg_asts = dst_regs->getRegs();
+        operands[1] = Operand(dst_reg_asts[1]);
+        operands[0] = Operand(dst_reg_asts[0]);
+ 
+
         break;
     }
     case amdgpu_gfx908_op_S_SETPC_B64:
     case amdgpu_gfx90a_op_S_SETPC_B64: 
     case amdgpu_gfx940_op_S_SETPC_B64: {
-        assert(operands.size() == 3);
+        assert(operands.size() == 2);
+        operands.resize(3);
+        operands[2] = operands[1];
+        MultiRegisterAST::Ptr src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
+        const std::vector<RegisterAST::Ptr> & src_reg_asts = src_regs->getRegs();
+        operands[1] = Operand(src_reg_asts[1]);
+        operands[0] = Operand(src_reg_asts[0]);
+
         break;
 
     }
     case amdgpu_gfx908_op_S_GETPC_B64:
     case amdgpu_gfx90a_op_S_GETPC_B64: 
     case amdgpu_gfx940_op_S_GETPC_B64: {
-        assert(operands.size() == 3);
+        assert(operands.size() == 2);
+        operands.resize(3);
+
         operands[2] = Operand(InstructionAPI::Immediate::makeImmediate(Result(u64,_addr+4)),false,false);
+        MultiRegisterAST::Ptr dst_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
+        const std::vector<RegisterAST::Ptr> & dst_reg_asts = dst_regs->getRegs();
+        operands[1] = Operand(dst_reg_asts[1]);
+        operands[0] = Operand(dst_reg_asts[0]);
+
         break;
     }
     default:

--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -438,7 +438,7 @@ void RoseInsnAMDGPUFactory::massageOperands(const Instruction &insn,
     case amdgpu_gfx90a_op_S_SWAPPC_B64: 
     case amdgpu_gfx940_op_S_SWAPPC_B64: {
         assert(operands.size() == 4);
-        operands.resize(6);
+        operands.reserve(6);
         operands[5] = operands[3];
         operands[4] = operands[2];
         MultiRegisterAST::Ptr src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[1].getValue());
@@ -457,7 +457,7 @@ void RoseInsnAMDGPUFactory::massageOperands(const Instruction &insn,
     case amdgpu_gfx90a_op_S_SETPC_B64: 
     case amdgpu_gfx940_op_S_SETPC_B64: {
         assert(operands.size() == 2);
-        operands.resize(3);
+        operands.reserve(3);
         operands[2] = operands[1];
         MultiRegisterAST::Ptr src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
         const std::vector<RegisterAST::Ptr> & src_reg_asts = src_regs->getRegs();
@@ -471,7 +471,7 @@ void RoseInsnAMDGPUFactory::massageOperands(const Instruction &insn,
     case amdgpu_gfx90a_op_S_GETPC_B64: 
     case amdgpu_gfx940_op_S_GETPC_B64: {
         assert(operands.size() == 2);
-        operands.resize(3);
+        operands.reserve(3);
 
         operands[2] = Operand(InstructionAPI::Immediate::makeImmediate(Result(u64,_addr+4)),false,false);
         MultiRegisterAST::Ptr dst_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -42,6 +42,7 @@
 #include "instructionAPI/h/InstructionDecoder.h"
 #include "instructionAPI/h/Instruction.h"
 #include "instructionAPI/h/Register.h"
+#include "instructionAPI/h/MultiRegister.h"
 #include "instructionAPI/h/Result.h"
 #include "parseAPI/h/CFG.h"
 #include "parseAPI/h/CodeObject.h"
@@ -1119,7 +1120,12 @@ public:
          defined = false;
       }
    }
+   virtual void visit(MultiRegisterAST *multirast) {
+      if (!defined) return;
+      for(auto my_Reg : multirast->getRegs())
+          visit(my_Reg.get());
 
+   }
    virtual void visit(Dereference *) {
       defined = false;
    }

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -1120,7 +1120,7 @@ public:
          defined = false;
       }
    }
-   virtual void visit(MultiRegisterAST *multirast) {
+   virtual void visit(MultiRegisterAST *) {
       defined = false;
    }
    virtual void visit(Dereference *) {

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -1121,10 +1121,7 @@ public:
       }
    }
    virtual void visit(MultiRegisterAST *multirast) {
-      if (!defined) return;
-      for(auto my_Reg : multirast->getRegs())
-          visit(my_Reg.get());
-
+      defined = false;
    }
    virtual void visit(Dereference *) {
       defined = false;

--- a/dyninstAPI/src/BPatch_memoryAccessAdapter.C
+++ b/dyninstAPI/src/BPatch_memoryAccessAdapter.C
@@ -33,6 +33,7 @@
 #include "Instruction.h"
 #include "Immediate.h"
 #include "Register.h"
+#include "MultiRegister.h"
 #include "Dereference.h"
 
 #include "common/src/arch.h"
@@ -298,6 +299,12 @@ void BPatch_memoryAccessAdapter::visit(RegisterAST* r)
     }
 	#endif        
 }
+void BPatch_memoryAccessAdapter::visit(MultiRegisterAST* mr)
+{
+    for (auto my_Reg : mr->getRegs())
+        visit(my_Reg.get());
+}
+
 
 void BPatch_memoryAccessAdapter::visit(Immediate* i)
 {

--- a/dyninstAPI/src/BPatch_memoryAccessAdapter.C
+++ b/dyninstAPI/src/BPatch_memoryAccessAdapter.C
@@ -299,10 +299,11 @@ void BPatch_memoryAccessAdapter::visit(RegisterAST* r)
     }
 	#endif        
 }
-void BPatch_memoryAccessAdapter::visit(MultiRegisterAST* mr)
+void BPatch_memoryAccessAdapter::visit(MultiRegisterAST* )
 {
-    for (auto my_Reg : mr->getRegs())
-        visit(my_Reg.get());
+
+    fprintf(stderr, "ASSERT: BPatch_memoryAccessAdapter used for power and arm only, no MultiRegister support!\n");
+    assert(0);
 }
 
 

--- a/dyninstAPI/src/BPatch_memoryAccessAdapter.h
+++ b/dyninstAPI/src/BPatch_memoryAccessAdapter.h
@@ -52,6 +52,7 @@ class BPatch_memoryAccessAdapter : public Dyninst::InstructionAPI::Visitor
   virtual void visit(Dyninst::InstructionAPI::BinaryFunction* b);
   virtual void visit(Dyninst::InstructionAPI::Dereference* d);
   virtual void visit(Dyninst::InstructionAPI::RegisterAST* r);
+  virtual void visit(Dyninst::InstructionAPI::MultiRegisterAST* mr);
   virtual void visit(Dyninst::InstructionAPI::Immediate* i);
     private:
         unsigned int bytes;

--- a/dyninstAPI/src/IAPI_to_AST.C
+++ b/dyninstAPI/src/IAPI_to_AST.C
@@ -31,6 +31,7 @@
 #include "IAPI_to_AST.h"
 
 #include "Register.h"
+#include "MultiRegister.h"
 #include "BinaryFunction.h"
 #include "Immediate.h"
 #include "Dereference.h"
@@ -93,3 +94,9 @@ void ASTFactory::visit(RegisterAST* r)
                       (void*)(astreg)));
 #endif
 }
+void ASTFactory::visit(MultiRegisterAST* r)
+{
+    for (auto my_Reg : r->getRegs())
+        visit(my_Reg.get());
+}
+

--- a/dyninstAPI/src/IAPI_to_AST.C
+++ b/dyninstAPI/src/IAPI_to_AST.C
@@ -94,9 +94,9 @@ void ASTFactory::visit(RegisterAST* r)
                       (void*)(astreg)));
 #endif
 }
-void ASTFactory::visit(MultiRegisterAST* r)
+void ASTFactory::visit(MultiRegisterAST* )
 {
-    for (auto my_Reg : r->getRegs())
-        visit(my_Reg.get());
+    fprintf(stderr,"ASTFactory doesn't support MultiRegisterAST!");  
+    assert(0);
 }
 

--- a/dyninstAPI/src/IAPI_to_AST.h
+++ b/dyninstAPI/src/IAPI_to_AST.h
@@ -54,6 +54,7 @@ class ASTFactory : public Dyninst::InstructionAPI::Visitor
   virtual void visit(Dyninst::InstructionAPI::Dereference* d);
   virtual void visit(Dyninst::InstructionAPI::Immediate* i);
   virtual void visit(Dyninst::InstructionAPI::RegisterAST* r);
+  virtual void visit(Dyninst::InstructionAPI::MultiRegisterAST* r);
   std::deque<AstNodePtr> m_stack;
   virtual ~ASTFactory() {}
   ASTFactory() {}

--- a/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
@@ -384,10 +384,9 @@ public:
       foundSP = true;
     }
   }
-  virtual void visit(MultiRegisterAST* r)
+  virtual void visit(MultiRegisterAST* )
   {
-      for (auto my_Reg : r->getRegs())
-          visit(my_Reg.get());
+    isThunk = false;
   }
 
   virtual void visit(Dereference* )

--- a/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
@@ -41,6 +41,7 @@
 #include "instructionAPI/h/InstructionDecoder.h"
 #include "../CFG/RelocGraph.h"
 #include "instructionAPI/h/Visitor.h"
+#include "instructionAPI/h/MultiRegister.h"
 
 #include "StackMod.h"
 #include "function.h"
@@ -383,6 +384,12 @@ public:
       foundSP = true;
     }
   }
+  virtual void visit(MultiRegisterAST* r)
+  {
+      for (auto my_Reg : r->getRegs())
+          visit(my_Reg.get());
+  }
+
   virtual void visit(Dereference* )
   {
     if (foundDeref) {

--- a/dyninstAPI/src/StackMod/StackAccess.C
+++ b/dyninstAPI/src/StackMod/StackAccess.C
@@ -36,6 +36,7 @@
 #include "InstructionCategories.h"
 #include "InstructionDecoder.h"
 #include "Expression.h"
+#include "MultiRegister.h"
 #include "Result.h"
 #include "Dereference.h"
 #include "Immediate.h"
@@ -224,6 +225,11 @@ public:
         containsToppedReg = true;
         results.push_back((long) top);
     }
+    virtual void visit(InstructionAPI::MultiRegisterAST *r) {
+        for (auto my_Reg : r->getRegs())
+            visit(my_Reg.get());
+    }
+
 
     virtual void visit(InstructionAPI::Dereference *) {
         defined = false;
@@ -586,6 +592,13 @@ class zeroAllGPRegisters : public InstructionAPI::Visitor
 
             results.push_back(0);
         }
+        virtual void visit(MultiRegisterAST* r)
+        {
+            for (auto my_Reg : r->getRegs())
+                visit(my_Reg.get());
+
+        }
+
         virtual void visit(Dereference* )
         {
             defined = false;

--- a/dyninstAPI/src/StackMod/StackAccess.C
+++ b/dyninstAPI/src/StackMod/StackAccess.C
@@ -225,9 +225,8 @@ public:
         containsToppedReg = true;
         results.push_back((long) top);
     }
-    virtual void visit(InstructionAPI::MultiRegisterAST *r) {
-        for (auto my_Reg : r->getRegs())
-            visit(my_Reg.get());
+    virtual void visit(InstructionAPI::MultiRegisterAST *) {
+        defined = false;
     }
 
 
@@ -592,11 +591,9 @@ class zeroAllGPRegisters : public InstructionAPI::Visitor
 
             results.push_back(0);
         }
-        virtual void visit(MultiRegisterAST* r)
+        virtual void visit(MultiRegisterAST* )
         {
-            for (auto my_Reg : r->getRegs())
-                visit(my_Reg.get());
-
+            defined = false;
         }
 
         virtual void visit(Dereference* )

--- a/instructionAPI/CMakeLists.txt
+++ b/instructionAPI/CMakeLists.txt
@@ -9,6 +9,7 @@ set(_sources
     src/Operation.C
     src/Operand.C
     src/Register.C
+    src/MultiRegister.C
     src/Ternary.C
     src/Expression.C
     src/BinaryFunction.C
@@ -51,6 +52,7 @@ set(_public_headers
     h/Operand.h
     h/Operation_impl.h
     h/Register.h
+    h/MultiRegister.h
     h/Result.h
     h/Ternary.h
     h/Visitor.h)

--- a/instructionAPI/h/ArchSpecificFormatters.h
+++ b/instructionAPI/h/ArchSpecificFormatters.h
@@ -89,6 +89,7 @@ namespace Dyninst {
             // Helper function for formatting consecutive registers that are displayed as a single operand
             // Called when architecture is passed to Instruction.format.
             static std::string formatRegister(MachRegister m_Reg, uint32_t num_elements, unsigned m_Low , unsigned m_High );
+            static std::string formatMultiRegister(MachRegister m_Reg, uint32_t size);
         private:
             std::map<std::string, std::string> binaryFuncModifier;
         };

--- a/instructionAPI/h/ArchSpecificFormatters.h
+++ b/instructionAPI/h/ArchSpecificFormatters.h
@@ -89,7 +89,7 @@ namespace Dyninst {
             // Helper function for formatting consecutive registers that are displayed as a single operand
             // Called when architecture is passed to Instruction.format.
             static std::string formatRegister(MachRegister m_Reg, uint32_t num_elements, unsigned m_Low , unsigned m_High );
-            static std::string formatMultiRegister(MachRegister m_Reg, uint32_t size);
+            static std::string formatMultiRegister(MachRegister m_Reg, uint32_t len);
         private:
             std::map<std::string, std::string> binaryFuncModifier;
         };

--- a/instructionAPI/h/Expression.h
+++ b/instructionAPI/h/Expression.h
@@ -168,7 +168,8 @@ namespace Dyninst
       /// rather than %InstructionAST::Ptrs.  All children which are %Expressions will be appended to \c children.
       virtual void getChildren(std::vector<Expression::Ptr>& children) const = 0;
       using InstructionAST::getChildren;
-      
+    private:
+      static Result sizeToResult(uint32_t total_size);
       
     protected:
       virtual bool isFlag() const;

--- a/instructionAPI/h/Expression.h
+++ b/instructionAPI/h/Expression.h
@@ -124,7 +124,10 @@ namespace Dyninst
       typedef boost::shared_ptr<Expression> Ptr;
     protected:      
       Expression(Result_Type t);
+      Expression(uint32_t total_size);
       Expression(MachRegister r);
+      Expression(MachRegister r, uint32_t len);
+      Expression(std::vector<MachRegister> rs);
     public:
       virtual ~Expression();
       Expression(const Expression&) = default;

--- a/instructionAPI/h/Expression.h
+++ b/instructionAPI/h/Expression.h
@@ -168,8 +168,6 @@ namespace Dyninst
       /// rather than %InstructionAST::Ptrs.  All children which are %Expressions will be appended to \c children.
       virtual void getChildren(std::vector<Expression::Ptr>& children) const = 0;
       using InstructionAST::getChildren;
-    private:
-      static Result sizeToResult(uint32_t total_size);
       
     protected:
       virtual bool isFlag() const;

--- a/instructionAPI/h/InstructionAST.h
+++ b/instructionAPI/h/InstructionAST.h
@@ -114,6 +114,7 @@ namespace Dyninst
       virtual std::string format(formatStyle how = defaultStyle) const = 0;
   
     protected:
+      friend class MultiRegisterAST;
       friend class RegisterAST;
       friend class Immediate;
       virtual bool isStrictEqual(const InstructionAST& rhs) const= 0;

--- a/instructionAPI/h/MultiRegister.h
+++ b/instructionAPI/h/MultiRegister.h
@@ -62,7 +62,7 @@ namespace Dyninst
       MultiRegisterAST(MachRegister r, uint32_t num_elements = 1 );
       MultiRegisterAST(std::vector<RegisterAST::Ptr> _in);
   
-      virtual ~MultiRegisterAST();
+      virtual ~MultiRegisterAST() = default;
       MultiRegisterAST(const MultiRegisterAST&) = default;
       
       /// By definition, a %MultiRegisterAST object has no children.
@@ -94,6 +94,7 @@ namespace Dyninst
       RegisterAST::Ptr getBaseRegAST() const { return m_Regs[0]; } 
       uint32_t length() const { return m_Regs.size(); }
       const std::vector<RegisterAST::Ptr> &getRegs() const { return m_Regs; }
+      bool areConsecutive() const { return consecutive; }
     protected:
 
       virtual bool checkRegID(MachRegister id, unsigned int low, unsigned int high) const;
@@ -101,6 +102,8 @@ namespace Dyninst
       virtual bool isFlag() const;
       
       std::vector<RegisterAST::Ptr> m_Regs;
+    private:
+      bool consecutive{false};
     };
   }
 }

--- a/instructionAPI/h/MultiRegister.h
+++ b/instructionAPI/h/MultiRegister.h
@@ -52,7 +52,7 @@ namespace Dyninst
     ///
 
 
-    class INSTRUCTION_EXPORT MultiRegisterAST : public Expression
+    class DYNINST_EXPORT MultiRegisterAST : public Expression
     {
     public:
       /// \brief A type definition for a reference-counted pointer to a %MultiRegisterAST.

--- a/instructionAPI/h/MultiRegister.h
+++ b/instructionAPI/h/MultiRegister.h
@@ -1,0 +1,111 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ * 
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ * 
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#if !defined(MULTIREGISTER_H)
+#define MULTIREGISTER_H
+
+#include "Expression.h"
+#include "Register.h"
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include <map>
+#include <sstream>
+
+#include "registers/MachRegister.h"
+#include "Architecture.h"
+
+namespace Dyninst
+{
+  namespace InstructionAPI
+  {
+    /// A %MultiRegisterAST object represents a ordered collection of registers as a single operand
+    /// As a %MultiRegisterAST is a %Expression, it may contain the physical register's contents if
+    /// they are known.
+    ///
+
+
+    class INSTRUCTION_EXPORT MultiRegisterAST : public Expression
+    {
+    public:
+      /// \brief A type definition for a reference-counted pointer to a %MultiRegisterAST.
+      typedef boost::shared_ptr<MultiRegisterAST> Ptr;
+      
+      /// Construct a register, assigning it the ID \c id.
+      MultiRegisterAST(MachRegister r, uint32_t num_elements = 1 );
+      MultiRegisterAST(std::vector<RegisterAST::Ptr> _in);
+  
+      virtual ~MultiRegisterAST();
+      MultiRegisterAST(const MultiRegisterAST&) = default;
+      
+      /// By definition, a %MultiRegisterAST object has no children.
+      /// \param children Since a %MultiRegisterAST has no children, the \c children parameter is unchanged by this method.
+      virtual void getChildren(vector<InstructionAST::Ptr>& children) const;
+      virtual void getChildren(vector<Expression::Ptr>& children) const;
+
+      /// By definition, the use set of a %MultiRegisterAST object is itself.
+      /// \param uses This %MultiRegisterAST will be inserted into \c uses.
+      virtual void getUses(set<InstructionAST::Ptr>& uses);
+
+      /// \c isUsed returns true if \c findMe is a %MultiRegisterAST that represents
+      /// the same register as this %MultiRegisterAST, and false otherwise.
+      virtual bool isUsed(InstructionAST::Ptr findMe) const;
+
+      /// The \c format method on a %MultiRegisterAST object returns the name associated with its ID.
+      virtual std::string format(Architecture, formatStyle how = defaultStyle) const;
+      /// The \c format method on a %MultiRegisterAST object returns the name associated with its ID.
+      virtual std::string format(formatStyle how = defaultStyle) const;
+
+      /// We define a partial ordering on registers by their register number so that they may be placed into sets
+      /// or other sorted containers.
+      //  For multiRegisters, the partial order is determined by baseReg ID, followed by length
+      bool operator<(const MultiRegisterAST& rhs) const;
+
+      virtual void apply(Visitor* v);
+      virtual bool bind(Expression* e, const Result& val);
+      
+      RegisterAST::Ptr getBaseRegAST() const { return m_Regs[0]; } 
+      uint32_t length() const { return m_Regs.size(); }
+      const std::vector<RegisterAST::Ptr> getRegs() const { return m_Regs; }
+    protected:
+
+      virtual bool checkRegID(MachRegister id, unsigned int low, unsigned int high) const;
+      virtual bool isStrictEqual(const InstructionAST& rhs) const;
+      virtual bool isFlag() const;
+      
+      std::vector<RegisterAST::Ptr> m_Regs;
+    };
+  }
+}
+
+
+  
+
+#endif // !defined(MULTIREGISTER_H)

--- a/instructionAPI/h/MultiRegister.h
+++ b/instructionAPI/h/MultiRegister.h
@@ -93,7 +93,7 @@ namespace Dyninst
       
       RegisterAST::Ptr getBaseRegAST() const { return m_Regs[0]; } 
       uint32_t length() const { return m_Regs.size(); }
-      const std::vector<RegisterAST::Ptr> getRegs() const { return m_Regs; }
+      const std::vector<RegisterAST::Ptr> &getRegs() const { return m_Regs; }
     protected:
 
       virtual bool checkRegID(MachRegister id, unsigned int low, unsigned int high) const;

--- a/instructionAPI/h/Register.h
+++ b/instructionAPI/h/Register.h
@@ -53,6 +53,7 @@ namespace Dyninst
 
     class DYNINST_EXPORT RegisterAST : public Expression
     {
+      friend class MultiRegisterAST;
     public:
       /// \brief A type definition for a reference-counted pointer to a %RegisterAST.
       typedef boost::shared_ptr<RegisterAST> Ptr;
@@ -108,8 +109,8 @@ namespace Dyninst
       virtual void apply(Visitor* v);
       virtual bool bind(Expression* e, const Result& val);
 
-    protected:
       virtual bool isStrictEqual(const InstructionAST& rhs) const;
+    protected:
       virtual bool isFlag() const;
       virtual bool checkRegID(MachRegister id, unsigned int low, unsigned int high) const;
       MachRegister getPromotedReg() const;

--- a/instructionAPI/h/Result.h
+++ b/instructionAPI/h/Result.h
@@ -774,6 +774,52 @@ namespace Dyninst
                             return 0;
                     };
                 }
+                static Result sizeToResult(uint32_t size)
+                {
+                    switch(size)
+                    {
+                        case 1:
+                            return Result(u8);
+                        case 2:
+                            return Result(u16);
+                        case 4:
+                            return Result(u32);
+                        case 6:
+                            return Result(u48);
+                        case 8:
+                            return Result(u64);
+                        case 10:
+                            return Result(dp_float);
+                        case 16:
+                            return Result(dbl128);
+                        case 32:
+                            return Result(m256);
+                        case 64:
+                            return Result(m512);
+                        case 0:
+                            return Result(bit_flag);
+                        default:
+                            assert(!"Result::sizetoResult unexpected machine register size!");
+                    }
+                }
+                static Result sizeToMask(uint32_t size)
+                {
+                    switch(size)
+                    {
+                        case 1:
+                            return Result(u8,0xff);
+                        case 2:
+                            return Result(u16,0xffff);
+                        case 4:
+                            return Result(u32,0xffffffff);
+                        case 6:
+                            return Result(u48,0xffffffffffff);
+                        case 8:
+                            return Result(u64,0xffffffffffffffff);
+                       default:
+                            assert(!"Result::sizeToMask unexpected machine register size!");
+                    }
+                }
         };
 
         DYNINST_EXPORT Result operator+(const Result& arg1, const Result& arg2);

--- a/instructionAPI/h/Visitor.h
+++ b/instructionAPI/h/Visitor.h
@@ -37,6 +37,7 @@ namespace InstructionAPI
     class BinaryFunction;
     class Immediate;
     class RegisterAST;
+    class MultiRegisterAST;
     class Dereference;
     
     class Visitor
@@ -57,6 +58,7 @@ namespace InstructionAPI
             virtual void visit(BinaryFunction* b) = 0;
             virtual void visit(Immediate* i) = 0;
             virtual void visit(RegisterAST* r) = 0;
+            virtual void visit(MultiRegisterAST* r) = 0;
             virtual void visit(Dereference* d) = 0;
     };
 }

--- a/instructionAPI/src/AMDGPU/gfx908/appendOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx908/appendOperands.C
@@ -31,351 +31,378 @@ namespace InstructionAPI {
     void InstructionDecoder_amdgpu_gfx908::appendOPR_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_ATTR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_ATTR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_ATTR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_DSMEM(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_DSMEM(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_DSMEM(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_FLAT_SCRATCH(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_FLAT_SCRATCH(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_FLAT_SCRATCH(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_PARAM(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_PARAM(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_PARAM(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_PC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_PC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_PC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SDST(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SDST(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SDST(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SDST_EXEC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SDST_EXEC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SDST_EXEC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SDST_M0(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SDST_M0(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SDST_M0(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SRC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SRC_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SRC_ACCVGPR_OR_CONST(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_ACCVGPR_OR_CONST(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_ACCVGPR_OR_CONST(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SRC_NOLDS(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_NOLDS(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_NOLDS(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SRC_NOLIT(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_NOLIT(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_NOLIT(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SRC_SIMPLE(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_SIMPLE(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_SIMPLE(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SRC_VGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_VGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_VGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SRC_VGPR_OR_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_VGPR_OR_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_VGPR_OR_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SREG(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SREG(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SREG(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SREG_NOVCC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SREG_NOVCC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SREG_NOVCC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SSRC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SSRC_LANESEL(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC_LANESEL(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC_LANESEL(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SSRC_NOLIT(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC_NOLIT(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC_NOLIT(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_SSRC_SPECIAL_SCC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC_SPECIAL_SCC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC_SPECIAL_SCC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_TGT(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_TGT(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_TGT(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_VCC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VCC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VCC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_VGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx908::appendOPR_VGPR_OR_LDS(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VGPR_OR_LDS(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VGPR_OR_LDS(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 

--- a/instructionAPI/src/AMDGPU/gfx908/decodeOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx908/decodeOperands.C
@@ -5601,7 +5601,7 @@ namespace InstructionAPI {
     Expression::Ptr InstructionDecoder_amdgpu_gfx908::decodeOPR_VCC(uint64_t input, uint32_t )
     {
         switch (input)  {
-            case 0:  return makeRegisterExpression(amdgpu_gfx908::vcc);
+            case 0:  return makeRegisterExpression(amdgpu_gfx908::vcc_lo);
             default: return makeRegisterExpression(amdgpu_gfx908::invalid);
         }
     }

--- a/instructionAPI/src/AMDGPU/gfx90a/appendOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx90a/appendOperands.C
@@ -31,325 +31,350 @@ namespace InstructionAPI {
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_DSMEM(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_DSMEM(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_DSMEM(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_FLAT_SCRATCH(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_FLAT_SCRATCH(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_FLAT_SCRATCH(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_PC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_PC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_PC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SDST(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SDST(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SDST(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SDST_EXEC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SDST_EXEC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SDST_EXEC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SDST_M0(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SDST_M0(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SDST_M0(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SRC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SRC_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SRC_NOLDS(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_NOLDS(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_NOLDS(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SRC_NOLIT(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_NOLIT(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_NOLIT(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SRC_SIMPLE(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_SIMPLE(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_SIMPLE(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SRC_VGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_VGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_VGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SRC_VGPR_OR_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_VGPR_OR_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_VGPR_OR_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SRC_VGPR_OR_ACCVGPR_OR_CONST(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_VGPR_OR_ACCVGPR_OR_CONST(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_VGPR_OR_ACCVGPR_OR_CONST(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SREG(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SREG(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SREG(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SREG_NOVCC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SREG_NOVCC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SREG_NOVCC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SSRC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SSRC_LANESEL(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC_LANESEL(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC_LANESEL(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SSRC_NOLIT(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC_NOLIT(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC_NOLIT(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_SSRC_SPECIAL_SCC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC_SPECIAL_SCC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC_SPECIAL_SCC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_VCC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VCC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VCC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_VGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_VGPR_OR_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VGPR_OR_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VGPR_OR_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx90a::appendOPR_VGPR_OR_LDS(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VGPR_OR_LDS(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VGPR_OR_LDS(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 

--- a/instructionAPI/src/AMDGPU/gfx90a/decodeOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx90a/decodeOperands.C
@@ -5496,7 +5496,7 @@ namespace InstructionAPI {
     Expression::Ptr InstructionDecoder_amdgpu_gfx90a::decodeOPR_VCC(uint64_t input, uint32_t )
     {
         switch (input)  {
-            case 0:  return makeRegisterExpression(amdgpu_gfx90a::vcc);
+            case 0:  return makeRegisterExpression(amdgpu_gfx90a::vcc_lo);
             default: return makeRegisterExpression(amdgpu_gfx90a::invalid);
         }
     }

--- a/instructionAPI/src/AMDGPU/gfx940/appendOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx940/appendOperands.C
@@ -31,325 +31,350 @@ namespace InstructionAPI {
     void InstructionDecoder_amdgpu_gfx940::appendOPR_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_DSMEM(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_DSMEM(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_DSMEM(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_FLAT_SCRATCH(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_FLAT_SCRATCH(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_FLAT_SCRATCH(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_PC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_PC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_PC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SDST(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SDST(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SDST(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SDST_EXEC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SDST_EXEC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SDST_EXEC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SDST_M0(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SDST_M0(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SDST_M0(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SRC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SRC_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SRC_NOLDS(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_NOLDS(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_NOLDS(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SRC_NOLIT(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_NOLIT(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_NOLIT(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SRC_SIMPLE(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_SIMPLE(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_SIMPLE(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SRC_VGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_VGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_VGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SRC_VGPR_OR_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_VGPR_OR_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_VGPR_OR_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SRC_VGPR_OR_ACCVGPR_OR_CONST(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SRC_VGPR_OR_ACCVGPR_OR_CONST(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SRC_VGPR_OR_ACCVGPR_OR_CONST(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SREG(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SREG(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SREG(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SREG_NOVCC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SREG_NOVCC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SREG_NOVCC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SSRC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SSRC_LANESEL(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC_LANESEL(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC_LANESEL(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SSRC_NOLIT(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC_NOLIT(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC_NOLIT(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_SSRC_SPECIAL_SCC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_SSRC_SPECIAL_SCC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_SSRC_SPECIAL_SCC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_VCC(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VCC(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VCC(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_VGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_VGPR_OR_ACCVGPR(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VGPR_OR_ACCVGPR(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VGPR_OR_ACCVGPR(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 
     void InstructionDecoder_amdgpu_gfx940::appendOPR_VGPR_OR_LDS(uint64_t input, bool isRead, bool isWritten, uint32_t vec_len /*= 1*/ , bool isImplicit /*= false*/)
     {
         Expression::Ptr first = decodeOPR_VGPR_OR_LDS(input,vec_len);
-        insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
-        if (boost::dynamic_pointer_cast<RegisterAST>(first) != NULL)
+        RegisterAST::Ptr regptr = boost::dynamic_pointer_cast<RegisterAST>(first);
+        if (regptr != NULL && vec_len > 1)
         {
-            for (uint32_t vec_id = 1; vec_id < vec_len; vec_id++)
-            {
-                insn_in_progress->appendOperand(decodeOPR_VGPR_OR_LDS(input+vec_id,0),isRead,isWritten,isImplicit);
-            }
+            insn_in_progress->appendOperand(makeMultiRegisterExpression(regptr->getID(),vec_len),isRead,isWritten,isImplicit);
+        }
+        else
+        {
+            insn_in_progress->appendOperand(first,isRead,isWritten,isImplicit);
         }
     }
 

--- a/instructionAPI/src/AMDGPU/gfx940/decodeOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx940/decodeOperands.C
@@ -5496,7 +5496,7 @@ namespace InstructionAPI {
     Expression::Ptr InstructionDecoder_amdgpu_gfx940::decodeOPR_VCC(uint64_t input, uint32_t )
     {
         switch (input)  {
-            case 0:  return makeRegisterExpression(amdgpu_gfx940::vcc);
+            case 0:  return makeRegisterExpression(amdgpu_gfx940::vcc_lo);
             default: return makeRegisterExpression(amdgpu_gfx940::invalid);
         }
     }

--- a/instructionAPI/src/ArchSpecificFormatters.C
+++ b/instructionAPI/src/ArchSpecificFormatters.C
@@ -268,6 +268,44 @@ std::string AmdgpuFormatter::formatRegister(MachRegister  m_Reg, uint32_t m_num_
     return name;
 }
 
+std::string AmdgpuFormatter::formatMultiRegister(MachRegister m_Reg, uint32_t size) {
+    std::string name = m_Reg.name();
+    std::string::size_type substr = name.rfind("::");
+    if(substr != std::string::npos){
+        name = name.substr(substr+2,name.length());
+    }
+    assert(size > 1);
+    uint32_t id = m_Reg & 0xff ;
+    uint32_t regClass = m_Reg.regClass();
+
+    DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_LOGICAL_OP
+
+    if(regClass == amdgpu_gfx908::SGPR || regClass == amdgpu_gfx90a::SGPR || 
+        regClass == amdgpu_gfx940::SGPR){
+        return "S["+std::to_string(id) + ":" + std::to_string(id+size-1)+"]";
+    }
+
+    if(regClass == amdgpu_gfx908::VGPR || regClass == amdgpu_gfx90a::VGPR || 
+        regClass == amdgpu_gfx940::VGPR){
+        return "V["+std::to_string(id) + ":" + std::to_string(id+size-1)+"]";
+    }
+
+    if(regClass == amdgpu_gfx908::ACC_VGPR || regClass == amdgpu_gfx90a::ACC_VGPR ||
+        regClass == amdgpu_gfx940::ACC_VGPR){
+        return "ACC["+std::to_string(id) + ":" + std::to_string(id+size-1)+"]";
+    }
+
+    DYNINST_DIAGNOSTIC_END_SUPPRESS_LOGICAL_OP
+
+    if(m_Reg == amdgpu_gfx908::vcc_lo || m_Reg == amdgpu_gfx90a::vcc_lo ||
+        m_Reg == amdgpu_gfx940::vcc_lo)
+        return "VCC";
+    if(m_Reg == amdgpu_gfx908::exec_lo || m_Reg == amdgpu_gfx90a::exec_lo || 
+        m_Reg == amdgpu_gfx940::exec_lo)
+        return "EXEC";
+
+    return name;
+}
 
 /////////////////////////// x86 Formatter functions
 

--- a/instructionAPI/src/ArchSpecificFormatters.C
+++ b/instructionAPI/src/ArchSpecificFormatters.C
@@ -270,14 +270,10 @@ std::string AmdgpuFormatter::formatRegister(MachRegister  m_Reg, uint32_t m_num_
 
 std::string AmdgpuFormatter::formatMultiRegister(MachRegister m_Reg, uint32_t size) {
     std::string name = m_Reg.name();
-    std::string::size_type substr = name.rfind("::");
-    if(substr != std::string::npos){
-        name = name.substr(substr+2,name.length());
-    }
-    assert(size > 1);
+    auto i = name.rfind("::");
+    name.erase(0,i+2);
     uint32_t id = m_Reg & 0xff ;
     uint32_t regClass = m_Reg.regClass();
-
     DYNINST_DIAGNOSTIC_BEGIN_SUPPRESS_LOGICAL_OP
 
     if(regClass == amdgpu_gfx908::SGPR || regClass == amdgpu_gfx90a::SGPR || 
@@ -303,8 +299,7 @@ std::string AmdgpuFormatter::formatMultiRegister(MachRegister m_Reg, uint32_t si
     if(m_Reg == amdgpu_gfx908::exec_lo || m_Reg == amdgpu_gfx90a::exec_lo || 
         m_Reg == amdgpu_gfx940::exec_lo)
         return "EXEC";
-
-    return name;
+    return "BAD-MULTIFORMAT_REGISTER:" + name;
 }
 
 /////////////////////////// x86 Formatter functions

--- a/instructionAPI/src/ArchSpecificFormatters.C
+++ b/instructionAPI/src/ArchSpecificFormatters.C
@@ -268,7 +268,7 @@ std::string AmdgpuFormatter::formatRegister(MachRegister  m_Reg, uint32_t m_num_
     return name;
 }
 
-std::string AmdgpuFormatter::formatMultiRegister(MachRegister m_Reg, uint32_t size) {
+std::string AmdgpuFormatter::formatMultiRegister(MachRegister m_Reg, uint32_t len) {
     std::string name = m_Reg.name();
     auto i = name.rfind("::");
     name.erase(0,i+2);
@@ -278,17 +278,17 @@ std::string AmdgpuFormatter::formatMultiRegister(MachRegister m_Reg, uint32_t si
 
     if(regClass == amdgpu_gfx908::SGPR || regClass == amdgpu_gfx90a::SGPR || 
         regClass == amdgpu_gfx940::SGPR){
-        return "S["+std::to_string(id) + ":" + std::to_string(id+size-1)+"]";
+        return "S["+std::to_string(id) + ":" + std::to_string(id+len-1)+"]";
     }
 
     if(regClass == amdgpu_gfx908::VGPR || regClass == amdgpu_gfx90a::VGPR || 
         regClass == amdgpu_gfx940::VGPR){
-        return "V["+std::to_string(id) + ":" + std::to_string(id+size-1)+"]";
+        return "V["+std::to_string(id) + ":" + std::to_string(id+len-1)+"]";
     }
 
     if(regClass == amdgpu_gfx908::ACC_VGPR || regClass == amdgpu_gfx90a::ACC_VGPR ||
         regClass == amdgpu_gfx940::ACC_VGPR){
-        return "ACC["+std::to_string(id) + ":" + std::to_string(id+size-1)+"]";
+        return "ACC["+std::to_string(id) + ":" + std::to_string(id+len-1)+"]";
     }
 
     DYNINST_DIAGNOSTIC_END_SUPPRESS_LOGICAL_OP

--- a/instructionAPI/src/Expression.C
+++ b/instructionAPI/src/Expression.C
@@ -38,7 +38,7 @@ namespace Dyninst
             InstructionAST(), userSetValue(t)
         {
         } 
-        Result Expression::sizeToResult(uint32_t size)
+        /*Result Expression::sizeToResult(uint32_t size)
         {
             switch(size)
             {
@@ -65,12 +65,12 @@ namespace Dyninst
                 default:
                     assert(!"unexpected machine register size!");
             }
-        }
+        }*/
 
         Expression::Expression(uint32_t size) :
             InstructionAST()
         {
-            userSetValue = sizeToResult(size);
+            userSetValue = Result::sizeToResult(size);
         }
         Expression::Expression(std::vector<MachRegister> rs) :
             InstructionAST()
@@ -78,7 +78,7 @@ namespace Dyninst
             uint32_t totalSize = 0;
             for (auto & mReg : rs)
                 totalSize += mReg.size();
-            Result result = sizeToResult(totalSize);
+            Result result = Result::sizeToResult(totalSize);
             this->setValue(result);
         }
         Expression::Expression(MachRegister r) :

--- a/instructionAPI/src/Expression.C
+++ b/instructionAPI/src/Expression.C
@@ -38,49 +38,48 @@ namespace Dyninst
             InstructionAST(), userSetValue(t)
         {
         } 
-        Expression::Expression(uint32_t size) :
-            InstructionAST()
+        Result Expression::sizeToResult(uint32_t size)
         {
             switch(size)
             {
                 case 1:
-                    userSetValue = Result(u8);
-                    break;
+                    return Result(u8);
                 case 2:
-                    userSetValue = Result(u16);
-                    break;
+                    return Result(u16);
                 case 4:
-                    userSetValue = Result(u32);
-                    break;
+                    return Result(u32);
                 case 6:
-                    userSetValue = Result(u48);
-                    break;
+                    return Result(u48);
                 case 8:
-                    userSetValue = Result(u64);
-                    break;
+                    return Result(u64);
                 case 10:
-                    userSetValue = Result(dp_float);
-                    break;
+                    return Result(dp_float);
                 case 16:
-                    userSetValue = Result(dbl128);
-                    break;
+                    return Result(dbl128);
                 case 32:
-                    userSetValue = Result(m256);
-                    break;
+                    return Result(m256);
                 case 64:
-                    userSetValue = Result(m512);
-                    break;
+                    return Result(m512);
                 case 0:
-                    // Special case for bitfields
-                    userSetValue = Result(bit_flag);
-                    break;
+                    return Result(bit_flag);
                 default:
                     assert(!"unexpected machine register size!");
             }
         }
-        Expression::Expression(std::vector<MachRegister> rs) :
-            Expression::Expression(rs.size() * rs[0].size())
+
+        Expression::Expression(uint32_t size) :
+            InstructionAST()
         {
+            userSetValue = sizeToResult(size);
+        }
+        Expression::Expression(std::vector<MachRegister> rs) :
+            InstructionAST()
+        {
+            uint32_t totalSize = 0;
+            for (auto & mReg : rs)
+                totalSize += mReg.size();
+            Result result = sizeToResult(totalSize);
+            this->setValue(result);
         }
         Expression::Expression(MachRegister r) :
             Expression::Expression(r.size())

--- a/instructionAPI/src/Expression.C
+++ b/instructionAPI/src/Expression.C
@@ -38,10 +38,10 @@ namespace Dyninst
             InstructionAST(), userSetValue(t)
         {
         } 
-        Expression::Expression(MachRegister r) :
+        Expression::Expression(uint32_t size) :
             InstructionAST()
         {
-            switch(r.size())
+            switch(size)
             {
                 case 1:
                     userSetValue = Result(u8);
@@ -78,6 +78,19 @@ namespace Dyninst
                     assert(!"unexpected machine register size!");
             }
         }
+        Expression::Expression(std::vector<MachRegister> rs) :
+            Expression::Expression(rs.size() * rs[0].size())
+        {
+        }
+        Expression::Expression(MachRegister r) :
+            Expression::Expression(r.size())
+        {
+        }
+         Expression::Expression(MachRegister r, uint32_t len) :
+            Expression::Expression(r.size() * len)
+        {
+        }
+
         Expression::~Expression()
         {
         }

--- a/instructionAPI/src/InstructionDecoderImpl.C
+++ b/instructionAPI/src/InstructionDecoderImpl.C
@@ -144,6 +144,12 @@ namespace Dyninst
             return make_shared(singleton_object_pool<RegisterAST>::construct(converted, 0, registerID.size() * 8,num_elements));
         }
         
+        Expression::Ptr InstructionDecoderImpl::makeMultiRegisterExpression(MachRegister registerID, uint32_t num_elements )
+        {
+            return make_shared(singleton_object_pool<MultiRegisterAST>::construct(registerID, num_elements));
+        }
+        
+       
 
         Expression::Ptr InstructionDecoderImpl::makeRegisterExpression(MachRegister registerID, unsigned int start , unsigned int end)
         {

--- a/instructionAPI/src/InstructionDecoderImpl.h
+++ b/instructionAPI/src/InstructionDecoderImpl.h
@@ -33,6 +33,7 @@
 
 #include <stdint.h>
 #include "Expression.h"
+#include "MultiRegister.h"
 #include "Architecture.h"
 #include "Operation_impl.h"
 #include "entryIDs.h"
@@ -71,6 +72,7 @@ class InstructionDecoderImpl
 
 
 
+        virtual Expression::Ptr makeMultiRegisterExpression(MachRegister reg, uint32_t num_elements);
         virtual Expression::Ptr makeRegisterExpression(MachRegister reg, uint32_t num_elements = 1);
         // added version to support loading partial values out of register
         virtual Expression::Ptr makeRegisterExpression(MachRegister reg, unsigned int start , unsigned int end);

--- a/instructionAPI/src/MultiRegister.C
+++ b/instructionAPI/src/MultiRegister.C
@@ -80,7 +80,7 @@ namespace Dyninst
     }
     bool MultiRegisterAST::isUsed(InstructionAST::Ptr findMe) const
     {
-        for (const auto regAST : m_Regs) {
+        for (const auto &regAST : m_Regs) {
             if (findMe->checkRegID(regAST->getID(), regAST->lowBit(), regAST->highBit()))
                 return true;
         }
@@ -89,24 +89,24 @@ namespace Dyninst
 
     std::string MultiRegisterAST::format(Architecture arch, formatStyle) const
     {
-        /*if(arch == Arch_amdgpu_gfx908 || arch == Arch_amdgpu_gfx90a || arch == Arch_amdgpu_gfx940){
-            return AmdgpuFormatter::formatRegister(m_Reg,m_num_elements,m_Low,m_High);
-        }*/
-        return ArchSpecificFormatter::getFormatter(arch).formatRegister(m_Regs[0]->getID().name());
+        if(arch == Arch_amdgpu_gfx908 || arch == Arch_amdgpu_gfx90a || arch == Arch_amdgpu_gfx940){
+            return AmdgpuFormatter::formatMultiRegister(m_Regs[0]->getID(),m_Regs.size());
+        }
+        assert(0 && " multi register currently defined for amdgpu formats only ");
+        return std::string("");
     }
 
     std::string MultiRegisterAST::format(formatStyle) const
     {
-        std::string name = m_Regs[0]->getID().name();
-        std::string::size_type substr = name.rfind("::");
-        if(substr != std::string::npos)
-        {
-            name = name.substr(substr + 2, name.length());
+        std::string ret("[");
+        ret.append(m_Regs[0]->format()); 
+        for (uint32_t i = 1; i < m_Regs.size(); i++){
+            ret.append(std::string(","));
+            ret.append(m_Regs[i]->format());
         }
-        /* we have moved to AT&T syntax (lowercase registers) */
-        for(char &c : name) c = std::toupper(c);
+        ret.append(std::string("]"));
 
-        return name;
+        return ret;
     }
 
     bool MultiRegisterAST::operator<(const MultiRegisterAST& rhs) const

--- a/instructionAPI/src/MultiRegister.C
+++ b/instructionAPI/src/MultiRegister.C
@@ -1,0 +1,167 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "MultiRegister.h"
+#include <vector>
+#include <set>
+#include <sstream>
+#include "Visitor.h"
+#include "../../common/src/singleton_object_pool.h"
+#include "InstructionDecoder-power.h"
+#include "registers/MachRegister.h"
+#include "Architecture.h"
+#include "ArchSpecificFormatters.h"
+#include "../../common/h/compiler_diagnostics.h"
+#include "registers/x86_regs.h"
+
+using namespace std;
+
+namespace Dyninst
+{
+  namespace InstructionAPI
+  {
+    MultiRegisterAST::MultiRegisterAST(MachRegister r, uint32_t num_elements) :
+            Expression(r,num_elements)
+    {
+        uint32_t regVal = r.val();
+        for (uint32_t i = 0; i < num_elements; i++){
+            m_Regs.push_back(make_shared(singleton_object_pool<RegisterAST>::construct(MachRegister(regVal+i), 0, r.size() * 8,num_elements)));
+        }
+    }
+
+    MultiRegisterAST::MultiRegisterAST(std::vector<RegisterAST::Ptr> inputRegASTs) : Expression(inputRegASTs[0]->getID(),inputRegASTs.size()), m_Regs{std::move(inputRegASTs)}
+    {
+    }
+
+
+    MultiRegisterAST::~MultiRegisterAST()
+    {
+        m_Regs.clear();
+    }
+    void MultiRegisterAST::getChildren(vector<InstructionAST::Ptr>& /*children*/) const
+    {
+      return;
+    }
+    void MultiRegisterAST::getChildren(vector<Expression::Ptr>& /*children*/) const
+    {
+        return;
+    }
+    void MultiRegisterAST::getUses(set<InstructionAST::Ptr>& uses)
+    {
+        uses.insert(shared_from_this());
+        return;
+    }
+    bool MultiRegisterAST::isUsed(InstructionAST::Ptr findMe) const
+    {
+        for (const auto regAST : m_Regs) {
+            if (findMe->checkRegID(regAST->getID(), regAST->lowBit(), regAST->highBit()))
+                return true;
+        }
+        return false;
+    }
+
+    std::string MultiRegisterAST::format(Architecture arch, formatStyle) const
+    {
+        /*if(arch == Arch_amdgpu_gfx908 || arch == Arch_amdgpu_gfx90a || arch == Arch_amdgpu_gfx940){
+            return AmdgpuFormatter::formatRegister(m_Reg,m_num_elements,m_Low,m_High);
+        }*/
+        return ArchSpecificFormatter::getFormatter(arch).formatRegister(m_Regs[0]->getID().name());
+    }
+
+    std::string MultiRegisterAST::format(formatStyle) const
+    {
+        std::string name = m_Regs[0]->getID().name();
+        std::string::size_type substr = name.rfind("::");
+        if(substr != std::string::npos)
+        {
+            name = name.substr(substr + 2, name.length());
+        }
+        /* we have moved to AT&T syntax (lowercase registers) */
+        for(char &c : name) c = std::toupper(c);
+
+        return name;
+    }
+
+    bool MultiRegisterAST::operator<(const MultiRegisterAST& rhs) const
+    {
+        const auto rhsBaseReg = rhs.getBaseRegAST();
+        const auto myBaseReg  = getBaseRegAST();
+        if (*myBaseReg < *rhsBaseReg) return true;
+        if (*rhsBaseReg < *myBaseReg) return false;
+        return (this->length() < rhs.length());
+    }
+    bool MultiRegisterAST::isStrictEqual(const InstructionAST& rhs) const
+    {
+      try {
+          const MultiRegisterAST& rhs_reg =  dynamic_cast<const MultiRegisterAST&>(rhs);
+          //rhs_reg.getRegs();
+          const auto myRegs = getRegs();
+          const auto rhsRegs = rhs_reg.getRegs();
+          if (myRegs.size() != rhsRegs.size())
+              return false;
+          for (uint32_t i =0; i< myRegs.size(); i++){
+              if(! myRegs[i]->isStrictEqual(*rhsRegs[i]) )
+                return false;
+          }
+          return true;
+      }
+      catch(bad_cast &b){
+          return false;
+      }
+    }
+    bool MultiRegisterAST::isFlag() const
+    {
+        return false; // TODO
+    }
+    bool MultiRegisterAST::checkRegID(MachRegister r, unsigned int low, unsigned int high) const
+    {
+        for (uint32_t i =0; i< m_Regs.size(); i++){
+            if(m_Regs[i]->checkRegID(r,low,high))
+                return true;
+        }
+        return false;
+    }
+    void MultiRegisterAST::apply(Visitor* v)
+    {
+        v->visit(this);
+    }
+    bool MultiRegisterAST::bind(Expression* e, const Result& val)
+    {
+        if(Expression::bind(e, val)) {
+            return true;
+        }
+        bool ret = false;
+        for (uint32_t i =0; i< m_Regs.size(); i++){
+            ret |= (m_Regs[i]->bind(e,val));
+        }
+        return ret;
+    }
+  }
+}

--- a/instructionAPI/src/MultiRegister.C
+++ b/instructionAPI/src/MultiRegister.C
@@ -76,11 +76,7 @@ namespace Dyninst
     }
     bool MultiRegisterAST::isUsed(InstructionAST::Ptr findMe) const
     {
-        for (const auto &regAST : m_Regs) {
-            if (findMe->checkRegID(regAST->getID(), regAST->lowBit(), regAST->highBit()))
-                return true;
-        }
-        return false;
+        return isStrictEqual(*findMe);
     }
 
     std::string MultiRegisterAST::format(Architecture arch, formatStyle) const

--- a/instructionAPI/src/MultiRegister.C
+++ b/instructionAPI/src/MultiRegister.C
@@ -137,12 +137,13 @@ namespace Dyninst
     }
     bool MultiRegisterAST::bind(Expression* e, const Result& val)
     {
-        if(Expression::bind(e, val)) {
-            return true;
-        }
+        Result copiedVal = val;
         bool ret = false;
         for (auto & m_Reg : m_Regs) {
-            ret |= (m_Reg->bind(e,val));
+            Result mask = Result::sizeToMask(m_Reg->size());
+            Result extractedVal = copiedVal & mask;
+            ret |= (m_Reg->bind(e,extractedVal));
+            copiedVal = copiedVal >> Result(u32,m_Reg->size()*8);
         }
         return ret;
     }

--- a/instructionAPI/src/MultiRegister.C
+++ b/instructionAPI/src/MultiRegister.C
@@ -91,12 +91,17 @@ namespace Dyninst
     std::string MultiRegisterAST::format(formatStyle) const
     {
         std::string ret("[");
+        bool isFirstEntry{true};
+        std::string ret("[");
         for (auto & m_Reg : m_Regs) {
-            ret.append(m_Reg->format());
-            ret.append(",");
+            if (isFirstEntry)  {
+                isFirstEntry = false;
+            }  else  {
+                ret += ",";
+            }
+            ret += m_Reg->format();            
         }
-        auto i = ret.rfind(",");
-        ret.erase(i,1);
+        ret += "]";
         ret.append(std::string("]"));
         return ret;
     }

--- a/instructionAPI/src/MultiRegister.C
+++ b/instructionAPI/src/MultiRegister.C
@@ -90,7 +90,6 @@ namespace Dyninst
 
     std::string MultiRegisterAST::format(formatStyle) const
     {
-        std::string ret("[");
         bool isFirstEntry{true};
         std::string ret("[");
         for (auto & m_Reg : m_Regs) {

--- a/instructionAPI/src/MultiRegister.C
+++ b/instructionAPI/src/MultiRegister.C
@@ -101,7 +101,6 @@ namespace Dyninst
             ret += m_Reg->format();            
         }
         ret += "]";
-        ret.append(std::string("]"));
         return ret;
     }
 

--- a/instructionAPI/src/Operand.C
+++ b/instructionAPI/src/Operand.C
@@ -31,6 +31,7 @@
 #include "../h/Operand.h"
 #include "../h/Dereference.h"
 #include "../h/Register.h"
+#include "../h/MultiRegister.h"
 #include "../h/Immediate.h"
 #include "../h/Expression.h"
 #include "../h/BinaryFunction.h"
@@ -56,15 +57,39 @@ namespace Dyninst
                 {
                     if(m_isRead || !(*tmp == *op_value))
                         regsRead.insert(tmp);
+                }else{
+                
+                    MultiRegisterAST::Ptr multitmp = boost::dynamic_pointer_cast<MultiRegisterAST>(*curUse);
+                    if(tmp)
+                    {
+                        for (auto reg : multitmp->getRegs()){
+                            if(m_isRead || !(*reg == *op_value))
+                                regsRead.insert(reg);
+                        } 
+                    }
+
                 }
             }
         }
         DYNINST_EXPORT void Operand::getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const
         {
-            RegisterAST::Ptr op_as_reg = boost::dynamic_pointer_cast<RegisterAST>(op_value);
-            if(m_isWritten && op_as_reg)
+            if(m_isWritten) 
             {
-                regsWritten.insert(op_as_reg);
+                RegisterAST::Ptr op_as_reg = boost::dynamic_pointer_cast<RegisterAST>(op_value);
+                if(op_as_reg){
+                    regsWritten.insert(op_as_reg);
+                }else
+                {
+                  
+                    MultiRegisterAST::Ptr op_as_multireg = boost::dynamic_pointer_cast<MultiRegisterAST>(op_value);
+                    if(op_as_reg)
+                    {
+                        for (auto reg : op_as_multireg->getRegs()){
+                            regsWritten.insert(reg);
+                        } 
+                
+                    }
+                }
             }
         }
 

--- a/instructionAPI/src/syscalls.C
+++ b/instructionAPI/src/syscalls.C
@@ -60,6 +60,7 @@ namespace x86 {
     }
 
     void visit(di::RegisterAST*) override { valid = false; }
+    void visit(di::MultiRegisterAST*) override { valid = false; }
 
     void visit(di::Dereference*) override { found_deref = true; }
   };

--- a/parseAPI/src/IA_x86.C
+++ b/parseAPI/src/IA_x86.C
@@ -161,10 +161,7 @@ class leaSimplifyVisitor : public InstructionAPI::Visitor
             exprStack.push(reg);
         }
         void visit(MultiRegisterAST *multireg) override {
-          for (auto my_Reg : multireg->getRegs()) {
-              visit(my_Reg.get()); 
-          }
-          // TODO
+          exprStack.push(multireg);
         }
 
         void visit(Dereference *deref) override {

--- a/parseAPI/src/IA_x86.C
+++ b/parseAPI/src/IA_x86.C
@@ -45,6 +45,7 @@
 
 #include <deque>
 #include "Register.h"
+#include "MultiRegister.h"
 
 #include <boost/variant2/variant.hpp>
 #include <stack>
@@ -159,6 +160,13 @@ class leaSimplifyVisitor : public InstructionAPI::Visitor
         void visit(RegisterAST *reg) override {
             exprStack.push(reg);
         }
+        void visit(MultiRegisterAST *multireg) override {
+          for (auto my_Reg : multireg->getRegs()) {
+              visit(my_Reg.get()); 
+          }
+          // TODO
+        }
+
         void visit(Dereference *deref) override {
             parsing_printf("%s[%d]: malformed lea instruction, dereference expression encountered\n",
                            FILE__, __LINE__);
@@ -235,6 +243,10 @@ namespace {
         virtual void visit(RegisterAST*) {
             return;
         }
+        virtual void visit(MultiRegisterAST*) {
+            return;
+        }
+
         virtual void visit(Dereference*) {
             return;
         }


### PR DESCRIPTION
This commit introduce a new ast that denotes the use of multiple registers as a single operand.

For now, the visitor for such a class is basically visiting the registers contained in it, in order.

The constructor of the Expression class has been restructured to avoid redundant implementation.