### PR TITLE
GithubCI: ignore libclang-cpp.so in system-libs test

### DIFF
--- a/.github/workflows/system-libs.yaml
+++ b/.github/workflows/system-libs.yaml
@@ -48,7 +48,7 @@ jobs:
            for dir in /usr/lib /usr/lib64; do                       \
              for file in $(find $dir -type f -name "*.so.*"); do    \
                if ! expr "$file" : ".*\.hmac" >/dev/null 2>&1; then \
-                 if [[ $f =~ "libclang-cpp.so" ]]; then continue; fi\
+                 if [[ $f =~ "libclang-cpp.so" ]]; then continue; fi;\
                  echo $file;                                        \
                  ./simpleParser $file;                              \
                fi                                                   \

--- a/.github/workflows/system-libs.yaml
+++ b/.github/workflows/system-libs.yaml
@@ -48,6 +48,7 @@ jobs:
            for dir in /usr/lib /usr/lib64; do                       \
              for file in $(find $dir -type f -name "*.so.*"); do    \
                if ! expr "$file" : ".*\.hmac" >/dev/null 2>&1; then \
+                 if [[ $f =~ "libclang-cpp.so" ]]; then continue; fi\
                  echo $file;                                        \
                  ./simpleParser $file;                              \
                fi                                                   \


### PR DESCRIPTION
For some reason, the debuginfod server on Fedora 37 hangs when trying to fetch data for libclang-cpp.15.so. It's not critical for this test, so just don't parse it.