### PR TITLE
Consolidate visibility control macros

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -16,6 +16,7 @@ set(_public_headers
     h/dyn_regs.h
     h/dyn_syscalls.h
     h/dyntypes.h
+    h/dyninst_visibility.h
     h/Edge.h
     h/entryIDs.h
     h/Graph.h

--- a/common/h/Annotatable.h
+++ b/common/h/Annotatable.h
@@ -50,8 +50,8 @@
 namespace Dyninst
 {
 
-COMMON_EXPORT bool annotation_debug_flag();
-COMMON_EXPORT int annotatable_printf(const char *format, ...)
+DYNINST_EXPORT bool annotation_debug_flag();
+DYNINST_EXPORT int annotatable_printf(const char *format, ...)
 	DYNINST_PRINTF_ANNOTATION(1, 2);
 
 typedef unsigned short AnnotationClassID;
@@ -60,7 +60,7 @@ typedef bool (*anno_cmp_func_t)(void *, void*);
 extern int newAnnotationClass();
 extern bool void_ptr_cmp_func(void *, void *);
 
-class COMMON_EXPORT AnnotationClassBase
+class DYNINST_EXPORT AnnotationClassBase
 {
    private:
       static std::vector<AnnotationClassBase *> *annotation_types;
@@ -127,9 +127,9 @@ typedef enum {
 	sp_rem_cont_item = 5
 } ser_post_op_t;
 
-COMMON_EXPORT const char *serPostOp2Str(ser_post_op_t);
+DYNINST_EXPORT const char *serPostOp2Str(ser_post_op_t);
 
-class COMMON_EXPORT AnnotatableDense
+class DYNINST_EXPORT AnnotatableDense
 {
 	typedef void *anno_list_t;
 
@@ -334,7 +334,7 @@ class COMMON_EXPORT AnnotatableDense
 
 #define AN_INLINE inline
 
-class COMMON_EXPORT AnnotatableSparse
+class DYNINST_EXPORT AnnotatableSparse
 {
    public:
       struct void_ptr_hasher

--- a/common/h/Buffer.h
+++ b/common/h/Buffer.h
@@ -48,7 +48,7 @@ namespace Dyninst {
 // Dyninst internal codeGen structure that aims to be more user-friendly. Tiers 2 and 3 
 // are TODO. 
 
-class COMMON_EXPORT Buffer {
+class DYNINST_EXPORT Buffer {
   public:
    Buffer(Address addr, unsigned initial_size);
    Buffer();

--- a/common/h/DynAST.h
+++ b/common/h/DynAST.h
@@ -163,7 +163,7 @@ class name : public AST {						\
   Children kids_;							\
  }									\
 
-class COMMON_EXPORT AST : public boost::enable_shared_from_this<AST> {
+class DYNINST_EXPORT AST : public boost::enable_shared_from_this<AST> {
  public:
 
   // This is a global list of all AST types, including those that are not
@@ -234,7 +234,7 @@ class COMMON_EXPORT AST : public boost::enable_shared_from_this<AST> {
   virtual bool isStrictEqual(const AST &rhs) const = 0;
 };
 
- class COMMON_EXPORT ASTVisitor {
+ class DYNINST_EXPORT ASTVisitor {
  public:
    typedef boost::shared_ptr<AST> ASTPtr;
 

--- a/common/h/Edge.h
+++ b/common/h/Edge.h
@@ -42,7 +42,7 @@ namespace Dyninst {
 class Graph;
 class Node;
     
-class COMMON_EXPORT Edge : public AnnotatableSparse {
+class DYNINST_EXPORT Edge : public AnnotatableSparse {
     friend class Node;
     friend class Graph;
     friend class Creator;
@@ -82,7 +82,7 @@ class COMMON_EXPORT Edge : public AnnotatableSparse {
 
  class EdgeIteratorImpl;
 
-class COMMON_EXPORT EdgeIterator {
+class DYNINST_EXPORT EdgeIterator {
     friend class Node;
     friend class Graph;
     friend class Edge;

--- a/common/h/Graph.h
+++ b/common/h/Graph.h
@@ -55,7 +55,7 @@ class Node;
 class NodeIterator;
 class EdgeIterator;
     
-class COMMON_EXPORT Graph : public AnnotatableSparse {
+class DYNINST_EXPORT Graph : public AnnotatableSparse {
     friend class Edge;
     friend class Node;
     friend class Creator;

--- a/common/h/MachSyscall.h
+++ b/common/h/MachSyscall.h
@@ -38,7 +38,7 @@ namespace ProcControlAPI
     MachSyscall makeFromID(boost::shared_ptr<Process> proc, unsigned long id);
 }
 
-class COMMON_EXPORT MachSyscall 
+class DYNINST_EXPORT MachSyscall 
 {
     public: 
         typedef unsigned long SyscallIDPlatform;

--- a/common/h/Node.h
+++ b/common/h/Node.h
@@ -52,7 +52,7 @@ class Graph;
 class NodeIterator;
 class EdgeIterator;
 
-class COMMON_EXPORT Node  {
+class DYNINST_EXPORT Node  {
     friend class Edge;
     friend class Graph;
     
@@ -114,7 +114,7 @@ class COMMON_EXPORT Node  {
     static const Address INVALID_ADDR;
 };
  
-class COMMON_EXPORT PhysicalNode : public Node {
+class DYNINST_EXPORT PhysicalNode : public Node {
 public:
 	typedef boost::shared_ptr<PhysicalNode> Ptr;
      
@@ -136,7 +136,7 @@ public:
     Address addr_; 
 };
 
-class  COMMON_EXPORT VirtualNode : public Node {
+class  DYNINST_EXPORT VirtualNode : public Node {
     friend class Edge;
     friend class Graph;
 
@@ -166,7 +166,7 @@ class  COMMON_EXPORT VirtualNode : public Node {
 
  class NodeIteratorImpl;
 
-class COMMON_EXPORT NodeIterator {
+class DYNINST_EXPORT NodeIterator {
     friend class Node;
     friend class Graph;
     friend class Edge;

--- a/common/h/SymReader.h
+++ b/common/h/SymReader.h
@@ -82,7 +82,7 @@ struct SymSegment {
  * that the underlying implementation could be made re-enterant safe (so it 
  * could be called from a signal handler).
  **/
-class COMMON_EXPORT SymReader
+class DYNINST_EXPORT SymReader
 {
  protected:
    SymReader() {}
@@ -123,7 +123,7 @@ class COMMON_EXPORT SymReader
    
 };
 
-class COMMON_EXPORT SymbolReaderFactory
+class DYNINST_EXPORT SymbolReaderFactory
 {
  public:
    SymbolReaderFactory() {}

--- a/common/h/VariableLocation.h
+++ b/common/h/VariableLocation.h
@@ -52,7 +52,7 @@ typedef enum {
    storageRegOffset
 } storageClass;
 
-COMMON_EXPORT const char *storageClass2Str(storageClass sc);
+DYNINST_EXPORT const char *storageClass2Str(storageClass sc);
 
 /*
  * storageRefClass: Encodes if a variable can be accessed through a register/address.
@@ -66,7 +66,7 @@ typedef enum {
    storageNoRef
 } storageRefClass;
 
-COMMON_EXPORT const char *storageRefClass2Str(storageRefClass sc);
+DYNINST_EXPORT const char *storageRefClass2Str(storageRefClass sc);
 
 //location for a variable
 //Use mr_reg instead of reg for new code.  reg left in for backwards

--- a/common/h/concurrent.h
+++ b/common/h/concurrent.h
@@ -47,12 +47,12 @@
 namespace Dyninst {
 
 namespace dyn_c_annotations {
-    void COMMON_EXPORT rwinit(void*);
-    void COMMON_EXPORT rwdeinit(void*);
-    void COMMON_EXPORT wlock(void*);
-    void COMMON_EXPORT wunlock(void*);
-    void COMMON_EXPORT rlock(void*);
-    void COMMON_EXPORT runlock(void*);
+    void DYNINST_EXPORT rwinit(void*);
+    void DYNINST_EXPORT rwdeinit(void*);
+    void DYNINST_EXPORT wlock(void*);
+    void DYNINST_EXPORT wunlock(void*);
+    void DYNINST_EXPORT rlock(void*);
+    void DYNINST_EXPORT runlock(void*);
 }
 
 namespace concurrent {
@@ -207,7 +207,7 @@ public:
     using unique_lock = boost::unique_lock<dyn_mutex>;
 };
 
-class COMMON_EXPORT dyn_rwlock {
+class DYNINST_EXPORT dyn_rwlock {
     // Reader management members
     boost::atomic<unsigned int> rin;
     boost::atomic<unsigned int> rout;
@@ -234,7 +234,7 @@ public:
     using shared_lock = boost::shared_lock<dyn_rwlock>;
 };
 
-class COMMON_EXPORT dyn_thread {
+class DYNINST_EXPORT dyn_thread {
 public:
     dyn_thread();
     unsigned int getId();

--- a/common/h/dyninst_visibility.h
+++ b/common/h/dyninst_visibility.h
@@ -31,8 +31,6 @@
 #ifndef DYNINST_COMMON_DYNINST_VISIBILITY_H
 #define DYNINST_COMMON_DYNINST_VISIBILITY_H
 
-#ifndef DYNINST_EXPORT
-# define DYNINST_EXPORT __attribute__((visibility ("default")))
-#endif
+#define DYNINST_EXPORT __attribute__((visibility ("default")))
 
 #endif

--- a/common/h/dyninst_visibility.h
+++ b/common/h/dyninst_visibility.h
@@ -1,61 +1,36 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __UTIL_H__
-#define __UTIL_H__
+#ifndef DYNINST_COMMON_DYNINST_VISIBILITY_H
+#define DYNINST_COMMON_DYNINST_VISIBILITY_H
 
-#include <string>
-#include "dyntypes.h"
-#include "dyninst_visibility.h"
-
-
-namespace Dyninst {
-
-DYNINST_EXPORT unsigned addrHashCommon(const Address &addr);
-DYNINST_EXPORT unsigned ptrHash(const void * addr);
-DYNINST_EXPORT unsigned ptrHash(void * addr);
-
-DYNINST_EXPORT unsigned addrHash(const Address &addr);
-DYNINST_EXPORT unsigned addrHash4(const Address &addr);
-DYNINST_EXPORT unsigned addrHash16(const Address &addr);
-
-DYNINST_EXPORT unsigned stringhash(const std::string &s);
-DYNINST_EXPORT std::string itos(int);
-DYNINST_EXPORT std::string utos(unsigned);
-
-#define WILDCARD_CHAR '?'
-#define MULTIPLE_WILDCARD_CHAR '*'
-
-DYNINST_EXPORT bool wildcardEquiv(const std::string &us, const std::string &them, bool checkCase = false );
-
-const char *platform_string();
-}
+#define DYNINST_EXPORT __attribute__((visibility ("default")))
 
 #endif

--- a/common/h/dyninst_visibility.h
+++ b/common/h/dyninst_visibility.h
@@ -31,6 +31,8 @@
 #ifndef DYNINST_COMMON_DYNINST_VISIBILITY_H
 #define DYNINST_COMMON_DYNINST_VISIBILITY_H
 
-#define DYNINST_EXPORT __attribute__((visibility ("default")))
+#ifndef DYNINST_EXPORT
+# define DYNINST_EXPORT __attribute__((visibility ("default")))
+#endif
 
 #endif

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -56,8 +56,8 @@ enum prefixEntryID : unsigned int {
 };
 
 namespace NS_x86 {
-COMMON_EXPORT extern dyn_hash_map<entryID, std::string> entryNames_IAPI;
-COMMON_EXPORT extern dyn_hash_map<prefixEntryID, std::string> prefixEntryNames_IAPI;
+DYNINST_EXPORT extern dyn_hash_map<entryID, std::string> entryNames_IAPI;
+DYNINST_EXPORT extern dyn_hash_map<prefixEntryID, std::string> prefixEntryNames_IAPI;
 }
 
 #endif

--- a/common/h/registers/MachRegister.h
+++ b/common/h/registers/MachRegister.h
@@ -41,7 +41,7 @@
 namespace Dyninst {
   typedef unsigned long MachRegisterVal;
 
-  class COMMON_EXPORT MachRegister {
+  class DYNINST_EXPORT MachRegister {
   private:
     int32_t reg;
 

--- a/common/h/registers/reg_def.h
+++ b/common/h/registers/reg_def.h
@@ -54,11 +54,11 @@
 // const.
 #  define DEF_REGISTER(name, value, Arch)                                                          \
     const signed int i##name = (value);                                                            \
-    COMMON_EXPORT MachRegister name(i##name, Arch "::" #name)
+    DYNINST_EXPORT MachRegister name(i##name, Arch "::" #name)
 #else
 #  define DEF_REGISTER(name, value, Arch)                                                          \
     const signed int i##name = (value);                                                            \
-    COMMON_EXPORT extern MachRegister name
+    DYNINST_EXPORT extern MachRegister name
 
 #endif
 

--- a/common/src/Annotatable.C
+++ b/common/src/Annotatable.C
@@ -84,7 +84,7 @@ int annotatable_printf(const char *format, ...)
 	return ret;
 }
 
-COMMON_EXPORT int AnnotationClass_nextId;
+DYNINST_EXPORT int AnnotationClass_nextId;
 
 bool void_ptr_cmp_func(void *v1, void *v2)
 {

--- a/common/src/MappedFile.h
+++ b/common/src/MappedFile.h
@@ -39,22 +39,22 @@ class MappedFile {
      static dyn_hash_map<std::string, MappedFile *> mapped_files;
 
    public:
-      COMMON_EXPORT static MappedFile *createMappedFile(std::string fullpath_);
-      COMMON_EXPORT static MappedFile *createMappedFile(void *map_loc, unsigned long size_, const std::string &name);
-      COMMON_EXPORT static void closeMappedFile(MappedFile *&mf);
+      DYNINST_EXPORT static MappedFile *createMappedFile(std::string fullpath_);
+      DYNINST_EXPORT static MappedFile *createMappedFile(void *map_loc, unsigned long size_, const std::string &name);
+      DYNINST_EXPORT static void closeMappedFile(MappedFile *&mf);
 
-      COMMON_EXPORT std::string filename();
-      COMMON_EXPORT void *base_addr() {return map_addr;}
+      DYNINST_EXPORT std::string filename();
+      DYNINST_EXPORT void *base_addr() {return map_addr;}
 #if defined(os_windows)
-      COMMON_EXPORT HANDLE getFileHandle() {return hFile;}
+      DYNINST_EXPORT HANDLE getFileHandle() {return hFile;}
 #else
-      COMMON_EXPORT int getFD() {return fd;}
+      DYNINST_EXPORT int getFD() {return fd;}
 #endif
-      COMMON_EXPORT unsigned long size() {return file_size;}
-      COMMON_EXPORT MappedFile *clone() { refCount++; return this; }
+      DYNINST_EXPORT unsigned long size() {return file_size;}
+      DYNINST_EXPORT MappedFile *clone() { refCount++; return this; }
 
-      COMMON_EXPORT void setSharing(bool s);
-      COMMON_EXPORT bool canBeShared();
+      DYNINST_EXPORT void setSharing(bool s);
+      DYNINST_EXPORT bool canBeShared();
 
    private:
 

--- a/common/src/Timer.h
+++ b/common/src/Timer.h
@@ -47,7 +47,7 @@
  * class timer
 ************************************************************************/
 
-class COMMON_EXPORT timer {
+class DYNINST_EXPORT timer {
 public:
      timer ();
      timer (const timer &);

--- a/common/src/addrtranslate.h
+++ b/common/src/addrtranslate.h
@@ -45,7 +45,7 @@ using namespace std;
 
 namespace Dyninst {
 
-class COMMON_EXPORT LoadedLib {
+class DYNINST_EXPORT LoadedLib {
    friend class AddressTranslate;
    friend class AddressTranslateSysV;
  protected:
@@ -90,7 +90,7 @@ class COMMON_EXPORT LoadedLib {
 
 struct LoadedLibCmp
 {
-   COMMON_EXPORT bool operator()(const LoadedLib *a, const LoadedLib *b) const
+   DYNINST_EXPORT bool operator()(const LoadedLib *a, const LoadedLib *b) const
    {
       if (a->getCodeLoadAddr() != b->getCodeLoadAddr()) 
          return a->getCodeLoadAddr() < b->getCodeLoadAddr();
@@ -98,7 +98,7 @@ struct LoadedLibCmp
    }
 };
 
-class COMMON_EXPORT AddressTranslate {
+class DYNINST_EXPORT AddressTranslate {
  protected:
    PID pid;
    PROC_HANDLE phandle;

--- a/common/src/arch-aarch64.h
+++ b/common/src/arch-aarch64.h
@@ -180,7 +180,7 @@ typedef unsigned codeBufIndex_t;
 // Helps to mitigate host/target endian mismatches
 unsigned int swapBytesIfNeeded(unsigned int i);
 
-class COMMON_EXPORT instruction {
+class DYNINST_EXPORT instruction {
 	private:
     instructUnion insn_;
 

--- a/common/src/arch-power.h
+++ b/common/src/arch-power.h
@@ -785,13 +785,13 @@ typedef unsigned codeBufIndex_t;
 #define MIN_IMM48      ((long)(~MAX_IMM48)) // compilers.
 
 // Helps to mitigate host/target endian mismatches
-COMMON_EXPORT unsigned int swapBytesIfNeeded(unsigned int i);
+DYNINST_EXPORT unsigned int swapBytesIfNeeded(unsigned int i);
 
 ///////////////////////////////////////////////////////
 // Bum bum bum.....
 ///////////////////////////////////////////////////////
 
-class COMMON_EXPORT instruction {
+class DYNINST_EXPORT instruction {
  private:
     instructUnion insn_;
 

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -864,7 +864,7 @@ enum {
   fCMPS
 };
 
-COMMON_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
+DYNINST_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_aaa, "aaa")
   (e_aad, "aad")
   (e_aam, "aam")
@@ -2025,7 +2025,7 @@ dyn_hash_map<prefixEntryID, std::string> prefixEntryNames_IAPI = map_list_of
 dyn_hash_map<entryID, flagInfo> ia32_instruction::flagTable;
 
 
-COMMON_EXPORT dyn_hash_map<entryID, flagInfo> const& ia32_instruction::getFlagTable()
+DYNINST_EXPORT dyn_hash_map<entryID, flagInfo> const& ia32_instruction::getFlagTable()
 {
   static std::once_flag flagTableInit;
   std::call_once(flagTableInit, [&]() {

--- a/common/src/arch-x86.h
+++ b/common/src/arch-x86.h
@@ -541,7 +541,7 @@ enum VEX_TYPE
 #define PREFIX_SZADDR  (unsigned char)(0x67)
 #endif
 
-COMMON_EXPORT void ia32_set_mode_64(bool mode);
+DYNINST_EXPORT void ia32_set_mode_64(bool mode);
 
 /**
  * AVX/AVX2/EVEX addressing modes (not in manual).
@@ -689,7 +689,7 @@ class ia32_instruction;
 
 class ia32_prefixes
 {
-  friend COMMON_EXPORT bool ia32_decode_prefixes(const unsigned char *addr, ia32_instruction &insn, bool mode_64);
+  friend DYNINST_EXPORT bool ia32_decode_prefixes(const unsigned char *addr, ia32_instruction &insn, bool mode_64);
   friend bool ia32_decode_rex(const unsigned char* addr, ia32_prefixes&,
                               ia32_locations *loc);
  private:
@@ -836,10 +836,10 @@ struct ia32_operand {  // operand as given in Intel book tables
 
 // An instruction table entry
 struct ia32_entry {
-  COMMON_EXPORT const char* name(ia32_locations* locs = NULL);
-  COMMON_EXPORT entryID getID(ia32_locations* locs = NULL) const;
+  DYNINST_EXPORT const char* name(ia32_locations* locs = NULL);
+  DYNINST_EXPORT entryID getID(ia32_locations* locs = NULL) const;
   // returns true if any flags are read/written, false otherwise
-  COMMON_EXPORT bool flagsUsed(std::set<Dyninst::MachRegister>& flagsRead, std::set<Dyninst::MachRegister>& flagsWritten,
+  DYNINST_EXPORT bool flagsUsed(std::set<Dyninst::MachRegister>& flagsRead, std::set<Dyninst::MachRegister>& flagsWritten,
 		 ia32_locations* locs = NULL);
   entryID id;
   unsigned int otable;       // which opcode table is next; if t_done it is the current one
@@ -876,10 +876,10 @@ class ia32_instruction
                                             const ia32_entry& gotit, 
                                             const char* addr, 
                                             ia32_instruction& instruct);
-  friend COMMON_EXPORT bool ia32_decode_prefixes(const unsigned char *addr, ia32_instruction &insn, bool mode_64);
-  friend COMMON_EXPORT ia32_instruction &
+  friend DYNINST_EXPORT bool ia32_decode_prefixes(const unsigned char *addr, ia32_instruction &insn, bool mode_64);
+  friend DYNINST_EXPORT ia32_instruction &
   ia32_decode(unsigned int capa, const unsigned char *addr, ia32_instruction &instruct, bool mode_64);
-  friend COMMON_EXPORT int
+  friend DYNINST_EXPORT int
   ia32_decode_opcode(unsigned int capa, const unsigned char *addr, ia32_instruction &instruct, ia32_entry **gotit_ret,
                        bool mode_64);
   friend unsigned int ia32_decode_operands(const ia32_prefixes &pref, const ia32_entry &gotit, const unsigned char *addr,
@@ -918,7 +918,7 @@ class ia32_instruction
   const ia32_condition& getCond() const { return *cond; }
   const ia32_locations& getLocationInfo() const { return *loc; }
 
-  COMMON_EXPORT static dyn_hash_map<entryID, flagInfo> const& getFlagTable();
+  DYNINST_EXPORT static dyn_hash_map<entryID, flagInfo> const& getFlagTable();
   static void initFlagTable(dyn_hash_map<entryID, flagInfo>&);
 private:
     static dyn_hash_map<entryID, flagInfo> flagTable;
@@ -948,7 +948,7 @@ private:
 #define IA32_SIZE_DECODER 0
 
 /* TODO: documentation*/
-COMMON_EXPORT bool ia32_decode_prefixes(const unsigned char *addr, ia32_instruction &insn, bool mode_64);
+DYNINST_EXPORT bool ia32_decode_prefixes(const unsigned char *addr, ia32_instruction &insn, bool mode_64);
 
 /**
  * Decode just the opcode of the given instruction. This implies that
@@ -956,7 +956,7 @@ COMMON_EXPORT bool ia32_decode_prefixes(const unsigned char *addr, ia32_instruct
  * and addr has been moved past the prefix bytes. Returns zero on success,
  * non zero otherwise.
  */
-COMMON_EXPORT int
+DYNINST_EXPORT int
 ia32_decode_opcode(unsigned int capa, const unsigned char *addr, ia32_instruction &instruct, ia32_entry **gotit_ret,
                    bool mode_64);
 
@@ -968,7 +968,7 @@ ia32_decode_opcode(unsigned int capa, const unsigned char *addr, ia32_instructio
  * is not defined. capabilities is a mask of the above flags (IA32_DECODE_*).
  * The mask determines what part of the instruction should be decoded.
  */
-COMMON_EXPORT ia32_instruction &
+DYNINST_EXPORT ia32_instruction &
 ia32_decode(unsigned int capabilities, const unsigned char *addr, ia32_instruction &, bool mode_64);
 
 
@@ -982,11 +982,11 @@ enum dynamic_call_address_mode {
    get_instruction: get the instruction that starts at instr.
    return the size of the instruction and set instType to a type descriptor
 */
-COMMON_EXPORT unsigned
+DYNINST_EXPORT unsigned
 get_instruction(const unsigned char *instr, unsigned &instType, const unsigned char **op_ptr, bool mode_64);
 
 /* get the target of a jump or call */
-COMMON_EXPORT Dyninst::Address get_target(const unsigned char *instr, unsigned type, unsigned size,
+DYNINST_EXPORT Dyninst::Address get_target(const unsigned char *instr, unsigned type, unsigned size,
 		   Dyninst::Address addr);
 
 // Size of a jump rel32 instruction
@@ -1047,7 +1047,7 @@ class instruction {
     op_ptr_ = insn.op_ptr_;
   }
   
-  COMMON_EXPORT instruction *copy() const;
+  DYNINST_EXPORT instruction *copy() const;
 
   instruction(const void *ptr, bool mode_64) :
       type_(0), size_(0), ptr_(NULL), op_ptr_(0) {
@@ -1070,7 +1070,7 @@ class instruction {
 
   // And the size necessary to reproduce this instruction
   // at some random point.
-  COMMON_EXPORT unsigned spaceToRelocate() const;
+  DYNINST_EXPORT unsigned spaceToRelocate() const;
 
   // return the type of the instruction
   unsigned type() const { return type_; }
@@ -1087,9 +1087,9 @@ class instruction {
   static unsigned maxInterFunctionJumpSize(unsigned addr_width) { return maxJumpSize(addr_width); }
 
   // And tell us how much space we'll need...
-  COMMON_EXPORT static unsigned jumpSize(Dyninst::Address from, Dyninst::Address to, unsigned addr_width);
-  COMMON_EXPORT static unsigned jumpSize(long disp, unsigned addr_width);
-  COMMON_EXPORT static unsigned maxJumpSize(unsigned addr_width);
+  DYNINST_EXPORT static unsigned jumpSize(Dyninst::Address from, Dyninst::Address to, unsigned addr_width);
+  DYNINST_EXPORT static unsigned jumpSize(long disp, unsigned addr_width);
+  DYNINST_EXPORT static unsigned maxJumpSize(unsigned addr_width);
 
     bool isCall() const { return type_ & IS_CALL; }
   bool isCallIndir() const { return (type_ & IS_CALL) && (type_ & INDIR); }
@@ -1150,7 +1150,7 @@ int displacement(const unsigned char *instr, unsigned type);
 
 /** Returns the immediate operand of an instruction **/
 
-    COMMON_EXPORT int count_prefixes(unsigned insnType);
+    DYNINST_EXPORT int count_prefixes(unsigned insnType);
 
 inline bool is_disp8(long disp) {
    return (disp >= -128 && disp < 127);
@@ -1170,9 +1170,9 @@ inline bool is_addr32(Dyninst::Address addr) {
     return (addr < UINT32_MAX);
 }
 
-COMMON_EXPORT void decode_SIB(unsigned sib, unsigned& scale, 
+DYNINST_EXPORT void decode_SIB(unsigned sib, unsigned& scale, 
         Dyninst::Register& index_reg, Dyninst::Register& base_reg);
-COMMON_EXPORT const unsigned char* skip_headers(const unsigned char*, 
+DYNINST_EXPORT const unsigned char* skip_headers(const unsigned char*, 
         ia32_instruction* = NULL);
 
 /* addresses on x86 don't have to be aligned */
@@ -1190,12 +1190,12 @@ inline Dyninst::Address region_hi_64(const Dyninst::Address x) { return x | 0x00
 
 #endif
 
-COMMON_EXPORT bool insn_hasSIB(unsigned,unsigned&,unsigned&,unsigned&);
-COMMON_EXPORT bool insn_hasDisp8(unsigned ModRM);
-COMMON_EXPORT bool insn_hasDisp32(unsigned ModRM);
+DYNINST_EXPORT bool insn_hasSIB(unsigned,unsigned&,unsigned&,unsigned&);
+DYNINST_EXPORT bool insn_hasDisp8(unsigned ModRM);
+DYNINST_EXPORT bool insn_hasDisp32(unsigned ModRM);
 
-COMMON_EXPORT bool isStackFramePrecheck_msvs( const unsigned char *buffer );
-COMMON_EXPORT bool isStackFramePrecheck_gcc( const unsigned char *buffer );
+DYNINST_EXPORT bool isStackFramePrecheck_msvs( const unsigned char *buffer );
+DYNINST_EXPORT bool isStackFramePrecheck_gcc( const unsigned char *buffer );
 
 } // namespace arch_x86
 

--- a/common/src/debug_common.h
+++ b/common/src/debug_common.h
@@ -35,11 +35,11 @@
 #include "util.h"
 #include "compiler_annotations.h"
 
-COMMON_EXPORT extern int common_debug_dwarf;
-COMMON_EXPORT extern int common_debug_addrtranslate;
-COMMON_EXPORT extern int common_debug_lineinfo;
-COMMON_EXPORT extern int common_debug_parsing;
-COMMON_EXPORT extern int common_debug_initialized;
+DYNINST_EXPORT extern int common_debug_dwarf;
+DYNINST_EXPORT extern int common_debug_addrtranslate;
+DYNINST_EXPORT extern int common_debug_lineinfo;
+DYNINST_EXPORT extern int common_debug_parsing;
+DYNINST_EXPORT extern int common_debug_initialized;
 
 #define common_debug_printf(debug_sys_var, debug_sys_printf, ...) \
    do {                                                                 \
@@ -54,16 +54,16 @@ COMMON_EXPORT extern int common_debug_initialized;
 #define lineinfo_printf(...)          common_debug_printf(lineinfo, lineinfo, __VA_ARGS__)
 #define common_parsing_printf(...)    common_debug_printf(parsing, common_parsing, __VA_ARGS__)
 
-COMMON_EXPORT int dwarf_printf_int(const char *format, ...)
+DYNINST_EXPORT int dwarf_printf_int(const char *format, ...)
         DYNINST_PRINTF_ANNOTATION(1, 2);
-COMMON_EXPORT int translate_printf_int(const char *format, ...)
+DYNINST_EXPORT int translate_printf_int(const char *format, ...)
         DYNINST_PRINTF_ANNOTATION(1, 2);
-COMMON_EXPORT int lineinfo_printf_int(const char *format, ...)
+DYNINST_EXPORT int lineinfo_printf_int(const char *format, ...)
         DYNINST_PRINTF_ANNOTATION(1, 2);
-COMMON_EXPORT int common_parsing_printf_int(const char *format, ...)
+DYNINST_EXPORT int common_parsing_printf_int(const char *format, ...)
         DYNINST_PRINTF_ANNOTATION(1, 2);
 
 // And initialization
-COMMON_EXPORT bool init_debug_common();
+DYNINST_EXPORT bool init_debug_common();
 
 #endif /* COMMON_DEBUG_H */

--- a/common/src/dthread.h
+++ b/common/src/dthread.h
@@ -56,7 +56,7 @@
 
 
 
-class PC_EXPORT DThread {
+class DYNINST_EXPORT DThread {
 #if defined(cap_pthreads)
    pthread_t thrd;
  public:
@@ -94,7 +94,7 @@ struct boost_mutex_selector<true>
 };
 
 template <bool isRecursive = false>
-class PC_EXPORT Mutex : public boost_mutex_selector<isRecursive>::mutex {
+class DYNINST_EXPORT Mutex : public boost_mutex_selector<isRecursive>::mutex {
 public:
 	typedef Mutex<isRecursive> type;
    
@@ -102,7 +102,7 @@ public:
 
 
 template <typename mutex_t = Mutex<false> >
-class PC_EXPORT CondVar {
+class DYNINST_EXPORT CondVar {
    boost::condition_variable_any cond;
    mutex_t *mutex;
    bool created_mutex;

--- a/common/src/freebsdHeaders.h
+++ b/common/src/freebsdHeaders.h
@@ -233,7 +233,7 @@ inline int P_select(int wid, fd_set *rd, fd_set *wr, fd_set *ex,
 		    struct timeval *tm) {
   return (select(wid, rd, wr, ex, tm));}
 
-extern std::string COMMON_EXPORT P_cplus_demangle( const std::string &symbol,
+extern std::string DYNINST_EXPORT P_cplus_demangle( const std::string &symbol,
 				bool includeTypes = false );
 
 inline int P_mkdir(const char *pathname, mode_t mode) {

--- a/common/src/freebsdKludges.h
+++ b/common/src/freebsdKludges.h
@@ -47,8 +47,8 @@ bool sysctl_getRunningStates(pid_t pid, std::map<Dyninst::LWP, bool> &runningSta
 
 map_entries *getVMMaps(int pid, unsigned &maps_size);
 
-COMMON_EXPORT bool PtraceBulkRead(Dyninst::Address inTraced, unsigned size, void *inSelf, int pid);
-COMMON_EXPORT bool PtraceBulkWrite(Dyninst::Address inTraced, unsigned size, const void *inSelf, int pid);
+DYNINST_EXPORT bool PtraceBulkRead(Dyninst::Address inTraced, unsigned size, void *inSelf, int pid);
+DYNINST_EXPORT bool PtraceBulkWrite(Dyninst::Address inTraced, unsigned size, const void *inSelf, int pid);
 
 #endif
 

--- a/common/src/linuxHeaders.h
+++ b/common/src/linuxHeaders.h
@@ -239,7 +239,7 @@ inline int P_rexec(char **ahost, u_short inport, char *user,
 		   char *passwd, char *cmd, int *fd2p) {
   return (rexec(ahost, inport, user, passwd, cmd, fd2p));}
 
-extern COMMON_EXPORT std::string P_cplus_demangle( const std::string &symbol,
+extern DYNINST_EXPORT std::string P_cplus_demangle( const std::string &symbol,
 				bool includeTypes = false );
 
 inline int P_mkdir(const char *pathname, mode_t mode) {

--- a/common/src/linuxKludges.h
+++ b/common/src/linuxKludges.h
@@ -37,16 +37,16 @@
 #include "common/src/vm_maps.h"
 #include "common/h/util.h"
 
-COMMON_EXPORT bool PtraceBulkRead(Dyninst::Address inTraced, unsigned size, void *inSelf, int pid);
+DYNINST_EXPORT bool PtraceBulkRead(Dyninst::Address inTraced, unsigned size, void *inSelf, int pid);
 
-COMMON_EXPORT bool PtraceBulkWrite(Dyninst::Address inTraced, unsigned size, const void *inSelf, int pid);
+DYNINST_EXPORT bool PtraceBulkWrite(Dyninst::Address inTraced, unsigned size, const void *inSelf, int pid);
 
-COMMON_EXPORT bool findProcLWPs(pid_t pid, std::vector<pid_t> &lwps);
+DYNINST_EXPORT bool findProcLWPs(pid_t pid, std::vector<pid_t> &lwps);
 
-COMMON_EXPORT map_entries *getVMMaps(int pid, unsigned &maps_size);
+DYNINST_EXPORT map_entries *getVMMaps(int pid, unsigned &maps_size);
 
 #define getVMMaps getLinuxMaps
-COMMON_EXPORT map_entries *getLinuxMaps(int pid, unsigned &maps_size);
+DYNINST_EXPORT map_entries *getLinuxMaps(int pid, unsigned &maps_size);
 
 #endif
 

--- a/common/src/lprintf.h
+++ b/common/src/lprintf.h
@@ -46,10 +46,10 @@
  * function prototypes.
 ************************************************************************/
 
-extern COMMON_EXPORT void log_msg(const char *);
-extern COMMON_EXPORT void log_printf(void (*)(const char *), const char *, ...)
+extern DYNINST_EXPORT void log_msg(const char *);
+extern DYNINST_EXPORT void log_printf(void (*)(const char *), const char *, ...)
         DYNINST_PRINTF_ANNOTATION(2, 3);
-extern COMMON_EXPORT void log_perror(void (*)(const char *), const char *);
+extern DYNINST_EXPORT void log_perror(void (*)(const char *), const char *);
 
 
 

--- a/common/src/parseauxv.h
+++ b/common/src/parseauxv.h
@@ -35,7 +35,7 @@
 #include <map>
 #include "dyntypes.h"
 
-class COMMON_EXPORT AuxvParser
+class DYNINST_EXPORT AuxvParser
 {
  private:
    int pid;

--- a/common/src/pathName.h
+++ b/common/src/pathName.h
@@ -61,8 +61,8 @@ bool executableFromArgv0AndPathAndCwd(std::string &result,
 				      const std::string &i_argv0,
 				      const std::string &path,
 				      const std::string &cwd);
-COMMON_EXPORT std::string extract_pathname_tail(const std::string &path);
+DYNINST_EXPORT std::string extract_pathname_tail(const std::string &path);
 
-COMMON_EXPORT std::string resolve_file_path(char const* path);
-COMMON_EXPORT std::string resolve_file_path(std::string);
+DYNINST_EXPORT std::string resolve_file_path(char const* path);
+DYNINST_EXPORT std::string resolve_file_path(std::string);
 #endif

--- a/common/src/stats.h
+++ b/common/src/stats.h
@@ -40,7 +40,7 @@
 
 class StatContainer;  // All your class declarations are forward. 
 
-class COMMON_EXPORT Statistic  {
+class DYNINST_EXPORT Statistic  {
  public:
     virtual bool is_count()  { return false; }
     virtual bool is_timer()  { return false; }
@@ -63,7 +63,7 @@ class COMMON_EXPORT Statistic  {
     StatContainer *container_;
 };
 
-class COMMON_EXPORT CntStatistic : public Statistic {
+class DYNINST_EXPORT CntStatistic : public Statistic {
  friend class StatContainer;
 
  protected:
@@ -107,7 +107,7 @@ class COMMON_EXPORT CntStatistic : public Statistic {
 };
 
 /* Wraps the timer class */
-class COMMON_EXPORT TimeStatistic : public Statistic {
+class DYNINST_EXPORT TimeStatistic : public Statistic {
  friend class StatContainer;
 
  protected:
@@ -150,15 +150,15 @@ typedef enum {
 /* A container for a group of (one expects) mutually related statistics. */
 class StatContainer {
  public:
-    COMMON_EXPORT StatContainer(); 
+    DYNINST_EXPORT StatContainer(); 
 
     /* Access or create a statistic indexed by the provided name.
      *
      * This operator may return null if the named statistic does
      * not exist.
      */
-    COMMON_EXPORT Statistic * operator[](const std::string &);
-    COMMON_EXPORT Statistic * operator[](const char *s) {
+    DYNINST_EXPORT Statistic * operator[](const std::string &);
+    DYNINST_EXPORT Statistic * operator[](const char *s) {
        std::string namestr(s);
        return (*this)[namestr];
     }
@@ -166,19 +166,19 @@ class StatContainer {
     // Create a new statistic of the given type indexed by name.
     // **This will replace any existing stat with the same index
     //   within this container**
-    COMMON_EXPORT void add(const std::string& name, StatType type);
+    DYNINST_EXPORT void add(const std::string& name, StatType type);
 
     // Access all of the existing statistics
-    COMMON_EXPORT dyn_hash_map< std::string, Statistic * > &
+    DYNINST_EXPORT dyn_hash_map< std::string, Statistic * > &
        allStats() { return stats_; }
 
     // And some pass-through methods, encapsulated for
     // ease of use
-    COMMON_EXPORT void startTimer(const std::string&);
-    COMMON_EXPORT void stopTimer(const std::string&);
-    COMMON_EXPORT void incrementCounter(const std::string&);
-    COMMON_EXPORT void decrementCounter(const std::string&);
-    COMMON_EXPORT void addCounter(const std::string&, int);
+    DYNINST_EXPORT void startTimer(const std::string&);
+    DYNINST_EXPORT void stopTimer(const std::string&);
+    DYNINST_EXPORT void incrementCounter(const std::string&);
+    DYNINST_EXPORT void decrementCounter(const std::string&);
+    DYNINST_EXPORT void addCounter(const std::string&, int);
 
  private:
     dyn_hash_map< std::string, Statistic * > stats_;

--- a/common/src/util.C
+++ b/common/src/util.C
@@ -41,7 +41,7 @@ using namespace std;
 
 namespace Dyninst {
 
-COMMON_EXPORT unsigned addrHashCommon(const Address &addr)
+DYNINST_EXPORT unsigned addrHashCommon(const Address &addr)
 {
    // inspired by hashs of string class
 
@@ -57,29 +57,29 @@ COMMON_EXPORT unsigned addrHashCommon(const Address &addr)
    return result;
 }
 
-COMMON_EXPORT unsigned addrHash(const Address & iaddr)
+DYNINST_EXPORT unsigned addrHash(const Address & iaddr)
 {
    return Dyninst::addrHashCommon(iaddr);
 }
 
-COMMON_EXPORT unsigned ptrHash(const void * iaddr)
+DYNINST_EXPORT unsigned ptrHash(const void * iaddr)
 {
    return Dyninst::addrHashCommon((Address)iaddr);
 }
 
-COMMON_EXPORT unsigned ptrHash(void * iaddr)
+DYNINST_EXPORT unsigned ptrHash(void * iaddr)
 {
    return Dyninst::addrHashCommon((Address)iaddr);
 }
 
-COMMON_EXPORT unsigned addrHash4(const Address &iaddr)
+DYNINST_EXPORT unsigned addrHash4(const Address &iaddr)
 {
    // call when you know that the low 2 bits are 0 (meaning they contribute
    // nothing to an even hash distribution)
    return Dyninst::addrHashCommon(iaddr >> 2);
 }
 
-COMMON_EXPORT unsigned addrHash16(const Address &iaddr)
+DYNINST_EXPORT unsigned addrHash16(const Address &iaddr)
 {
    // call when you know that the low 4 bits are 0 (meaning they contribute
    // nothing to an even hash distribution)
@@ -219,7 +219,7 @@ const char *platform_string()
 //the cache information.  Thus the cache will live in libcommon.
 class SymElf;
 
-COMMON_EXPORT map<string, SymElf *> *getSymelfCache() {
+DYNINST_EXPORT map<string, SymElf *> *getSymelfCache() {
    static map<string, SymElf *> elfmap;
    return &elfmap;
 }

--- a/dataflowAPI/h/ABI.h
+++ b/dataflowAPI/h/ABI.h
@@ -43,27 +43,27 @@ class ABI{
     int addr_width;
 
  public:
-    DATAFLOW_EXPORT const bitArray &getCallReadRegisters() const;
-    DATAFLOW_EXPORT const bitArray &getCallWrittenRegisters() const;
-    DATAFLOW_EXPORT const bitArray &getReturnReadRegisters() const;
-    DATAFLOW_EXPORT const bitArray &getReturnRegisters() const;
-    DATAFLOW_EXPORT const bitArray &getParameterRegisters() const;
+    DYNINST_EXPORT const bitArray &getCallReadRegisters() const;
+    DYNINST_EXPORT const bitArray &getCallWrittenRegisters() const;
+    DYNINST_EXPORT const bitArray &getReturnReadRegisters() const;
+    DYNINST_EXPORT const bitArray &getReturnRegisters() const;
+    DYNINST_EXPORT const bitArray &getParameterRegisters() const;
     // No such thing as return written...
 
     // Syscall!
-    DATAFLOW_EXPORT const bitArray &getSyscallReadRegisters() const;
-    DATAFLOW_EXPORT const bitArray &getSyscallWrittenRegisters() const;
+    DYNINST_EXPORT const bitArray &getSyscallReadRegisters() const;
+    DYNINST_EXPORT const bitArray &getSyscallWrittenRegisters() const;
 
-    DATAFLOW_EXPORT const bitArray &getAllRegs() const;
+    DYNINST_EXPORT const bitArray &getAllRegs() const;
 
-    DATAFLOW_EXPORT int getIndex(MachRegister machReg);
-    DATAFLOW_EXPORT std::map<MachRegister,int>* getIndexMap();
+    DYNINST_EXPORT int getIndex(MachRegister machReg);
+    DYNINST_EXPORT std::map<MachRegister,int>* getIndexMap();
 
-    DATAFLOW_EXPORT static void initialize32();
-    DATAFLOW_EXPORT static void initialize64();
+    DYNINST_EXPORT static void initialize32();
+    DYNINST_EXPORT static void initialize64();
 
-    DATAFLOW_EXPORT static ABI* getABI(int addr_width);
-    DATAFLOW_EXPORT bitArray getBitArray();
+    DYNINST_EXPORT static ABI* getABI(int addr_width);
+    DYNINST_EXPORT bitArray getBitArray();
  private:
     static dyn_tls bitArray* callRead_;
     static dyn_tls bitArray* callRead64_;

--- a/dataflowAPI/h/Absloc.h
+++ b/dataflowAPI/h/Absloc.h
@@ -73,18 +73,18 @@ class Absloc {
     PredicatedRegister,
     Unknown } Type;
 
-   DATAFLOW_EXPORT static Absloc makePC(Dyninst::Architecture arch);
-   DATAFLOW_EXPORT static Absloc makeSP(Dyninst::Architecture arch);
-   DATAFLOW_EXPORT static Absloc makeFP(Dyninst::Architecture arch);
+   DYNINST_EXPORT static Absloc makePC(Dyninst::Architecture arch);
+   DYNINST_EXPORT static Absloc makeSP(Dyninst::Architecture arch);
+   DYNINST_EXPORT static Absloc makeFP(Dyninst::Architecture arch);
   
   // Some static functions for "well-known" Abslocs
-  DATAFLOW_EXPORT bool isPC() const;
-  DATAFLOW_EXPORT bool isSPR() const;
+  DYNINST_EXPORT bool isPC() const;
+  DYNINST_EXPORT bool isSPR() const;
   
-  DATAFLOW_EXPORT bool isSP() const;
-  DATAFLOW_EXPORT bool isFP() const;
+  DYNINST_EXPORT bool isSP() const;
+  DYNINST_EXPORT bool isFP() const;
 
- DATAFLOW_EXPORT Absloc() :
+ DYNINST_EXPORT Absloc() :
   type_(Unknown),
     reg_(),
     off_(-1),
@@ -93,7 +93,7 @@ class Absloc {
     addr_(-1),
     preg_(),
     trueCond_(false) {}
- DATAFLOW_EXPORT Absloc(MachRegister reg) :
+ DYNINST_EXPORT Absloc(MachRegister reg) :
   type_(Register),
      reg_(reg),
      off_(-1),
@@ -104,7 +104,7 @@ class Absloc {
      trueCond_(false)
      {}
     
- DATAFLOW_EXPORT Absloc(Address addr) :
+ DYNINST_EXPORT Absloc(Address addr) :
     type_(Heap),
     reg_(),
     off_(-1),
@@ -114,7 +114,7 @@ class Absloc {
     preg_(),
     trueCond_(false)
     {}
- DATAFLOW_EXPORT Absloc(int o,
+ DYNINST_EXPORT Absloc(int o,
 			int r,
 			ParseAPI::Function *f) :
     type_(Stack),
@@ -126,7 +126,7 @@ class Absloc {
     preg_(),
     trueCond_(false)
     {}
- DATAFLOW_EXPORT Absloc(MachRegister r, MachRegister p, bool c):
+ DYNINST_EXPORT Absloc(MachRegister r, MachRegister p, bool c):
      type_(PredicatedRegister),
      reg_(r),
      off_(-1),
@@ -136,31 +136,31 @@ class Absloc {
      preg_(p),
      trueCond_(c) {}
     
-  DATAFLOW_EXPORT std::string format() const;
+  DYNINST_EXPORT std::string format() const;
 
-  DATAFLOW_EXPORT const Type &type() const { return type_; }
+  DYNINST_EXPORT const Type &type() const { return type_; }
 
-  DATAFLOW_EXPORT bool isValid() const { return type_ != Unknown; }
+  DYNINST_EXPORT bool isValid() const { return type_ != Unknown; }
 
-  DATAFLOW_EXPORT const MachRegister &reg() const { assert(type_ == Register || type_ == PredicatedRegister); return reg_; }
+  DYNINST_EXPORT const MachRegister &reg() const { assert(type_ == Register || type_ == PredicatedRegister); return reg_; }
 
-  DATAFLOW_EXPORT int off() const { assert(type_ == Stack); return off_; }
-  DATAFLOW_EXPORT int region() const { assert(type_ == Stack); return region_; }
-  DATAFLOW_EXPORT ParseAPI::Function *func() const { assert(type_ == Stack); return func_; }
+  DYNINST_EXPORT int off() const { assert(type_ == Stack); return off_; }
+  DYNINST_EXPORT int region() const { assert(type_ == Stack); return region_; }
+  DYNINST_EXPORT ParseAPI::Function *func() const { assert(type_ == Stack); return func_; }
 
-  DATAFLOW_EXPORT Address addr() const { assert(type_ == Heap); return addr_; }
-  DATAFLOW_EXPORT const MachRegister &predReg() const { assert(type_ == PredicatedRegister); return preg_;}
-  DATAFLOW_EXPORT bool isTrueCondition() const { assert(type_ == PredicatedRegister); return trueCond_;}
-  DATAFLOW_EXPORT void flipPredicateCondition() { assert(type_ == PredicatedRegister); trueCond_ = !trueCond_; }
+  DYNINST_EXPORT Address addr() const { assert(type_ == Heap); return addr_; }
+  DYNINST_EXPORT const MachRegister &predReg() const { assert(type_ == PredicatedRegister); return preg_;}
+  DYNINST_EXPORT bool isTrueCondition() const { assert(type_ == PredicatedRegister); return trueCond_;}
+  DYNINST_EXPORT void flipPredicateCondition() { assert(type_ == PredicatedRegister); trueCond_ = !trueCond_; }
   
-  DATAFLOW_EXPORT bool operator<(const Absloc &rhs) const;
-  DATAFLOW_EXPORT bool operator==(const Absloc &rhs) const;
+  DYNINST_EXPORT bool operator<(const Absloc &rhs) const;
+  DYNINST_EXPORT bool operator==(const Absloc &rhs) const;
 
-  DATAFLOW_EXPORT bool operator!=(const Absloc &rhs) const {
+  DYNINST_EXPORT bool operator!=(const Absloc &rhs) const {
     return !(*this == rhs);
   }
 
-  DATAFLOW_EXPORT static char typeToChar(const Type t) {
+  DYNINST_EXPORT static char typeToChar(const Type t) {
     switch(t) {
     case Register:
       return 'r';
@@ -200,47 +200,47 @@ class AbsRegion {
   // Set operations get included here? Or third-party
   // functions?
   
-  DATAFLOW_EXPORT bool contains(const Absloc::Type t) const;
-  DATAFLOW_EXPORT bool contains(const Absloc &abs) const;
-  DATAFLOW_EXPORT bool contains(const AbsRegion &rhs) const;
+  DYNINST_EXPORT bool contains(const Absloc::Type t) const;
+  DYNINST_EXPORT bool contains(const Absloc &abs) const;
+  DYNINST_EXPORT bool contains(const AbsRegion &rhs) const;
 
-  DATAFLOW_EXPORT bool containsOfType(Absloc::Type t) const;
+  DYNINST_EXPORT bool containsOfType(Absloc::Type t) const;
 
-  DATAFLOW_EXPORT bool operator==(const AbsRegion &rhs) const;
-  DATAFLOW_EXPORT bool operator!=(const AbsRegion &rhs) const;
-  DATAFLOW_EXPORT bool operator<(const AbsRegion &rhs) const;
+  DYNINST_EXPORT bool operator==(const AbsRegion &rhs) const;
+  DYNINST_EXPORT bool operator!=(const AbsRegion &rhs) const;
+  DYNINST_EXPORT bool operator<(const AbsRegion &rhs) const;
 
-  DATAFLOW_EXPORT const std::string format() const;
+  DYNINST_EXPORT const std::string format() const;
 
-  DATAFLOW_EXPORT AbsRegion() :
+  DYNINST_EXPORT AbsRegion() :
     type_(Absloc::Unknown),
     size_(0) {}
 
-  DATAFLOW_EXPORT AbsRegion(Absloc::Type t) :
+  DYNINST_EXPORT AbsRegion(Absloc::Type t) :
     type_(t),
     size_(0) {}
 
-  DATAFLOW_EXPORT AbsRegion(Absloc a) :
+  DYNINST_EXPORT AbsRegion(Absloc a) :
     type_(Absloc::Unknown),
       absloc_(a),
       size_(0) {}
 
 
-  DATAFLOW_EXPORT void setGenerator(AST::Ptr generator) {
+  DYNINST_EXPORT void setGenerator(AST::Ptr generator) {
       generator_ = generator;
   }
 
-  DATAFLOW_EXPORT void setSize(size_t size) {
+  DYNINST_EXPORT void setSize(size_t size) {
     size_ = size;
   }
 
-  DATAFLOW_EXPORT Absloc absloc() const { return absloc_; }
-  DATAFLOW_EXPORT Absloc::Type type() const { return type_; }
-  DATAFLOW_EXPORT size_t size() const { return size_; }
-  DATAFLOW_EXPORT AST::Ptr generator() const { return generator_; }
+  DYNINST_EXPORT Absloc absloc() const { return absloc_; }
+  DYNINST_EXPORT Absloc::Type type() const { return type_; }
+  DYNINST_EXPORT size_t size() const { return size_; }
+  DYNINST_EXPORT AST::Ptr generator() const { return generator_; }
 
-  DATAFLOW_EXPORT bool isImprecise() const { return type_ != Absloc::Unknown; }
-  DATAFLOW_EXPORT void flipPredicateCondition() { absloc_.flipPredicateCondition(); }
+  DYNINST_EXPORT bool isImprecise() const { return type_ != Absloc::Unknown; }
+  DYNINST_EXPORT void flipPredicateCondition() { absloc_.flipPredicateCondition(); }
   friend std::ostream &operator<<(std::ostream &os, const AbsRegion &a) {
     os << a.format();
     return os;
@@ -274,26 +274,26 @@ class Assignment {
 
   typedef std::set<AbsRegion> Aliases;
 
-  DATAFLOW_EXPORT const std::vector<AbsRegion> &inputs() const { return inputs_; }
-  DATAFLOW_EXPORT std::vector<AbsRegion> &inputs() { return inputs_; }
+  DYNINST_EXPORT const std::vector<AbsRegion> &inputs() const { return inputs_; }
+  DYNINST_EXPORT std::vector<AbsRegion> &inputs() { return inputs_; }
 
-  DATAFLOW_EXPORT const InstructionAPI::Instruction &insn() const { return insn_; }
-  DATAFLOW_EXPORT InstructionAPI::Instruction &insn() { return insn_; }
-  DATAFLOW_EXPORT Address addr() const { return addr_; }
+  DYNINST_EXPORT const InstructionAPI::Instruction &insn() const { return insn_; }
+  DYNINST_EXPORT InstructionAPI::Instruction &insn() { return insn_; }
+  DYNINST_EXPORT Address addr() const { return addr_; }
 
-  DATAFLOW_EXPORT const AbsRegion &out() const { return out_; }
-  DATAFLOW_EXPORT AbsRegion &out() { return out_; }
+  DYNINST_EXPORT const AbsRegion &out() const { return out_; }
+  DYNINST_EXPORT AbsRegion &out() { return out_; }
 
-  DATAFLOW_EXPORT const std::string format() const;
+  DYNINST_EXPORT const std::string format() const;
 
   // FIXME
   Aliases aliases;
 
   // Factory functions. 
-  DATAFLOW_EXPORT static std::set<Assignment::Ptr> create(InstructionAPI::Instruction insn,
+  DYNINST_EXPORT static std::set<Assignment::Ptr> create(InstructionAPI::Instruction insn,
 					  Address addr);
 
-  DATAFLOW_EXPORT Assignment(const InstructionAPI::Instruction& i,
+  DYNINST_EXPORT Assignment(const InstructionAPI::Instruction& i,
                              const Address a,
                              ParseAPI::Function *f,
                              ParseAPI::Block *b,
@@ -306,7 +306,7 @@ class Assignment {
        inputs_(ins),
        out_(o) {}
 
-  DATAFLOW_EXPORT Assignment(const InstructionAPI::Instruction& i,
+  DYNINST_EXPORT Assignment(const InstructionAPI::Instruction& i,
                              const Address a,
                              ParseAPI::Function *f,
                              ParseAPI::Block *b,
@@ -317,14 +317,14 @@ class Assignment {
        block_(b),
        out_(o) {}
 
-  DATAFLOW_EXPORT static Assignment::Ptr makeAssignment(const InstructionAPI::Instruction& i,
+  DYNINST_EXPORT static Assignment::Ptr makeAssignment(const InstructionAPI::Instruction& i,
                              const Address a,
                              ParseAPI::Function *f,
                              ParseAPI::Block *b,
                              const std::vector<AbsRegion> &ins,
                              const AbsRegion &o);
 
-  DATAFLOW_EXPORT static Assignment::Ptr makeAssignment(const InstructionAPI::Instruction& i,
+  DYNINST_EXPORT static Assignment::Ptr makeAssignment(const InstructionAPI::Instruction& i,
                              const Address a,
                              ParseAPI::Function *f,
                              ParseAPI::Block *b,
@@ -336,12 +336,12 @@ class Assignment {
   // we'll add it to the dependence list. Otherwise 
   // we'll join the provided input set to the known
   // inputs.
-  DATAFLOW_EXPORT void addInput(const AbsRegion &reg);
-  DATAFLOW_EXPORT void addInputs(const std::vector<AbsRegion> &regions);
+  DYNINST_EXPORT void addInput(const AbsRegion &reg);
+  DYNINST_EXPORT void addInputs(const std::vector<AbsRegion> &regions);
 
-  DATAFLOW_EXPORT ParseAPI::Function *func() const { return func_; }
+  DYNINST_EXPORT ParseAPI::Function *func() const { return func_; }
 
-  DATAFLOW_EXPORT ParseAPI::Block *block() const { return block_; }
+  DYNINST_EXPORT ParseAPI::Block *block() const { return block_; }
   friend std::ostream &operator<<(std::ostream &os, const Assignment::Ptr &a) {
     os << a->format();
     return os;

--- a/dataflowAPI/h/AbslocInterface.h
+++ b/dataflowAPI/h/AbslocInterface.h
@@ -54,20 +54,20 @@ namespace Dyninst {
 
 class AbsRegionConverter {
  public:
- DATAFLOW_EXPORT AbsRegionConverter(bool cache, bool stack) :
+ DYNINST_EXPORT AbsRegionConverter(bool cache, bool stack) :
   cacheEnabled_(cache), stackAnalysisEnabled_(stack) {}
 
   // Definition: the first AbsRegion represents the expression.
   // If it's a memory reference, any other AbsRegions represent
   // registers used in this expression.
 
-  DATAFLOW_EXPORT void convertAll(InstructionAPI::Expression::Ptr expr,
+  DYNINST_EXPORT void convertAll(InstructionAPI::Expression::Ptr expr,
 				  Address addr,
 				  ParseAPI::Function *func,
                                   ParseAPI::Block *block,
 				  std::vector<AbsRegion> &regions);
   
-  DATAFLOW_EXPORT void convertAll(const InstructionAPI::Instruction &insn,
+  DYNINST_EXPORT void convertAll(const InstructionAPI::Instruction &insn,
 				  Address addr,
 				  ParseAPI::Function *func,
                                   ParseAPI::Block *block,
@@ -76,24 +76,24 @@ class AbsRegionConverter {
 
   // Single converters
   
-  DATAFLOW_EXPORT AbsRegion convert(InstructionAPI::RegisterAST::Ptr reg);
+  DYNINST_EXPORT AbsRegion convert(InstructionAPI::RegisterAST::Ptr reg);
 
-  DATAFLOW_EXPORT AbsRegion convert(InstructionAPI::Expression::Ptr expr,
+  DYNINST_EXPORT AbsRegion convert(InstructionAPI::Expression::Ptr expr,
 				    Address addr,
 				    ParseAPI::Function *func,
                                     ParseAPI::Block *block);
 
-  DATAFLOW_EXPORT AbsRegion convertPredicatedRegister(InstructionAPI::RegisterAST::Ptr r,
+  DYNINST_EXPORT AbsRegion convertPredicatedRegister(InstructionAPI::RegisterAST::Ptr r,
           InstructionAPI::RegisterAST::Ptr p,
           bool c);
 
   // Cons up a stack reference at the current addr
-  DATAFLOW_EXPORT AbsRegion stack(Address addr,
+  DYNINST_EXPORT AbsRegion stack(Address addr,
 				  ParseAPI::Function *func,
                                   ParseAPI::Block *block,
 				  bool push);
   
-  DATAFLOW_EXPORT AbsRegion frame(Address addr,
+  DYNINST_EXPORT AbsRegion frame(Address addr,
 				  ParseAPI::Function *func,
                                   ParseAPI::Block *block,
 				  bool push);
@@ -129,9 +129,9 @@ class AbsRegionConverter {
 
 class AssignmentConverter {
  public:  
- DATAFLOW_EXPORT AssignmentConverter(bool cache, bool stack) : cacheEnabled_(cache), aConverter(false, stack) {}
+ DYNINST_EXPORT AssignmentConverter(bool cache, bool stack) : cacheEnabled_(cache), aConverter(false, stack) {}
 
-  DATAFLOW_EXPORT void convert(const InstructionAPI::Instruction &insn,
+  DYNINST_EXPORT void convert(const InstructionAPI::Instruction &insn,
                                const Address &addr,
                                ParseAPI::Function *func,
                                ParseAPI::Block *block,

--- a/dataflowAPI/h/SymEval.h
+++ b/dataflowAPI/h/SymEval.h
@@ -80,21 +80,21 @@ namespace DataflowAPI {
 // Define the operations used by ROSE
 
 struct Variable {
-  DATAFLOW_EXPORT Variable() : reg(), addr(0) {}
-  DATAFLOW_EXPORT Variable(AbsRegion r) : reg(r), addr(0) {}
-  DATAFLOW_EXPORT Variable(AbsRegion r, Address a) : reg(r), addr(a) {}
+  DYNINST_EXPORT Variable() : reg(), addr(0) {}
+  DYNINST_EXPORT Variable(AbsRegion r) : reg(r), addr(0) {}
+  DYNINST_EXPORT Variable(AbsRegion r, Address a) : reg(r), addr(a) {}
 
-  DATAFLOW_EXPORT bool operator==(const Variable &rhs) const { 
+  DYNINST_EXPORT bool operator==(const Variable &rhs) const { 
     return ((rhs.addr == addr) && (rhs.reg == reg));
   }
 
-  DATAFLOW_EXPORT bool operator<(const Variable &rhs) const { 
+  DYNINST_EXPORT bool operator<(const Variable &rhs) const { 
     if (addr < rhs.addr) return true;
     if (reg < rhs.reg) return true;
     return false;
   }
 
-  DATAFLOW_EXPORT const std::string format() const {
+  DYNINST_EXPORT const std::string format() const {
     std::stringstream ret;
     ret << "V(" << reg;
     if (addr) ret << ":" << std::hex << addr << std::dec;
@@ -112,21 +112,21 @@ struct Variable {
 };
 
 struct Constant {
-  DATAFLOW_EXPORT Constant() : val(0), size(0) {}
-  DATAFLOW_EXPORT Constant(uint64_t v) : val(v), size(0) {}
-  DATAFLOW_EXPORT Constant(uint64_t v, size_t s) : val(v), size(s) {}
+  DYNINST_EXPORT Constant() : val(0), size(0) {}
+  DYNINST_EXPORT Constant(uint64_t v) : val(v), size(0) {}
+  DYNINST_EXPORT Constant(uint64_t v, size_t s) : val(v), size(s) {}
 
- DATAFLOW_EXPORT  bool operator==(const Constant &rhs) const {
+ DYNINST_EXPORT  bool operator==(const Constant &rhs) const {
     return ((rhs.val == val) && (rhs.size == size));
   }
 
-  DATAFLOW_EXPORT bool operator<(const Constant &rhs) const {
+  DYNINST_EXPORT bool operator<(const Constant &rhs) const {
     if (val < rhs.val) return true;
     if (size < rhs.size) return true;
     return false;
   }
 
-  DATAFLOW_EXPORT const std::string format() const {
+  DYNINST_EXPORT const std::string format() const {
     std::stringstream ret;
     ret << val;
     if (size) {
@@ -181,14 +181,14 @@ typedef enum {
     extendMSBOp
 } Op;
 
-DATAFLOW_EXPORT ROSEOperation(Op o) : op(o), size(0) {}
-DATAFLOW_EXPORT ROSEOperation(Op o, size_t s) : op(o), size(s) {}
+DYNINST_EXPORT ROSEOperation(Op o) : op(o), size(0) {}
+DYNINST_EXPORT ROSEOperation(Op o, size_t s) : op(o), size(s) {}
 
-DATAFLOW_EXPORT bool operator==(const ROSEOperation &rhs) const {
+DYNINST_EXPORT bool operator==(const ROSEOperation &rhs) const {
     return ((rhs.op == op) && (rhs.size == size));
 }
 
-DATAFLOW_EXPORT const std::string format() const {
+DYNINST_EXPORT const std::string format() const {
     std::stringstream ret;
     ret << "<";
     switch(op) {
@@ -348,20 +348,20 @@ public:
   // static const AST::Ptr Placeholder;
   //
   // Single version: hand in an Assignment, get an AST
-    DATAFLOW_EXPORT static std::pair<AST::Ptr, bool> expand(const Assignment::Ptr &assignment, bool applyVisitors = true);
+    DYNINST_EXPORT static std::pair<AST::Ptr, bool> expand(const Assignment::Ptr &assignment, bool applyVisitors = true);
 
   // Hand in a set of Assignments
   // get back a map of Assignments->ASTs
   // We assume the assignments are prepped in the input; whatever
   // they point to is discarded.
-  DATAFLOW_EXPORT static bool expand(Result_t &res, 
+  DYNINST_EXPORT static bool expand(Result_t &res, 
                                      std::set<InstructionAPI::Instruction> &failedInsns,
                                      bool applyVisitors = true);
 
   // Hand in a Graph (of SliceNodes, natch) and get back a Result;
   // prior results from the Graph
   // are substituted into anything that uses them.
-  DATAFLOW_EXPORT static Retval_t expand(Dyninst::Graph::Ptr slice, DataflowAPI::Result_t &res);
+  DYNINST_EXPORT static Retval_t expand(Dyninst::Graph::Ptr slice, DataflowAPI::Result_t &res);
   
  private:
 

--- a/dataflowAPI/h/liveness.h
+++ b/dataflowAPI/h/liveness.h
@@ -51,7 +51,7 @@ struct livenessData{
 	bitArray in, out, use, def;
 };
 
-class DATAFLOW_EXPORT LivenessAnalyzer{
+class DYNINST_EXPORT LivenessAnalyzer{
 	std::map<ParseAPI::Block*, livenessData> blockLiveInfo;
 	std::map<ParseAPI::Function*, bool> liveFuncCalculated;
         std::map<ParseAPI::Function*, bitArray> funcRegsDefined;

--- a/dataflowAPI/h/slicing.h
+++ b/dataflowAPI/h/slicing.h
@@ -80,7 +80,7 @@ typedef boost::shared_ptr<Graph> GraphPtr;
 // Used in temp slicer; should probably
 // replace OperationNodes when we fix up
 // the DDG code.
-class DATAFLOW_EXPORT SliceNode : public Node {
+class DYNINST_EXPORT SliceNode : public Node {
  public:
   typedef boost::shared_ptr<SliceNode> Ptr;
       
@@ -120,7 +120,7 @@ class SliceEdge : public Edge {
   public:
    typedef boost::shared_ptr<SliceEdge> Ptr;
 
-   DATAFLOW_EXPORT static SliceEdge::Ptr create(SliceNode::Ptr source,
+   DYNINST_EXPORT static SliceEdge::Ptr create(SliceNode::Ptr source,
                                                 SliceNode::Ptr target,
                                                 AbsRegion const&data) {
       return Ptr(new SliceEdge(source, target, data)); 
@@ -146,29 +146,29 @@ class Slicer {
   // The cache is keyed with basic block starting address.
   typedef dyn_hash_map<Address, InsnVec> InsnCache;
 
-  DATAFLOW_EXPORT Slicer(AssignmentPtr a,
+  DYNINST_EXPORT Slicer(AssignmentPtr a,
 	 ParseAPI::Block *block,
 	 ParseAPI::Function *func,
 	 bool cache = true,
 	 bool stackAnalysis = true);
 
-  DATAFLOW_EXPORT Slicer(AssignmentPtr a,
+  DYNINST_EXPORT Slicer(AssignmentPtr a,
           ParseAPI::Block *block,
           ParseAPI::Function *func,
           AssignmentConverter *ac);
 
-  DATAFLOW_EXPORT Slicer(AssignmentPtr a,
+  DYNINST_EXPORT Slicer(AssignmentPtr a,
           ParseAPI::Block *block,
           ParseAPI::Function *func,
           AssignmentConverter *ac,
           InsnCache *c);
 
 
-  DATAFLOW_EXPORT ~Slicer();
+  DYNINST_EXPORT ~Slicer();
     
-  DATAFLOW_EXPORT static bool isWidenNode(Node::Ptr n);
+  DYNINST_EXPORT static bool isWidenNode(Node::Ptr n);
 
-  struct DATAFLOW_EXPORT ContextElement {
+  struct DYNINST_EXPORT ContextElement {
     // We can implicitly find the callsite given a block,
     // since calls end blocks. It's easier to look up 
     // the successor this way than with an address.
@@ -196,7 +196,7 @@ class Slicer {
 
 
   // Where we are in a particular search...
-  struct DATAFLOW_EXPORT Location {
+  struct DYNINST_EXPORT Location {
     // The block we're looking through
     ParseAPI::Function *func;
     ParseAPI::Block *block; // current block
@@ -226,7 +226,7 @@ class Slicer {
   // keep a list of the currently active elements
   // that are at the `leading edge' of the 
   // under-construction slice
-  struct DATAFLOW_EXPORT Element {
+  struct DYNINST_EXPORT Element {
     Element(ParseAPI::Block * b,
         ParseAPI::Function * f,
         AbsRegion const& r,
@@ -254,7 +254,7 @@ class Slicer {
 
   // State for recursive slicing is a context, location pair
   // and a list of AbsRegions that are being searched for.
-  struct DATAFLOW_EXPORT SliceFrame {
+  struct DYNINST_EXPORT SliceFrame {
     SliceFrame(
         Location const& l,
         Context const& c)
@@ -285,55 +285,55 @@ class Slicer {
     typedef std::pair<ParseAPI::Function *, int> StackDepth_t;
     typedef std::stack<StackDepth_t> CallStack_t;
 
-    DATAFLOW_EXPORT bool performCacheClear() { if (clearCache) {clearCache = false; return true;} else return false; }
-    DATAFLOW_EXPORT void setClearCache(bool b) { clearCache = b; }
-    DATAFLOW_EXPORT bool searchForControlFlowDep() { return controlFlowDep; }
-    DATAFLOW_EXPORT void setSearchForControlFlowDep(bool cfd) { controlFlowDep = cfd; }
+    DYNINST_EXPORT bool performCacheClear() { if (clearCache) {clearCache = false; return true;} else return false; }
+    DYNINST_EXPORT void setClearCache(bool b) { clearCache = b; }
+    DYNINST_EXPORT bool searchForControlFlowDep() { return controlFlowDep; }
+    DYNINST_EXPORT void setSearchForControlFlowDep(bool cfd) { controlFlowDep = cfd; }
 
     // A negative number means that we do not bound slicing size.
-    DATAFLOW_EXPORT virtual int slicingSizeLimitFactor() { return -1; }
+    DYNINST_EXPORT virtual int slicingSizeLimitFactor() { return -1; }
 
-    DATAFLOW_EXPORT virtual bool allowImprecision() { return false; }
-    DATAFLOW_EXPORT virtual bool widenAtPoint(AssignmentPtr) { return false; }
-    DATAFLOW_EXPORT virtual bool endAtPoint(AssignmentPtr) { return false; }
-    DATAFLOW_EXPORT virtual bool followCall(ParseAPI::Function * /*callee*/,
+    DYNINST_EXPORT virtual bool allowImprecision() { return false; }
+    DYNINST_EXPORT virtual bool widenAtPoint(AssignmentPtr) { return false; }
+    DYNINST_EXPORT virtual bool endAtPoint(AssignmentPtr) { return false; }
+    DYNINST_EXPORT virtual bool followCall(ParseAPI::Function * /*callee*/,
                                            CallStack_t & /*cs*/,
                                            AbsRegion /*argument*/) { 
        return false; 
     }
-    DATAFLOW_EXPORT virtual std::vector<ParseAPI::Function *> 
+    DYNINST_EXPORT virtual std::vector<ParseAPI::Function *> 
         followCallBackward(ParseAPI::Block * /*callerB*/,
             CallStack_t & /*cs*/,
             AbsRegion /*argument*/) {
             std::vector<ParseAPI::Function *> vec;
             return vec;
         }
-    DATAFLOW_EXPORT virtual bool addPredecessor(AbsRegion /*reg*/) {
+    DYNINST_EXPORT virtual bool addPredecessor(AbsRegion /*reg*/) {
         return true;
     }
-    DATAFLOW_EXPORT virtual bool widenAtAssignment(const AbsRegion & /*in*/,
+    DYNINST_EXPORT virtual bool widenAtAssignment(const AbsRegion & /*in*/,
                                                   const AbsRegion & /*out*/) { 
        return false; 
     }
-    DATAFLOW_EXPORT virtual ~Predicates() {}
+    DYNINST_EXPORT virtual ~Predicates() {}
 
     // Callback function when adding a new node to the slice.
     // Return true if we want to continue slicing
-    DATAFLOW_EXPORT virtual bool addNodeCallback(AssignmentPtr,
+    DYNINST_EXPORT virtual bool addNodeCallback(AssignmentPtr,
                                                  std::set<ParseAPI::Edge*> &) { return true;}
     // Callback function after we have added new a node and corresponding new edges to the slice.
     // This function allows users to inspect the current slice graph and determine which abslocs
     // need further slicing and which abslocs are no longer interesting, by modifying the current
     // SliceFrame.
-    DATAFLOW_EXPORT virtual bool modifyCurrentFrame(SliceFrame &, GraphPtr, Slicer*) {return true;} 						
-    DATAFLOW_EXPORT virtual bool ignoreEdge(ParseAPI::Edge*) { return false;}
-    DATAFLOW_EXPORT Predicates() : clearCache(false), controlFlowDep(false) {}						
+    DYNINST_EXPORT virtual bool modifyCurrentFrame(SliceFrame &, GraphPtr, Slicer*) {return true;} 						
+    DYNINST_EXPORT virtual bool ignoreEdge(ParseAPI::Edge*) { return false;}
+    DYNINST_EXPORT Predicates() : clearCache(false), controlFlowDep(false) {}						
 
   };
 
-  DATAFLOW_EXPORT GraphPtr forwardSlice(Predicates &predicates);
+  DYNINST_EXPORT GraphPtr forwardSlice(Predicates &predicates);
   
-  DATAFLOW_EXPORT GraphPtr backwardSlice(Predicates &predicates);
+  DYNINST_EXPORT GraphPtr backwardSlice(Predicates &predicates);
 
  private:
 

--- a/dataflowAPI/h/stackanalysis.h
+++ b/dataflowAPI/h/stackanalysis.h
@@ -82,7 +82,7 @@ public:
    // This class represents a stack pointer definition by recording the block
    // and address of the definition, as well as the original absloc that was
    // defined by the definition.
-   class DATAFLOW_EXPORT Definition {
+   class DYNINST_EXPORT Definition {
    public:
       typedef enum {TOP, BOTTOM, DEF} Type;
       Address addr;
@@ -133,7 +133,7 @@ public:
    };
 
    // This class represents offsets on the stack, which we call heights.
-   class DATAFLOW_EXPORT Height {
+   class DYNINST_EXPORT Height {
    public:
       typedef signed long Height_t;
       typedef enum {TOP, BOTTOM, HEIGHT} Type;
@@ -241,7 +241,7 @@ public:
    // pointer definitions to adjust the locations of variables on the stack.
    // Thus, it makes sense to associate each stack pointer (Height) to the point
    // at which it was defined (Definition).
-   class DATAFLOW_EXPORT DefHeight {
+   class DYNINST_EXPORT DefHeight {
    public:
       DefHeight(const Definition &d, const Height &h) : def(d), height(h) {}
 
@@ -265,7 +265,7 @@ public:
    // result, we need a structure to hold sets of DefHeights.  This class fills
    // that role, providing several useful methods to build, modify, and
    // extract information from such sets.
-   class DATAFLOW_EXPORT DefHeightSet {
+   class DYNINST_EXPORT DefHeightSet {
    public:
       bool operator==(const DefHeightSet &other) const {
          return defHeights == other.defHeights;
@@ -354,7 +354,7 @@ public:
    // function T : (RegisterVector, RegisterID, RegisterID, value) ->
    // (RegisterVector).
    typedef std::map<Absloc, DefHeightSet> AbslocState;
-   class DATAFLOW_EXPORT TransferFunc {
+   class DYNINST_EXPORT TransferFunc {
    public:
       typedef enum {TOP, BOTTOM, OTHER} Type;
 
@@ -495,31 +495,31 @@ public:
    typedef std::map<ParseAPI::Block *, std::map<Offset, TransferSet> >
       CallEffects;
 
-   DATAFLOW_EXPORT StackAnalysis();
-   DATAFLOW_EXPORT StackAnalysis(ParseAPI::Function *f);
-   DATAFLOW_EXPORT StackAnalysis(ParseAPI::Function *f,
+   DYNINST_EXPORT StackAnalysis();
+   DYNINST_EXPORT StackAnalysis(ParseAPI::Function *f);
+   DYNINST_EXPORT StackAnalysis(ParseAPI::Function *f,
       const std::map<Address, Address> &crm,
       const std::map<Address, TransferSet> &fs,
       const std::set<Address> &toppable = std::set<Address>());
 
-    DATAFLOW_EXPORT virtual ~StackAnalysis() = default;
-    DATAFLOW_EXPORT StackAnalysis& operator=(const Dyninst::StackAnalysis&) = default;
+    DYNINST_EXPORT virtual ~StackAnalysis() = default;
+    DYNINST_EXPORT StackAnalysis& operator=(const Dyninst::StackAnalysis&) = default;
 
-    DATAFLOW_EXPORT Height find(ParseAPI::Block *, Address addr, Absloc loc);
-    DATAFLOW_EXPORT DefHeightSet findDefHeight(ParseAPI::Block *block,
+    DYNINST_EXPORT Height find(ParseAPI::Block *, Address addr, Absloc loc);
+    DYNINST_EXPORT DefHeightSet findDefHeight(ParseAPI::Block *block,
         Address addr, Absloc loc);
-   DATAFLOW_EXPORT Height findSP(ParseAPI::Block *, Address addr);
-   DATAFLOW_EXPORT Height findFP(ParseAPI::Block *, Address addr);
-   DATAFLOW_EXPORT void findDefinedHeights(ParseAPI::Block* b, Address addr,
+   DYNINST_EXPORT Height findSP(ParseAPI::Block *, Address addr);
+   DYNINST_EXPORT Height findFP(ParseAPI::Block *, Address addr);
+   DYNINST_EXPORT void findDefinedHeights(ParseAPI::Block* b, Address addr,
       std::vector<std::pair<Absloc, Height> >& heights);
    // TODO: Update DataflowAPI manual
-   DATAFLOW_EXPORT void findDefHeightPairs(ParseAPI::Block *b, Address addr,
+   DYNINST_EXPORT void findDefHeightPairs(ParseAPI::Block *b, Address addr,
       std::vector<std::pair<Absloc, DefHeightSet> > &defHeights);
 
-   DATAFLOW_EXPORT bool canGetFunctionSummary();
-   DATAFLOW_EXPORT bool getFunctionSummary(TransferSet &summary);
+   DYNINST_EXPORT bool canGetFunctionSummary();
+   DYNINST_EXPORT bool getFunctionSummary(TransferSet &summary);
 
-   DATAFLOW_EXPORT void debug();
+   DYNINST_EXPORT void debug();
 
 private:
    std::string format(const AbslocState &input) const;

--- a/dataflowAPI/src/ExpressionConversionVisitor.h
+++ b/dataflowAPI/src/ExpressionConversionVisitor.h
@@ -64,15 +64,15 @@ namespace Dyninst
       typedef PowerpcConditionRegisterAccessGranularity regField;
 
     public:
-    DATAFLOW_EXPORT ExpressionConversionVisitor(Architecture a, uint64_t ad, uint64_t s) :
+    DYNINST_EXPORT ExpressionConversionVisitor(Architecture a, uint64_t ad, uint64_t s) :
       roseExpression(NULL), arch(a), addr(ad), size(s) {}
       
-      DATAFLOW_EXPORT SgAsmExpression *getRoseExpression() { return roseExpression; }
+      DYNINST_EXPORT SgAsmExpression *getRoseExpression() { return roseExpression; }
       
-      DATAFLOW_EXPORT virtual void visit(InstructionAPI::BinaryFunction *binfunc);
-      DATAFLOW_EXPORT virtual void visit(InstructionAPI::Immediate *immed);
-      DATAFLOW_EXPORT virtual void visit(InstructionAPI::RegisterAST *regast);
-      DATAFLOW_EXPORT virtual void visit(InstructionAPI::Dereference *deref);
+      DYNINST_EXPORT virtual void visit(InstructionAPI::BinaryFunction *binfunc);
+      DYNINST_EXPORT virtual void visit(InstructionAPI::Immediate *immed);
+      DYNINST_EXPORT virtual void visit(InstructionAPI::RegisterAST *regast);
+      DYNINST_EXPORT virtual void visit(InstructionAPI::Dereference *deref);
       
     private:
 

--- a/dataflowAPI/src/RoseInsnFactory.h
+++ b/dataflowAPI/src/RoseInsnFactory.h
@@ -85,11 +85,11 @@ namespace Dyninst {
             typedef boost::shared_ptr<InstructionAPI::Instruction> InstructionPtr;
             uint64_t _addr = 0 ;
         public:
-            DATAFLOW_EXPORT RoseInsnFactory(void) { }
+            DYNINST_EXPORT RoseInsnFactory(void) { }
 
-            DATAFLOW_EXPORT virtual ~RoseInsnFactory(void) { }
+            DYNINST_EXPORT virtual ~RoseInsnFactory(void) { }
 
-            DATAFLOW_EXPORT virtual SgAsmInstruction *convert(const InstructionAPI::Instruction &insn, uint64_t addr);
+            DYNINST_EXPORT virtual SgAsmInstruction *convert(const InstructionAPI::Instruction &insn, uint64_t addr);
 
         protected:
             virtual SgAsmInstruction *createInsn() = 0;
@@ -112,9 +112,9 @@ namespace Dyninst {
 
         class RoseInsnX86Factory : public RoseInsnFactory {
         public:
-            DATAFLOW_EXPORT RoseInsnX86Factory(Architecture arch) : a(arch) { }
+            DYNINST_EXPORT RoseInsnX86Factory(Architecture arch) : a(arch) { }
 
-            DATAFLOW_EXPORT virtual ~RoseInsnX86Factory() { }
+            DYNINST_EXPORT virtual ~RoseInsnX86Factory() { }
 
         private:
             Architecture a;
@@ -137,9 +137,9 @@ namespace Dyninst {
 
         class RoseInsnPPCFactory : public RoseInsnFactory {
         public:
-            DATAFLOW_EXPORT RoseInsnPPCFactory(void) { }
+            DYNINST_EXPORT RoseInsnPPCFactory(void) { }
 
-            DATAFLOW_EXPORT virtual ~RoseInsnPPCFactory(void) { }
+            DYNINST_EXPORT virtual ~RoseInsnPPCFactory(void) { }
 
         private:
             virtual SgAsmInstruction *createInsn();
@@ -163,9 +163,9 @@ namespace Dyninst {
 
         class RoseInsnArmv8Factory : public RoseInsnFactory {
         public:
-            DATAFLOW_EXPORT RoseInsnArmv8Factory(Architecture arch) : a(arch) { }
+            DYNINST_EXPORT RoseInsnArmv8Factory(Architecture arch) : a(arch) { }
 
-            DATAFLOW_EXPORT virtual ~RoseInsnArmv8Factory() { }
+            DYNINST_EXPORT virtual ~RoseInsnArmv8Factory() { }
 
         private:
             Architecture a;
@@ -188,9 +188,9 @@ namespace Dyninst {
 
         class RoseInsnAMDGPUFactory : public RoseInsnFactory {
         public:
-            DATAFLOW_EXPORT RoseInsnAMDGPUFactory(Architecture arch) : a(arch) { }
+            DYNINST_EXPORT RoseInsnAMDGPUFactory(Architecture arch) : a(arch) { }
 
-            DATAFLOW_EXPORT virtual ~RoseInsnAMDGPUFactory() { }
+            DYNINST_EXPORT virtual ~RoseInsnAMDGPUFactory() { }
 
         private:
             Architecture a;

--- a/dataflowAPI/src/SymEvalVisitors.h
+++ b/dataflowAPI/src/SymEvalVisitors.h
@@ -51,19 +51,19 @@ class StackVisitor : public ASTVisitor {
 	       StackAnalysis::Height &frameHeight) :
     addr_(a), func_(func), stack_(stackHeight), frame_(frameHeight) {}
 
-    DATAFLOW_EXPORT virtual AST::Ptr visit(AST *);
-    DATAFLOW_EXPORT virtual AST::Ptr visit(BottomAST *);
-    DATAFLOW_EXPORT virtual AST::Ptr visit(ConstantAST *);
-    DATAFLOW_EXPORT virtual AST::Ptr visit(VariableAST *);
-    DATAFLOW_EXPORT virtual AST::Ptr visit(RoseAST *);
-    DATAFLOW_EXPORT virtual AST::Ptr visit(StackAST *);
-    DATAFLOW_EXPORT virtual ASTPtr visit(InputVariableAST *) {return AST::Ptr();}
-    DATAFLOW_EXPORT virtual ASTPtr visit(ReferenceAST *) {return AST::Ptr();}
-    DATAFLOW_EXPORT virtual ASTPtr visit(StpAST *) {return AST::Ptr();}
-    DATAFLOW_EXPORT virtual ASTPtr visit(YicesAST *) {return AST::Ptr();}
-    DATAFLOW_EXPORT virtual ASTPtr visit(SemanticsAST *) {return AST::Ptr();}
+    DYNINST_EXPORT virtual AST::Ptr visit(AST *);
+    DYNINST_EXPORT virtual AST::Ptr visit(BottomAST *);
+    DYNINST_EXPORT virtual AST::Ptr visit(ConstantAST *);
+    DYNINST_EXPORT virtual AST::Ptr visit(VariableAST *);
+    DYNINST_EXPORT virtual AST::Ptr visit(RoseAST *);
+    DYNINST_EXPORT virtual AST::Ptr visit(StackAST *);
+    DYNINST_EXPORT virtual ASTPtr visit(InputVariableAST *) {return AST::Ptr();}
+    DYNINST_EXPORT virtual ASTPtr visit(ReferenceAST *) {return AST::Ptr();}
+    DYNINST_EXPORT virtual ASTPtr visit(StpAST *) {return AST::Ptr();}
+    DYNINST_EXPORT virtual ASTPtr visit(YicesAST *) {return AST::Ptr();}
+    DYNINST_EXPORT virtual ASTPtr visit(SemanticsAST *) {return AST::Ptr();}
 
-    DATAFLOW_EXPORT virtual ~StackVisitor() {}
+    DYNINST_EXPORT virtual ~StackVisitor() {}
 
   private:
   Address addr_;
@@ -77,20 +77,20 @@ class BooleanVisitor : public ASTVisitor {
  public:
     BooleanVisitor() {}
 
-    DATAFLOW_EXPORT virtual AST::Ptr visit(AST *);
-    DATAFLOW_EXPORT virtual AST::Ptr visit(BottomAST *);
-    DATAFLOW_EXPORT virtual AST::Ptr visit(ConstantAST *);
-    DATAFLOW_EXPORT virtual AST::Ptr visit(VariableAST *);
-    DATAFLOW_EXPORT virtual AST::Ptr visit(RoseAST *);
-    DATAFLOW_EXPORT virtual AST::Ptr visit(StackAST *);
-    DATAFLOW_EXPORT virtual ASTPtr visit(InputVariableAST *) {return AST::Ptr();}
-    DATAFLOW_EXPORT virtual ASTPtr visit(ReferenceAST *) {return AST::Ptr();}
-    DATAFLOW_EXPORT virtual ASTPtr visit(StpAST *) {return AST::Ptr();}
-    DATAFLOW_EXPORT virtual ASTPtr visit(YicesAST *) {return AST::Ptr();}
-    DATAFLOW_EXPORT virtual ASTPtr visit(SemanticsAST *) {return AST::Ptr();}
+    DYNINST_EXPORT virtual AST::Ptr visit(AST *);
+    DYNINST_EXPORT virtual AST::Ptr visit(BottomAST *);
+    DYNINST_EXPORT virtual AST::Ptr visit(ConstantAST *);
+    DYNINST_EXPORT virtual AST::Ptr visit(VariableAST *);
+    DYNINST_EXPORT virtual AST::Ptr visit(RoseAST *);
+    DYNINST_EXPORT virtual AST::Ptr visit(StackAST *);
+    DYNINST_EXPORT virtual ASTPtr visit(InputVariableAST *) {return AST::Ptr();}
+    DYNINST_EXPORT virtual ASTPtr visit(ReferenceAST *) {return AST::Ptr();}
+    DYNINST_EXPORT virtual ASTPtr visit(StpAST *) {return AST::Ptr();}
+    DYNINST_EXPORT virtual ASTPtr visit(YicesAST *) {return AST::Ptr();}
+    DYNINST_EXPORT virtual ASTPtr visit(SemanticsAST *) {return AST::Ptr();}
 
   
-    DATAFLOW_EXPORT virtual ~BooleanVisitor() {}
+    DYNINST_EXPORT virtual ~BooleanVisitor() {}
     
   private:
 };

--- a/dwarf/h/dwarfExprParser.h
+++ b/dwarf/h/dwarfExprParser.h
@@ -46,16 +46,16 @@ namespace DwarfDyninst{
 
 class DwarfResult;
 
-DYNDWARF_EXPORT int Register_DWARFtoMachineEnc32(int n);
-DYNDWARF_EXPORT int Register_DWARFtoMachineEnc64(int n);
+DYNINST_EXPORT int Register_DWARFtoMachineEnc32(int n);
+DYNINST_EXPORT int Register_DWARFtoMachineEnc64(int n);
 
-DYNDWARF_EXPORT bool decodeDwarfExpression(Dwarf_Op * expr,
+DYNINST_EXPORT bool decodeDwarfExpression(Dwarf_Op * expr,
         Dwarf_Sword listlen,
         long int *initialStackValue,
         Dyninst::VariableLocation &loc,
         Dyninst::Architecture arch);
 
-DYNDWARF_EXPORT bool decodeDwarfExpression(Dwarf_Op * expr,
+DYNINST_EXPORT bool decodeDwarfExpression(Dwarf_Op * expr,
         Dwarf_Sword listlen,
         long int *initialStackValue,
         DwarfResult &res,

--- a/dwarf/h/dwarfFrameParser.h
+++ b/dwarf/h/dwarfFrameParser.h
@@ -60,7 +60,7 @@ typedef enum {
     FE_No_Error
 } FrameErrors_t;
 
-class DYNDWARF_EXPORT DwarfFrameParser {
+class DYNINST_EXPORT DwarfFrameParser {
 public:
 
     typedef boost::shared_ptr<DwarfFrameParser> Ptr;

--- a/dwarf/h/dwarfHandle.h
+++ b/dwarf/h/dwarfHandle.h
@@ -45,7 +45,7 @@ class DwarfFrameParser;
 
 typedef boost::shared_ptr<DwarfFrameParser> DwarfFrameParserPtr;
 
-class DYNDWARF_EXPORT DwarfHandle {
+class DYNINST_EXPORT DwarfHandle {
   public:
    typedef DwarfHandle* ptr;
   private:

--- a/dwarf/h/dwarfResult.h
+++ b/dwarf/h/dwarfResult.h
@@ -44,7 +44,7 @@ class ProcessReader;
 
 namespace DwarfDyninst {
 
-class DYNDWARF_EXPORT DwarfResult {
+class DYNINST_EXPORT DwarfResult {
     // An interface for building representations of Dwarf expressions.
     // In concrete mode, we have access to process state and
     // can calculate a value. In symbolic mode we lack this information
@@ -110,7 +110,7 @@ protected:
 
 };
 
-class DYNDWARF_EXPORT SymbolicDwarfResult : public DwarfResult {
+class DYNINST_EXPORT SymbolicDwarfResult : public DwarfResult {
 
 public:
     SymbolicDwarfResult(VariableLocation &v, Architecture a) :
@@ -139,7 +139,7 @@ private:
     VariableLocation &var;
 };
 
-class DYNDWARF_EXPORT ConcreteDwarfResult : public DwarfResult {
+class DYNINST_EXPORT ConcreteDwarfResult : public DwarfResult {
 
 public:
     ConcreteDwarfResult(ProcessReader *r, Architecture a, 

--- a/dwarf/src/dwarf_subrange.h
+++ b/dwarf/src/dwarf_subrange.h
@@ -51,8 +51,8 @@ struct dwarf_bounds {
 	dwarf_result lower, upper;
 };
 
-DYNDWARF_EXPORT dwarf_bounds dwarf_subrange_bounds(Dwarf_Die *die);
-DYNDWARF_EXPORT dwarf_result dwarf_subrange_length_from_enum(Dwarf_Die *die);
+DYNINST_EXPORT dwarf_bounds dwarf_subrange_bounds(Dwarf_Die *die);
+DYNINST_EXPORT dwarf_result dwarf_subrange_length_from_enum(Dwarf_Die *die);
 
 } // namespace DwarfDyninst
 } // namespace Dyninst

--- a/dynC_API/CMakeLists.txt
+++ b/dynC_API/CMakeLists.txt
@@ -20,7 +20,6 @@ dyninst_library(
   PUBLIC_HEADER_FILES ${_public_headers}
   PRIVATE_HEADER_FILES ${_private_headers}
   SOURCE_FILES ${_sources}
-  DEFINES DYNC_EXPORTS
   DYNINST_DEPS common dyninstAPI symtabAPI
 )
 # cmake-format: on

--- a/dynC_API/h/dynC.h
+++ b/dynC_API/h/dynC.h
@@ -40,32 +40,21 @@
 #include <string>
 #include <map>
 #include <vector>
-
-#if !defined(DYNC_EXPORT)
-  #if defined(_MSC_VER)
-    #if defined(DYNC_EXPORTS)
-      #define DYNC_EXPORT __declspec(dllexport)
-    #else
-      #define DYNC_EXPORT __declspec(dllimport)
-    #endif
-  #else
-    #define DYNC_EXPORT __attribute__((visibility ("default")))
-#endif
-#endif
+#include "dyninst_visibility.h"
 
 namespace dynC_API{
-   DYNC_EXPORT BPatch_snippet *createSnippet(const char *s, BPatch_point &point);
-   DYNC_EXPORT std::map<BPatch_point *, BPatch_snippet *> *createSnippet(const char *s, std::vector<BPatch_point *> points);
+   DYNINST_EXPORT BPatch_snippet *createSnippet(const char *s, BPatch_point &point);
+   DYNINST_EXPORT std::map<BPatch_point *, BPatch_snippet *> *createSnippet(const char *s, std::vector<BPatch_point *> points);
 
-   DYNC_EXPORT BPatch_snippet *createSnippet(FILE *f, BPatch_point &point);
-   DYNC_EXPORT std::map<BPatch_point *, BPatch_snippet *> *createSnippet(FILE *f, std::vector<BPatch_point *> points);
+   DYNINST_EXPORT BPatch_snippet *createSnippet(FILE *f, BPatch_point &point);
+   DYNINST_EXPORT std::map<BPatch_point *, BPatch_snippet *> *createSnippet(FILE *f, std::vector<BPatch_point *> points);
 
-   DYNC_EXPORT BPatch_snippet *createSnippet(std::string str, BPatch_point &point);
-   DYNC_EXPORT std::map<BPatch_point *, BPatch_snippet *> *createSnippet(std::string str, std::vector<BPatch_point *> points);
+   DYNINST_EXPORT BPatch_snippet *createSnippet(std::string str, BPatch_point &point);
+   DYNINST_EXPORT std::map<BPatch_point *, BPatch_snippet *> *createSnippet(std::string str, std::vector<BPatch_point *> points);
 
-   DYNC_EXPORT BPatch_snippet *createSnippet(const char *s, BPatch_addressSpace &addSpace);
-   DYNC_EXPORT BPatch_snippet *createSnippet(FILE *f, BPatch_addressSpace &addSpace);
-   DYNC_EXPORT BPatch_snippet *createSnippet(std::string str, BPatch_addressSpace &addSpace);
+   DYNINST_EXPORT BPatch_snippet *createSnippet(const char *s, BPatch_addressSpace &addSpace);
+   DYNINST_EXPORT BPatch_snippet *createSnippet(FILE *f, BPatch_addressSpace &addSpace);
+   DYNINST_EXPORT BPatch_snippet *createSnippet(std::string str, BPatch_addressSpace &addSpace);
    
 //dynC internal
    std::string mangle(const char *varName, const char *snippetName, const char *typeName);

--- a/dyninstAPI/h/BPatch.h
+++ b/dyninstAPI/h/BPatch.h
@@ -115,7 +115,7 @@ typedef struct {
 } BPatch_remoteHost;
 // --------------------------------------------------------------------
 
-class BPATCH_DLL_EXPORT BPatch {
+class DYNINST_EXPORT BPatch {
     friend class BPatch_thread;
     friend class BPatch_process;
     friend class BPatch_point;

--- a/dyninstAPI/h/BPatch_Set.h
+++ b/dyninstAPI/h/BPatch_Set.h
@@ -69,7 +69,7 @@ struct comparison {
 };
 
 template<class Key, class Compare = comparison<Key> >
-class BPATCH_DLL_EXPORT BPatch_Set {
+class DYNINST_EXPORT BPatch_Set {
    friend class BPatch_basicBlock;
    friend class BPatch_function;
    friend class BPatch_flowGraph;

--- a/dyninstAPI/h/BPatch_addressSpace.h
+++ b/dyninstAPI/h/BPatch_addressSpace.h
@@ -62,7 +62,7 @@ namespace Dyninst {
     typedef boost::shared_ptr<PatchMgr> PatchMgrPtr;
     typedef boost::shared_ptr<DynAddrSpace> DynAddrSpacePtr;
     typedef boost::shared_ptr<Instance> InstancePtr;
-    BPATCH_DLL_EXPORT PatchMgrPtr convert(const BPatch_addressSpace *);
+    DYNINST_EXPORT PatchMgrPtr convert(const BPatch_addressSpace *);
   }
   namespace SymtabAPI {
     class Symbol;
@@ -90,7 +90,7 @@ typedef enum{
 } processType;
 
 
-class BPATCH_DLL_EXPORT BPatchSnippetHandle {
+class DYNINST_EXPORT BPatchSnippetHandle {
   friend class BPatch_point;
   friend class BPatch_image;
   friend class BPatch_process;
@@ -142,7 +142,7 @@ class BPATCH_DLL_EXPORT BPatchSnippetHandle {
   
 };
 
-class BPATCH_DLL_EXPORT BPatch_addressSpace {
+class DYNINST_EXPORT BPatch_addressSpace {
   friend class BPatch;
   friend class BPatch_image;
   friend class BPatch_function;

--- a/dyninstAPI/h/BPatch_basicBlock.h
+++ b/dyninstAPI/h/BPatch_basicBlock.h
@@ -61,11 +61,11 @@ class BPatch_basicBlock;
 namespace Dyninst {
   namespace ParseAPI {
     class Block;
-    BPATCH_DLL_EXPORT Block *convert(const BPatch_basicBlock *);
+    DYNINST_EXPORT Block *convert(const BPatch_basicBlock *);
   }
   namespace PatchAPI {
     class PatchBlock;
-    BPATCH_DLL_EXPORT PatchBlock *convert(const BPatch_basicBlock *);
+    DYNINST_EXPORT PatchBlock *convert(const BPatch_basicBlock *);
   }
 }
 
@@ -73,13 +73,13 @@ namespace Dyninst {
 namespace std {
 template <>
    struct less<BPatch_basicBlock *> {
-   BPATCH_DLL_EXPORT bool operator()(const BPatch_basicBlock * const &l, const BPatch_basicBlock * const &r) const;
+   DYNINST_EXPORT bool operator()(const BPatch_basicBlock * const &l, const BPatch_basicBlock * const &r) const;
 };
 }
 
 template <>
 struct comparison <BPatch_basicBlock *> {
-   BPATCH_DLL_EXPORT bool operator()(const BPatch_basicBlock * const &x, 
+   DYNINST_EXPORT bool operator()(const BPatch_basicBlock * const &x, 
                    const BPatch_basicBlock * const &y) const;
 };
 
@@ -94,7 +94,7 @@ struct comparison <BPatch_basicBlock *> {
  */
 class BPatch_flowGraph;
 
-struct BPATCH_DLL_EXPORT insnPredicate
+struct DYNINST_EXPORT insnPredicate
 {
   using result_type = bool;
   using argument_type = Dyninst::InstructionAPI::Instruction;
@@ -103,7 +103,7 @@ struct BPATCH_DLL_EXPORT insnPredicate
     
 };
 
-class BPATCH_DLL_EXPORT BPatch_basicBlock {
+class DYNINST_EXPORT BPatch_basicBlock {
   friend class BPatch_flowGraph;
   friend class TarjanDominator;
   friend class dominatorCFG;
@@ -318,6 +318,6 @@ class BPATCH_DLL_EXPORT BPatch_basicBlock {
 
 };
 
-BPATCH_DLL_EXPORT std::ostream& operator<<(std::ostream&,BPatch_basicBlock&);
+DYNINST_EXPORT std::ostream& operator<<(std::ostream&,BPatch_basicBlock&);
 
 #endif /* _BPatch_basicBlock_h_ */

--- a/dyninstAPI/h/BPatch_basicBlockLoop.h
+++ b/dyninstAPI/h/BPatch_basicBlockLoop.h
@@ -58,7 +58,7 @@ class PatchLoop;
 class BPatch_variableExpr;
 class BPatch_loopTreeNode;
 
-class BPATCH_DLL_EXPORT BPatch_basicBlockLoop : 
+class DYNINST_EXPORT BPatch_basicBlockLoop : 
    public Dyninst::AnnotatableSparse 
 {
 	friend class BPatch_flowGraph;

--- a/dyninstAPI/h/BPatch_binaryEdit.h
+++ b/dyninstAPI/h/BPatch_binaryEdit.h
@@ -60,7 +60,7 @@ class func_instance;
 class rpcMgr;
 struct batchInsertionRecord;
 
-class BPATCH_DLL_EXPORT BPatch_binaryEdit : public BPatch_addressSpace {
+class DYNINST_EXPORT BPatch_binaryEdit : public BPatch_addressSpace {
     friend class BPatch;
     friend class BPatch_image;
     friend class BPatch_function;

--- a/dyninstAPI/h/BPatch_dll.h
+++ b/dyninstAPI/h/BPatch_dll.h
@@ -32,23 +32,23 @@
 #define _BPatch_dll_h_
 
 // TEMPORARY PARADYND FLOWGRAPH KLUGE
-// If we are building BPatch classes into paradynd we want BPATCH_DLL_EXPORT 
+// If we are building BPatch classes into paradynd we want DYNINST_EXPORT 
 // to be defined as the empty string (for all platforms). This currently tests
 // SHM_SAMPLING because it is defined for paradynd and not for the dyninst
 // dll or dyninst clients, read '#if PARADYND'. 
 #ifdef SHM_SAMPLING
-#define	BPATCH_DLL_EXPORT
+#define	DYNINST_EXPORT
 #else
 #if defined(_MSC_VER)
 
 #ifdef BPATCH_DLL_BUILD
 // we are building the dyninstAPI DLL
-#define	BPATCH_DLL_EXPORT	__declspec(dllexport)
+#define	DYNINST_EXPORT	__declspec(dllexport)
 
 #else
 
 // we are not building the dyninstAPI DLL
-#define	BPATCH_DLL_EXPORT	__declspec(dllimport)
+#define	DYNINST_EXPORT	__declspec(dllimport)
 #if _MSC_VER >= 1300
 #define	BPATCH_DLL_IMPORT   1
 #endif
@@ -57,7 +57,7 @@
 #else
 
 // we are not building for a Windows target 
-#define	BPATCH_DLL_EXPORT  __attribute__((visibility ("default")))
+#define	DYNINST_EXPORT  __attribute__((visibility ("default")))
 
 #endif
 
@@ -65,6 +65,6 @@
 
 
 // declare our version string
-extern "C" BPATCH_DLL_EXPORT const char V_libdyninstAPI[];
+extern "C" DYNINST_EXPORT const char V_libdyninstAPI[];
 
 #endif /* _BPatch_dll_h_ */

--- a/dyninstAPI/h/BPatch_edge.h
+++ b/dyninstAPI/h/BPatch_edge.h
@@ -47,11 +47,11 @@ typedef enum {
 namespace Dyninst {
    namespace ParseAPI {
       class Edge;
-      BPATCH_DLL_EXPORT Edge *convert(const BPatch_edge *);
+      DYNINST_EXPORT Edge *convert(const BPatch_edge *);
    }
    namespace PatchAPI {
       class PatchEdge;
-      BPATCH_DLL_EXPORT PatchEdge *convert(const BPatch_edge *);
+      DYNINST_EXPORT PatchEdge *convert(const BPatch_edge *);
    }
 }
 
@@ -59,7 +59,7 @@ namespace Dyninst {
 
 /** An edge between two blocks
  */
-class BPATCH_DLL_EXPORT BPatch_edge {
+class DYNINST_EXPORT BPatch_edge {
    friend Dyninst::ParseAPI::Edge *Dyninst::ParseAPI::convert(const BPatch_edge *);
    friend Dyninst::PatchAPI::PatchEdge *Dyninst::PatchAPI::convert(const BPatch_edge *);
 

--- a/dyninstAPI/h/BPatch_flowGraph.h
+++ b/dyninstAPI/h/BPatch_flowGraph.h
@@ -62,7 +62,7 @@ namespace Dyninst {
         class PatchLoop;
     }
 }    
-class BPATCH_DLL_EXPORT BPatch_flowGraph : 
+class DYNINST_EXPORT BPatch_flowGraph : 
       public Dyninst::AnnotatableSparse 
 {
   friend class BPatch_basicBlock;

--- a/dyninstAPI/h/BPatch_frame.h
+++ b/dyninstAPI/h/BPatch_frame.h
@@ -45,7 +45,7 @@ typedef enum {
 class BPatch_function;
 class BPatch_thread;
 
-class BPATCH_DLL_EXPORT BPatch_frame {
+class DYNINST_EXPORT BPatch_frame {
     friend class BPatch_thread;
     BPatch_thread *thread;
 

--- a/dyninstAPI/h/BPatch_function.h
+++ b/dyninstAPI/h/BPatch_function.h
@@ -61,18 +61,18 @@ class BPatch_function;
 namespace Dyninst {
   namespace ParseAPI {
     class Function;
-     BPATCH_DLL_EXPORT Function *convert(const BPatch_function *);
+     DYNINST_EXPORT Function *convert(const BPatch_function *);
   }
   namespace PatchAPI {
      class PatchFunction;
-     BPATCH_DLL_EXPORT PatchFunction *convert(const BPatch_function *);
+     DYNINST_EXPORT PatchFunction *convert(const BPatch_function *);
   }
 }
 
 
 
 
-class BPATCH_DLL_EXPORT BPatch_function : 
+class DYNINST_EXPORT BPatch_function : 
    public BPatch_sourceObj, 
    public Dyninst::AnnotatableSparse
 {

--- a/dyninstAPI/h/BPatch_image.h
+++ b/dyninstAPI/h/BPatch_image.h
@@ -63,12 +63,12 @@ namespace Dyninst {
   namespace PatchAPI {
     class PatchMgr;
     typedef boost::shared_ptr<PatchMgr> PatchMgrPtr;
-    BPATCH_DLL_EXPORT PatchMgrPtr convert(const BPatch_image *);
+    DYNINST_EXPORT PatchMgrPtr convert(const BPatch_image *);
   }
 }
 
 
-class BPATCH_DLL_EXPORT BPatch_image: public BPatch_sourceObj {
+class DYNINST_EXPORT BPatch_image: public BPatch_sourceObj {
   friend class BPatch; // registerLoaded... callbacks
   friend class BPatch_module; // access to findOrCreate...
   friend class BPatch_object; // Also access to findOrCreate

--- a/dyninstAPI/h/BPatch_instruction.h
+++ b/dyninstAPI/h/BPatch_instruction.h
@@ -45,7 +45,7 @@ class internal_instruction;
 #endif
 #define DYNINST_CLASS_NAME BPatch_instruction
 
-class BPATCH_DLL_EXPORT BPatch_instruction {
+class DYNINST_EXPORT BPatch_instruction {
   friend class BPatch_basicBlock;
 
  public:
@@ -114,7 +114,7 @@ class BPATCH_DLL_EXPORT BPatch_instruction {
   int  conditionCode_NP(int which = 0) const { return condition[which]; }
 };
 
-class BPATCH_DLL_EXPORT BPatch_branchInstruction : public BPatch_instruction{
+class DYNINST_EXPORT BPatch_branchInstruction : public BPatch_instruction{
     friend class BPatch_basicBlock;
 
  public:
@@ -138,7 +138,7 @@ class BPatch_registerExpr;
 class BPatch_addressSpace;
 class BPatch_point;
 
-class BPATCH_DLL_EXPORT BPatch_register {
+class DYNINST_EXPORT BPatch_register {
     friend class BPatch_registerExpr;
     friend class BPatch_addressSpace;
     friend class BPatch_point;

--- a/dyninstAPI/h/BPatch_loopTreeNode.h
+++ b/dyninstAPI/h/BPatch_loopTreeNode.h
@@ -56,7 +56,7 @@ class PatchLoopTreeNode;
  *  @see BPatch_flowGraph
  */
 
-class BPATCH_DLL_EXPORT BPatch_loopTreeNode {
+class DYNINST_EXPORT BPatch_loopTreeNode {
     friend class BPatch_flowGraph;
 
  public:

--- a/dyninstAPI/h/BPatch_memoryAccess_NP.h
+++ b/dyninstAPI/h/BPatch_memoryAccess_NP.h
@@ -60,7 +60,7 @@ class internal_instruction;
 //extern void initOpCodeInfo();
 
 /* This is believed to be machine independent, modulo register numbers of course */
-class BPATCH_DLL_EXPORT BPatch_addrSpec_NP
+class DYNINST_EXPORT BPatch_addrSpec_NP
 {
   // the formula is regs[0] + 2 ^ scale * regs[1] + imm
   long imm;      // immediate
@@ -80,7 +80,7 @@ public:
 };
 
 typedef BPatch_addrSpec_NP BPatch_countSpec_NP;
-class BPATCH_DLL_EXPORT BPatch_memoryAccess : public BPatch_instruction
+class DYNINST_EXPORT BPatch_memoryAccess : public BPatch_instruction
 {
   friend class BPatch_function;
   friend class AstMemoryNode;

--- a/dyninstAPI/h/BPatch_module.h
+++ b/dyninstAPI/h/BPatch_module.h
@@ -61,7 +61,7 @@ namespace Dyninst {
    namespace SymtabAPI {
       class Module;
        struct AddressRange;
-      BPATCH_DLL_EXPORT Module *convert(const BPatch_module *);
+      DYNINST_EXPORT Module *convert(const BPatch_module *);
    }
    namespace PatchAPI {
 	   class PatchFunction;
@@ -72,7 +72,7 @@ namespace Dyninst {
 extern BPatch_builtInTypeCollection * builtInTypes;
 
 
-class BPATCH_DLL_EXPORT BPatch_module: public BPatch_sourceObj{
+class DYNINST_EXPORT BPatch_module: public BPatch_sourceObj{
 
     friend class BPatch_function;
     friend class BPatch_flowGraph;

--- a/dyninstAPI/h/BPatch_object.h
+++ b/dyninstAPI/h/BPatch_object.h
@@ -52,20 +52,20 @@ class BPatch_snippet;
 namespace Dyninst { 
    namespace ParseAPI { 
       class CodeObject; 
-      BPATCH_DLL_EXPORT CodeObject *convert(const BPatch_object *);
+      DYNINST_EXPORT CodeObject *convert(const BPatch_object *);
    }
    namespace PatchAPI {
       class PatchObject;
-      BPATCH_DLL_EXPORT PatchObject *convert(const BPatch_object *);
+      DYNINST_EXPORT PatchObject *convert(const BPatch_object *);
    }
    namespace SymtabAPI {
       class Symtab;
-      BPATCH_DLL_EXPORT Symtab *convert(const BPatch_object *);
+      DYNINST_EXPORT Symtab *convert(const BPatch_object *);
    }
 }
 
 
-class BPATCH_DLL_EXPORT BPatch_object {
+class DYNINST_EXPORT BPatch_object {
 
     friend Dyninst::ParseAPI::CodeObject *Dyninst::ParseAPI::convert(const BPatch_object *);
     friend Dyninst::PatchAPI::PatchObject *Dyninst::PatchAPI::convert(const BPatch_object *);

--- a/dyninstAPI/h/BPatch_parRegion.h
+++ b/dyninstAPI/h/BPatch_parRegion.h
@@ -46,7 +46,7 @@ typedef enum{
   OMP_BARRIER, OMP_ATOMIC, OMP_FLUSH, OMP_ORDERED, OMP_ANY
 } parRegType;
 
-class BPATCH_DLL_EXPORT BPatch_parRegion {
+class DYNINST_EXPORT BPatch_parRegion {
   BPatch_function * func;
   int_parRegion * parReg;
   

--- a/dyninstAPI/h/BPatch_point.h
+++ b/dyninstAPI/h/BPatch_point.h
@@ -63,7 +63,7 @@ namespace Dyninst {
       class Instance;
       class Point;
       typedef boost::shared_ptr<Instance> InstancePtr;
-      BPATCH_DLL_EXPORT Point *convert(const BPatch_point *, BPatch_callWhen);
+      DYNINST_EXPORT Point *convert(const BPatch_point *, BPatch_callWhen);
    }
 }
 
@@ -85,7 +85,7 @@ namespace Dyninst {
    needs to link instPoint back pointer (and we don't want to include
    that here) */
 
-class BPATCH_DLL_EXPORT BPatch_point {
+class DYNINST_EXPORT BPatch_point {
     friend class BPatch_process;
     friend class BPatch_binaryEdit;
     friend class BPatch_addressSpace;

--- a/dyninstAPI/h/BPatch_process.h
+++ b/dyninstAPI/h/BPatch_process.h
@@ -131,7 +131,7 @@ class OneTimeCodeInfo {
 /*
  * Represents a process
  */
-class BPATCH_DLL_EXPORT BPatch_process : public BPatch_addressSpace {
+class DYNINST_EXPORT BPatch_process : public BPatch_addressSpace {
   friend class BPatch;
   friend class BPatch_image;
   friend class BPatch_function;

--- a/dyninstAPI/h/BPatch_snippet.h
+++ b/dyninstAPI/h/BPatch_snippet.h
@@ -58,7 +58,7 @@ namespace Dyninst {
    namespace PatchAPI {
       class Snippet;
       typedef boost::shared_ptr<Snippet> SnippetPtr;
-      BPATCH_DLL_EXPORT SnippetPtr convert(const BPatch_snippet *);
+      DYNINST_EXPORT SnippetPtr convert(const BPatch_snippet *);
    }
 }
 
@@ -110,7 +110,7 @@ typedef enum {
     BPatch_deref
 } BPatch_unOp;
 
-class BPATCH_DLL_EXPORT BPatch_snippet {
+class DYNINST_EXPORT BPatch_snippet {
 
     friend class BPatch_process;
     friend class BPatch_binaryEdit;
@@ -189,7 +189,7 @@ class BPATCH_DLL_EXPORT BPatch_snippet {
 
 };
 
-class BPATCH_DLL_EXPORT BPatch_arithExpr: public BPatch_snippet {
+class DYNINST_EXPORT BPatch_arithExpr: public BPatch_snippet {
  public:
     //  BPatch_arithExpr::BPatch_arithExpr (Binary Arithmetic Operation)
     //  
@@ -202,7 +202,7 @@ class BPATCH_DLL_EXPORT BPatch_arithExpr: public BPatch_snippet {
     BPatch_arithExpr(BPatch_unOp op, const BPatch_snippet &lOperand);
 };
 
-class BPATCH_DLL_EXPORT BPatch_boolExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_boolExpr : public BPatch_snippet {
  public:
     //  BPatch_boolExpr::BPatch_boolExpr
     //  Creates a representation of boolean operation
@@ -210,7 +210,7 @@ class BPATCH_DLL_EXPORT BPatch_boolExpr : public BPatch_snippet {
                      const BPatch_snippet &rOperand);
 };
 
-class BPATCH_DLL_EXPORT BPatch_constExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_constExpr : public BPatch_snippet {
  public:
     //  BPatch_constExpr::BPatch_constExpr
     //  Creates a representation of a (signed int) value
@@ -246,14 +246,14 @@ class BPATCH_DLL_EXPORT BPatch_constExpr : public BPatch_snippet {
 
 };
 
-class BPATCH_DLL_EXPORT BPatch_whileExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_whileExpr : public BPatch_snippet {
   public:
    // BPatch_whileExpr::BPatch_whileExpr (while loop)
    BPatch_whileExpr(const BPatch_snippet &condition,
                     const BPatch_snippet &body);
 };
 
-class BPATCH_DLL_EXPORT BPatch_funcCallExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_funcCallExpr : public BPatch_snippet {
  public:
     //  BPatch_funcCallExpr::BPatch_funcCallExpr
     //  Creates a representation of a function call
@@ -261,7 +261,7 @@ class BPATCH_DLL_EXPORT BPatch_funcCallExpr : public BPatch_snippet {
                          const BPatch_Vector<BPatch_snippet *> &args);
 };
 
-class BPATCH_DLL_EXPORT BPatch_ifExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_ifExpr : public BPatch_snippet {
  public:
     //  BPatch_ifExpr::BPatch_ifExpr
     //  Creates a conditional expression "if <conditional> tClause;"
@@ -276,7 +276,7 @@ class BPATCH_DLL_EXPORT BPatch_ifExpr : public BPatch_snippet {
                    const BPatch_snippet &fClause);
 };
 
-class BPATCH_DLL_EXPORT BPatch_nullExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_nullExpr : public BPatch_snippet {
  public:
     //  BPatch_nullExpr::BPatch_nullExpr
     //  Creates a null snippet that can be used as a placeholder.
@@ -284,7 +284,7 @@ class BPATCH_DLL_EXPORT BPatch_nullExpr : public BPatch_snippet {
 
 };
 
-class BPATCH_DLL_EXPORT BPatch_paramExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_paramExpr : public BPatch_snippet {
  public:
     //  BPatch_paramExpr::BPatch_paramExpr
     //  Represents a parameter of a function (used in creating funcCallExpr)
@@ -295,7 +295,7 @@ class BPATCH_DLL_EXPORT BPatch_paramExpr : public BPatch_snippet {
     BPatch_paramExpr(int n, BPatch_ploc loc=BPatch_ploc_guess);
 };
 
-class BPATCH_DLL_EXPORT BPatch_retExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_retExpr : public BPatch_snippet {
  public:
     //  BPatch_retExpr::BPatch_retExpr
     //  Represents the return value from the function in which the 
@@ -303,7 +303,7 @@ class BPATCH_DLL_EXPORT BPatch_retExpr : public BPatch_snippet {
     BPatch_retExpr();
 };
 
-class BPATCH_DLL_EXPORT BPatch_retAddrExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_retAddrExpr : public BPatch_snippet {
  public:
     //  BPatch_retAddrExpr::BPatch_retAddrExpr
     //  Represents the return address from the function in which the
@@ -311,7 +311,7 @@ class BPATCH_DLL_EXPORT BPatch_retAddrExpr : public BPatch_snippet {
     BPatch_retAddrExpr();
 };
 
-class BPATCH_DLL_EXPORT BPatch_registerExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_registerExpr : public BPatch_snippet {
  public:
     friend class BPatch_addressSpace;
     //  BPatch_registerExpr::BPatch_registerExpr
@@ -322,14 +322,14 @@ class BPATCH_DLL_EXPORT BPatch_registerExpr : public BPatch_snippet {
                     BPatch_registerExpr(Dyninst::MachRegister reg);
 };
 
-class BPATCH_DLL_EXPORT BPatch_sequence : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_sequence : public BPatch_snippet {
  public:
     //  BPatch_sequence::BPatch_sequence
     //  Represents a sequence of statements
     BPatch_sequence(const BPatch_Vector<BPatch_snippet *> &items);
 };
 
-class BPATCH_DLL_EXPORT BPatch_variableExpr : public BPatch_snippet 
+class DYNINST_EXPORT BPatch_variableExpr : public BPatch_snippet 
 {
     friend class BPatch_process;
     friend class BPatch_addressSpace;
@@ -445,7 +445,7 @@ class BPATCH_DLL_EXPORT BPatch_variableExpr : public BPatch_snippet
     BPatch_Vector<BPatch_variableExpr *> * getComponents();
 };
 
-class BPATCH_DLL_EXPORT BPatch_breakPointExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_breakPointExpr : public BPatch_snippet {
  public:
     //  BPatch_breakPointExpr::BPatch_breakPointExpr
     //  Creates a representation of a break point in the target process
@@ -470,7 +470,7 @@ class BPATCH_DLL_EXPORT BPatch_breakPointExpr : public BPatch_snippet {
 // VG(8/14/02): added conditional parameter
 
 
-class BPATCH_DLL_EXPORT BPatch_effectiveAddressExpr : public BPatch_snippet
+class DYNINST_EXPORT BPatch_effectiveAddressExpr : public BPatch_snippet
 {
  public:
   //  BPatch_effectiveAddressExpr:: BPatch_effectiveAddressExpr
@@ -481,7 +481,7 @@ class BPATCH_DLL_EXPORT BPatch_effectiveAddressExpr : public BPatch_snippet
 
 
 // Number of bytes moved
-class BPATCH_DLL_EXPORT BPatch_bytesAccessedExpr : public BPatch_snippet
+class DYNINST_EXPORT BPatch_bytesAccessedExpr : public BPatch_snippet
 {
  public:
   //  BPatch_bytesAccessedExpr::BPatch_bytesAccessedExpr
@@ -497,7 +497,7 @@ class BPATCH_DLL_EXPORT BPatch_bytesAccessedExpr : public BPatch_snippet
 // machineConditionExpr, so that remains TBD...
 
 
-class BPATCH_DLL_EXPORT BPatch_ifMachineConditionExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_ifMachineConditionExpr : public BPatch_snippet {
  public:
   //  BPatch_ifMachineConditionExpr::BPatch_ifMachineConditionExpr
   //  
@@ -506,14 +506,14 @@ class BPATCH_DLL_EXPORT BPatch_ifMachineConditionExpr : public BPatch_snippet {
 };
 
 
-class BPATCH_DLL_EXPORT BPatch_threadIndexExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_threadIndexExpr : public BPatch_snippet {
  public:
   //
   // BPatch_threadIndexExpr::BPatch_threadIndexExpr
   BPatch_threadIndexExpr();
 };
 
-class BPATCH_DLL_EXPORT BPatch_tidExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_tidExpr : public BPatch_snippet {
  public:
   //
   // BPatch_tidExpr::BPatch_tidExpr
@@ -528,7 +528,7 @@ typedef enum {
     BPatch_interpAsReturnAddr,
 } BPatch_stInterpret;
 
-class BPATCH_DLL_EXPORT BPatch_shadowExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_shadowExpr : public BPatch_snippet {
  public:
   // BPatch_stopThreadExpr 
   //  This snippet type stops the thread that executes it.  It
@@ -542,7 +542,7 @@ class BPATCH_DLL_EXPORT BPatch_shadowExpr : public BPatch_snippet {
 		    BPatch_stInterpret interp = BPatch_noInterp);
 };
 
-class BPATCH_DLL_EXPORT BPatch_stopThreadExpr : public BPatch_snippet {
+class DYNINST_EXPORT BPatch_stopThreadExpr : public BPatch_snippet {
  public:
   // BPatch_stopThreadExpr 
   //  This snippet type stops the thread that executes it.  It
@@ -564,7 +564,7 @@ class BPATCH_DLL_EXPORT BPatch_stopThreadExpr : public BPatch_snippet {
    BPatch_stInterpret interp = BPatch_noInterp);
 };
 
-class BPATCH_DLL_EXPORT BPatch_originalAddressExpr : public BPatch_snippet
+class DYNINST_EXPORT BPatch_originalAddressExpr : public BPatch_snippet
 {
  public:
   //  BPatch_originalAddressExpr
@@ -574,7 +574,7 @@ class BPATCH_DLL_EXPORT BPatch_originalAddressExpr : public BPatch_snippet
   BPatch_originalAddressExpr();
 };
 
-class BPATCH_DLL_EXPORT BPatch_actualAddressExpr : public BPatch_snippet
+class DYNINST_EXPORT BPatch_actualAddressExpr : public BPatch_snippet
 {
  public:
   //  BPatch_actualAddressExpr
@@ -584,7 +584,7 @@ class BPATCH_DLL_EXPORT BPatch_actualAddressExpr : public BPatch_snippet
   BPatch_actualAddressExpr();
 };
 
-class BPATCH_DLL_EXPORT BPatch_dynamicTargetExpr : public BPatch_snippet
+class DYNINST_EXPORT BPatch_dynamicTargetExpr : public BPatch_snippet
 {
  public:
   //  BPatch_dynamicTargetExpr
@@ -594,7 +594,7 @@ class BPATCH_DLL_EXPORT BPatch_dynamicTargetExpr : public BPatch_snippet
   BPatch_dynamicTargetExpr();
 };
 
-class BPATCH_DLL_EXPORT BPatch_scrambleRegistersExpr : public BPatch_snippet
+class DYNINST_EXPORT BPatch_scrambleRegistersExpr : public BPatch_snippet
 {
 
   public:

--- a/dyninstAPI/h/BPatch_sourceBlock.h
+++ b/dyninstAPI/h/BPatch_sourceBlock.h
@@ -46,7 +46,7 @@
   * @see BPatch_basicBlock
   */
 
-class BPATCH_DLL_EXPORT BPatch_sourceBlock {
+class DYNINST_EXPORT BPatch_sourceBlock {
 	friend class BPatch_flowGraph;
 
 private:

--- a/dyninstAPI/h/BPatch_sourceObj.h
+++ b/dyninstAPI/h/BPatch_sourceObj.h
@@ -64,7 +64,7 @@ typedef enum BPatch_sourceType {
 } BPatch_sourceType;
 
 
-class BPATCH_DLL_EXPORT BPatch_sourceObj {
+class DYNINST_EXPORT BPatch_sourceObj {
  public:
     virtual ~BPatch_sourceObj() { }
 

--- a/dyninstAPI/h/BPatch_statement.h
+++ b/dyninstAPI/h/BPatch_statement.h
@@ -36,7 +36,7 @@
 class BPatch_module;
 
 
-class BPATCH_DLL_EXPORT BPatch_statement
+class DYNINST_EXPORT BPatch_statement
 {
   friend class BPatch_module;
   friend class BPatch_image;

--- a/dyninstAPI/h/BPatch_thread.h
+++ b/dyninstAPI/h/BPatch_thread.h
@@ -54,7 +54,7 @@ typedef Dyninst::THR_ID dynthread_t;
  * Represents a thread of execution.
  */
 
-class BPATCH_DLL_EXPORT BPatch_thread {
+class DYNINST_EXPORT BPatch_thread {
     friend class BPatch_frame;
     friend class BPatch_process;
     friend class BPatch_addressSpace;

--- a/dyninstAPI/h/BPatch_type.h
+++ b/dyninstAPI/h/BPatch_type.h
@@ -44,7 +44,7 @@ class BPatch_type;
 namespace Dyninst { 
    namespace SymtabAPI {
       class Type;
-      BPATCH_DLL_EXPORT boost::shared_ptr<Type> convert(const BPatch_type *, Type::do_share_t);
+      DYNINST_EXPORT boost::shared_ptr<Type> convert(const BPatch_type *, Type::do_share_t);
       inline Type* convert(const BPatch_type* t) {
         return convert(t, Type::share).get();
       }
@@ -166,7 +166,7 @@ class BPatch_module;
  */
 
 
-class BPATCH_DLL_EXPORT BPatch_field {
+class DYNINST_EXPORT BPatch_field {
   friend class BPatch_variableExpr;
   friend class BPatch_cblock;
   
@@ -220,7 +220,7 @@ class BPATCH_DLL_EXPORT BPatch_field {
 #undef DYNINST_CLASS_NAME
 #endif
 #define DYNINST_CLASS_NAME BPatch_cblock
-class BPATCH_DLL_EXPORT BPatch_cblock {
+class DYNINST_EXPORT BPatch_cblock {
 private:
   // the list of fields
   BPatch_Vector<BPatch_field *> fieldList;
@@ -239,7 +239,7 @@ public:
   BPatch_Vector<BPatch_function *> * getFunctions();
 };
 
-class BPATCH_DLL_EXPORT BPatch_type{
+class DYNINST_EXPORT BPatch_type{
     friend class BPatch;
     friend class BPatch_module;
     friend class BPatch_function;
@@ -321,7 +321,7 @@ public:
 // It is desgined store information about a variable in a function.
 // Scope needs to be addressed in this class.
 
-class BPATCH_DLL_EXPORT BPatch_localVar{
+class DYNINST_EXPORT BPatch_localVar{
     friend class BPatch;
     friend class BPatch_function;
 

--- a/dyninstAPI/h/StackMod.h
+++ b/dyninstAPI/h/StackMod.h
@@ -48,7 +48,7 @@ if(!(X)) { \
     throw(stackmod_exception(#X));\
 }
 
-class BPATCH_DLL_EXPORT StackMod
+class DYNINST_EXPORT StackMod
 {
     public:
         enum MType
@@ -83,7 +83,7 @@ class BPATCH_DLL_EXPORT StackMod
 };
 
 /* Modification to insert stack space at [low, high) */
-class BPATCH_DLL_EXPORT Insert : public StackMod
+class DYNINST_EXPORT Insert : public StackMod
 {
     friend class StackModChecker; 
     public:
@@ -105,7 +105,7 @@ class BPATCH_DLL_EXPORT Insert : public StackMod
 };
 
 /* Modification to remove stack space at [low, high) */
-class BPATCH_DLL_EXPORT Remove : public StackMod
+class DYNINST_EXPORT Remove : public StackMod
 {
     friend class StackModChecker; 
     public:
@@ -128,7 +128,7 @@ class BPATCH_DLL_EXPORT Remove : public StackMod
 
 /* Modification to move stack space from [srcLow, srcHigh)
  * to [destLow, destLow+(srcHigh-srcLow)) */
-class BPATCH_DLL_EXPORT Move : public StackMod
+class DYNINST_EXPORT Move : public StackMod
 {
     public:
         // Constructor
@@ -153,7 +153,7 @@ class BPATCH_DLL_EXPORT Move : public StackMod
 
 /* Modification to insert a stack canary at function entry
  * (and canary verification at function exit(s)) */
-class BPATCH_DLL_EXPORT Canary : public StackMod
+class DYNINST_EXPORT Canary : public StackMod
 {
     public:
         // Constructors
@@ -189,7 +189,7 @@ class BPATCH_DLL_EXPORT Canary : public StackMod
 /* Modification to randomize the locations of the DWARF-specified
  * local variables. This modification has no effect on functions
  * without DWARF information. */
-class BPATCH_DLL_EXPORT Randomize : public StackMod
+class DYNINST_EXPORT Randomize : public StackMod
 {
     public:
         // Constructor

--- a/elf/h/Elf_X.h
+++ b/elf/h/Elf_X.h
@@ -80,7 +80,7 @@ class Elf_X_Nhdr;
 // ------------------------------------------------------------------------
 // Class Elf_X simulates the Elf(32|64)_Ehdr structure.
 // Also works for ELF archives. 
-class DYNELF_EXPORT Elf_X {
+class DYNINST_EXPORT Elf_X {
   public:
     static Elf_X *newElf_X(int input, Elf_Cmd cmd, Elf_X *ref = NULL, std::string name = std::string());
     static Elf_X *newElf_X(char *mem_image, size_t mem_size, std::string name = std::string());
@@ -170,7 +170,7 @@ class DYNELF_EXPORT Elf_X {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Phdr simulates the Elf(32|64)_Phdr structure.
-class DYNELF_EXPORT Elf_X_Phdr {
+class DYNINST_EXPORT Elf_X_Phdr {
    friend class Elf_X;
   public:
     Elf_X_Phdr();
@@ -206,7 +206,7 @@ class DYNELF_EXPORT Elf_X_Phdr {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Shdr simulates the Elf(32|64)_Shdr structure.
-class DYNELF_EXPORT Elf_X_Shdr {
+class DYNINST_EXPORT Elf_X_Shdr {
     friend class Elf_X;
 
   public:
@@ -264,7 +264,7 @@ class DYNELF_EXPORT Elf_X_Shdr {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Data simulates the Elf_Data structure.
-class DYNELF_EXPORT Elf_X_Data {
+class DYNINST_EXPORT Elf_X_Data {
   public:
     Elf_X_Data();
     Elf_X_Data(bool is64_, Elf_Data *input);
@@ -308,7 +308,7 @@ class DYNELF_EXPORT Elf_X_Data {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Versym simulates the SHT_GNU_versym structure.
-class DYNELF_EXPORT Elf_X_Versym {
+class DYNINST_EXPORT Elf_X_Versym {
   public:
     Elf_X_Versym();
     Elf_X_Versym(bool is64_, Elf_Data *input);
@@ -329,7 +329,7 @@ class DYNELF_EXPORT Elf_X_Versym {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Verdaux simulates the Elf(32|64)_Verdaux structure.
-class DYNELF_EXPORT Elf_X_Verdaux {
+class DYNINST_EXPORT Elf_X_Verdaux {
   public:
     Elf_X_Verdaux();
     Elf_X_Verdaux(bool is64_, void *input);
@@ -351,7 +351,7 @@ class DYNELF_EXPORT Elf_X_Verdaux {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Verdef simulates the Elf(32|64)_Verdef structure.
-class DYNELF_EXPORT Elf_X_Verdef {
+class DYNINST_EXPORT Elf_X_Verdef {
   public:
     Elf_X_Verdef();
     Elf_X_Verdef(bool is64_, void *input);
@@ -379,7 +379,7 @@ class DYNELF_EXPORT Elf_X_Verdef {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Vernaux simulates the Elf(32|64)_Vernaux structure.
-class DYNELF_EXPORT Elf_X_Vernaux {
+class DYNINST_EXPORT Elf_X_Vernaux {
   public:
     Elf_X_Vernaux();
     Elf_X_Vernaux(bool is64_, void *input);
@@ -404,7 +404,7 @@ class DYNELF_EXPORT Elf_X_Vernaux {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Verneed simulates the Elf(32|64)_Verneed structure.
-class DYNELF_EXPORT Elf_X_Verneed {
+class DYNINST_EXPORT Elf_X_Verneed {
   public:
     Elf_X_Verneed();
     Elf_X_Verneed(bool is64_, void *input);
@@ -431,7 +431,7 @@ class DYNELF_EXPORT Elf_X_Verneed {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Sym simulates the Elf(32|64)_Sym structure.
-class DYNELF_EXPORT Elf_X_Sym {
+class DYNINST_EXPORT Elf_X_Sym {
   public:
     Elf_X_Sym();
     Elf_X_Sym(bool is64_, Elf_Data *input);
@@ -470,7 +470,7 @@ class DYNELF_EXPORT Elf_X_Sym {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Rel simulates the Elf(32|64)_Rel structure.
-class DYNELF_EXPORT Elf_X_Rel {
+class DYNINST_EXPORT Elf_X_Rel {
   public:
    Elf_X_Rel();
    Elf_X_Rel(bool is64_, Elf_Data *input);
@@ -498,7 +498,7 @@ class DYNELF_EXPORT Elf_X_Rel {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Rela simulates the Elf(32|64)_Rela structure.
-class DYNELF_EXPORT Elf_X_Rela {
+class DYNINST_EXPORT Elf_X_Rela {
   public:
     Elf_X_Rela();
     Elf_X_Rela(bool is64_, Elf_Data *input);
@@ -528,7 +528,7 @@ class DYNELF_EXPORT Elf_X_Rela {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Dyn simulates the Elf(32|64)_Dyn structure.
-class DYNELF_EXPORT Elf_X_Dyn {
+class DYNINST_EXPORT Elf_X_Dyn {
   public:
     Elf_X_Dyn();
     Elf_X_Dyn(bool is64_, Elf_Data *input);
@@ -556,7 +556,7 @@ class DYNELF_EXPORT Elf_X_Dyn {
 
 // ------------------------------------------------------------------------
 // Class Elf_X_Nhdr simulates the Elf(32|64)_Shdr structure.
-class DYNELF_EXPORT Elf_X_Nhdr {
+class DYNINST_EXPORT Elf_X_Nhdr {
     friend class Elf_X;
 
   public:

--- a/instructionAPI/h/ArchSpecificFormatters.h
+++ b/instructionAPI/h/ArchSpecificFormatters.h
@@ -50,7 +50,7 @@ namespace Dyninst {
             virtual bool        operandPrintOrderReversed() const;
             virtual ~ArchSpecificFormatter() = default;
             ArchSpecificFormatter& operator=(const ArchSpecificFormatter&) = default;
-            static INSTRUCTION_EXPORT ArchSpecificFormatter& getFormatter(Dyninst::Architecture a);
+            static DYNINST_EXPORT ArchSpecificFormatter& getFormatter(Dyninst::Architecture a);
 
         };
 

--- a/instructionAPI/h/BinaryFunction.h
+++ b/instructionAPI/h/BinaryFunction.h
@@ -52,10 +52,10 @@ namespace Dyninst
     /// For the purposes of representing a single operand of an instruction, the %BinaryFunctions of interest are addition and multiplication of
     /// integer values; this allows a %Expression to represent all addressing modes on the architectures currently
     /// supported by the %Instruction API.
-    class INSTRUCTION_EXPORT BinaryFunction : public Expression
+    class DYNINST_EXPORT BinaryFunction : public Expression
     {
 		public:
-			class INSTRUCTION_EXPORT funcT
+			class DYNINST_EXPORT funcT
 			{
 				public:
 					funcT(std::string name) : m_name(name) 
@@ -80,7 +80,7 @@ namespace Dyninst
 			};
       
       
-			class INSTRUCTION_EXPORT addResult : public funcT
+			class DYNINST_EXPORT addResult : public funcT
 			{
 				public:
 					addResult() : funcT("+") 
@@ -97,7 +97,7 @@ namespace Dyninst
 					}
 			};
 			
-			class INSTRUCTION_EXPORT multResult : public funcT
+			class DYNINST_EXPORT multResult : public funcT
 			{
 				public:
 					multResult() : funcT("*")
@@ -114,7 +114,7 @@ namespace Dyninst
 					}
 			};
       
-			class INSTRUCTION_EXPORT leftShiftResult : public funcT
+			class DYNINST_EXPORT leftShiftResult : public funcT
 			{
 				public:
 					leftShiftResult() : funcT("<<")
@@ -131,7 +131,7 @@ namespace Dyninst
 					}
 			};
 			
-			class INSTRUCTION_EXPORT rightArithmeticShiftResult : public funcT
+			class DYNINST_EXPORT rightArithmeticShiftResult : public funcT
 			{
 				public:
 					rightArithmeticShiftResult() : funcT("ASR")
@@ -148,7 +148,7 @@ namespace Dyninst
 					}
 			};
 			
-			class INSTRUCTION_EXPORT andResult : public funcT
+			class DYNINST_EXPORT andResult : public funcT
 			{
 				public:
 					andResult() : funcT("&")
@@ -165,7 +165,7 @@ namespace Dyninst
 					}
 			};
 			
-			class INSTRUCTION_EXPORT orResult : public funcT
+			class DYNINST_EXPORT orResult : public funcT
 			{
 				public:
 					orResult() : funcT("|")
@@ -182,7 +182,7 @@ namespace Dyninst
 					}
 			};
 			
-			class INSTRUCTION_EXPORT rightLogicalShiftResult : public funcT
+			class DYNINST_EXPORT rightLogicalShiftResult : public funcT
 			{
 				public:
 					rightLogicalShiftResult() : funcT("LSR")
@@ -221,7 +221,7 @@ namespace Dyninst
 					}
 			};
 			
-			class INSTRUCTION_EXPORT rightRotateResult : public funcT
+			class DYNINST_EXPORT rightRotateResult : public funcT
 			{
 				public:
 					rightRotateResult() : funcT("ROR")

--- a/instructionAPI/h/Dereference.h
+++ b/instructionAPI/h/Dereference.h
@@ -68,7 +68,7 @@ namespace Dyninst
     /// For example, the %Expression shown in Figure 6 could have its root %Dereference, which interprets the memory being dereferenced
     /// as a unsigned 16-bit integer, replaced with a %Dereference that
     /// interprets the memory being dereferenced as any other type.  The remainder of the %Expression tree would, however, remain unchanged.
-    class INSTRUCTION_EXPORT Dereference : public Expression
+    class DYNINST_EXPORT Dereference : public Expression
     {
 
     public:

--- a/instructionAPI/h/Expression.h
+++ b/instructionAPI/h/Expression.h
@@ -117,7 +117,7 @@ namespace Dyninst
     /// the state of the registers known and the state of memory
     /// unknown"
     ///
-    class INSTRUCTION_EXPORT Expression : public InstructionAST
+    class DYNINST_EXPORT Expression : public InstructionAST
     {
     public:
       /// \brief A type definition for a reference counted pointer to a %Expression.
@@ -172,7 +172,7 @@ namespace Dyninst
       Result userSetValue;
       
     };
-    class INSTRUCTION_EXPORT DummyExpr : public Expression
+    class DYNINST_EXPORT DummyExpr : public Expression
     {
         public:
             virtual void getChildren(vector<InstructionAST::Ptr>& ) const {}

--- a/instructionAPI/h/Immediate.h
+++ b/instructionAPI/h/Immediate.h
@@ -46,7 +46,7 @@ namespace Dyninst
     /// and \c clearValue interface are disabled on %Immediate objects.
     /// If an immediate value is being modified, a new %Immediate object should
     /// be created to represent the new value.
-    class INSTRUCTION_EXPORT Immediate : public Expression
+    class DYNINST_EXPORT Immediate : public Expression
     {
     public:
       Immediate(const Result& val);
@@ -74,7 +74,7 @@ namespace Dyninst
       virtual bool isStrictEqual(const InstructionAST& rhs) const;
     };
 
-    class INSTRUCTION_EXPORT NamedImmediate : public Immediate
+    class DYNINST_EXPORT NamedImmediate : public Immediate
     {
     public:
         NamedImmediate(std::string name, const Result &val);
@@ -88,7 +88,7 @@ namespace Dyninst
     };
 
 
-    class INSTRUCTION_EXPORT ArmConditionImmediate : public Immediate
+    class DYNINST_EXPORT ArmConditionImmediate : public Immediate
     {
     public:
         ArmConditionImmediate(const Result &val);
@@ -101,7 +101,7 @@ namespace Dyninst
         std::map<unsigned int, std::string> m_condLookupMap;
     };
 
-    class INSTRUCTION_EXPORT ArmPrfmTypeImmediate : public Immediate
+    class DYNINST_EXPORT ArmPrfmTypeImmediate : public Immediate
     {
     public:
 	ArmPrfmTypeImmediate(const Result &val);

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -80,7 +80,7 @@ namespace Dyninst
         /// Component version information corresponding to \c libInstructionAPI.so.(major).(minor).(maintenance)
         /// Note that \c maintenance may be absent from the binary (in which case, it will be zero in the interface).
 
-        INSTRUCTION_EXPORT static void version(int& major, int& minor, int& maintenance);
+        DYNINST_EXPORT static void version(int& major, int& minor, int& maintenance);
       union raw_insn_T
       {
 #if defined(__powerpc__) || defined(__powerpc64__)
@@ -125,47 +125,47 @@ namespace Dyninst
       /// which operands are read and written
       /// in the %Operation object \c what to the value computations in \c operandSource.
 
-      INSTRUCTION_EXPORT Instruction(Operation what, size_t size, const unsigned char* raw,
+      DYNINST_EXPORT Instruction(Operation what, size_t size, const unsigned char* raw,
                                      Dyninst::Architecture arch);
-      INSTRUCTION_EXPORT Instruction();
+      DYNINST_EXPORT Instruction();
 
-      INSTRUCTION_EXPORT virtual ~Instruction();
+      DYNINST_EXPORT virtual ~Instruction();
 
-      INSTRUCTION_EXPORT Instruction(const Instruction& o);
-      INSTRUCTION_EXPORT const Instruction& operator=(const Instruction& rhs);
+      DYNINST_EXPORT Instruction(const Instruction& o);
+      DYNINST_EXPORT const Instruction& operator=(const Instruction& rhs);
 
 
       /// \return The %Operation used by the %Instruction
       ///
       /// See Operation for details of the %Operation interface.
-      INSTRUCTION_EXPORT Operation& getOperation();
-      INSTRUCTION_EXPORT const Operation& getOperation() const;
+      DYNINST_EXPORT Operation& getOperation();
+      DYNINST_EXPORT const Operation& getOperation() const;
 
       /// The vector \c operands has the instruction's operands appended to it
       /// in the same order that they were decoded.
-      INSTRUCTION_EXPORT void getOperands(std::vector<Operand>& operands) const;
+      DYNINST_EXPORT void getOperands(std::vector<Operand>& operands) const;
 
       /// Returns a vector of non-implicit operands in printed order
-      INSTRUCTION_EXPORT std::vector<Operand> getDisplayOrderedOperands() const;
+      DYNINST_EXPORT std::vector<Operand> getDisplayOrderedOperands() const;
 
       /// The \c getOperand method returns the operand at position \c index, or
       /// an empty operand if \c index does not correspond to a valid operand in this
       /// instruction.
-      INSTRUCTION_EXPORT Operand getOperand(int index) const;
+      DYNINST_EXPORT Operand getOperand(int index) const;
 
-      INSTRUCTION_EXPORT Operand getPredicateOperand() const;
-      INSTRUCTION_EXPORT bool hasPredicateOperand() const;
+      DYNINST_EXPORT Operand getPredicateOperand() const;
+      DYNINST_EXPORT bool hasPredicateOperand() const;
 
       /// Returns a pointer to the buffer from which this instruction
       /// was decoded.
-      INSTRUCTION_EXPORT unsigned char rawByte(unsigned int index) const;
+      DYNINST_EXPORT unsigned char rawByte(unsigned int index) const;
 
       /// Returns the size of the corresponding machine instruction, in bytes.
-      INSTRUCTION_EXPORT size_t size() const;
+      DYNINST_EXPORT size_t size() const;
 
       /// Returns a pointer to the raw byte representation of the corresponding
       /// machine instruction.
-      INSTRUCTION_EXPORT const void* ptr() const;
+      DYNINST_EXPORT const void* ptr() const;
 
       /// \param regsWritten Insert the set of registers written by the instruction into \c regsWritten.
       ///
@@ -184,23 +184,23 @@ namespace Dyninst
       /// read.  Any element of the write set or read set that is not explicitly written or read is implicitly
       /// written or read.
 
-      INSTRUCTION_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
+      DYNINST_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
 
       /// \param regsRead Insert the set of registers read by the instruction into \c regsRead.
       ///
       /// If an operand is used to compute an effective address, the registers
       /// involved are read but not written, regardless of the effect on the operand.
-      INSTRUCTION_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
+      DYNINST_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
 
       /// \param candidate Subexpression to search for among the values read by this %Instruction object.
       ///
       /// Returns true if \c candidate is read by this %Instruction.
-      INSTRUCTION_EXPORT bool isRead(Expression::Ptr candidate) const;
+      DYNINST_EXPORT bool isRead(Expression::Ptr candidate) const;
 
       /// \param candidate Subexpression to search for among the values written by this %Instruction object.
       ///
       /// Returns true if \c candidate is written by this %Instruction.
-      INSTRUCTION_EXPORT bool isWritten(Expression::Ptr candidate) const;
+      DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) const;
 
 
       /// \return Returns true if the instruction reads at least one memory address as data.
@@ -209,9 +209,9 @@ namespace Dyninst
       /// reads the memory at that address.
       /// Also, on platforms where a stack pop is guaranteed to read memory,
       /// \c readsMemory will return true for a pop operation.
-      INSTRUCTION_EXPORT bool readsMemory() const;
+      DYNINST_EXPORT bool readsMemory() const;
 
-      INSTRUCTION_EXPORT ArchSpecificFormatter& getFormatter() const;
+      DYNINST_EXPORT ArchSpecificFormatter& getFormatter() const;
 
       /// \return Returns true if the instruction writes at least one memory address.
       ///
@@ -219,7 +219,7 @@ namespace Dyninst
       /// writes the memory at that address.
       /// Also, on platforms where a stack push is guaranteed to write memory,
       /// \c writesMemory will return true for a push operation.
-      INSTRUCTION_EXPORT bool writesMemory() const;
+      DYNINST_EXPORT bool writesMemory() const;
 
       /// \param memAccessors Addresses read by this instruction are inserted into \c memAccessors
       ///
@@ -228,12 +228,12 @@ namespace Dyninst
       /// Note that this method returns ASTs representing address computations, and not address accesses.  For instance,
       /// an instruction accessing memory through a register dereference would return a %Expression tree containing
       /// just the register that determines the address being accessed, not a tree representing a dereference of that register.
-      INSTRUCTION_EXPORT void getMemoryReadOperands(std::set<Expression::Ptr>& memAccessors) const;
+      DYNINST_EXPORT void getMemoryReadOperands(std::set<Expression::Ptr>& memAccessors) const;
 
       /// \param memAccessors Addresses written by this instruction are inserted into \c memAccessors
       ///
       /// The addresses written are in the same form as those returned by \c getMemoryReadOperands above.
-      INSTRUCTION_EXPORT void getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const;
+      DYNINST_EXPORT void getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const;
 
       /// \return An expression evaluating to the non-fallthrough control flow targets, if any, of this instruction.
       ///
@@ -251,41 +251,41 @@ namespace Dyninst
       /// in the %Instruction API; if other code performs this type of analysis,
       /// it may update the information in the %Dereference object using the setValue method in the %Expression interface.
       /// More details about this may be found in Expression and Dereference.
-      INSTRUCTION_EXPORT Expression::Ptr getControlFlowTarget() const;
+      DYNINST_EXPORT Expression::Ptr getControlFlowTarget() const;
 
       /// \return False if control flow will unconditionally go to the result of
       /// \c getControlFlowTarget after executing this instruction.
-      INSTRUCTION_EXPORT bool allowsFallThrough() const;
+      DYNINST_EXPORT bool allowsFallThrough() const;
 
       /// \return The instruction as a string of assembly language
       ///
       /// \c format is principally a helper function; %Instructions are meant to be written to
       /// output streams via \c operator<<.  \c format is included in the public interface for
       /// diagnostic purposes.
-      INSTRUCTION_EXPORT std::string format(Address addr = 0) const;
+      DYNINST_EXPORT std::string format(Address addr = 0) const;
 
       /// Returns true if this %Instruction object is valid.  Invalid instructions indicate that
       /// an %InstructionDecoder has reached the end of its assigned range, and that decoding should terminate.
-      INSTRUCTION_EXPORT bool isValid() const;
+      DYNINST_EXPORT bool isValid() const;
 
       /// Returns true if this %Instruction object represents a legal instruction, as specified by the architecture
       /// used to decode this instruction.
-      INSTRUCTION_EXPORT bool isLegalInsn() const;
+      DYNINST_EXPORT bool isLegalInsn() const;
 
-      INSTRUCTION_EXPORT Architecture getArch() const;
+      DYNINST_EXPORT Architecture getArch() const;
 
       /// Currently, the valid categories are c_CallInsn, c_ReturnInsn, c_BranchInsn, c_CompareInsn,
       /// and c_NoCategory, as defined in %InstructionCategories.h.
-      INSTRUCTION_EXPORT InsnCategory getCategory() const;
+      DYNINST_EXPORT InsnCategory getCategory() const;
 
       typedef std::list<CFT>::const_iterator cftConstIter;
-      INSTRUCTION_EXPORT cftConstIter cft_begin() const {
+      DYNINST_EXPORT cftConstIter cft_begin() const {
           return m_Successors.begin();
       }
-        INSTRUCTION_EXPORT cftConstIter cft_end() const {
+        DYNINST_EXPORT cftConstIter cft_end() const {
             return m_Successors.end();
         }
-        INSTRUCTION_EXPORT bool operator<(const Instruction& rhs) const
+        DYNINST_EXPORT bool operator<(const Instruction& rhs) const
         {
             if(m_size < rhs.m_size) return true;
             if(m_size <= sizeof(m_RawInsn.small_insn)) {
@@ -293,14 +293,14 @@ namespace Dyninst
             }
             return memcmp(m_RawInsn.large_insn, rhs.m_RawInsn.large_insn, m_size) < 0;
         }
-        INSTRUCTION_EXPORT bool operator==(const Instruction& rhs) const {
+        DYNINST_EXPORT bool operator==(const Instruction& rhs) const {
             if(m_size != rhs.m_size) return false;
             if(m_size <= sizeof(m_RawInsn.small_insn)) {
                 return m_RawInsn.small_insn == rhs.m_RawInsn.small_insn;
             }
             return memcmp(m_RawInsn.large_insn, rhs.m_RawInsn.large_insn, m_size) == 0;
         }
-        INSTRUCTION_EXPORT void updateMnemonic(std::string new_mnemonic) {
+        DYNINST_EXPORT void updateMnemonic(std::string new_mnemonic) {
                 m_InsnOp.updateMnemonic(new_mnemonic);
             }
 

--- a/instructionAPI/h/InstructionAST.h
+++ b/instructionAPI/h/InstructionAST.h
@@ -67,7 +67,7 @@ namespace Dyninst
     /// - They are of the same type
     /// - If leaf nodes, they represent the same immediate value or the same register
     /// - If non-leaf nodes, they represent the same operation and their corresponding children are equal
-    class INSTRUCTION_EXPORT InstructionAST : public boost::enable_shared_from_this<InstructionAST>
+    class DYNINST_EXPORT InstructionAST : public boost::enable_shared_from_this<InstructionAST>
     {
     public:
       typedef boost::shared_ptr<InstructionAST> Ptr;

--- a/instructionAPI/h/InstructionCategories.h
+++ b/instructionAPI/h/InstructionCategories.h
@@ -51,7 +51,7 @@ namespace Dyninst
       c_GPUKernelExitInsn,
       c_NoCategory
     };
-    INSTRUCTION_EXPORT InsnCategory entryToCategory(entryID e);
+    DYNINST_EXPORT InsnCategory entryToCategory(entryID e);
     
   }
 }

--- a/instructionAPI/h/InstructionDecoder.h
+++ b/instructionAPI/h/InstructionDecoder.h
@@ -47,7 +47,7 @@ namespace Dyninst
     ///
       class InstructionDecoderImpl;
 
-    class INSTRUCTION_EXPORT InstructionDecoder
+    class DYNINST_EXPORT InstructionDecoder
     {
       friend class Instruction;
         public:
@@ -57,9 +57,9 @@ namespace Dyninst
       InstructionDecoder(const unsigned char* buffer, size_t size, Architecture arch);
       InstructionDecoder(const void* buffer, size_t size, Architecture arch);
 
-      INSTRUCTION_EXPORT ~InstructionDecoder() = default;
-      INSTRUCTION_EXPORT InstructionDecoder(const InstructionDecoder& o) = default;
-      INSTRUCTION_EXPORT InstructionDecoder& operator=(const InstructionDecoder  & o) = default;
+      DYNINST_EXPORT ~InstructionDecoder() = default;
+      DYNINST_EXPORT InstructionDecoder(const InstructionDecoder& o) = default;
+      DYNINST_EXPORT InstructionDecoder& operator=(const InstructionDecoder  & o) = default;
       /// Decode the current instruction in this %InstructionDecoder object's buffer, interpreting it as
       /// machine language of the type understood by this %InstructionDecoder.
       /// If the buffer does not contain a valid instruction stream, a null %Instruction pointer
@@ -71,7 +71,7 @@ namespace Dyninst
       /// the size of the instruction decoded.
       Instruction decode(const unsigned char *buffer);
       void doDelayedDecode(const Instruction* insn_to_complete);
-      struct INSTRUCTION_EXPORT buffer
+      struct DYNINST_EXPORT buffer
       {
           const unsigned char* start;
           const unsigned char* end;

--- a/instructionAPI/h/Operand.h
+++ b/instructionAPI/h/Operand.h
@@ -72,45 +72,45 @@ namespace Dyninst
 
       /// \brief Get the registers read by this operand
       /// \param regsRead Has the registers read inserted into it
-      INSTRUCTION_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
+      DYNINST_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
       /// \brief Get the registers written by this operand
       /// \param regsWritten Has the registers written  inserted into it
-      INSTRUCTION_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
+      DYNINST_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
 
-      INSTRUCTION_EXPORT RegisterAST::Ptr getPredicate() const;
+      DYNINST_EXPORT RegisterAST::Ptr getPredicate() const;
 
       /// Returns true if this operand is read
-      INSTRUCTION_EXPORT bool isRead(Expression::Ptr candidate) const;
+      DYNINST_EXPORT bool isRead(Expression::Ptr candidate) const;
       /// Returns true if this operand is written
-      INSTRUCTION_EXPORT bool isWritten(Expression::Ptr candidate) const;
+      DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) const;
 
-      INSTRUCTION_EXPORT bool isRead() const { return m_isRead; }
-      INSTRUCTION_EXPORT bool isWritten() const { return m_isWritten; }
+      DYNINST_EXPORT bool isRead() const { return m_isRead; }
+      DYNINST_EXPORT bool isWritten() const { return m_isWritten; }
 
-      INSTRUCTION_EXPORT bool isImplicit() const { return m_isImplicit; }
-      INSTRUCTION_EXPORT void setImplicit(bool i) { m_isImplicit = i; }
+      DYNINST_EXPORT bool isImplicit() const { return m_isImplicit; }
+      DYNINST_EXPORT void setImplicit(bool i) { m_isImplicit = i; }
 
-      INSTRUCTION_EXPORT bool isTruePredicate() const { return m_isTruePredicate; }
-      INSTRUCTION_EXPORT bool isFalsePredicate() const { return m_isFalsePredicate; }
+      DYNINST_EXPORT bool isTruePredicate() const { return m_isTruePredicate; }
+      DYNINST_EXPORT bool isFalsePredicate() const { return m_isFalsePredicate; }
       
       /// Returns true if this operand reads memory
-      INSTRUCTION_EXPORT bool readsMemory() const;
+      DYNINST_EXPORT bool readsMemory() const;
       /// Returns true if this operand writes memory
-      INSTRUCTION_EXPORT bool writesMemory() const;
+      DYNINST_EXPORT bool writesMemory() const;
       /// \brief Inserts the effective addresses read by this operand into memAccessors
       /// \param memAccessors If this is a memory read operand, insert the \c %Expression::Ptr representing
       /// the address being read into \c memAccessors.
-      INSTRUCTION_EXPORT void addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const;
+      DYNINST_EXPORT void addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const;
       /// \brief Inserts the effective addresses written by this operand into memAccessors
       /// \param memAccessors If this is a memory write operand, insert the \c %Expression::Ptr representing
       /// the address being written into \c memAccessors.
-      INSTRUCTION_EXPORT void addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const;
+      DYNINST_EXPORT void addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const;
       /// \brief Return a printable string representation of the operand.
       /// \return The operand in a disassembly format
-      INSTRUCTION_EXPORT std::string format(Architecture arch, Address addr = 0) const;
+      DYNINST_EXPORT std::string format(Architecture arch, Address addr = 0) const;
 
       /// The \c getValue method returns an %Expression::Ptr to the AST contained by the operand.
-      INSTRUCTION_EXPORT Expression::Ptr getValue() const;
+      DYNINST_EXPORT Expression::Ptr getValue() const;
       
     private:
       Expression::Ptr op_value{};

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -109,43 +109,43 @@ namespace Dyninst
       friend class Instruction; // to make use of the update size function
       
     public:
-      INSTRUCTION_EXPORT Operation(NS_x86::ia32_entry* e, NS_x86::ia32_prefixes* p = NULL, ia32_locations* l = NULL,
+      DYNINST_EXPORT Operation(NS_x86::ia32_entry* e, NS_x86::ia32_prefixes* p = NULL, ia32_locations* l = NULL,
                                   Architecture arch = Arch_none);
-      INSTRUCTION_EXPORT Operation(const Operation& o);
-      INSTRUCTION_EXPORT Operation();
-      INSTRUCTION_EXPORT Operation(entryID id, std::string m, Architecture arch);
+      DYNINST_EXPORT Operation(const Operation& o);
+      DYNINST_EXPORT Operation();
+      DYNINST_EXPORT Operation(entryID id, std::string m, Architecture arch);
 
-      INSTRUCTION_EXPORT const Operation& operator=(const Operation& o);
+      DYNINST_EXPORT const Operation& operator=(const Operation& o);
       
       /// Returns the set of registers implicitly read (i.e. those not included in the operands, but read anyway)
-      INSTRUCTION_EXPORT const registerSet& implicitReads() ;
+      DYNINST_EXPORT const registerSet& implicitReads() ;
       /// Returns the set of registers implicitly written (i.e. those not included in the operands, but written anyway)
-      INSTRUCTION_EXPORT const registerSet& implicitWrites() ;
+      DYNINST_EXPORT const registerSet& implicitWrites() ;
       /// Returns the mnemonic for the operation.  Like \c instruction::format, this is exposed for debugging
       /// and will be replaced with stream operators in the public interface.
-      INSTRUCTION_EXPORT std::string format() const;
+      DYNINST_EXPORT std::string format() const;
       /// Returns the entry ID corresponding to this operation.  Entry IDs are enumerated values that correspond
       /// to assembly mnemonics.
-      INSTRUCTION_EXPORT entryID getID() const;
+      DYNINST_EXPORT entryID getID() const;
       /// Returns the prefix entry ID corresponding to this operation, if any.
       /// Prefix IDs are enumerated values that correspond to assembly prefix mnemonics.
-      INSTRUCTION_EXPORT prefixEntryID getPrefixID() const;
+      DYNINST_EXPORT prefixEntryID getPrefixID() const;
 
       /// Returns true if the expression represented by \c candidate is read implicitly.
-      INSTRUCTION_EXPORT bool isRead(Expression::Ptr candidate) ;
+      DYNINST_EXPORT bool isRead(Expression::Ptr candidate) ;
       /// Returns true if the expression represented by \c candidate is written implicitly.
-      INSTRUCTION_EXPORT bool isWritten(Expression::Ptr candidate) ;
+      DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) ;
       /// Returns the set of memory locations implicitly read.
-      INSTRUCTION_EXPORT const VCSet& getImplicitMemReads() ;
+      DYNINST_EXPORT const VCSet& getImplicitMemReads() ;
       /// Returns the set of memory locations implicitly written.
-      INSTRUCTION_EXPORT const VCSet& getImplicitMemWrites() ;
+      DYNINST_EXPORT const VCSet& getImplicitMemWrites() ;
 
       void updateMnemonic(std::string new_mnemonic){
         mnemonic = new_mnemonic;
       }
 
 
-      INSTRUCTION_EXPORT const VCSet& getImplicitMemWrites() const;
+      DYNINST_EXPORT const VCSet& getImplicitMemWrites() const;
       bool isVectorInsn;
 
     private:

--- a/instructionAPI/h/Register.h
+++ b/instructionAPI/h/Register.h
@@ -51,7 +51,7 @@ namespace Dyninst
     ///
 
 
-    class INSTRUCTION_EXPORT RegisterAST : public Expression
+    class DYNINST_EXPORT RegisterAST : public Expression
     {
     public:
       /// \brief A type definition for a reference-counted pointer to a %RegisterAST.
@@ -125,7 +125,7 @@ namespace Dyninst
      * class except it handles the syntactial differences between register operands
      * and mask register operands.
      */
-    class INSTRUCTION_EXPORT MaskRegisterAST : public RegisterAST
+    class DYNINST_EXPORT MaskRegisterAST : public RegisterAST
     {
         public:
             MaskRegisterAST(MachRegister r) : RegisterAST(r) {}

--- a/instructionAPI/h/Result.h
+++ b/instructionAPI/h/Result.h
@@ -232,7 +232,7 @@ namespace Dyninst
         // machine states.  From this, you may construct abstractions to represent the set of possible results.
         // Alternately, you may use instrumentation to determine the exact machine state at the time an
         // instruction executes, which will allow you to evaluate the %Result of an %Expression in its actual context.
-        class INSTRUCTION_EXPORT Result
+        class DYNINST_EXPORT Result
         {
             public:
                 Result_Value val;
@@ -776,12 +776,12 @@ namespace Dyninst
                 }
         };
 
-        INSTRUCTION_EXPORT Result operator+(const Result& arg1, const Result& arg2);
-        INSTRUCTION_EXPORT Result operator*(const Result& arg1, const Result& arg2);
-        INSTRUCTION_EXPORT Result operator<<(const Result& arg1, const Result& arg2);
-        INSTRUCTION_EXPORT Result operator>>(const Result& arg1, const Result& arg2);
-        INSTRUCTION_EXPORT Result operator&(const Result& arg1, const Result& arg2);
-        INSTRUCTION_EXPORT Result operator|(const Result& arg1, const Result& arg2);
+        DYNINST_EXPORT Result operator+(const Result& arg1, const Result& arg2);
+        DYNINST_EXPORT Result operator*(const Result& arg1, const Result& arg2);
+        DYNINST_EXPORT Result operator<<(const Result& arg1, const Result& arg2);
+        DYNINST_EXPORT Result operator>>(const Result& arg1, const Result& arg2);
+        DYNINST_EXPORT Result operator&(const Result& arg1, const Result& arg2);
+        DYNINST_EXPORT Result operator|(const Result& arg1, const Result& arg2);
 
     }
 }

--- a/instructionAPI/h/Ternary.h
+++ b/instructionAPI/h/Ternary.h
@@ -49,7 +49,7 @@ namespace Dyninst
     ///
 
 
-    class INSTRUCTION_EXPORT TernaryAST : public Expression
+    class DYNINST_EXPORT TernaryAST : public Expression
     {
     public:
       /// \brief A type definition for a reference-counted pointer to a %TernaryAST.

--- a/instructionAPI/h/interrupts.h
+++ b/instructionAPI/h/interrupts.h
@@ -37,7 +37,7 @@
 namespace Dyninst { namespace InstructionAPI {
 
 // Checks if instruction is a software interrupt
-bool INSTRUCTION_EXPORT isSoftwareInterrupt(Instruction const& ins);
+bool DYNINST_EXPORT isSoftwareInterrupt(Instruction const& ins);
 
 }}
 

--- a/instructionAPI/h/syscalls.h
+++ b/instructionAPI/h/syscalls.h
@@ -42,7 +42,7 @@ namespace Dyninst { namespace InstructionAPI {
    *  as well as by idioms. This checks for both for all supported
    *  platforms.
    */
-bool INSTRUCTION_EXPORT isSystemCall(Instruction const& ins);
+bool DYNINST_EXPORT isSystemCall(Instruction const& ins);
 
 }}
 

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -80,7 +80,7 @@ namespace Dyninst
         }
 
         int Instruction::numInsnsAllocated = 0;
-        INSTRUCTION_EXPORT Instruction::Instruction(Operation what,
+        DYNINST_EXPORT Instruction::Instruction(Operation what,
                 size_t size, const unsigned char* raw,
                 Dyninst::Architecture arch)
             : m_InsnOp(what), m_Valid(what.getID() != e_No_Entry), arch_decoded_from(arch),
@@ -129,7 +129,7 @@ namespace Dyninst
             dec.doDelayedDecode(this);
         }
 
-        INSTRUCTION_EXPORT Instruction::Instruction() :
+        DYNINST_EXPORT Instruction::Instruction() :
             m_Valid(false), m_size(0), arch_decoded_from(Arch_none), formatter(nullptr)
         {
 #if defined(DEBUG_INSN_ALLOCATIONS)
@@ -141,7 +141,7 @@ namespace Dyninst
 #endif
         }
 
-        INSTRUCTION_EXPORT Instruction::~Instruction()
+        DYNINST_EXPORT Instruction::~Instruction()
         {
 
             if(m_size > sizeof(m_RawInsn.small_insn))
@@ -158,7 +158,7 @@ namespace Dyninst
 #endif      
         }
 
-        INSTRUCTION_EXPORT Instruction::Instruction(const Instruction& o) :
+        DYNINST_EXPORT Instruction::Instruction(const Instruction& o) :
             m_Operands(o.m_Operands),
             m_InsnOp(o.m_InsnOp),
             m_Valid(o.m_Valid),
@@ -188,7 +188,7 @@ namespace Dyninst
 #endif
         }
 
-        INSTRUCTION_EXPORT const Instruction& Instruction::operator=(const Instruction& rhs)
+        DYNINST_EXPORT const Instruction& Instruction::operator=(const Instruction& rhs)
         {
             m_Operands = rhs.m_Operands;
             //m_Operands.reserve(rhs.m_Operands.size());
@@ -218,28 +218,28 @@ namespace Dyninst
             return *this;
         }    
 
-        INSTRUCTION_EXPORT bool Instruction::isValid() const
+        DYNINST_EXPORT bool Instruction::isValid() const
         {
             return m_Valid;
         }
 
-        INSTRUCTION_EXPORT Operation& Instruction::getOperation()
+        DYNINST_EXPORT Operation& Instruction::getOperation()
         {
             return m_InsnOp;
         }
-        INSTRUCTION_EXPORT const Operation& Instruction::getOperation() const
+        DYNINST_EXPORT const Operation& Instruction::getOperation() const
         {
             return m_InsnOp;
         }
 
-        INSTRUCTION_EXPORT void Instruction::getOperands(std::vector<Operand>& operands) const
+        DYNINST_EXPORT void Instruction::getOperands(std::vector<Operand>& operands) const
         {
 
             DECODE_OPERANDS();
             std::copy(m_Operands.begin(), m_Operands.end(), std::back_inserter(operands));
         }
 
-        INSTRUCTION_EXPORT std::vector<Operand> Instruction::getDisplayOrderedOperands() const
+        DYNINST_EXPORT std::vector<Operand> Instruction::getDisplayOrderedOperands() const
         {
             DECODE_OPERANDS();
 
@@ -256,7 +256,7 @@ namespace Dyninst
             return operands;
         }
 
-        INSTRUCTION_EXPORT Operand Instruction::getOperand(int index) const
+        DYNINST_EXPORT Operand Instruction::getOperand(int index) const
         {
             DECODE_OPERANDS();
             if(index < 0 || index >= (int)(m_Operands.size()))
@@ -269,7 +269,7 @@ namespace Dyninst
             return *found;
         }
 
-        INSTRUCTION_EXPORT const void* Instruction::ptr() const
+        DYNINST_EXPORT const void* Instruction::ptr() const
         {
             if(m_size > sizeof(m_RawInsn.small_insn))
             {
@@ -280,7 +280,7 @@ namespace Dyninst
                 return reinterpret_cast<const void*>(&m_RawInsn.small_insn);
             }
         }
-        INSTRUCTION_EXPORT unsigned char Instruction::rawByte(unsigned int index) const
+        DYNINST_EXPORT unsigned char Instruction::rawByte(unsigned int index) const
         {
             if(index >= m_size) return 0;
             if(m_size > sizeof(m_RawInsn.small_insn))
@@ -293,13 +293,13 @@ namespace Dyninst
             }
         }
 
-        INSTRUCTION_EXPORT size_t Instruction::size() const
+        DYNINST_EXPORT size_t Instruction::size() const
         {
             return m_size;
 
         }
 
-        INSTRUCTION_EXPORT void Instruction::getReadSet(std::set<RegisterAST::Ptr>& regsRead) const
+        DYNINST_EXPORT void Instruction::getReadSet(std::set<RegisterAST::Ptr>& regsRead) const
         {
             DECODE_OPERANDS();
             for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
@@ -313,7 +313,7 @@ namespace Dyninst
 
         }
 
-        INSTRUCTION_EXPORT void Instruction::getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const
+        DYNINST_EXPORT void Instruction::getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const
         { 
             DECODE_OPERANDS();
             for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
@@ -327,7 +327,7 @@ namespace Dyninst
 
         }
 
-        INSTRUCTION_EXPORT bool Instruction::isRead(Expression::Ptr candidate) const
+        DYNINST_EXPORT bool Instruction::isRead(Expression::Ptr candidate) const
         {
             DECODE_OPERANDS();
             for(std::list<Operand >::const_iterator curOperand = m_Operands.begin();
@@ -344,7 +344,7 @@ namespace Dyninst
             return m_InsnOp.isRead(candidate);
         }
 
-        INSTRUCTION_EXPORT bool Instruction::isWritten(Expression::Ptr candidate) const
+        DYNINST_EXPORT bool Instruction::isWritten(Expression::Ptr candidate) const
         {
             DECODE_OPERANDS();
 
@@ -360,7 +360,7 @@ namespace Dyninst
             return m_InsnOp.isWritten(candidate);
         }
 
-        INSTRUCTION_EXPORT bool Instruction::readsMemory() const
+        DYNINST_EXPORT bool Instruction::readsMemory() const
         {
             DECODE_OPERANDS();
             if(getCategory() == c_PrefetchInsn)
@@ -379,7 +379,7 @@ namespace Dyninst
             return !m_InsnOp.getImplicitMemReads().empty();
         }
 
-        INSTRUCTION_EXPORT bool Instruction::writesMemory() const
+        DYNINST_EXPORT bool Instruction::writesMemory() const
         {
             DECODE_OPERANDS();
             for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
@@ -394,7 +394,7 @@ namespace Dyninst
             return !m_InsnOp.getImplicitMemWrites().empty();
         }
 
-        INSTRUCTION_EXPORT void Instruction::getMemoryReadOperands(std::set<Expression::Ptr>& memAccessors) const
+        DYNINST_EXPORT void Instruction::getMemoryReadOperands(std::set<Expression::Ptr>& memAccessors) const
         {
             DECODE_OPERANDS();
             for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
@@ -407,7 +407,7 @@ namespace Dyninst
                         memAccessors.begin()));
         }
 
-        INSTRUCTION_EXPORT void Instruction::getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const
+        DYNINST_EXPORT void Instruction::getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const
         {
             DECODE_OPERANDS();
             for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
@@ -420,7 +420,7 @@ namespace Dyninst
                         memAccessors.begin()));
         }
 
-        INSTRUCTION_EXPORT Operand Instruction::getPredicateOperand() const
+        DYNINST_EXPORT Operand Instruction::getPredicateOperand() const
         {
             DECODE_OPERANDS();
             for(auto const &op : m_Operands) {
@@ -431,7 +431,7 @@ namespace Dyninst
 
             return Operand(Expression::Ptr(), false, false);
         }
-        INSTRUCTION_EXPORT bool Instruction::hasPredicateOperand() const
+        DYNINST_EXPORT bool Instruction::hasPredicateOperand() const
         {
             DECODE_OPERANDS();
             for(auto const &op : m_Operands) {
@@ -443,7 +443,7 @@ namespace Dyninst
             return false;
         }
 
-        INSTRUCTION_EXPORT Expression::Ptr Instruction::getControlFlowTarget() const
+        DYNINST_EXPORT Expression::Ptr Instruction::getControlFlowTarget() const
         {
             // We assume control flow transfer instructions have the PC as
             // an implicit write, and that we have decoded the control flow
@@ -467,11 +467,11 @@ namespace Dyninst
             return m_Successors.front().target;
         }
 
-        INSTRUCTION_EXPORT ArchSpecificFormatter& Instruction::getFormatter() const {
+        DYNINST_EXPORT ArchSpecificFormatter& Instruction::getFormatter() const {
             return *formatter;
         }
 
-        INSTRUCTION_EXPORT std::string Instruction::format(Address addr) const
+        DYNINST_EXPORT std::string Instruction::format(Address addr) const
         {
             // if Arch_none, this is an error and the formatter is nullptr,
             // so return an error string (could also abort or except)
@@ -543,7 +543,7 @@ namespace Dyninst
             return opstr + formatter->getInstructionString(formattedOperands);
         }
 
-        INSTRUCTION_EXPORT bool Instruction::allowsFallThrough() const
+        DYNINST_EXPORT bool Instruction::allowsFallThrough() const
         {
             switch(m_InsnOp.getID())
             {
@@ -598,12 +598,12 @@ namespace Dyninst
             // can't happen but make the compiler happy
             return false;
         }
-        INSTRUCTION_EXPORT bool Instruction::isLegalInsn() const
+        DYNINST_EXPORT bool Instruction::isLegalInsn() const
         {
             return (m_InsnOp.getID() != e_No_Entry);
         }
 
-        INSTRUCTION_EXPORT Architecture Instruction::getArch() const {
+        DYNINST_EXPORT Architecture Instruction::getArch() const {
             return arch_decoded_from;
         }
 
@@ -614,7 +614,7 @@ namespace Dyninst
             Expression::Ptr retLoc = Expression::Ptr(new Dereference(stackPtr, u32));
             return retLoc;
         }
-        INSTRUCTION_EXPORT InsnCategory Instruction::getCategory() const
+        DYNINST_EXPORT InsnCategory Instruction::getCategory() const
         {
             if(m_InsnOp.isVectorInsn) return c_VectorInsn;
             InsnCategory c = entryToCategory(m_InsnOp.getID());

--- a/instructionAPI/src/InstructionDecoder-x86.C
+++ b/instructionAPI/src/InstructionDecoder-x86.C
@@ -136,7 +136,7 @@ namespace Dyninst
         }
 
 
-    INSTRUCTION_EXPORT InstructionDecoder_x86::InstructionDecoder_x86(Architecture a) :
+    DYNINST_EXPORT InstructionDecoder_x86::InstructionDecoder_x86(Architecture a) :
       InstructionDecoderImpl(a),
       locs(NULL),
       decodedInstruction(NULL),
@@ -146,14 +146,14 @@ namespace Dyninst
       if(a == Arch_x86_64) InstructionDecoder_x86::setMode(true);
       
     }
-    INSTRUCTION_EXPORT InstructionDecoder_x86::~InstructionDecoder_x86()
+    DYNINST_EXPORT InstructionDecoder_x86::~InstructionDecoder_x86()
     {
         free(decodedInstruction);
         free(locs);
     }
     static const unsigned char modrm_use_sib = 4;
     
-    INSTRUCTION_EXPORT void InstructionDecoder_x86::setMode(bool is64)
+    DYNINST_EXPORT void InstructionDecoder_x86::setMode(bool is64)
     {
         InstructionDecoder_x86::is64BitMode = is64;
     }
@@ -1924,7 +1924,7 @@ namespace Dyninst
     }
 
     
-      INSTRUCTION_EXPORT Instruction InstructionDecoder_x86::decode(InstructionDecoder::buffer& b)
+      DYNINST_EXPORT Instruction InstructionDecoder_x86::decode(InstructionDecoder::buffer& b)
     {
         return InstructionDecoderImpl::decode(b);
     }

--- a/instructionAPI/src/InstructionDecoder-x86.h
+++ b/instructionAPI/src/InstructionDecoder-x86.h
@@ -63,15 +63,15 @@ namespace Dyninst
         {
             friend class Instruction;
             public:
-                INSTRUCTION_EXPORT InstructionDecoder_x86(Architecture a);
+                DYNINST_EXPORT InstructionDecoder_x86(Architecture a);
       
-                INSTRUCTION_EXPORT virtual ~InstructionDecoder_x86();
+                DYNINST_EXPORT virtual ~InstructionDecoder_x86();
             private:
-                INSTRUCTION_EXPORT InstructionDecoder_x86(const InstructionDecoder_x86& o);
+                DYNINST_EXPORT InstructionDecoder_x86(const InstructionDecoder_x86& o);
             public:
-                INSTRUCTION_EXPORT virtual Instruction decode(InstructionDecoder::buffer& b);
+                DYNINST_EXPORT virtual Instruction decode(InstructionDecoder::buffer& b);
       
-                INSTRUCTION_EXPORT virtual void setMode(bool is64);
+                DYNINST_EXPORT virtual void setMode(bool is64);
                 virtual void doDelayedDecode(const Instruction* insn_to_complete);
 
             protected:

--- a/instructionAPI/src/InstructionDecoder.C
+++ b/instructionAPI/src/InstructionDecoder.C
@@ -45,20 +45,20 @@ namespace Dyninst
 {
   namespace InstructionAPI
   {
-    INSTRUCTION_EXPORT InstructionDecoder::InstructionDecoder(const unsigned char* buffer_, size_t size, Architecture arch) :
+    DYNINST_EXPORT InstructionDecoder::InstructionDecoder(const unsigned char* buffer_, size_t size, Architecture arch) :
         m_buf(buffer_, size)
     {
         m_Impl = InstructionDecoderImpl::makeDecoderImpl(arch);
         m_Impl->setMode(arch == Arch_x86_64);
     }
-    INSTRUCTION_EXPORT InstructionDecoder::InstructionDecoder(const void* buffer_, size_t size, Architecture arch) :
+    DYNINST_EXPORT InstructionDecoder::InstructionDecoder(const void* buffer_, size_t size, Architecture arch) :
         m_buf(reinterpret_cast<const unsigned char*>(buffer_), size)
     {
         m_Impl = InstructionDecoderImpl::makeDecoderImpl(arch);
         m_Impl->setMode(arch == Arch_x86_64);
     }
     
-    INSTRUCTION_EXPORT Instruction InstructionDecoder::decode()
+    DYNINST_EXPORT Instruction InstructionDecoder::decode()
     {
       if(m_buf.start >= m_buf.end) return Instruction();
       Instruction const& ins = m_Impl->decode(m_buf);
@@ -79,12 +79,12 @@ namespace Dyninst
       return ins;
     }
     
-    INSTRUCTION_EXPORT Instruction InstructionDecoder::decode(const unsigned char* b)
+    DYNINST_EXPORT Instruction InstructionDecoder::decode(const unsigned char* b)
     {
       buffer tmp(b, b+maxInstructionLength);
       return m_Impl->decode(tmp);
     }
-    INSTRUCTION_EXPORT void InstructionDecoder::doDelayedDecode(const Instruction* i)
+    DYNINST_EXPORT void InstructionDecoder::doDelayedDecode(const Instruction* i)
     {
         m_Impl->doDelayedDecode(i);
     }

--- a/instructionAPI/src/Operand.C
+++ b/instructionAPI/src/Operand.C
@@ -43,7 +43,7 @@ namespace Dyninst
 {
     namespace InstructionAPI
     {
-        INSTRUCTION_EXPORT void Operand::getReadSet(std::set<RegisterAST::Ptr>& regsRead) const
+        DYNINST_EXPORT void Operand::getReadSet(std::set<RegisterAST::Ptr>& regsRead) const
         {
             std::set<InstructionAST::Ptr> useSet;
             // This thing returns something only for RegisterAST Expression
@@ -59,7 +59,7 @@ namespace Dyninst
                 }
             }
         }
-        INSTRUCTION_EXPORT void Operand::getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const
+        DYNINST_EXPORT void Operand::getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const
         {
             RegisterAST::Ptr op_as_reg = boost::dynamic_pointer_cast<RegisterAST>(op_value);
             if(m_isWritten && op_as_reg)
@@ -68,7 +68,7 @@ namespace Dyninst
             }
         }
 
-        INSTRUCTION_EXPORT RegisterAST::Ptr Operand::getPredicate() const
+        DYNINST_EXPORT RegisterAST::Ptr Operand::getPredicate() const
         {
             RegisterAST::Ptr op_as_reg = boost::dynamic_pointer_cast<RegisterAST>(op_value);
             if (m_isTruePredicate || m_isFalsePredicate) {
@@ -77,25 +77,25 @@ namespace Dyninst
             return nullptr;
         }
 
-        INSTRUCTION_EXPORT bool Operand::isRead(Expression::Ptr candidate) const
+        DYNINST_EXPORT bool Operand::isRead(Expression::Ptr candidate) const
         {
             // The whole expression of a read, any subexpression of a write
             return op_value->isUsed(candidate) && (m_isRead || !(*candidate == *op_value));
         }
-        INSTRUCTION_EXPORT bool Operand::isWritten(Expression::Ptr candidate) const
+        DYNINST_EXPORT bool Operand::isWritten(Expression::Ptr candidate) const
         {
             // Whole expression of a write
             return m_isWritten && (*op_value == *candidate);
         }    
-        INSTRUCTION_EXPORT bool Operand::readsMemory() const
+        DYNINST_EXPORT bool Operand::readsMemory() const
         {
             return (boost::dynamic_pointer_cast<Dereference>(op_value) && m_isRead);
         }
-        INSTRUCTION_EXPORT bool Operand::writesMemory() const
+        DYNINST_EXPORT bool Operand::writesMemory() const
         {
             return (boost::dynamic_pointer_cast<Dereference>(op_value) && m_isWritten);
         }
-        INSTRUCTION_EXPORT void Operand::addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const
+        DYNINST_EXPORT void Operand::addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const
         {
             if(m_isRead && boost::dynamic_pointer_cast<Dereference>(op_value))
             {
@@ -109,7 +109,7 @@ namespace Dyninst
                 }
             }
         }
-        INSTRUCTION_EXPORT void Operand::addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const
+        DYNINST_EXPORT void Operand::addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const
         {
             if(m_isWritten && boost::dynamic_pointer_cast<Dereference>(op_value))
             {
@@ -125,7 +125,7 @@ namespace Dyninst
         }
 
 
-        INSTRUCTION_EXPORT std::string Operand::format(Architecture arch, Address addr) const
+        DYNINST_EXPORT std::string Operand::format(Architecture arch, Address addr) const
         {
             if(!op_value) return "ERROR: format() called on empty operand!";
             if (addr) {
@@ -146,7 +146,7 @@ namespace Dyninst
             return s;
         }
 
-        INSTRUCTION_EXPORT Expression::Ptr Operand::getValue() const
+        DYNINST_EXPORT Expression::Ptr Operand::getValue() const
         {
             return op_value;
         }

--- a/parseAPI/h/CFG.h
+++ b/parseAPI/h/CFG.h
@@ -86,11 +86,11 @@ enum EdgeTypeEnum {
     _edgetype_end_
 };
 
-PARSER_EXPORT std::string format(EdgeTypeEnum e);
+DYNINST_EXPORT std::string format(EdgeTypeEnum e);
 
 class Block;
 
-class PARSER_EXPORT Edge {
+class DYNINST_EXPORT Edge {
    friend class CFGModifier;
     friend class Block;
  protected:
@@ -155,7 +155,7 @@ class PARSER_EXPORT Edge {
  * 
  * EdgePredicates are composable by AND.
  */
-class PARSER_EXPORT EdgePredicate 
+class DYNINST_EXPORT EdgePredicate 
 {
  public:
     virtual bool pred_impl(Edge *) const;
@@ -169,14 +169,14 @@ class PARSER_EXPORT EdgePredicate
  };
 
 /* may follow branches into the function if there is shared code */
-class PARSER_EXPORT Intraproc : public EdgePredicate {
+class DYNINST_EXPORT Intraproc : public EdgePredicate {
  public:
     bool pred_impl(Edge *) const;
 
 };
 
 /* follow interprocedural edges */
- class PARSER_EXPORT Interproc : public EdgePredicate {
+ class DYNINST_EXPORT Interproc : public EdgePredicate {
     public:
         bool pred_impl(Edge *) const;
 };
@@ -185,7 +185,7 @@ class PARSER_EXPORT Intraproc : public EdgePredicate {
  * For proper ostritch-like denial of 
  * unresolved control flow edges
  */
- class PARSER_EXPORT NoSinkPredicate : public ParseAPI::EdgePredicate {
+ class DYNINST_EXPORT NoSinkPredicate : public ParseAPI::EdgePredicate {
  public:
     NoSinkPredicate() { }
 
@@ -196,7 +196,7 @@ class PARSER_EXPORT Intraproc : public EdgePredicate {
 
 /* doesn't follow branches into the function if there is shared code */
 class Function;
- class PARSER_EXPORT SingleContext : public EdgePredicate {
+ class DYNINST_EXPORT SingleContext : public EdgePredicate {
  private:
     const Function * _context;
     bool _forward;
@@ -211,7 +211,7 @@ class Function;
 
 /* Doesn't follow branches into the function if there is shared code. 
  * Will follow interprocedural call/return edges */
- class PARSER_EXPORT SingleContextOrInterproc : public EdgePredicate {
+ class DYNINST_EXPORT SingleContextOrInterproc : public EdgePredicate {
     private:
         const Function * _context;
         bool _forward;
@@ -231,7 +231,7 @@ class Function;
 
 class CodeRegion;
 
-class PARSER_EXPORT Block :
+class DYNINST_EXPORT Block :
         public Dyninst::SimpleInterval<Address, int>,
         public boost::lockable_adapter<boost::recursive_mutex> {
     friend class CFGModifier;
@@ -376,7 +376,7 @@ class FuncExtent;
 class Loop;
 class LoopTreeNode;
 
-class PARSER_EXPORT Function : public AnnotatableSparse, public boost::lockable_adapter<boost::recursive_mutex> {
+class DYNINST_EXPORT Function : public AnnotatableSparse, public boost::lockable_adapter<boost::recursive_mutex> {
    friend class CFGModifier;
    friend class LoopAnalyzer;
  protected:
@@ -701,7 +701,7 @@ inline std::pair<Address, Block*> Function::get_next_block(
 }
 
 /* Describes a contiguous extent of a Function object */
-class PARSER_EXPORT FuncExtent : public Dyninst::SimpleInterval<Address, Function* > {
+class DYNINST_EXPORT FuncExtent : public Dyninst::SimpleInterval<Address, Function* > {
  private:
     Function * _func;
     Address _start;
@@ -741,7 +741,7 @@ class PARSER_EXPORT FuncExtent : public Dyninst::SimpleInterval<Address, Functio
 /** Natural loops
   */
 
-class PARSER_EXPORT Loop  
+class DYNINST_EXPORT Loop  
 {
 	friend class LoopAnalyzer;
 
@@ -854,7 +854,7 @@ private:
  *  @see BPatch_flowGraph
  */
 
-class PARSER_EXPORT LoopTreeNode {
+class DYNINST_EXPORT LoopTreeNode {
     friend class LoopAnalyzer;
 
  public:

--- a/parseAPI/h/CFGFactory.h
+++ b/parseAPI/h/CFGFactory.h
@@ -78,7 +78,7 @@ enum EdgeState {
     destroyed_all
 };
 
-class PARSER_EXPORT CFGFactory  {
+class DYNINST_EXPORT CFGFactory  {
  public:
     CFGFactory() {}
     virtual ~CFGFactory();

--- a/parseAPI/h/CFGModifier.h
+++ b/parseAPI/h/CFGModifier.h
@@ -56,40 +56,40 @@ class CFGModifier {
    // it's just a namespace. 
 
    // Redirect the target of an existing edge. 
-   PARSER_EXPORT static bool redirect(Edge *edge, Block *target);
+   DYNINST_EXPORT static bool redirect(Edge *edge, Block *target);
 
    // Split a block at a provided point.; we double-check whether the address
    // is a valid instruction boundary unless trust is true. 
    // Newlast is the new "last insn" of the original block; provide it if
    // you don't want to waste time disassembling to figure it out.
-   PARSER_EXPORT static Block *split(Block *, Address, bool trust = false, Address newlast = -1);
+   DYNINST_EXPORT static Block *split(Block *, Address, bool trust = false, Address newlast = -1);
    
    // Parse and add a new region of code to a CodeObject
    // The void * becomes "owned" by the CodeObject, as it's used
    // as a backing store; it cannot be ephemeral.
    // Returns the new entry block. 
-   PARSER_EXPORT static InsertedRegion *insert(CodeObject *obj, 
+   DYNINST_EXPORT static InsertedRegion *insert(CodeObject *obj, 
                                                Address base, void *data, 
                                                unsigned size);
 
    // Remove blocks from the CFG; the block must be unreachable
    // (that is, have no in-edges) unless force is true.
-   PARSER_EXPORT static bool remove(std::vector<Block *> &, bool force = false);
+   DYNINST_EXPORT static bool remove(std::vector<Block *> &, bool force = false);
 
    // As the above, but for functions. 
-   PARSER_EXPORT static bool remove(Function *);
+   DYNINST_EXPORT static bool remove(Function *);
 
    // Label a block as the entry of a new function. If the block is already an
    // entry that function is returned; otherwise we create a new function and
    // return it.
-   PARSER_EXPORT static Function *makeEntry(Block *);
+   DYNINST_EXPORT static Function *makeEntry(Block *);
 };
 
 class InsertedRegion : public CodeRegion {
   public:
    
-   PARSER_EXPORT InsertedRegion(Address base, void *data, unsigned size, Architecture arch); 
-   PARSER_EXPORT virtual ~InsertedRegion();
+   DYNINST_EXPORT InsertedRegion(Address base, void *data, unsigned size, Architecture arch); 
+   DYNINST_EXPORT virtual ~InsertedRegion();
    
    
    // names: not overriden (as there are no names [yet])
@@ -98,32 +98,32 @@ class InsertedRegion : public CodeRegion {
    // Addresses are provided by the user, as Dyninst etc. have
    // well-known ways of allocating additional code by extending
    // the binary or allocating memory, etc. 
-   PARSER_EXPORT Address low() const { return base_; }
-   PARSER_EXPORT Address high() const { return base_ + size_; }
+   DYNINST_EXPORT Address low() const { return base_; }
+   DYNINST_EXPORT Address high() const { return base_ + size_; }
 
    /** InstructionSource implementation **/
-   PARSER_EXPORT bool isValidAddress(const Address a) const { 
+   DYNINST_EXPORT bool isValidAddress(const Address a) const { 
       return (a >= low() && a < high());
    }
-   PARSER_EXPORT void* getPtrToInstruction(const Address a) const {
+   DYNINST_EXPORT void* getPtrToInstruction(const Address a) const {
       if (!isValidAddress(a)) return NULL;
       return (void *)((char *)buf_ + (a - base_));
    }
-   PARSER_EXPORT void* getPtrToData(const Address) const {
+   DYNINST_EXPORT void* getPtrToData(const Address) const {
       return NULL; 
    }
-   PARSER_EXPORT bool isCode(const Address a) const { return isValidAddress(a); }
-   PARSER_EXPORT bool isData(const Address) const { return false; }
-   PARSER_EXPORT bool isReadOnly(const Address) const { return false; }
-   PARSER_EXPORT Address offset() const { return base_; }
-   PARSER_EXPORT Address length() const { return size_; }
-   PARSER_EXPORT unsigned int getAddressWidth() const {
+   DYNINST_EXPORT bool isCode(const Address a) const { return isValidAddress(a); }
+   DYNINST_EXPORT bool isData(const Address) const { return false; }
+   DYNINST_EXPORT bool isReadOnly(const Address) const { return false; }
+   DYNINST_EXPORT Address offset() const { return base_; }
+   DYNINST_EXPORT Address length() const { return size_; }
+   DYNINST_EXPORT unsigned int getAddressWidth() const {
       if (arch_ == Arch_ppc64 || arch_ == Arch_x86_64 || arch_ == Arch_aarch64) return 8;
       else return 4;
    }
-   PARSER_EXPORT Architecture getArch() const { return arch_; }
+   DYNINST_EXPORT Architecture getArch() const { return arch_; }
 
-   PARSER_EXPORT bool wasUserAdded() const { return true; }
+   DYNINST_EXPORT bool wasUserAdded() const { return true; }
 
   private:
     Address base_;

--- a/parseAPI/h/CodeObject.h
+++ b/parseAPI/h/CodeObject.h
@@ -65,28 +65,28 @@ typedef enum {
 class CodeObject {
    friend class CFGModifier;
  public:
-    PARSER_EXPORT static void version(int& major, int& minor, int& maintenance);
+    DYNINST_EXPORT static void version(int& major, int& minor, int& maintenance);
     typedef std::set<Function*,Function::less> funclist;
 
-    PARSER_EXPORT CodeObject(CodeSource * cs, 
+    DYNINST_EXPORT CodeObject(CodeSource * cs, 
                              CFGFactory * fact = NULL, 
                              ParseCallback * cb = NULL,
                              bool defensiveMode = false,
                              bool ignoreParse = false);
-    PARSER_EXPORT ~CodeObject();
+    DYNINST_EXPORT ~CodeObject();
 
     /** Parsing interface **/
     
     // `hint-based' parsing
-    PARSER_EXPORT void parse();
+    DYNINST_EXPORT void parse();
     
     // `exact-target' parsing; optinally recursive
-    PARSER_EXPORT void parse(Address target, bool recursive);
-    PARSER_EXPORT void parse(const std::vector<Address> &targets, bool recursive);
+    DYNINST_EXPORT void parse(Address target, bool recursive);
+    DYNINST_EXPORT void parse(const std::vector<Address> &targets, bool recursive);
 
     // `even-more-exact-target' parsing; optinally recursive
-    PARSER_EXPORT void parse(CodeRegion *cr, Address target, bool recursive);
-    PARSER_EXPORT void parse(const std::vector<std::pair<Address, CodeRegion *>> &targets, bool recursive);
+    DYNINST_EXPORT void parse(CodeRegion *cr, Address target, bool recursive);
+    DYNINST_EXPORT void parse(const std::vector<std::pair<Address, CodeRegion *>> &targets, bool recursive);
 
     // parses new edges in already parsed functions
 	struct NewEdgeToParse {
@@ -98,45 +98,45 @@ class CodeObject {
         NewEdgeToParse(Block* a, Address b, bool c, EdgeTypeEnum d) : source(a), target(b), edge_type(d), checked(c) { }
 	};
 
-    PARSER_EXPORT bool parseNewEdges( std::vector<NewEdgeToParse> & worklist ); 
+    DYNINST_EXPORT bool parseNewEdges( std::vector<NewEdgeToParse> & worklist ); 
 
     // `speculative' parsing
-    PARSER_EXPORT void parseGaps(CodeRegion *cr, GapParsingType type=IdiomMatching);
+    DYNINST_EXPORT void parseGaps(CodeRegion *cr, GapParsingType type=IdiomMatching);
 
     /** Lookup routines **/
 
     // functions
-    PARSER_EXPORT Function * findFuncByEntry(CodeRegion * cr, Address entry);
-    PARSER_EXPORT int findFuncsByBlock(CodeRegion *cr, Block* b, std::set<Function*> &funcs);
-    PARSER_EXPORT int findFuncs(CodeRegion * cr, 
+    DYNINST_EXPORT Function * findFuncByEntry(CodeRegion * cr, Address entry);
+    DYNINST_EXPORT int findFuncsByBlock(CodeRegion *cr, Block* b, std::set<Function*> &funcs);
+    DYNINST_EXPORT int findFuncs(CodeRegion * cr, 
             Address addr, 
             std::set<Function*> & funcs);
       // Find functions overlapping the range [start,end)
-    PARSER_EXPORT int findFuncs(CodeRegion * cr,
+    DYNINST_EXPORT int findFuncs(CodeRegion * cr,
             Address start, Address end,
             std::set<Function*> & funcs);
-    PARSER_EXPORT int findCurrentFuncs(CodeRegion * cr,
+    DYNINST_EXPORT int findCurrentFuncs(CodeRegion * cr,
             Address addr,
             std::set<Function*> & funcs);
 
 
-    PARSER_EXPORT const funclist & funcs() { return flist; }
+    DYNINST_EXPORT const funclist & funcs() { return flist; }
 
     // blocks
-    PARSER_EXPORT Block * findBlockByEntry(CodeRegion * cr, Address entry);
-    PARSER_EXPORT int findBlocks(CodeRegion * cr, 
+    DYNINST_EXPORT Block * findBlockByEntry(CodeRegion * cr, Address entry);
+    DYNINST_EXPORT int findBlocks(CodeRegion * cr, 
         Address addr, std::set<Block*> & blocks);
     // finds blocks without parsing. 
-    PARSER_EXPORT int findCurrentBlocks(CodeRegion * cr, 
+    DYNINST_EXPORT int findCurrentBlocks(CodeRegion * cr, 
         Address addr, std::set<Block*> & blocks);
-    PARSER_EXPORT Block * findNextBlock(CodeRegion * cr, Address addr);
+    DYNINST_EXPORT Block * findNextBlock(CodeRegion * cr, Address addr);
 
     /* Misc */
-    PARSER_EXPORT CodeSource * cs() const { return _cs; }
-    PARSER_EXPORT CFGFactory * fact() const { return _fact; }
-    PARSER_EXPORT bool defensiveMode() { return defensive; }
+    DYNINST_EXPORT CodeSource * cs() const { return _cs; }
+    DYNINST_EXPORT CFGFactory * fact() const { return _fact; }
+    DYNINST_EXPORT bool defensiveMode() { return defensive; }
 
-    PARSER_EXPORT bool isIATcall(Address insn, std::string &calleeName);
+    DYNINST_EXPORT bool isIATcall(Address insn, std::string &calleeName);
 
     // This is for callbacks; it is often much more efficient to 
     // batch callbacks and deliver them all at once than one at a time. 
@@ -144,28 +144,28 @@ class CodeObject {
     // "The following blocks were deleted" than "block 1 was deleted;
     // block 2 lost an edge; block 2 was deleted..."
 
-    PARSER_EXPORT void startCallbackBatch();
-    PARSER_EXPORT void finishCallbackBatch();
-    PARSER_EXPORT void registerCallback(ParseCallback *cb);
-    PARSER_EXPORT void unregisterCallback(ParseCallback *cb);
+    DYNINST_EXPORT void startCallbackBatch();
+    DYNINST_EXPORT void finishCallbackBatch();
+    DYNINST_EXPORT void registerCallback(ParseCallback *cb);
+    DYNINST_EXPORT void unregisterCallback(ParseCallback *cb);
 
     /*
      * Calling finalize() forces completion of all on-demand
      * parsing operations for this object, if any remain.
      */
-    PARSER_EXPORT void finalize();
+    DYNINST_EXPORT void finalize();
 
     /*
      * Deletion support
      */
-    PARSER_EXPORT void destroy(Edge *);
-    PARSER_EXPORT void destroy(Block *);
-    PARSER_EXPORT void destroy(Function *);
+    DYNINST_EXPORT void destroy(Edge *);
+    DYNINST_EXPORT void destroy(Block *);
+    DYNINST_EXPORT void destroy(Function *);
 
     /*
      * Hacky "for insertion" method
      */
-    PARSER_EXPORT Address getFreeAddr() const;
+    DYNINST_EXPORT Address getFreeAddr() const;
     ParseData* parse_data();
 
  private:

--- a/parseAPI/h/CodeSource.h
+++ b/parseAPI/h/CodeSource.h
@@ -59,7 +59,7 @@ class CFGModifier;
 **/
 
 
-class PARSER_EXPORT CodeRegion : public Dyninst::InstructionSource, public Dyninst::SimpleInterval<Address> {
+class DYNINST_EXPORT CodeRegion : public Dyninst::InstructionSource, public Dyninst::SimpleInterval<Address> {
  public:
 
     /* Fills a vector with any names associated with the function at at 
@@ -111,7 +111,7 @@ struct Hint {
     }
 };
 
-class PARSER_EXPORT CodeSource : public Dyninst::InstructionSource {
+class DYNINST_EXPORT CodeSource : public Dyninst::InstructionSource {
    friend class CFGModifier;
  private:
     bool _regions_overlap;
@@ -225,7 +225,7 @@ class PARSER_EXPORT CodeSource : public Dyninst::InstructionSource {
     binaries supported by the SymtabAPI 
 **/
 
-class PARSER_EXPORT SymtabCodeRegion : public CodeRegion {
+class DYNINST_EXPORT SymtabCodeRegion : public CodeRegion {
  private:
     SymtabAPI::Symtab * _symtab;
     SymtabAPI::Region * _region;
@@ -258,7 +258,7 @@ class PARSER_EXPORT SymtabCodeRegion : public CodeRegion {
     SymtabAPI::Region * symRegion() const { return _region; }
 };
 
-class PARSER_EXPORT SymtabCodeSource : public CodeSource, public boost::lockable_adapter<boost::recursive_mutex> {
+class DYNINST_EXPORT SymtabCodeSource : public CodeSource, public boost::lockable_adapter<boost::recursive_mutex> {
  private:
     SymtabAPI::Symtab * _symtab;
     bool owns_symtab;

--- a/parseAPI/h/GraphAdapter.h
+++ b/parseAPI/h/GraphAdapter.h
@@ -91,5 +91,5 @@ boost::graph_traits<Function>::degree_size_type degree(boost::graph_traits<Funct
   return in_degree(v,g)+out_degree(v,g);
   
 }  
-PARSER_EXPORT bool dominates(Function& f, Address a, Address b);
-PARSER_EXPORT bool dominates(Function& f, Block* a, Block* b);
+DYNINST_EXPORT bool dominates(Function& f, Address a, Address b);
+DYNINST_EXPORT bool dominates(Function& f, Block* a, Block* b);

--- a/parseAPI/h/InstructionSource.h
+++ b/parseAPI/h/InstructionSource.h
@@ -38,7 +38,7 @@
 
 namespace Dyninst {
 
-class PARSER_EXPORT InstructionSource
+class DYNINST_EXPORT InstructionSource
 {
 public:
     InstructionSource() {}

--- a/parseAPI/h/SymLiteCodeSource.h
+++ b/parseAPI/h/SymLiteCodeSource.h
@@ -55,29 +55,29 @@ class SymReaderCodeRegion : public CodeRegion {
     void* rawData;
     
  public:
-    PARSER_EXPORT SymReaderCodeRegion(SymReader *, SymSegment *);
-    PARSER_EXPORT ~SymReaderCodeRegion();
+    DYNINST_EXPORT SymReaderCodeRegion(SymReader *, SymSegment *);
+    DYNINST_EXPORT ~SymReaderCodeRegion();
 
-    PARSER_EXPORT void names(Address, std::vector<std::string> &) override;
-    PARSER_EXPORT bool findCatchBlock(Address addr, Address & catchStart) override;
+    DYNINST_EXPORT void names(Address, std::vector<std::string> &) override;
+    DYNINST_EXPORT bool findCatchBlock(Address addr, Address & catchStart) override;
 
     /** InstructionSource implementation **/
-    PARSER_EXPORT bool isValidAddress(const Address) const override;
-    PARSER_EXPORT void* getPtrToInstruction(const Address) const override;
-    PARSER_EXPORT void* getPtrToData(const Address) const override;
-    PARSER_EXPORT unsigned int getAddressWidth() const override;
-    PARSER_EXPORT bool isCode(const Address) const override;
-    PARSER_EXPORT bool isData(const Address) const override;
-    PARSER_EXPORT bool isReadOnly(const Address) const override;
-    PARSER_EXPORT Address offset() const override;
-    PARSER_EXPORT Address length() const override;
-    PARSER_EXPORT Architecture getArch() const override;
+    DYNINST_EXPORT bool isValidAddress(const Address) const override;
+    DYNINST_EXPORT void* getPtrToInstruction(const Address) const override;
+    DYNINST_EXPORT void* getPtrToData(const Address) const override;
+    DYNINST_EXPORT unsigned int getAddressWidth() const override;
+    DYNINST_EXPORT bool isCode(const Address) const override;
+    DYNINST_EXPORT bool isData(const Address) const override;
+    DYNINST_EXPORT bool isReadOnly(const Address) const override;
+    DYNINST_EXPORT Address offset() const override;
+    DYNINST_EXPORT Address length() const override;
+    DYNINST_EXPORT Architecture getArch() const override;
 
     /** interval **/
-    PARSER_EXPORT Address low() const override { return offset(); }
-    PARSER_EXPORT Address high() const override { return offset() + length(); }
+    DYNINST_EXPORT Address low() const override { return offset(); }
+    DYNINST_EXPORT Address high() const override { return offset() + length(); }
 
-    PARSER_EXPORT SymSegment * symRegion() const { return _region; }
+    DYNINST_EXPORT SymSegment * symRegion() const { return _region; }
 };
 
 class SymReaderCodeSource : public CodeSource {
@@ -91,37 +91,37 @@ class SymReaderCodeSource : public CodeSource {
     bool _have_stats;
     
  public:
-    PARSER_EXPORT SymReaderCodeSource(SymReader *);
-    PARSER_EXPORT SymReaderCodeSource(const char *);
+    DYNINST_EXPORT SymReaderCodeSource(SymReader *);
+    DYNINST_EXPORT SymReaderCodeSource(const char *);
 
-    PARSER_EXPORT ~SymReaderCodeSource();
+    DYNINST_EXPORT ~SymReaderCodeSource();
 
-    PARSER_EXPORT bool nonReturning(Address func_entry);
-    PARSER_EXPORT bool nonReturningSyscall(int num);
+    DYNINST_EXPORT bool nonReturning(Address func_entry);
+    DYNINST_EXPORT bool nonReturningSyscall(int num);
 
-    PARSER_EXPORT bool resizeRegion(SymSegment *, Address newDiskSize);
+    DYNINST_EXPORT bool resizeRegion(SymSegment *, Address newDiskSize);
 
-    PARSER_EXPORT SymReader * getSymReaderObject() {return _symtab;} 
+    DYNINST_EXPORT SymReader * getSymReaderObject() {return _symtab;} 
 
     /** InstructionSource implementation **/
-    PARSER_EXPORT bool isValidAddress(const Address) const;
-    PARSER_EXPORT void* getPtrToInstruction(const Address) const;
-    PARSER_EXPORT void* getPtrToData(const Address) const;
-    PARSER_EXPORT unsigned int getAddressWidth() const;
-    PARSER_EXPORT bool isCode(const Address) const;
-    PARSER_EXPORT bool isData(const Address) const;
-    PARSER_EXPORT bool isReadOnly(const Address) const;
-    PARSER_EXPORT Address offset() const;
-    PARSER_EXPORT Address length() const;
-    PARSER_EXPORT Architecture getArch() const;
+    DYNINST_EXPORT bool isValidAddress(const Address) const;
+    DYNINST_EXPORT void* getPtrToInstruction(const Address) const;
+    DYNINST_EXPORT void* getPtrToData(const Address) const;
+    DYNINST_EXPORT unsigned int getAddressWidth() const;
+    DYNINST_EXPORT bool isCode(const Address) const;
+    DYNINST_EXPORT bool isData(const Address) const;
+    DYNINST_EXPORT bool isReadOnly(const Address) const;
+    DYNINST_EXPORT Address offset() const;
+    DYNINST_EXPORT Address length() const;
+    DYNINST_EXPORT Architecture getArch() const;
 
-    PARSER_EXPORT void removeHint(Hint);
+    DYNINST_EXPORT void removeHint(Hint);
 
-    PARSER_EXPORT static void addNonReturning(std::string func_name);
+    DYNINST_EXPORT static void addNonReturning(std::string func_name);
     
     // statistics accessor
-    PARSER_EXPORT void print_stats() const;
-    PARSER_EXPORT bool have_stats() const { return _have_stats; }
+    DYNINST_EXPORT void print_stats() const;
+    DYNINST_EXPORT bool have_stats() const { return _have_stats; }
 
     // manage statistics
     void incrementCounter(const std::string& name) const;

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -38,7 +38,6 @@
 #include <limits>
 #include <algorithm>
 // For Mutex
-#define PROCCONTROL_EXPORTS
 
 #include "dyntypes.h"
 

--- a/parseAPI/src/debug_parse.h
+++ b/parseAPI/src/debug_parse.h
@@ -39,11 +39,11 @@
 namespace Dyninst {
 namespace ParseAPI {
 
-    extern int PARSER_EXPORT parsing_printf_int(const char *format, ...)
+    extern int DYNINST_EXPORT parsing_printf_int(const char *format, ...)
             DYNINST_PRINTF_ANNOTATION(1, 2);
-    extern int PARSER_EXPORT malware_printf_int(const char *format, ...)
+    extern int DYNINST_EXPORT malware_printf_int(const char *format, ...)
             DYNINST_PRINTF_ANNOTATION(1, 2);
-    extern int PARSER_EXPORT indirect_collect_printf_int(const char *format, ...)
+    extern int DYNINST_EXPORT indirect_collect_printf_int(const char *format, ...)
             DYNINST_PRINTF_ANNOTATION(1, 2);
     extern int dyn_debug_parsing;
     extern int dyn_debug_malware;

--- a/patchAPI/h/AddrSpace.h
+++ b/patchAPI/h/AddrSpace.h
@@ -45,7 +45,7 @@ namespace PatchAPI {
 /* Interface specification for the interation between a PatchMgr and
    the address space */
 
-class PATCHAPI_EXPORT AddrSpace {
+class DYNINST_EXPORT AddrSpace {
     friend class PatchMgr;
     friend class PatchFunction;
 

--- a/patchAPI/h/CFGMaker.h
+++ b/patchAPI/h/CFGMaker.h
@@ -51,7 +51,7 @@ namespace PatchAPI {
 /* A factory class to make / copy CFG structures.
    We provide default implementations.  */
 
-class PATCHAPI_EXPORT CFGMaker {
+class DYNINST_EXPORT CFGMaker {
   public:
     CFGMaker() {}
     virtual ~CFGMaker() {}

--- a/patchAPI/h/Command.h
+++ b/patchAPI/h/Command.h
@@ -42,7 +42,7 @@ namespace PatchAPI {
    instrumentation request (public interface) or an internal step of
    instrumentation (plugin interface) */
 
-class PATCHAPI_EXPORT Command {
+class DYNINST_EXPORT Command {
   public:
     Command() {}
     virtual ~Command() {}
@@ -56,7 +56,7 @@ class PATCHAPI_EXPORT Command {
 /* A BatchCommand is in fact a list of Commands, and is to iterate all Commands
    in the list to run() or undo(). */
 
-class PATCHAPI_EXPORT BatchCommand : public Command {
+class DYNINST_EXPORT BatchCommand : public Command {
   public:
     BatchCommand* create();
     BatchCommand() {}
@@ -80,7 +80,7 @@ class PATCHAPI_EXPORT BatchCommand : public Command {
    after executing all Commands in its list. Instrumenter is for code relocation
    and code generation. */
 
-class PATCHAPI_EXPORT Patcher : public BatchCommand {
+class DYNINST_EXPORT Patcher : public BatchCommand {
   public:
    using Ptr = boost::shared_ptr<Patcher>;
    static Ptr create(Dyninst::PatchAPI::PatchMgrPtr mgr) {
@@ -96,7 +96,7 @@ class PATCHAPI_EXPORT Patcher : public BatchCommand {
 
 /* Default implementation of some basic instrumentation Commands */
 
-class PATCHAPI_EXPORT PushFrontCommand : public Command {
+class DYNINST_EXPORT PushFrontCommand : public Command {
   public:
     static PushFrontCommand* create(Dyninst::PatchAPI::Point* pt,
                       Dyninst::PatchAPI::SnippetPtr snip) {
@@ -115,7 +115,7 @@ class PATCHAPI_EXPORT PushFrontCommand : public Command {
    Dyninst::PatchAPI::InstancePtr instance_;
 };
 
-class PATCHAPI_EXPORT PushBackCommand : public Command {
+class DYNINST_EXPORT PushBackCommand : public Command {
   public:
     static PushBackCommand* create(Dyninst::PatchAPI::Point* pt,
                       Dyninst::PatchAPI::SnippetPtr snip) {
@@ -136,7 +136,7 @@ class PATCHAPI_EXPORT PushBackCommand : public Command {
     Dyninst::PatchAPI::InstancePtr instance_;
 };
 
-class PATCHAPI_EXPORT RemoveSnippetCommand : public Command {
+class DYNINST_EXPORT RemoveSnippetCommand : public Command {
   public:
     static RemoveSnippetCommand* create(Dyninst::PatchAPI::InstancePtr instance) {
       return new RemoveSnippetCommand(instance);
@@ -151,7 +151,7 @@ class PATCHAPI_EXPORT RemoveSnippetCommand : public Command {
     Dyninst::PatchAPI::InstancePtr instance_;
 };
 
-class PATCHAPI_EXPORT RemoveCallCommand : public Command {
+class DYNINST_EXPORT RemoveCallCommand : public Command {
   public:
     static RemoveCallCommand* create(Dyninst::PatchAPI::PatchMgrPtr mgr,
                       Dyninst::PatchAPI::PatchBlock* call_block,
@@ -172,7 +172,7 @@ class PATCHAPI_EXPORT RemoveCallCommand : public Command {
     Dyninst::PatchAPI::PatchFunction* context_;
 };
 
-class PATCHAPI_EXPORT ReplaceCallCommand : public Command {
+class DYNINST_EXPORT ReplaceCallCommand : public Command {
   public:
     static ReplaceCallCommand* create(Dyninst::PatchAPI::PatchMgrPtr mgr,
                       Dyninst::PatchAPI::PatchBlock* call_block,
@@ -196,7 +196,7 @@ class PATCHAPI_EXPORT ReplaceCallCommand : public Command {
     Dyninst::PatchAPI::PatchFunction* context_;
 };
 
-class PATCHAPI_EXPORT ReplaceFuncCommand : public Command {
+class DYNINST_EXPORT ReplaceFuncCommand : public Command {
   public:
     static ReplaceFuncCommand* create(Dyninst::PatchAPI::PatchMgrPtr mgr,
                       Dyninst::PatchAPI::PatchFunction* old_func,

--- a/patchAPI/h/Instrumenter.h
+++ b/patchAPI/h/Instrumenter.h
@@ -44,7 +44,7 @@ namespace PatchAPI {
 /* Relocate the original code and generate snippet binary code in mutatee's
    address space. */
 
-class PATCHAPI_EXPORT Instrumenter : public BatchCommand {
+class DYNINST_EXPORT Instrumenter : public BatchCommand {
   public:
     friend class Patcher;
     static Instrumenter* create(AddrSpace* as);

--- a/patchAPI/h/PatchCFG.h
+++ b/patchAPI/h/PatchCFG.h
@@ -52,7 +52,7 @@ class PatchBlock;
 class PatchFunction;
 class PatchCallback;
 
-class PATCHAPI_EXPORT PatchEdge {
+class DYNINST_EXPORT PatchEdge {
    friend class PatchBlock;
    friend class PatchFunction;
    friend class PatchObject;
@@ -95,7 +95,7 @@ class PATCHAPI_EXPORT PatchEdge {
     EdgePoints points_;
 };
 
-class PATCHAPI_EXPORT PatchBlock {
+class DYNINST_EXPORT PatchBlock {
   friend class PatchEdge;
   friend class PatchFunction;
   friend class PatchObject;
@@ -178,7 +178,7 @@ class PATCHAPI_EXPORT PatchBlock {
 class PatchLoop;
 class PatchLoopTreeNode;
 
-class PATCHAPI_EXPORT PatchFunction {
+class DYNINST_EXPORT PatchFunction {
    friend class PatchEdge;
    friend class PatchBlock;
    friend class PatchObject;
@@ -311,7 +311,7 @@ class PATCHAPI_EXPORT PatchFunction {
 };
 
 
-class PATCHAPI_EXPORT PatchLoop  
+class DYNINST_EXPORT PatchLoop  
 {
 	friend class PatchFunction;
 private:
@@ -388,7 +388,7 @@ private:
 }; // class PatchLoop
 
 
-class PATCHAPI_EXPORT PatchLoopTreeNode {
+class DYNINST_EXPORT PatchLoopTreeNode {
 
  public:
     // A loop node contains a single Loop instance

--- a/patchAPI/h/PatchCallback.h
+++ b/patchAPI/h/PatchCallback.h
@@ -49,7 +49,7 @@ class PatchBlock;
 class PatchEdge;
 class Point;
 
-class PATCHAPI_EXPORT PatchCallback {
+class DYNINST_EXPORT PatchCallback {
 
   public:
   PatchCallback() : batching_(false) {}

--- a/patchAPI/h/PatchMgr.h
+++ b/patchAPI/h/PatchMgr.h
@@ -64,7 +64,7 @@ Scope(PatchFunction *f) : obj(NULL), func(f), block(NULL), wholeProgram(false) {
 };
 
 
-class PATCHAPI_EXPORT PatchMgr : public boost::enable_shared_from_this<PatchMgr> {
+class DYNINST_EXPORT PatchMgr : public boost::enable_shared_from_this<PatchMgr> {
   friend class Point;
   friend class PatchObject; // for splitting blocks as that is _not_ public.
   typedef std::pair<PatchFunction *, PatchBlock *> BlockInstance;

--- a/patchAPI/h/PatchModifier.h
+++ b/patchAPI/h/PatchModifier.h
@@ -50,7 +50,7 @@ namespace PatchAPI {
    class PatchFunction;
    class PatchModifier;
 
-class PATCHAPI_EXPORT InsertedCode {
+class DYNINST_EXPORT InsertedCode {
    friend class PatchModifier;
 
   public:
@@ -68,7 +68,7 @@ class PATCHAPI_EXPORT InsertedCode {
 };   
    
 
-class PATCHAPI_EXPORT PatchModifier {
+class DYNINST_EXPORT PatchModifier {
   public:
    // These are all static methods as this class has no state; so really, 
    // it's just a namespace. 

--- a/patchAPI/h/PatchObject.h
+++ b/patchAPI/h/PatchObject.h
@@ -47,7 +47,7 @@ class PatchParseCallback;
 
 /* PatchObject represents a binary object, which could be either a library or
    executable. It is also an instrumentation  unit. */
-class PATCHAPI_EXPORT PatchObject {
+class DYNINST_EXPORT PatchObject {
   friend class AddrSpace;
   friend class PatchParseCallback;
 

--- a/patchAPI/h/Point.h
+++ b/patchAPI/h/Point.h
@@ -163,7 +163,7 @@ Location(PatchFunction *f, PatchBlock *b, Dyninst::Address a, InstructionAPI::In
    generation engine happens to put instrumentation from them at the same
    place */
 
-class PATCHAPI_EXPORT Point {
+class DYNINST_EXPORT Point {
   friend class PatchMgr;
   friend class PatchBlock;
   friend class PatchFunction;
@@ -323,7 +323,7 @@ enum SnippetState {
 
 /* A representation of a particular snippet inserted at a
    particular point */
-class PATCHAPI_EXPORT Instance : public boost::enable_shared_from_this<Instance> {
+class DYNINST_EXPORT Instance : public boost::enable_shared_from_this<Instance> {
   public:
    typedef boost::shared_ptr<Instance> Ptr;
 
@@ -357,7 +357,7 @@ class PATCHAPI_EXPORT Instance : public boost::enable_shared_from_this<Instance>
 
 /* Factory class for creating a point that could be either PatchAPI::Point or
    the subclass of PatchAPI::Point.   */
-class PATCHAPI_EXPORT PointMaker {
+class DYNINST_EXPORT PointMaker {
    friend class PatchMgr;
   public:
     PointMaker(PatchMgrPtr mgr) : mgr_(mgr) {}

--- a/patchAPI/h/Snippet.h
+++ b/patchAPI/h/Snippet.h
@@ -49,7 +49,7 @@ namespace PatchAPI {
       generate code, e.g., codeGen in dyninst.
     - Implement generateCode().
  */
-class PATCHAPI_EXPORT Snippet {
+class DYNINST_EXPORT Snippet {
   public:
     typedef boost::shared_ptr<Snippet> Ptr;
     Snippet() {}

--- a/proccontrol/CMakeLists.txt
+++ b/proccontrol/CMakeLists.txt
@@ -110,7 +110,6 @@ dyninst_library(
   PUBLIC_HEADER_FILES ${_public_headers}
   PRIVATE_HEADER_FILES ${_private_headers}
   SOURCE_FILES ${_sources}
-  DEFINES PROCCONTROL_EXPORTS
   DYNINST_DEPS common ${SYMREADER}
   PUBLIC_DEPS Dyninst::Boost_headers
   PRIVATE_DEPS ${CMAKE_DL_LIBS} Dyninst::Thread_DB Threads::Threads

--- a/proccontrol/h/Decoder.h
+++ b/proccontrol/h/Decoder.h
@@ -37,7 +37,7 @@
 namespace Dyninst {
 namespace ProcControlAPI {
 
-class PC_EXPORT Decoder
+class DYNINST_EXPORT Decoder
 {
  public:
    Decoder();

--- a/proccontrol/h/Event.h
+++ b/proccontrol/h/Event.h
@@ -46,7 +46,7 @@ class HandleCallbacks;
 namespace Dyninst {
 namespace ProcControlAPI {
 
-class PC_EXPORT ArchEvent
+class DYNINST_EXPORT ArchEvent
 {
 private:
    std::string name;
@@ -99,7 +99,7 @@ class EventSyscall;
 class EventPreSyscall;
 class EventPostSyscall;
 
-class PC_EXPORT Event : public boost::enable_shared_from_this<Event>
+class DYNINST_EXPORT Event : public boost::enable_shared_from_this<Event>
 {
    friend void boost::checked_delete<Event>(Event *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const Event>(const Event *) CHECKED_DELETE_NOEXCEPT;
@@ -307,7 +307,7 @@ OS& operator<<(OS& str, Event& e)
 	return str;
 }
 
-class PC_EXPORT EventTerminate : public Event
+class DYNINST_EXPORT EventTerminate : public Event
 {
    friend void boost::checked_delete<EventTerminate>(EventTerminate *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventTerminate>(const EventTerminate *) CHECKED_DELETE_NOEXCEPT;
@@ -318,7 +318,7 @@ class PC_EXPORT EventTerminate : public Event
    virtual ~EventTerminate();
 };
 
-class PC_EXPORT EventExit : public EventTerminate
+class DYNINST_EXPORT EventExit : public EventTerminate
 {
    friend void boost::checked_delete<EventExit>(EventExit *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventExit>(const EventExit *) CHECKED_DELETE_NOEXCEPT;
@@ -332,7 +332,7 @@ class PC_EXPORT EventExit : public EventTerminate
    virtual ~EventExit();
 };
 
-class PC_EXPORT EventCrash : public EventTerminate
+class DYNINST_EXPORT EventCrash : public EventTerminate
 {
    friend void boost::checked_delete<EventCrash>(EventCrash *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventCrash>(const EventCrash *) CHECKED_DELETE_NOEXCEPT;
@@ -346,7 +346,7 @@ class PC_EXPORT EventCrash : public EventTerminate
    virtual ~EventCrash();
 };
 
-class PC_EXPORT EventForceTerminate : public EventTerminate
+class DYNINST_EXPORT EventForceTerminate : public EventTerminate
 {
    friend void boost::checked_delete<EventForceTerminate>(EventForceTerminate *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventForceTerminate>(const EventForceTerminate *) CHECKED_DELETE_NOEXCEPT;
@@ -360,7 +360,7 @@ class PC_EXPORT EventForceTerminate : public EventTerminate
    virtual ~EventForceTerminate();
 };
 
-class PC_EXPORT EventExec : public Event
+class DYNINST_EXPORT EventExec : public Event
 {
    friend void boost::checked_delete<EventExec>(EventExec *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventExec>(const EventExec *) CHECKED_DELETE_NOEXCEPT;
@@ -376,7 +376,7 @@ class PC_EXPORT EventExec : public Event
    void setExecPath(std::string path_);
 };
 
-class PC_EXPORT EventStop : public Event
+class DYNINST_EXPORT EventStop : public Event
 {
    friend void boost::checked_delete<EventStop>(EventStop *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventStop>(const EventStop *) CHECKED_DELETE_NOEXCEPT;
@@ -387,7 +387,7 @@ class PC_EXPORT EventStop : public Event
    virtual ~EventStop();
 };
 
-class PC_EXPORT EventNewThread : public Event
+class DYNINST_EXPORT EventNewThread : public Event
 {
    friend void boost::checked_delete<EventNewThread>(EventNewThread *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventNewThread>(const EventNewThread *) CHECKED_DELETE_NOEXCEPT;
@@ -402,7 +402,7 @@ class PC_EXPORT EventNewThread : public Event
 };
 
 class int_eventNewUserThread;
-class PC_EXPORT EventNewUserThread : public EventNewThread
+class DYNINST_EXPORT EventNewUserThread : public EventNewThread
 {
    friend void boost::checked_delete<EventNewUserThread>(EventNewUserThread *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventNewUserThread>(const EventNewUserThread *) CHECKED_DELETE_NOEXCEPT;
@@ -421,7 +421,7 @@ class PC_EXPORT EventNewUserThread : public EventNewThread
 };
 
 class int_eventNewLWP;
-class PC_EXPORT EventNewLWP : public EventNewThread
+class DYNINST_EXPORT EventNewLWP : public EventNewThread
 {
    friend void boost::checked_delete<EventNewLWP>(EventNewLWP *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventNewLWP>(const EventNewLWP *) CHECKED_DELETE_NOEXCEPT;
@@ -439,7 +439,7 @@ class PC_EXPORT EventNewLWP : public EventNewThread
    virtual Thread::const_ptr getNewThread() const;
 };
 
-class PC_EXPORT EventThreadDestroy : public Event
+class DYNINST_EXPORT EventThreadDestroy : public Event
 {
    friend void boost::checked_delete<EventThreadDestroy>(EventThreadDestroy *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventThreadDestroy>(const EventThreadDestroy *) CHECKED_DELETE_NOEXCEPT;
@@ -450,7 +450,7 @@ class PC_EXPORT EventThreadDestroy : public Event
    virtual ~EventThreadDestroy() = 0;
 };
 
-class PC_EXPORT EventUserThreadDestroy : public EventThreadDestroy
+class DYNINST_EXPORT EventUserThreadDestroy : public EventThreadDestroy
 {
    friend void boost::checked_delete<EventUserThreadDestroy>(EventUserThreadDestroy *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventUserThreadDestroy>(const EventUserThreadDestroy *) CHECKED_DELETE_NOEXCEPT;
@@ -461,7 +461,7 @@ class PC_EXPORT EventUserThreadDestroy : public EventThreadDestroy
    virtual ~EventUserThreadDestroy();
 };
 
-class PC_EXPORT EventLWPDestroy : public EventThreadDestroy
+class DYNINST_EXPORT EventLWPDestroy : public EventThreadDestroy
 {
    friend void boost::checked_delete<EventLWPDestroy>(EventLWPDestroy *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventLWPDestroy>(const EventLWPDestroy *) CHECKED_DELETE_NOEXCEPT;
@@ -472,7 +472,7 @@ class PC_EXPORT EventLWPDestroy : public EventThreadDestroy
    virtual ~EventLWPDestroy();
 };
 
-class PC_EXPORT EventFork : public Event
+class DYNINST_EXPORT EventFork : public Event
 {
    friend void boost::checked_delete<EventFork>(EventFork *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventFork>(const EventFork *) CHECKED_DELETE_NOEXCEPT;
@@ -487,7 +487,7 @@ class PC_EXPORT EventFork : public Event
    Process::const_ptr getChildProcess() const;
 };
 
-class PC_EXPORT EventSignal : public Event
+class DYNINST_EXPORT EventSignal : public Event
 {
 public:
    // causes of signal. unknown refers to all non-access violations.
@@ -520,7 +520,7 @@ public:
    bool isFirst() const { return first; }
 };
 
-class PC_EXPORT EventBootstrap : public Event
+class DYNINST_EXPORT EventBootstrap : public Event
 {
    friend void boost::checked_delete<EventBootstrap>(EventBootstrap *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventBootstrap>(const EventBootstrap *) CHECKED_DELETE_NOEXCEPT;
@@ -531,7 +531,7 @@ class PC_EXPORT EventBootstrap : public Event
    virtual ~EventBootstrap();
 };
 
-class PC_EXPORT EventPreBootstrap : public Event
+class DYNINST_EXPORT EventPreBootstrap : public Event
 {
    friend void boost::checked_delete<EventPreBootstrap>(EventPreBootstrap *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventPreBootstrap>(const EventPreBootstrap *) CHECKED_DELETE_NOEXCEPT;
@@ -544,7 +544,7 @@ class PC_EXPORT EventPreBootstrap : public Event
 
 
 class int_eventRPC;
-class PC_EXPORT EventRPC : public Event
+class DYNINST_EXPORT EventRPC : public Event
 {
    friend void boost::checked_delete<EventRPC>(EventRPC *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventRPC>(const EventRPC *) CHECKED_DELETE_NOEXCEPT;
@@ -563,7 +563,7 @@ class PC_EXPORT EventRPC : public Event
    int_eventRPC *getInternal() const;
 };
 
-class PC_EXPORT EventRPCLaunch : public Event
+class DYNINST_EXPORT EventRPCLaunch : public Event
 {
    friend void boost::checked_delete<EventRPCLaunch>(EventRPCLaunch *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventRPCLaunch>(const EventRPCLaunch *) CHECKED_DELETE_NOEXCEPT;
@@ -575,7 +575,7 @@ class PC_EXPORT EventRPCLaunch : public Event
    virtual ~EventRPCLaunch();
 };
 
-class PC_EXPORT EventSingleStep : public Event
+class DYNINST_EXPORT EventSingleStep : public Event
 {
    friend void boost::checked_delete<EventSingleStep>(EventSingleStep *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventSingleStep>(const EventSingleStep *) CHECKED_DELETE_NOEXCEPT;
@@ -586,7 +586,7 @@ class PC_EXPORT EventSingleStep : public Event
    virtual ~EventSingleStep();
 };
 
-class PC_EXPORT EventSyscall : public Event
+class DYNINST_EXPORT EventSyscall : public Event
 {
    friend void boost::checked_delete<EventSyscall>(EventSyscall *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventSyscall>(const EventSyscall *) CHECKED_DELETE_NOEXCEPT;
@@ -606,7 +606,7 @@ class PC_EXPORT EventSyscall : public Event
     long getSyscallNumber() const;
 };
 
-class PC_EXPORT EventPreSyscall : public EventSyscall
+class DYNINST_EXPORT EventPreSyscall : public EventSyscall
 {
    friend void boost::checked_delete<EventPreSyscall>(EventPreSyscall *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventPreSyscall>(const EventPreSyscall *) CHECKED_DELETE_NOEXCEPT;
@@ -620,7 +620,7 @@ class PC_EXPORT EventPreSyscall : public EventSyscall
    virtual ~EventPreSyscall();
 };
 
-class PC_EXPORT EventPostSyscall : public EventSyscall
+class DYNINST_EXPORT EventPostSyscall : public EventSyscall
 {
    friend void boost::checked_delete<EventPostSyscall>(EventPostSyscall *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventPostSyscall>(const EventPostSyscall *) CHECKED_DELETE_NOEXCEPT;
@@ -637,7 +637,7 @@ class PC_EXPORT EventPostSyscall : public EventSyscall
 };
 
 class int_eventBreakpoint;
-class PC_EXPORT EventBreakpoint : public Event
+class DYNINST_EXPORT EventBreakpoint : public Event
 {
    friend void boost::checked_delete<EventBreakpoint>(EventBreakpoint *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventBreakpoint>(const EventBreakpoint *) CHECKED_DELETE_NOEXCEPT;
@@ -660,7 +660,7 @@ class PC_EXPORT EventBreakpoint : public Event
 
 
 class int_eventBreakpointClear;
-class PC_EXPORT EventBreakpointClear : public Event
+class DYNINST_EXPORT EventBreakpointClear : public Event
 {
    friend void boost::checked_delete<EventBreakpointClear>(EventBreakpointClear *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventBreakpointClear>(const EventBreakpointClear *) CHECKED_DELETE_NOEXCEPT;
@@ -693,7 +693,7 @@ class EventBreakpointRestore : public Event
    int_eventBreakpointRestore *getInternal() const;
 };
 
-class PC_EXPORT EventLibrary : public Event
+class DYNINST_EXPORT EventLibrary : public Event
 {
    friend void boost::checked_delete<EventLibrary>(EventLibrary *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventLibrary>(const EventLibrary *) CHECKED_DELETE_NOEXCEPT;
@@ -715,7 +715,7 @@ class PC_EXPORT EventLibrary : public Event
 };
 
 class int_eventAsync;
-class PC_EXPORT EventAsync : public Event
+class DYNINST_EXPORT EventAsync : public Event
 {
    friend void boost::checked_delete<EventAsync>(EventAsync *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventAsync>(const EventAsync *) CHECKED_DELETE_NOEXCEPT;
@@ -731,7 +731,7 @@ class PC_EXPORT EventAsync : public Event
    int_eventAsync *getInternal() const;
 };
 
-class PC_EXPORT EventChangePCStop : public Event
+class DYNINST_EXPORT EventChangePCStop : public Event
 {
    friend void boost::checked_delete<EventChangePCStop>(EventChangePCStop *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventChangePCStop>(const EventChangePCStop *) CHECKED_DELETE_NOEXCEPT;
@@ -743,7 +743,7 @@ class PC_EXPORT EventChangePCStop : public Event
 };
 
 class int_eventDetach;
-class PC_EXPORT EventDetach : public Event
+class DYNINST_EXPORT EventDetach : public Event
 {
    friend void boost::checked_delete<EventDetach>(EventDetach *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventDetach>(const EventDetach *) CHECKED_DELETE_NOEXCEPT;
@@ -758,7 +758,7 @@ class PC_EXPORT EventDetach : public Event
    virtual bool procStopper() const;
 };
 
-class PC_EXPORT EventIntBootstrap : public Event
+class DYNINST_EXPORT EventIntBootstrap : public Event
 {
    friend void boost::checked_delete<EventIntBootstrap>(EventIntBootstrap *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventIntBootstrap>(const EventIntBootstrap *) CHECKED_DELETE_NOEXCEPT;
@@ -774,7 +774,7 @@ class PC_EXPORT EventIntBootstrap : public Event
    void setData(void *v);
 };
 
-class PC_EXPORT EventNop : public Event
+class DYNINST_EXPORT EventNop : public Event
 {
    friend void boost::checked_delete<EventNop>(EventNop *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventNop>(const EventNop *) CHECKED_DELETE_NOEXCEPT;
@@ -786,7 +786,7 @@ class PC_EXPORT EventNop : public Event
 };
 
 class int_eventThreadDB;
-class PC_EXPORT EventThreadDB : public Event
+class DYNINST_EXPORT EventThreadDB : public Event
 {
    friend void boost::checked_delete<EventThreadDB>(EventThreadDB *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventThreadDB>(const EventThreadDB *) CHECKED_DELETE_NOEXCEPT;
@@ -802,7 +802,7 @@ class PC_EXPORT EventThreadDB : public Event
    virtual bool triggersCB() const;
 };
 
-class PC_EXPORT EventWinStopThreadDestroy : public EventThreadDestroy
+class DYNINST_EXPORT EventWinStopThreadDestroy : public EventThreadDestroy
 {
    friend void boost::checked_delete<EventWinStopThreadDestroy>(EventWinStopThreadDestroy *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventWinStopThreadDestroy>(const EventWinStopThreadDestroy *) CHECKED_DELETE_NOEXCEPT;
@@ -814,7 +814,7 @@ class PC_EXPORT EventWinStopThreadDestroy : public EventThreadDestroy
 };
 
 class int_eventControlAuthority;
-class PC_EXPORT EventControlAuthority : public Event
+class DYNINST_EXPORT EventControlAuthority : public Event
 {
    friend void boost::checked_delete<EventControlAuthority>(EventControlAuthority *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventControlAuthority>(const EventControlAuthority *) CHECKED_DELETE_NOEXCEPT;
@@ -842,7 +842,7 @@ class PC_EXPORT EventControlAuthority : public Event
 };
 
 class int_eventAsyncIO;
-class PC_EXPORT EventAsyncIO : public Event {
+class DYNINST_EXPORT EventAsyncIO : public Event {
    friend void boost::checked_delete<EventAsyncIO>(EventAsyncIO *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventAsyncIO>(const EventAsyncIO *) CHECKED_DELETE_NOEXCEPT;
   protected:
@@ -859,7 +859,7 @@ class PC_EXPORT EventAsyncIO : public Event {
    void *getOpaqueVal() const;
 };
 
-class PC_EXPORT EventAsyncRead : public EventAsyncIO {
+class DYNINST_EXPORT EventAsyncRead : public EventAsyncIO {
    friend void boost::checked_delete<EventAsyncRead>(EventAsyncRead *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventAsyncRead>(const EventAsyncRead *) CHECKED_DELETE_NOEXCEPT;
   public:
@@ -874,7 +874,7 @@ class PC_EXPORT EventAsyncRead : public EventAsyncIO {
    Dyninst::Address getAddress() const;
 };
 
-class PC_EXPORT EventAsyncWrite : public EventAsyncIO {
+class DYNINST_EXPORT EventAsyncWrite : public EventAsyncIO {
    friend void boost::checked_delete<EventAsyncWrite>(EventAsyncWrite *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventAsyncWrite>(const EventAsyncWrite *) CHECKED_DELETE_NOEXCEPT;
   public:
@@ -888,7 +888,7 @@ class PC_EXPORT EventAsyncWrite : public EventAsyncIO {
    Dyninst::Address getAddress() const;
 };
 
-class PC_EXPORT EventAsyncReadAllRegs : public EventAsyncIO {
+class DYNINST_EXPORT EventAsyncReadAllRegs : public EventAsyncIO {
    friend void boost::checked_delete<EventAsyncReadAllRegs>(EventAsyncReadAllRegs *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventAsyncReadAllRegs>(const EventAsyncReadAllRegs *) CHECKED_DELETE_NOEXCEPT;
   public:
@@ -901,7 +901,7 @@ class PC_EXPORT EventAsyncReadAllRegs : public EventAsyncIO {
    const RegisterPool &getRegisters() const;
 };
 
-class PC_EXPORT EventAsyncSetAllRegs : public EventAsyncIO {
+class DYNINST_EXPORT EventAsyncSetAllRegs : public EventAsyncIO {
    friend void boost::checked_delete<EventAsyncSetAllRegs>(EventAsyncSetAllRegs *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventAsyncSetAllRegs>(const EventAsyncSetAllRegs *) CHECKED_DELETE_NOEXCEPT;
   public:
@@ -913,7 +913,7 @@ class PC_EXPORT EventAsyncSetAllRegs : public EventAsyncIO {
 };
 
 class int_eventAsyncFileRead;
-class PC_EXPORT EventAsyncFileRead : public Event {
+class DYNINST_EXPORT EventAsyncFileRead : public Event {
    friend void boost::checked_delete<EventAsyncFileRead>(EventAsyncFileRead *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const EventAsyncFileRead>(const EventAsyncFileRead *) CHECKED_DELETE_NOEXCEPT;
    int_eventAsyncFileRead *iev;

--- a/proccontrol/h/EventType.h
+++ b/proccontrol/h/EventType.h
@@ -36,7 +36,7 @@
 namespace Dyninst {
 namespace ProcControlAPI {
 
-class PC_EXPORT EventType
+class DYNINST_EXPORT EventType
 {
  public:
    static const int Error               = -1;

--- a/proccontrol/h/Generator.h
+++ b/proccontrol/h/Generator.h
@@ -53,7 +53,7 @@ class ArchEvent;
 class Event;
 class Mailbox;
 
-class PC_EXPORT Generator
+class DYNINST_EXPORT Generator
 {
  public:
    static Generator *getDefaultGenerator();
@@ -126,7 +126,7 @@ class PC_EXPORT Generator
    bool eventBlock_;
 };
 
-class PC_EXPORT GeneratorMT : public Generator
+class DYNINST_EXPORT GeneratorMT : public Generator
 {
  private:
    GeneratorMTInternals *sync;

--- a/proccontrol/h/Handler.h
+++ b/proccontrol/h/Handler.h
@@ -40,7 +40,7 @@
 namespace Dyninst {
 namespace ProcControlAPI {
 
-class PC_EXPORT Handler 
+class DYNINST_EXPORT Handler 
 {
  protected:
    std::string name;

--- a/proccontrol/h/Mailbox.h
+++ b/proccontrol/h/Mailbox.h
@@ -36,7 +36,7 @@
 namespace Dyninst {
 namespace ProcControlAPI {
 
-class PC_EXPORT Mailbox
+class DYNINST_EXPORT Mailbox
 {
 public:
 	typedef enum {
@@ -58,7 +58,7 @@ public:
    virtual void unlock_queue() = 0;
 };
 
-extern PC_EXPORT Mailbox* mbox();
+extern DYNINST_EXPORT Mailbox* mbox();
 
 }
 }

--- a/proccontrol/h/PCErrors.h
+++ b/proccontrol/h/PCErrors.h
@@ -42,8 +42,8 @@
 #include "util.h"
 #include "dyntypes.h"
 
-PC_EXPORT extern void pc_print_lock();
-PC_EXPORT extern void pc_print_unlock();
+DYNINST_EXPORT extern void pc_print_lock();
+DYNINST_EXPORT extern void pc_print_unlock();
 #if defined(PROCCTRL_LOCK_PRINTS)
 #define PC_PRINT_LOCK pc_print_lock()
 #define PC_PRINT_UNLOCK pc_print_unlock()
@@ -118,11 +118,11 @@ PC_EXPORT extern void pc_print_unlock();
 
 #endif
 
-PC_EXPORT extern bool dyninst_debug_proccontrol;
-PC_EXPORT extern const char *thrdName();
-PC_EXPORT extern FILE* pctrl_err_out;
+DYNINST_EXPORT extern bool dyninst_debug_proccontrol;
+DYNINST_EXPORT extern const char *thrdName();
+DYNINST_EXPORT extern FILE* pctrl_err_out;
 
-PC_EXPORT extern unsigned long gettod();
+DYNINST_EXPORT extern unsigned long gettod();
 
 namespace Dyninst {
 namespace ProcControlAPI {
@@ -154,14 +154,14 @@ const err_t err_notfound       = 0x10014;
 const err_t err_dstack         = 0x10107;
 const err_t err_eof            = 0x10108;
 
-PC_EXPORT err_t getLastError();
-PC_EXPORT void clearLastError();
-PC_EXPORT const char* getLastErrorMsg();
-PC_EXPORT void globalSetLastError(err_t err, const char *msg = NULL);
-PC_EXPORT void setDebugChannel(FILE *f);
-PC_EXPORT void setDebug(bool enable);
-PC_EXPORT const char *getGenericErrorMsg(err_t e);
-PC_EXPORT FILE *getDebugChannel();
+DYNINST_EXPORT err_t getLastError();
+DYNINST_EXPORT void clearLastError();
+DYNINST_EXPORT const char* getLastErrorMsg();
+DYNINST_EXPORT void globalSetLastError(err_t err, const char *msg = NULL);
+DYNINST_EXPORT void setDebugChannel(FILE *f);
+DYNINST_EXPORT void setDebug(bool enable);
+DYNINST_EXPORT const char *getGenericErrorMsg(err_t e);
+DYNINST_EXPORT FILE *getDebugChannel();
 
 }
 }

--- a/proccontrol/h/PCProcess.h
+++ b/proccontrol/h/PCProcess.h
@@ -81,7 +81,7 @@ class SymbolReaderFactory;
 
 namespace ProcControlAPI {
 
-   extern PC_EXPORT bool is_restricted_ptrace;
+   extern DYNINST_EXPORT bool is_restricted_ptrace;
  
 
 class Process;
@@ -106,7 +106,7 @@ class MemoryUsage;
 
 class ExecFileInfo;
 
-class PC_EXPORT Breakpoint 
+class DYNINST_EXPORT Breakpoint 
 {
    friend class ::int_breakpoint;
    friend void boost::checked_delete<Breakpoint>(Breakpoint *) CHECKED_DELETE_NOEXCEPT;
@@ -140,7 +140,7 @@ class PC_EXPORT Breakpoint
    bool suppressCallbacks() const;
 };
 
-class PC_EXPORT Library
+class DYNINST_EXPORT Library
 {
    friend class ::int_library;
    friend void boost::checked_delete<Library>(Library *) CHECKED_DELETE_NOEXCEPT;
@@ -165,7 +165,7 @@ class PC_EXPORT Library
    void setData(void *p) const;
 };
 
-class PC_EXPORT LibraryPool
+class DYNINST_EXPORT LibraryPool
 {
    friend class ::int_process;
    friend class Dyninst::ProcControlAPI::Process;
@@ -174,7 +174,7 @@ class PC_EXPORT LibraryPool
    LibraryPool();
    ~LibraryPool();
  public:
-   class PC_EXPORT iterator  {
+   class DYNINST_EXPORT iterator  {
       friend class Dyninst::ProcControlAPI::LibraryPool;
    private:
       std::set<int_library *>::iterator int_iter;
@@ -193,7 +193,7 @@ class PC_EXPORT LibraryPool
       typedef std::forward_iterator_tag iterator_category;
   };
 
-   class PC_EXPORT const_iterator  {
+   class DYNINST_EXPORT const_iterator  {
      friend class Dyninst::ProcControlAPI::LibraryPool;
   private:
      std::set<int_library *>::iterator int_iter;
@@ -230,7 +230,7 @@ class PC_EXPORT LibraryPool
 
 };
 
-class PC_EXPORT IRPC
+class DYNINST_EXPORT IRPC
 {
    friend class ::int_iRPC;
    friend void boost::checked_delete<IRPC>(IRPC *) CHECKED_DELETE_NOEXCEPT;
@@ -280,7 +280,7 @@ class PC_EXPORT IRPC
    bool continueStoppedIRPC();
 };
 
-class PC_EXPORT Process : public boost::enable_shared_from_this<Process>
+class DYNINST_EXPORT Process : public boost::enable_shared_from_this<Process>
 {
  private:
    friend class ::int_process;
@@ -421,7 +421,7 @@ class PC_EXPORT Process : public boost::enable_shared_from_this<Process>
    /**
     * Memory management
     **/
-   class PC_EXPORT mem_perm {
+   class DYNINST_EXPORT mem_perm {
        bool read;
        bool write;
        bool execute;
@@ -556,7 +556,7 @@ class PC_EXPORT Process : public boost::enable_shared_from_this<Process>
 	ExecFileInfo* getExecutableInfo() const;
 };
 
-class PC_EXPORT Thread : public boost::enable_shared_from_this<Thread>
+class DYNINST_EXPORT Thread : public boost::enable_shared_from_this<Thread>
 {
  protected:
    friend class ::int_thread;
@@ -642,7 +642,7 @@ class PC_EXPORT Thread : public boost::enable_shared_from_this<Thread>
    void setData(void *p) const;
 };
 
-class PC_EXPORT ThreadPool
+class DYNINST_EXPORT ThreadPool
 {
  private:
    friend class ::int_threadPool;
@@ -654,7 +654,7 @@ class PC_EXPORT ThreadPool
    /**
     * Iterators
     **/
-   class PC_EXPORT iterator {
+   class DYNINST_EXPORT iterator {
       friend class Dyninst::ProcControlAPI::ThreadPool;
    private:
       static const int uninitialized_val = -1;
@@ -674,7 +674,7 @@ class PC_EXPORT ThreadPool
    iterator end();
    iterator find(Dyninst::LWP lwp);
 
-   class PC_EXPORT const_iterator {
+   class DYNINST_EXPORT const_iterator {
       friend class Dyninst::ProcControlAPI::ThreadPool;
    private:
       static const int uninitialized_val = -1;
@@ -707,7 +707,7 @@ class PC_EXPORT ThreadPool
    Thread::ptr getInitialThread();
 };
 
-class PC_EXPORT RegisterPool
+class DYNINST_EXPORT RegisterPool
 { 
    friend class Dyninst::ProcControlAPI::Thread;
    friend class Dyninst::ProcControlAPI::ThreadSet;
@@ -718,7 +718,7 @@ class PC_EXPORT RegisterPool
    RegisterPool(const RegisterPool &rp);
    ~RegisterPool();
    
-   class PC_EXPORT iterator {
+   class DYNINST_EXPORT iterator {
       friend class Dyninst::ProcControlAPI::RegisterPool;
    private:
       typedef std::map<Dyninst::MachRegister, Dyninst::MachRegisterVal>::iterator int_iter; 
@@ -736,7 +736,7 @@ class PC_EXPORT RegisterPool
    iterator end();
    iterator find(Dyninst::MachRegister r);
 
-   class PC_EXPORT const_iterator {
+   class DYNINST_EXPORT const_iterator {
       friend class Dyninst::ProcControlAPI::RegisterPool;
    private:
       typedef std::map<Dyninst::MachRegister, Dyninst::MachRegisterVal>::const_iterator int_iter; 
@@ -762,7 +762,7 @@ class PC_EXPORT RegisterPool
    Thread::ptr getThread();
 };
 
-class PC_EXPORT EventNotify
+class DYNINST_EXPORT EventNotify
 {
  private:
    friend class ::int_notify;
@@ -776,9 +776,9 @@ class PC_EXPORT EventNotify
    void registerCB(notify_cb_t cb);
    void removeCB(notify_cb_t cb);
 };
-PC_EXPORT EventNotify *evNotify();
+DYNINST_EXPORT EventNotify *evNotify();
 
-class PC_EXPORT ExecFileInfo
+class DYNINST_EXPORT ExecFileInfo
 {
   public:
 	void* fileHandle;

--- a/proccontrol/h/PlatFeatures.h
+++ b/proccontrol/h/PlatFeatures.h
@@ -63,7 +63,7 @@ class int_fileInfo;
 namespace Dyninst {
 namespace ProcControlAPI {
 
-class PC_EXPORT LibraryTracking
+class DYNINST_EXPORT LibraryTracking
 {
    friend class ::int_libraryTracking;
    friend class ::int_process;
@@ -80,7 +80,7 @@ class PC_EXPORT LibraryTracking
    bool refreshLibraries();
 };
 
-class PC_EXPORT LibraryTrackingSet
+class DYNINST_EXPORT LibraryTrackingSet
 {
    friend class ProcessSet;
    friend class PSetFeatures;
@@ -94,7 +94,7 @@ class PC_EXPORT LibraryTrackingSet
    bool refreshLibraries() const;
 };
 
-class PC_EXPORT LWPTracking
+class DYNINST_EXPORT LWPTracking
 {
    friend class ::linux_process;
    friend class ::int_process;
@@ -113,7 +113,7 @@ class PC_EXPORT LWPTracking
    bool refreshLWPs();
 };
 
-class PC_EXPORT LWPTrackingSet
+class DYNINST_EXPORT LWPTrackingSet
 {
    friend class ProcessSet;
    friend class PSetFeatures;
@@ -127,7 +127,7 @@ class PC_EXPORT LWPTrackingSet
    bool refreshLWPs() const;
 };
 
-class PC_EXPORT ThreadTracking
+class DYNINST_EXPORT ThreadTracking
 {
    friend class ::int_process;
    friend class ::thread_db_process;
@@ -146,7 +146,7 @@ class PC_EXPORT ThreadTracking
    bool refreshThreads();
 };
 
-class PC_EXPORT ThreadTrackingSet
+class DYNINST_EXPORT ThreadTrackingSet
 {
    friend class ProcessSet;
    friend class PSetFeatures;
@@ -160,7 +160,7 @@ class PC_EXPORT ThreadTrackingSet
    bool refreshThreads() const;
 };
 
-class PC_EXPORT FollowFork
+class DYNINST_EXPORT FollowFork
 {
    friend class ::linux_process;
    friend class ::int_process;
@@ -187,7 +187,7 @@ class PC_EXPORT FollowFork
    static follow_t default_should_follow_fork;
 };
 
-class PC_EXPORT FollowForkSet
+class DYNINST_EXPORT FollowForkSet
 {
    friend class ProcessSet;
    friend class PSetFeatures;
@@ -199,7 +199,7 @@ class PC_EXPORT FollowForkSet
    bool setFollowFork(FollowFork::follow_t f) const;
 };
 
-class PC_EXPORT CallStackCallback
+class DYNINST_EXPORT CallStackCallback
 {
   private:
    static const bool top_first_default_value = false;
@@ -212,7 +212,7 @@ class PC_EXPORT CallStackCallback
    virtual ~CallStackCallback();
 };
 
-class PC_EXPORT CallStackUnwinding
+class DYNINST_EXPORT CallStackUnwinding
 {
    friend class ::int_process;
    friend class ::int_thread;
@@ -225,7 +225,7 @@ class PC_EXPORT CallStackUnwinding
    bool walkStack(CallStackCallback *stk_cb) const;
 };
 
-class PC_EXPORT MemoryUsage
+class DYNINST_EXPORT MemoryUsage
 {
    friend class ::int_process;
    friend class ::int_memUsage;
@@ -240,7 +240,7 @@ class PC_EXPORT MemoryUsage
    bool resident(unsigned long &resident) const;
 };
 
-class PC_EXPORT MemoryUsageSet
+class DYNINST_EXPORT MemoryUsageSet
 {
    friend class ProcessSet;
    friend class PSetFeatures;
@@ -262,7 +262,7 @@ class PC_EXPORT MemoryUsageSet
    bool resident(std::map<Process::const_ptr, unsigned long> &res) const;
 };
 
-class PC_EXPORT CallStackUnwindingSet
+class DYNINST_EXPORT CallStackUnwindingSet
 {
   private:
    ThreadSet::weak_ptr wts;
@@ -272,7 +272,7 @@ class PC_EXPORT CallStackUnwindingSet
    bool walkStack(CallStackCallback *stk_cb);
 };
 
-class PC_EXPORT MultiToolControl
+class DYNINST_EXPORT MultiToolControl
 {
    friend class ::int_process;
    friend class ::int_multiToolControl;
@@ -305,7 +305,7 @@ typedef sigset_t dyn_sigset_t;
 #endif
 
 //On posix system, the sigset referenced below is a pointer to a sigset_t
-class PC_EXPORT SignalMask
+class DYNINST_EXPORT SignalMask
 {
    friend class ::int_process;
    friend class ::int_signalMask;
@@ -375,7 +375,7 @@ class FileInfo {
 
 typedef std::multimap<Process::const_ptr, FileInfo> FileSet;
 
-class PC_EXPORT RemoteIO
+class DYNINST_EXPORT RemoteIO
 {
   protected:
    Process::weak_ptr proc;
@@ -398,7 +398,7 @@ class PC_EXPORT RemoteIO
    bool readFileContents(const FileSet *fset);
 };
 
-class PC_EXPORT RemoteIOSet
+class DYNINST_EXPORT RemoteIOSet
 {
   protected:
    ProcessSet::weak_ptr pset;

--- a/proccontrol/h/ProcessSet.h
+++ b/proccontrol/h/ProcessSet.h
@@ -80,7 +80,7 @@ typedef boost::shared_ptr<const ThreadSet> ThreadSet_const_ptr;
  * Iteration over AddressSet is sorted by the Address. So, all Processes
  * that share an Address will appear together when iterating over the set.
  **/
-class PC_EXPORT AddressSet
+class DYNINST_EXPORT AddressSet
 {
   private:
    int_addressSet *iaddrs;
@@ -164,7 +164,7 @@ class PC_EXPORT AddressSet
  * perform collective operations on the entire set, which may be more effecient
  * than the equivalent sequential operations.
  **/
-class PC_EXPORT ProcessSet : public boost::enable_shared_from_this<ProcessSet>
+class DYNINST_EXPORT ProcessSet : public boost::enable_shared_from_this<ProcessSet>
 {
    friend class ThreadSet;
   private:
@@ -227,7 +227,7 @@ class PC_EXPORT ProcessSet : public boost::enable_shared_from_this<ProcessSet>
    /**
     * Iterator and standard set utilities
     **/
-   class PC_EXPORT iterator {
+   class DYNINST_EXPORT iterator {
       friend class Dyninst::ProcControlAPI::ProcessSet;
      private:
       int_processSet::iterator int_iter;
@@ -246,7 +246,7 @@ class PC_EXPORT ProcessSet : public boost::enable_shared_from_this<ProcessSet>
 	  typedef std::forward_iterator_tag iterator_category;
    };
 
-   class PC_EXPORT const_iterator {
+   class DYNINST_EXPORT const_iterator {
       friend class Dyninst::ProcControlAPI::ProcessSet;
      private:
       int_processSet::iterator int_iter;
@@ -405,7 +405,7 @@ class PC_EXPORT ProcessSet : public boost::enable_shared_from_this<ProcessSet>
    const MemoryUsageSet *getMemoryUsage() const;
 };
 
-class PC_EXPORT ThreadSet : public boost::enable_shared_from_this<ThreadSet> {
+class DYNINST_EXPORT ThreadSet : public boost::enable_shared_from_this<ThreadSet> {
   private:
    int_threadSet *ithrset;
    TSetFeatures *features;
@@ -440,7 +440,7 @@ class PC_EXPORT ThreadSet : public boost::enable_shared_from_this<ThreadSet> {
    /**
     * Iterator and standard set utilities
     **/
-   class PC_EXPORT iterator {
+   class DYNINST_EXPORT iterator {
       friend class Dyninst::ProcControlAPI::ThreadSet;
      protected:
       std::set<Thread::ptr>::iterator int_iter;
@@ -453,7 +453,7 @@ class PC_EXPORT ThreadSet : public boost::enable_shared_from_this<ThreadSet> {
       ThreadSet::iterator operator++(int);
    };
 
-   class PC_EXPORT const_iterator {
+   class DYNINST_EXPORT const_iterator {
       friend class Dyninst::ProcControlAPI::ThreadSet;
      protected:
       std::set<Thread::ptr>::iterator int_iter;

--- a/proccontrol/src/proc_service_wrapper.h
+++ b/proccontrol/src/proc_service_wrapper.h
@@ -64,52 +64,52 @@ struct ps_prochandle;
 
 
 /* Read or write process memory at the given address.  */
-extern PC_EXPORT ps_err_e ps_pdread (struct ps_prochandle *,
+extern DYNINST_EXPORT ps_err_e ps_pdread (struct ps_prochandle *,
 			   psaddr_t, void *, size_t);
-extern PC_EXPORT ps_err_e ps_pdwrite (struct ps_prochandle *,
+extern DYNINST_EXPORT ps_err_e ps_pdwrite (struct ps_prochandle *,
 			    psaddr_t, const void *, size_t);
-extern PC_EXPORT ps_err_e ps_ptread (struct ps_prochandle *,
+extern DYNINST_EXPORT ps_err_e ps_ptread (struct ps_prochandle *,
 			   psaddr_t, void *, size_t);
-extern PC_EXPORT ps_err_e ps_ptwrite (struct ps_prochandle *,
+extern DYNINST_EXPORT ps_err_e ps_ptwrite (struct ps_prochandle *,
 			    psaddr_t, const void *, size_t);
 
 
 /* Get and set the given LWP's general or FPU register set.  */
-extern PC_EXPORT ps_err_e ps_lgetregs (struct ps_prochandle *,
+extern DYNINST_EXPORT ps_err_e ps_lgetregs (struct ps_prochandle *,
 			     lwpid_t, prgregset_t);
-extern PC_EXPORT ps_err_e ps_lsetregs (struct ps_prochandle *,
+extern DYNINST_EXPORT ps_err_e ps_lsetregs (struct ps_prochandle *,
 			     lwpid_t, const prgregset_t);
-extern PC_EXPORT ps_err_e ps_lgetfpregs (struct ps_prochandle *,
+extern DYNINST_EXPORT ps_err_e ps_lgetfpregs (struct ps_prochandle *,
 			       lwpid_t, prfpregset_t *);
-extern PC_EXPORT ps_err_e ps_lsetfpregs (struct ps_prochandle *,
+extern DYNINST_EXPORT ps_err_e ps_lsetfpregs (struct ps_prochandle *,
 			       lwpid_t, const prfpregset_t *);
 
 /* Return the PID of the process.  */
-extern PC_EXPORT pid_t ps_getpid (struct ps_prochandle *);
+extern DYNINST_EXPORT pid_t ps_getpid (struct ps_prochandle *);
 
 /* Fetch the special per-thread address associated with the given LWP.
    This call is only used on a few platforms (most use a normal register).
    The meaning of the `int' parameter is machine-dependent.  */
-extern PC_EXPORT ps_err_e ps_get_thread_area (const struct ps_prochandle *,
+extern DYNINST_EXPORT ps_err_e ps_get_thread_area (const struct ps_prochandle *,
 				    lwpid_t, int, psaddr_t *);
 
 
 /* Look up the named symbol in the named DSO in the symbol tables
    associated with the process being debugged, filling in *SYM_ADDR
    with the corresponding run-time address.  */
-extern PC_EXPORT ps_err_e ps_pglobal_lookup (struct ps_prochandle *,
+extern DYNINST_EXPORT ps_err_e ps_pglobal_lookup (struct ps_prochandle *,
 				   const char *object_name,
 				   const char *sym_name,
 				   psaddr_t *sym_addr);
 
 
 /* Stop or continue the entire process.  */
-extern PC_EXPORT ps_err_e ps_pstop (const struct ps_prochandle *);
-extern PC_EXPORT ps_err_e ps_pcontinue (const struct ps_prochandle *);
+extern DYNINST_EXPORT ps_err_e ps_pstop (const struct ps_prochandle *);
+extern DYNINST_EXPORT ps_err_e ps_pcontinue (const struct ps_prochandle *);
 
 /* Stop or continue the given LWP alone.  */
-extern PC_EXPORT ps_err_e ps_lstop (const struct ps_prochandle *, lwpid_t);
-extern PC_EXPORT ps_err_e ps_lcontinue (const struct ps_prochandle *, lwpid_t);
+extern DYNINST_EXPORT ps_err_e ps_lstop (const struct ps_prochandle *, lwpid_t);
+extern DYNINST_EXPORT ps_err_e ps_lcontinue (const struct ps_prochandle *, lwpid_t);
 
 #endif
 #endif

--- a/proccontrol/src/windows_handler.h
+++ b/proccontrol/src/windows_handler.h
@@ -62,7 +62,7 @@ public:
    DEBUG_EVENT evt;
 };
 
-class PC_EXPORT WinEventNewThread : public EventNewLWP
+class DYNINST_EXPORT WinEventNewThread : public EventNewLWP
 {
    friend void boost::checked_delete<WinEventNewThread>(WinEventNewThread *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const WinEventNewThread>(const WinEventNewThread *) CHECKED_DELETE_NOEXCEPT;
@@ -84,7 +84,7 @@ private:
 	LPVOID tls_base;
 };
 
-class PC_EXPORT WinEventThreadInfo : public Event
+class DYNINST_EXPORT WinEventThreadInfo : public Event
 {
    friend void boost::checked_delete<WinEventThreadInfo>(WinEventThreadInfo *) CHECKED_DELETE_NOEXCEPT;
    friend void boost::checked_delete<const WinEventThreadInfo>(const WinEventThreadInfo *) CHECKED_DELETE_NOEXCEPT;

--- a/stackwalk/CMakeLists.txt
+++ b/stackwalk/CMakeLists.txt
@@ -70,7 +70,6 @@ dyninst_library(
   PUBLIC_HEADER_FILES ${_public_headers}
   PRIVATE_HEADER_FILES ${_private_headers}
   SOURCE_FILES ${_sources}
-  DEFINES STACKWALKER_EXPORTS
   DYNINST_DEPS common dynDwarf dynElf instructionAPI pcontrol ${SYMREADER}
   PUBLIC_DEPS Dyninst::Boost_headers
   PRIVATE_DEPS Dyninst::ElfUtils

--- a/stackwalk/h/frame.h
+++ b/stackwalk/h/frame.h
@@ -45,7 +45,7 @@ namespace Stackwalker {
 class Walker;
 class FrameStepper;
 
-class SW_EXPORT Frame : public AnnotatableDense {
+class DYNINST_EXPORT Frame : public AnnotatableDense {
   friend class Walker;
   friend class CallTree;
   friend class ::StackCallback;
@@ -132,19 +132,19 @@ protected:
 
 //Default FrameComparators, if none provided
 typedef bool (*frame_cmp_t)(const Frame &a, const Frame &b); //Return true if a < b, by some comparison
-SW_EXPORT bool frame_addr_cmp(const Frame &a, const Frame &b); //Default
-SW_EXPORT bool frame_lib_offset_cmp(const Frame &a, const Frame &b);
-SW_EXPORT bool frame_symname_cmp(const Frame &a, const Frame &b);
-SW_EXPORT bool frame_lineno_cmp(const Frame &a, const Frame &b);
+DYNINST_EXPORT bool frame_addr_cmp(const Frame &a, const Frame &b); //Default
+DYNINST_EXPORT bool frame_lib_offset_cmp(const Frame &a, const Frame &b);
+DYNINST_EXPORT bool frame_symname_cmp(const Frame &a, const Frame &b);
+DYNINST_EXPORT bool frame_lineno_cmp(const Frame &a, const Frame &b);
 
 class FrameNode;
-struct SW_EXPORT frame_cmp_wrapper {
+struct DYNINST_EXPORT frame_cmp_wrapper {
    frame_cmp_t f;
    bool operator()(const FrameNode *a, const FrameNode *b) const;
 };
 typedef std::set<FrameNode *, frame_cmp_wrapper> frame_set_t;
 
-class SW_EXPORT FrameNode {
+class DYNINST_EXPORT FrameNode {
    friend class CallTree;
    friend class WalkerSet;
    friend struct frame_cmp_wrapper;
@@ -193,7 +193,7 @@ class SW_EXPORT FrameNode {
    const Walker *getWalker() const { return walker; }
 };
 
-class SW_EXPORT CallTree {
+class DYNINST_EXPORT CallTree {
    friend class WalkerSet;
   public:
 

--- a/stackwalk/h/framestepper.h
+++ b/stackwalk/h/framestepper.h
@@ -51,7 +51,7 @@ class StepperGroup;
 
 typedef enum { gcf_success, gcf_stackbottom, gcf_not_me, gcf_error } gcframe_ret_t;
 
-class SW_EXPORT FrameStepper {
+class DYNINST_EXPORT FrameStepper {
 protected:
   Walker *walker;
 public:
@@ -80,7 +80,7 @@ public:
   static const unsigned wanderer_priority = 0x10060;
 };
 
-class SW_EXPORT FrameFuncHelper
+class DYNINST_EXPORT FrameFuncHelper
 {
  protected:
    ProcessState *proc;
@@ -116,7 +116,7 @@ class ARM_FrameHelper : public FrameFuncHelper {
 */
 
 class FrameFuncStepperImpl;
-class SW_EXPORT FrameFuncStepper : public FrameStepper {
+class DYNINST_EXPORT FrameFuncStepper : public FrameStepper {
 private:
    FrameFuncStepperImpl *impl;
 public:
@@ -129,7 +129,7 @@ public:
 };
 
 class DebugStepperImpl;
-class SW_EXPORT DebugStepper : public FrameStepper {
+class DYNINST_EXPORT DebugStepper : public FrameStepper {
 private:
    DebugStepperImpl *impl;
 public:
@@ -142,7 +142,7 @@ public:
 };
 
 class CallChecker;
-class SW_EXPORT WandererHelper
+class DYNINST_EXPORT WandererHelper
 {
  private:
    ProcessState *proc;
@@ -161,7 +161,7 @@ class SW_EXPORT WandererHelper
 };
 
 class StepperWandererImpl;
-class SW_EXPORT StepperWanderer : public FrameStepper {
+class DYNINST_EXPORT StepperWanderer : public FrameStepper {
  private:
    StepperWandererImpl *impl;
  public:
@@ -175,7 +175,7 @@ class SW_EXPORT StepperWanderer : public FrameStepper {
 };
 
 class SigHandlerStepperImpl;
-class SW_EXPORT SigHandlerStepper : public FrameStepper {
+class DYNINST_EXPORT SigHandlerStepper : public FrameStepper {
  private:
    SigHandlerStepperImpl *impl;
  public:
@@ -189,7 +189,7 @@ class SW_EXPORT SigHandlerStepper : public FrameStepper {
 };
 
 class BottomOfStackStepperImpl;
-class SW_EXPORT BottomOfStackStepper : public FrameStepper {
+class DYNINST_EXPORT BottomOfStackStepper : public FrameStepper {
  private:
    BottomOfStackStepperImpl *impl;
  public:
@@ -203,7 +203,7 @@ class SW_EXPORT BottomOfStackStepper : public FrameStepper {
 };
 
 class DyninstInstrStepperImpl;
-class SW_EXPORT DyninstInstrStepper : public FrameStepper {
+class DYNINST_EXPORT DyninstInstrStepper : public FrameStepper {
  private:
    DyninstInstrStepperImpl *impl;
  public:
@@ -216,7 +216,7 @@ class SW_EXPORT DyninstInstrStepper : public FrameStepper {
 };
 
 class AnalysisStepperImpl;
-class SW_EXPORT AnalysisStepper : public FrameStepper {
+class DYNINST_EXPORT AnalysisStepper : public FrameStepper {
   private:
    AnalysisStepperImpl *impl;
   public:
@@ -228,7 +228,7 @@ class SW_EXPORT AnalysisStepper : public FrameStepper {
    virtual const char *getName() const;
 };
 
-class SW_EXPORT DyninstDynamicHelper
+class DYNINST_EXPORT DyninstDynamicHelper
 {
  public:
    virtual bool isInstrumentation(Address ra, Address *orig_ra,
@@ -237,7 +237,7 @@ class SW_EXPORT DyninstDynamicHelper
 };
 
 class DyninstDynamicStepperImpl;
-class SW_EXPORT DyninstDynamicStepper : public FrameStepper {
+class DYNINST_EXPORT DyninstDynamicStepper : public FrameStepper {
  private:
    DyninstDynamicStepperImpl *impl;
  public:
@@ -250,7 +250,7 @@ class SW_EXPORT DyninstDynamicStepper : public FrameStepper {
 };
 
 class DyninstInstFrameStepperImpl;
-class SW_EXPORT DyninstInstFrameStepper : public FrameStepper {
+class DYNINST_EXPORT DyninstInstFrameStepper : public FrameStepper {
  private:
    DyninstInstFrameStepperImpl *impl;
  public:

--- a/stackwalk/h/procstate.h
+++ b/stackwalk/h/procstate.h
@@ -55,7 +55,7 @@ class LibraryState;
 class ThreadState;
 class Walker;
 
-class SW_EXPORT ProcessState {
+class DYNINST_EXPORT ProcessState {
    friend class Walker;
 protected:
    Dyninst::PID pid;
@@ -123,7 +123,7 @@ class ProcSelf : public ProcessState {
   virtual ~ProcSelf();
 };
 
-class SW_EXPORT ProcDebug : public ProcessState {
+class DYNINST_EXPORT ProcDebug : public ProcessState {
  protected:
    Dyninst::ProcControlAPI::Process::ptr proc;
    ProcDebug(Dyninst::ProcControlAPI::Process::ptr p);

--- a/stackwalk/h/swk_errors.h
+++ b/stackwalk/h/swk_errors.h
@@ -61,14 +61,14 @@ namespace Stackwalker {
   const err_t err_nothrd         = 0x10016;
   const err_t err_proccontrol    = 0x10017;
 
-  SW_EXPORT err_t getLastError();
-  SW_EXPORT void clearLastError();
-  SW_EXPORT const char *getLastErrorMsg();
-  SW_EXPORT void setLastError(err_t err, const char *msg = NULL);
-  SW_EXPORT void setDebugChannel(FILE *f);
-  SW_EXPORT void setDebug(bool enable);
+  DYNINST_EXPORT err_t getLastError();
+  DYNINST_EXPORT void clearLastError();
+  DYNINST_EXPORT const char *getLastErrorMsg();
+  DYNINST_EXPORT void setLastError(err_t err, const char *msg = NULL);
+  DYNINST_EXPORT void setDebugChannel(FILE *f);
+  DYNINST_EXPORT void setDebug(bool enable);
 
-  SW_EXPORT FILE *getDebugChannel();
+  DYNINST_EXPORT FILE *getDebugChannel();
 
   extern int sw_printf(const char *format, ...) DYNINST_PRINTF_ANNOTATION(1, 2);
   extern int dyn_debug_stackwalk;

--- a/stackwalk/h/symlookup.h
+++ b/stackwalk/h/symlookup.h
@@ -40,7 +40,7 @@ namespace Stackwalker {
 class Walker;
 class ProcessState;
 
-class SW_EXPORT SymbolLookup {
+class DYNINST_EXPORT SymbolLookup {
   friend class Walker;
  protected:
   Walker *walker;
@@ -58,7 +58,7 @@ class SW_EXPORT SymbolLookup {
   std::string executable_path;
 };
 
-class SW_EXPORT SwkSymtab : public SymbolLookup {
+class DYNINST_EXPORT SwkSymtab : public SymbolLookup {
  public:
     SwkSymtab(std::string exec_name);
     virtual bool lookupAtAddr(Dyninst::Address addr, 

--- a/stackwalk/h/walker.h
+++ b/stackwalk/h/walker.h
@@ -70,7 +70,7 @@ class StepperGroup;
 class CallTree;
 class int_walkerSet;
 
-class SW_EXPORT Walker {
+class DYNINST_EXPORT Walker {
  private:
    //Object creation functions
    Walker(ProcessState *p,
@@ -169,7 +169,7 @@ class SW_EXPORT Walker {
    static SymbolReaderFactory *symrfact;
 };
 
-class SW_EXPORT WalkerSet {
+class DYNINST_EXPORT WalkerSet {
   private:
    int_walkerSet *iwalkerset;
    WalkerSet();

--- a/symlite/h/SymLite-elf.h
+++ b/symlite/h/SymLite-elf.h
@@ -36,13 +36,13 @@
 
 namespace Dyninst {
 
-struct SYMLITE_EXPORT SymCacheEntry {
+struct DYNINST_EXPORT SymCacheEntry {
    Dyninst::Offset symaddress;
    void *symloc;
    const char *demangled_name;
 };
 
-class SYMLITE_EXPORT SymElf : public Dyninst::SymReader
+class DYNINST_EXPORT SymElf : public Dyninst::SymReader
 {
    friend class SymElfFactory;
  private:
@@ -107,7 +107,7 @@ class SYMLITE_EXPORT SymElf : public Dyninst::SymReader
    
 };
 
-class SYMLITE_EXPORT SymElfFactory : public Dyninst::SymbolReaderFactory
+class DYNINST_EXPORT SymElfFactory : public Dyninst::SymbolReaderFactory
 {
 private:
    std::map<std::string, SymElf *> *open_symelfs;

--- a/symtabAPI/doc/API/Symtab/Symbol.tex
+++ b/symtabAPI/doc/API/Symtab/Symbol.tex
@@ -87,7 +87,7 @@ isCommonStorage & bool & True if the symbol represents a common section (Fortran
 \end{tabular}
 
 \begin{apient}
-SYMTAB_EXPORT Symbol(const std::string& name,
+DYNINST_EXPORT Symbol(const std::string& name,
                      SymbolType type,
                      SymbolLinkage linkage,
                      SymbolVisibility visibility,

--- a/symtabAPI/h/AddrLookup.h
+++ b/symtabAPI/h/AddrLookup.h
@@ -49,7 +49,7 @@ typedef struct {
    Address dataAddr;
 } LoadedLibrary;
 
-class SYMTAB_EXPORT AddressLookup : public AnnotatableSparse
+class DYNINST_EXPORT AddressLookup : public AnnotatableSparse
 {
  private:
    AddressTranslate *translator;

--- a/symtabAPI/h/Aggregate.h
+++ b/symtabAPI/h/Aggregate.h
@@ -58,7 +58,7 @@ class DwarfWalker;
 
 struct SymbolCompareByAddr;
 
-class SYMTAB_EXPORT Aggregate
+class DYNINST_EXPORT Aggregate
 {
    friend class Symtab;
    friend struct SymbolCompareByAddr;

--- a/symtabAPI/h/Archive.h
+++ b/symtabAPI/h/Archive.h
@@ -46,7 +46,7 @@ class Symtab;
 /**
  * Helps facilitate lazy parsing and quick lookup once parsing is finished
  */
-class SYMTAB_EXPORT ArchiveMember {
+class DYNINST_EXPORT ArchiveMember {
     public:
         ArchiveMember() : name_(""), offset_(0), member_(NULL) {}
         ArchiveMember(const std::string name, const Offset offset,
@@ -74,7 +74,7 @@ class SYMTAB_EXPORT ArchiveMember {
         Symtab *member_;
 };
 
-class SYMTAB_EXPORT Archive : public AnnotatableSparse {
+class DYNINST_EXPORT Archive : public AnnotatableSparse {
    public:
       static bool openArchive(Archive *&img, std::string filename);
       static bool openArchive(Archive *&img, char *mem_image, size_t image_size);

--- a/symtabAPI/h/Collections.h
+++ b/symtabAPI/h/Collections.h
@@ -58,7 +58,7 @@ class DwarfWalker;
  */
 
 
-class SYMTAB_EXPORT localVarCollection {
+class DYNINST_EXPORT localVarCollection {
 
   dyn_c_vector<localVar* > localVars;
 
@@ -78,7 +78,7 @@ public:
  * Due to DWARF weirdness, this can be shared between multiple BPatch_modules.
  * So we reference-count to make life easier.
  */
-class SYMTAB_EXPORT typeCollection
+class DYNINST_EXPORT typeCollection
 {
     friend class Symtab;
     friend class Object;
@@ -181,7 +181,7 @@ public:
  *
  */
 
-class SYMTAB_EXPORT builtInTypeCollection {
+class DYNINST_EXPORT builtInTypeCollection {
 
     dyn_c_hash_map<int, boost::shared_ptr<Type>> builtInTypesByID;
     dyn_c_hash_map<std::string, boost::shared_ptr<Type>> builtInTypesByName;

--- a/symtabAPI/h/ExceptionBlock.h
+++ b/symtabAPI/h/ExceptionBlock.h
@@ -48,16 +48,16 @@ namespace SymtabAPI {
  * Currently only used on Linux
  **/
 
-class SYMTAB_EXPORT ExceptionBlock : public AnnotatableSparse {
+class DYNINST_EXPORT ExceptionBlock : public AnnotatableSparse {
   // Accessors provide consistent access to the *original* offsets.
   // We allow this to be updated (e.g. to account for relocated code
    public:
       ExceptionBlock(Offset tStart, unsigned tSize, Offset cStart);
       ExceptionBlock(Offset cStart);
-      SYMTAB_EXPORT ExceptionBlock(const ExceptionBlock &eb) = default;
-      SYMTAB_EXPORT ~ExceptionBlock() = default;
-      SYMTAB_EXPORT ExceptionBlock() = default;
-      SYMTAB_EXPORT ExceptionBlock& operator=(const ExceptionBlock &eb) = default;
+      DYNINST_EXPORT ExceptionBlock(const ExceptionBlock &eb) = default;
+      DYNINST_EXPORT ~ExceptionBlock() = default;
+      DYNINST_EXPORT ExceptionBlock() = default;
+      DYNINST_EXPORT ExceptionBlock& operator=(const ExceptionBlock &eb) = default;
 
       bool hasTry() const;
       Offset tryStart() const;
@@ -90,7 +90,7 @@ class SYMTAB_EXPORT ExceptionBlock : public AnnotatableSparse {
       }
 
 
-      friend SYMTAB_EXPORT std::ostream &operator<<(std::ostream &os, const ExceptionBlock &q);
+      friend DYNINST_EXPORT std::ostream &operator<<(std::ostream &os, const ExceptionBlock &q);
    private:
       Offset tryStart_{};
       unsigned trySize_{};
@@ -103,7 +103,7 @@ class SYMTAB_EXPORT ExceptionBlock : public AnnotatableSparse {
       Offset fdeEnd_ptr{};
 };
 
-SYMTAB_EXPORT  std::ostream &operator<<(std::ostream &os, const ExceptionBlock &q);
+DYNINST_EXPORT  std::ostream &operator<<(std::ostream &os, const ExceptionBlock &q);
 
 }//namespace SymtabAPI
 

--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -46,7 +46,7 @@
 #include "Variable.h"
 #include "VariableLocation.h"
 
-SYMTAB_EXPORT std::ostream &operator<<(std::ostream &os, const Dyninst::SymtabAPI::Function &);
+DYNINST_EXPORT std::ostream &operator<<(std::ostream &os, const Dyninst::SymtabAPI::Function &);
 
 namespace Dyninst{
 namespace SymtabAPI{
@@ -56,7 +56,7 @@ class Type;
 class FunctionBase;
 class DwarfWalker;
 
-class SYMTAB_EXPORT FuncRange {
+class DYNINST_EXPORT FuncRange {
   public:
    FuncRange(Dyninst::Offset off_, size_t size_, FunctionBase *cont_) :
      container(cont_),
@@ -78,7 +78,7 @@ class SYMTAB_EXPORT FuncRange {
 typedef std::vector<FuncRange> FuncRangeCollection;
 typedef std::vector<FunctionBase *> InlineCollection;
 
-class SYMTAB_EXPORT FunctionBase
+class DYNINST_EXPORT FunctionBase
 {
    friend class InlinedFunction;
    friend class Function;
@@ -154,7 +154,7 @@ class SYMTAB_EXPORT FunctionBase
  *  `Function` can be derived from (e.g., ParseAPI::PLTFunction), but does not create an
  *  interface separate from FunctionBase.
  */
- class SYMTAB_EXPORT Function : public FunctionBase, public Aggregate
+ class DYNINST_EXPORT Function : public FunctionBase, public Aggregate
 {
 	friend std::ostream &::operator<<(std::ostream &os, const Dyninst::SymtabAPI::Function &);
 
@@ -187,7 +187,7 @@ class SYMTAB_EXPORT FunctionBase
      Module * getModule() const override;
  };
 
-class SYMTAB_EXPORT InlinedFunction : public FunctionBase
+class DYNINST_EXPORT InlinedFunction : public FunctionBase
 {
    friend class Symtab;
    friend class DwarfWalker;

--- a/symtabAPI/h/LineInformation.h
+++ b/symtabAPI/h/LineInformation.h
@@ -44,7 +44,7 @@
 namespace Dyninst{
 namespace SymtabAPI{
 
-class SYMTAB_EXPORT LineInformation final :
+class DYNINST_EXPORT LineInformation final :
                         private RangeLookupTypes< Statement >::type
 {
 public:

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -51,7 +51,7 @@ namespace Dyninst { namespace SymtabAPI {
 
   typedef Dyninst::SimpleInterval<Offset, Module *> ModRange;
 
-  class SYMTAB_EXPORT Module : public LookupInterface {
+  class DYNINST_EXPORT Module : public LookupInterface {
     friend class Symtab;
 
   public:

--- a/symtabAPI/h/RangeLookup.h
+++ b/symtabAPI/h/RangeLookup.h
@@ -52,7 +52,7 @@
 namespace Dyninst {
     namespace SymtabAPI {
 
-        struct SYMTAB_EXPORT AddressRange : std::pair<Offset, Offset>
+        struct DYNINST_EXPORT AddressRange : std::pair<Offset, Offset>
         {
             template <typename T>
             AddressRange(Dyninst::SimpleInterval<T> i) {

--- a/symtabAPI/h/Region.h
+++ b/symtabAPI/h/Region.h
@@ -44,7 +44,7 @@ class relocationEntry;
 class Symtab;
 
 
-class SYMTAB_EXPORT Region : public AnnotatableSparse {
+class DYNINST_EXPORT Region : public AnnotatableSparse {
    friend class Object;
    friend class Symtab;
    friend class SymtabTranslatorBase;

--- a/symtabAPI/h/Statement.h
+++ b/symtabAPI/h/Statement.h
@@ -40,7 +40,7 @@ namespace Dyninst { namespace SymtabAPI {
 
   class LineInformation;
 
-  class SYMTAB_EXPORT Statement : public AddressRange {
+  class DYNINST_EXPORT Statement : public AddressRange {
     friend class Module;
     friend class LineInformation;
 

--- a/symtabAPI/h/Symbol.h
+++ b/symtabAPI/h/Symbol.h
@@ -71,7 +71,7 @@ class Symtab;
  * class Symbol
 ************************************************************************/
 
-class SYMTAB_EXPORT Symbol : public AnnotatableSparse
+class DYNINST_EXPORT Symbol : public AnnotatableSparse
 {
    friend class typeCommon;
    friend class Symtab;
@@ -281,7 +281,7 @@ class SYMTAB_EXPORT Symbol : public AnnotatableSparse
    bool versionHidden_;
 };
 
-class SYMTAB_EXPORT LookupInterface 
+class DYNINST_EXPORT LookupInterface 
 {
    public:
       LookupInterface();
@@ -312,7 +312,7 @@ class SYMTAB_EXPORT LookupInterface
       virtual ~LookupInterface();
 };
 
-SYMTAB_EXPORT std::ostream& operator<< (std::ostream &os, const Symbol &s);
+DYNINST_EXPORT std::ostream& operator<< (std::ostream &os, const Symbol &s);
 
 }//namespace SymtabAPI
 }//namespace Dyninst

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -76,7 +76,7 @@ struct symtab_impl;
 
 typedef Dyninst::ProcessReader MemRegReader;
 
-class SYMTAB_EXPORT Symtab : public LookupInterface,
+class DYNINST_EXPORT Symtab : public LookupInterface,
                public AnnotatableSparse
 {
    friend class Archive;

--- a/symtabAPI/h/SymtabReader.h
+++ b/symtabAPI/h/SymtabReader.h
@@ -48,7 +48,7 @@ class Symtab;
 class Region;
 class FastParser;
 
-class SYMTAB_EXPORT SymtabReaderFactory : public SymbolReaderFactory
+class DYNINST_EXPORT SymtabReaderFactory : public SymbolReaderFactory
 {
   private:
    std::map<std::string, SymReader *> open_syms;
@@ -60,7 +60,7 @@ class SYMTAB_EXPORT SymtabReaderFactory : public SymbolReaderFactory
    virtual bool closeSymbolReader(SymReader *sr);
 };
 
-class SYMTAB_EXPORT SymtabReader : public SymReader {
+class DYNINST_EXPORT SymtabReader : public SymReader {
    friend class SymtabReaderFactory;
   protected:
    Symtab *symtab;
@@ -107,7 +107,7 @@ class SYMTAB_EXPORT SymtabReader : public SymReader {
 };
 
 extern "C" {
-   SYMTAB_EXPORT SymbolReaderFactory *getSymtabReaderFactory();
+   DYNINST_EXPORT SymbolReaderFactory *getSymtabReaderFactory();
 }
 
 }

--- a/symtabAPI/h/Type.h
+++ b/symtabAPI/h/Type.h
@@ -87,7 +87,7 @@ typedef enum {dataEnum,
 	      dataTypeClass
 } dataClass;
 
-SYMTAB_EXPORT const char *dataClass2Str(dataClass dc);
+DYNINST_EXPORT const char *dataClass2Str(dataClass dc);
 
 typedef int typeId_t;
 
@@ -108,11 +108,11 @@ typedef enum {
  *
  */
  
-SYMTAB_EXPORT const char *visibility2Str(visibility_t v);
+DYNINST_EXPORT const char *visibility2Str(visibility_t v);
 				  
 #define TYPE_ANNOTATABLE_CLASS AnnotatableDense
 
-class SYMTAB_EXPORT Type : public  TYPE_ANNOTATABLE_CLASS
+class DYNINST_EXPORT Type : public  TYPE_ANNOTATABLE_CLASS
 {
    friend class typeCollection;
    static Type* upgradePlaceholder(Type *placeholder, Type *new_type);
@@ -245,7 +245,7 @@ public:
 
 #define FIELD_ANNOTATABLE_CLASS AnnotatableDense
 
-class SYMTAB_EXPORT Field : public FIELD_ANNOTATABLE_CLASS
+class DYNINST_EXPORT Field : public FIELD_ANNOTATABLE_CLASS
 {
    friend class typeStruct;
    friend class typeUnion;
@@ -287,14 +287,14 @@ class SYMTAB_EXPORT Field : public FIELD_ANNOTATABLE_CLASS
 // We have to do this thanks to reference types and C++'s lovely 
 // multiple inheritance
 
-class SYMTAB_EXPORT fieldListInterface {
+class DYNINST_EXPORT fieldListInterface {
  public:
    virtual ~fieldListInterface() = default;
    fieldListInterface& operator=(const fieldListInterface&) = default;
    virtual dyn_c_vector<Field *> *getComponents() const = 0;
 };
 
-class SYMTAB_EXPORT rangedInterface {
+class DYNINST_EXPORT rangedInterface {
  public:
    virtual ~rangedInterface() = default;
    rangedInterface& operator=(const rangedInterface&) = default;
@@ -302,7 +302,7 @@ class SYMTAB_EXPORT rangedInterface {
    virtual unsigned long getHigh() const  = 0;
 };  
 
-class SYMTAB_EXPORT derivedInterface{
+class DYNINST_EXPORT derivedInterface{
  public:
    virtual ~derivedInterface() = default;
    derivedInterface& operator=(const derivedInterface&) = default;
@@ -312,7 +312,7 @@ class SYMTAB_EXPORT derivedInterface{
 
 // Intermediate types (interfaces + Type)
 
-class SYMTAB_EXPORT fieldListType : public Type, public fieldListInterface 
+class DYNINST_EXPORT fieldListType : public Type, public fieldListInterface 
 {
  private:
    void fixupComponents();
@@ -351,7 +351,7 @@ class SYMTAB_EXPORT fieldListType : public Type, public fieldListInterface
 fieldListType& Type::asFieldListType() { return dynamic_cast<fieldListType&>(*this); }
 bool Type::isFieldListType() { return dynamic_cast<fieldListType*>(this) != NULL; }
 
-class SYMTAB_EXPORT rangedType : public Type, public rangedInterface {
+class DYNINST_EXPORT rangedType : public Type, public rangedInterface {
  protected:
    unsigned long low_;
    unsigned long hi_;
@@ -369,7 +369,7 @@ class SYMTAB_EXPORT rangedType : public Type, public rangedInterface {
 rangedType& Type::asRangedType() { return dynamic_cast<rangedType&>(*this); }
 bool Type::isRangedType() { return dynamic_cast<rangedType*>(this) != NULL; }
 
-class SYMTAB_EXPORT derivedType : public Type, public derivedInterface {
+class DYNINST_EXPORT derivedType : public Type, public derivedInterface {
  protected:
    boost::shared_ptr<Type> baseType_;
  protected:
@@ -387,7 +387,7 @@ bool Type::isDerivedType() { return dynamic_cast<derivedType*>(this) != NULL; }
 
 // Derived classes from Type
 
-class SYMTAB_EXPORT typeEnum : public derivedType {
+class DYNINST_EXPORT typeEnum : public derivedType {
  private:  
    dyn_c_vector<std::pair<std::string, int> > consts;
    bool is_scoped_{false}; // C++11 scoped enum (i.e., 'enum class')?
@@ -408,7 +408,7 @@ class SYMTAB_EXPORT typeEnum : public derivedType {
 typeEnum& Type::asEnumType() { return dynamic_cast<typeEnum&>(*this); }
 bool Type::isEnumType() { return dynamic_cast<typeEnum*>(this) != NULL; }
 
-class SYMTAB_EXPORT typeFunction : public Type {
+class DYNINST_EXPORT typeFunction : public Type {
  protected:
    void fixupUnknowns(Module *);
  private:
@@ -443,7 +443,7 @@ class SYMTAB_EXPORT typeFunction : public Type {
 };
 typeFunction& Type::asFunctionType() { return dynamic_cast<typeFunction&>(*this); }
 
-class SYMTAB_EXPORT typeScalar : public Type {
+class DYNINST_EXPORT typeScalar : public Type {
 public:
   struct properties_t {
 	  // Summary properties
@@ -499,7 +499,7 @@ public:
   bool isCompatible(Type *otype);
 };
 
-class SYMTAB_EXPORT typeCommon : public fieldListType {
+class DYNINST_EXPORT typeCommon : public fieldListType {
  private:
    dyn_c_vector<CBlock *> cblocks;
  protected:
@@ -518,7 +518,7 @@ class SYMTAB_EXPORT typeCommon : public fieldListType {
 typeCommon& Type::asCommonType() { return dynamic_cast<typeCommon&>(*this); }
 bool Type::isCommonType() { return dynamic_cast<typeCommon*>(this) != NULL; }
 
-class SYMTAB_EXPORT CBlock : public AnnotatableSparse
+class DYNINST_EXPORT CBlock : public AnnotatableSparse
 {
    friend class typeCommon;
  private:
@@ -536,7 +536,7 @@ class SYMTAB_EXPORT CBlock : public AnnotatableSparse
    void fixupUnknowns(Module *);
 };
 
-class SYMTAB_EXPORT typeStruct : public fieldListType {
+class DYNINST_EXPORT typeStruct : public fieldListType {
  protected:
    void updateSize();
    void postFieldInsert(int nsize);
@@ -566,7 +566,7 @@ class SYMTAB_EXPORT typeStruct : public fieldListType {
 };
 bool Type::isStructType() { return dynamic_cast<typeStruct*>(this) != NULL; }
 
-class SYMTAB_EXPORT typeUnion : public fieldListType {
+class DYNINST_EXPORT typeUnion : public fieldListType {
  protected:
    void updateSize();
    void postFieldInsert(int nsize);
@@ -594,7 +594,7 @@ class SYMTAB_EXPORT typeUnion : public fieldListType {
    bool isCompatible(Type *otype);
 };
 
-class SYMTAB_EXPORT typePointer : public derivedType {
+class DYNINST_EXPORT typePointer : public derivedType {
  protected: 
    void fixupUnknowns(Module *);
  public:
@@ -621,7 +621,7 @@ class SYMTAB_EXPORT typePointer : public derivedType {
    bool setPtr(Type* ptr) { return setPtr(ptr->reshare()); }
 };
 
-class SYMTAB_EXPORT typeTypedef: public derivedType {
+class DYNINST_EXPORT typeTypedef: public derivedType {
  private:
    unsigned int sizeHint_;
  
@@ -648,7 +648,7 @@ class SYMTAB_EXPORT typeTypedef: public derivedType {
    bool operator==(const typeTypedef &otype) const { return *this == static_cast<const Type&>(otype); }
 };
 
-class SYMTAB_EXPORT typeRef : public derivedType {
+class DYNINST_EXPORT typeRef : public derivedType {
  private:
 	bool is_rvalue_{false};
  protected:
@@ -675,7 +675,7 @@ class SYMTAB_EXPORT typeRef : public derivedType {
    bool is_rvalue() const noexcept { return is_rvalue_; }
 };
 
-class SYMTAB_EXPORT typeSubrange : public rangedType {
+class DYNINST_EXPORT typeSubrange : public rangedType {
  private:
    //typeSubrange(int ID, int size, const char *low, const char *hi, const char *name);
  public:
@@ -687,7 +687,7 @@ class SYMTAB_EXPORT typeSubrange : public rangedType {
    bool isCompatible(Type *otype);
 };
 
-class SYMTAB_EXPORT typeArray : public rangedType {
+class DYNINST_EXPORT typeArray : public rangedType {
  private:
    boost::shared_ptr<Type> arrayElem;
    unsigned int sizeHint_;

--- a/symtabAPI/h/Variable.h
+++ b/symtabAPI/h/Variable.h
@@ -50,7 +50,7 @@ class Aggregate;
 class Function;
 class FunctionBase;
 
-class SYMTAB_EXPORT Variable : public Aggregate, public AnnotatableSparse {
+class DYNINST_EXPORT Variable : public Aggregate, public AnnotatableSparse {
 	friend class Symtab;
 	friend std::ostream &operator<<(std::ostream &os, const Variable &);
 	private:
@@ -80,7 +80,7 @@ class SYMTAB_EXPORT Variable : public Aggregate, public AnnotatableSparse {
    void print(std::ostream &) const;
 };
 
-class SYMTAB_EXPORT localVar : public AnnotatableSparse
+class DYNINST_EXPORT localVar : public AnnotatableSparse
 {
 	friend class typeCommon;
 	friend class localVarCollection;

--- a/symtabAPI/h/relocationEntry.h
+++ b/symtabAPI/h/relocationEntry.h
@@ -48,7 +48,7 @@ namespace SymtabAPI {
 
 class Symbol;
 
-class SYMTAB_EXPORT relocationEntry : public AnnotatableSparse {
+class DYNINST_EXPORT relocationEntry : public AnnotatableSparse {
    public:
 
       relocationEntry();
@@ -81,7 +81,7 @@ class SYMTAB_EXPORT relocationEntry : public AnnotatableSparse {
       // dump output.  Currently setup as a debugging aid, not really
       //  for object persistance....
       //std::ostream & operator<<(std::ostream &s) const;
-      friend SYMTAB_EXPORT std::ostream & operator<<(std::ostream &os, const relocationEntry &q);
+      friend DYNINST_EXPORT std::ostream & operator<<(std::ostream &os, const relocationEntry &q);
 
       enum {pltrel = 1, dynrel = 2};
       bool operator==(const relocationEntry &) const;
@@ -106,7 +106,7 @@ class SYMTAB_EXPORT relocationEntry : public AnnotatableSparse {
 
 
 // relocation information for calls to functions not in this image
-SYMTAB_EXPORT std::ostream &operator<<(std::ostream &os, const relocationEntry &q);
+DYNINST_EXPORT std::ostream &operator<<(std::ostream &os, const relocationEntry &q);
 
 }//namespace SymtabAPI
 

--- a/symtabAPI/h/symutil.h
+++ b/symtabAPI/h/symutil.h
@@ -64,7 +64,7 @@ typedef enum {
    lang_CMFortran
 } supportedLanguages;
 
-SYMTAB_EXPORT const char *supportedLanguages2Str(supportedLanguages s);
+DYNINST_EXPORT const char *supportedLanguages2Str(supportedLanguages s);
 
 typedef enum {
    obj_Unknown,

--- a/symtabAPI/h/symutil.h
+++ b/symtabAPI/h/symutil.h
@@ -34,7 +34,7 @@
 #define _symtab_util_h_
 
 #include "dyntypes.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 #include <string>
 
 #if defined(_MSC_VER)	

--- a/symtabAPI/src/Aggregate.C
+++ b/symtabAPI/src/Aggregate.C
@@ -164,7 +164,7 @@ bool Aggregate::addMangledNameInternal(std::string name, bool /*isPrimary*/, boo
     return true;
 }
 
-SYMTAB_EXPORT bool Aggregate::addMangledName(string name, bool isPrimary, bool isDebug)
+DYNINST_EXPORT bool Aggregate::addMangledName(string name, bool isPrimary, bool isDebug)
 {
    if (!addMangledNameInternal(name, isPrimary, false))
       return false;
@@ -203,7 +203,7 @@ SYMTAB_EXPORT bool Aggregate::addMangledName(string name, bool isPrimary, bool i
     return true;
  }
 
-SYMTAB_EXPORT bool Aggregate::addPrettyName(string name, bool isPrimary, bool isDebug)
+DYNINST_EXPORT bool Aggregate::addPrettyName(string name, bool isPrimary, bool isDebug)
 {
     // Check to see if we're duplicating
    {
@@ -218,7 +218,7 @@ SYMTAB_EXPORT bool Aggregate::addPrettyName(string name, bool isPrimary, bool is
    return addMangledName(name, isPrimary, isDebug);
 }
 
-SYMTAB_EXPORT bool Aggregate::addTypedName(string name, bool isPrimary, bool isDebug)
+DYNINST_EXPORT bool Aggregate::addTypedName(string name, bool isPrimary, bool isDebug)
 {
     // Check to see if we're duplicating
    {

--- a/symtabAPI/src/ExceptionBlock.C
+++ b/symtabAPI/src/ExceptionBlock.C
@@ -34,7 +34,7 @@ namespace Dyninst  {
 namespace SymtabAPI  {
 
 
-SYMTAB_EXPORT ExceptionBlock::ExceptionBlock(Offset tStart,
+DYNINST_EXPORT ExceptionBlock::ExceptionBlock(Offset tStart,
       unsigned tSize,
       Offset cStart)
 : tryStart_(tStart), trySize_(tSize), catchStart_(cStart), hasTry_(true),
@@ -42,33 +42,33 @@ SYMTAB_EXPORT ExceptionBlock::ExceptionBlock(Offset tStart,
 {
 }
 
-   SYMTAB_EXPORT ExceptionBlock::ExceptionBlock(Offset cStart)
+   DYNINST_EXPORT ExceptionBlock::ExceptionBlock(Offset cStart)
 : tryStart_(0), trySize_(0), catchStart_(cStart), hasTry_(false),
   tryStart_ptr(0), tryEnd_ptr(0), catchStart_ptr(0), fdeStart_ptr(0), fdeEnd_ptr(0)
 {
 }
 
-SYMTAB_EXPORT bool ExceptionBlock::hasTry() const
+DYNINST_EXPORT bool ExceptionBlock::hasTry() const
 {
    return hasTry_;
 }
 
-SYMTAB_EXPORT Offset ExceptionBlock::tryStart() const
+DYNINST_EXPORT Offset ExceptionBlock::tryStart() const
 {
    return tryStart_;
 }
 
-SYMTAB_EXPORT Offset ExceptionBlock::tryEnd() const
+DYNINST_EXPORT Offset ExceptionBlock::tryEnd() const
 {
    return tryStart_ + trySize_;
 }
 
-SYMTAB_EXPORT Offset ExceptionBlock::trySize() const
+DYNINST_EXPORT Offset ExceptionBlock::trySize() const
 {
    return trySize_;
 }
 
-SYMTAB_EXPORT bool ExceptionBlock::contains(Offset a) const
+DYNINST_EXPORT bool ExceptionBlock::contains(Offset a) const
 {
    return (a >= tryStart_ && a < tryStart_ + trySize_);
 }

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -195,7 +195,7 @@ public:
      return (char *)mf->base_addr();
   }
 
-  SYMTAB_EXPORT ObjectType objType() const;
+  DYNINST_EXPORT ObjectType objType() const;
   const char *interpreter_name() const;
 
 
@@ -279,12 +279,12 @@ public:
     bool hasModinfo() const { return hasModinfo_; }
     bool hasGnuLinkonceThisModule() const { return hasGnuLinkonceThisModule_; }
     bool isLoadable() const;
-    SYMTAB_EXPORT bool isOnlyExecutable() const;
-    SYMTAB_EXPORT bool isExecutable() const;
-    SYMTAB_EXPORT bool isSharedLibrary() const;
-    SYMTAB_EXPORT bool isOnlySharedLibrary() const;
-    SYMTAB_EXPORT bool isDebugOnly() const;
-    SYMTAB_EXPORT bool isLinuxKernelModule() const;
+    DYNINST_EXPORT bool isOnlyExecutable() const;
+    DYNINST_EXPORT bool isExecutable() const;
+    DYNINST_EXPORT bool isSharedLibrary() const;
+    DYNINST_EXPORT bool isOnlySharedLibrary() const;
+    DYNINST_EXPORT bool isDebugOnly() const;
+    DYNINST_EXPORT bool isLinuxKernelModule() const;
 
     std::vector<relocationEntry> &getPLTRelocs() { return fbt_; }
     std::vector<relocationEntry> &getDynRelocs() { return relocation_table_; }
@@ -300,7 +300,7 @@ public:
     unsigned gotSize() const { return got_size_; }
     Offset gotAddr() const { return got_addr_; }
 
-    SYMTAB_EXPORT virtual void getSegmentsSymReader(std::vector<SymSegment> &segs) override;
+    DYNINST_EXPORT virtual void getSegmentsSymReader(std::vector<SymSegment> &segs) override;
 
     private:
     std::vector<std::vector<boost::shared_ptr<void> > > freeList;

--- a/symtabAPI/src/Object-nt.C
+++ b/symtabAPI/src/Object-nt.C
@@ -1076,7 +1076,7 @@ Object::Object(MappedFile *mf_,
    rebase(0);
 }
 
-SYMTAB_EXPORT ObjectType Object::objType() const 
+DYNINST_EXPORT ObjectType Object::objType() const 
 {
 	return is_aout() ? obj_Executable : obj_SharedLib;
 }

--- a/symtabAPI/src/Object-nt.h
+++ b/symtabAPI/src/Object-nt.h
@@ -177,42 +177,42 @@ class Object : public AObject
     const Object& operator=(const Object &);
 
  public:
-    SYMTAB_EXPORT Object(MappedFile *, bool defensive, 
+    DYNINST_EXPORT Object(MappedFile *, bool defensive, 
                          void (*)(const char *) = log_msg, bool alloc_syms = true, Symtab* st = NULL);
   
-    SYMTAB_EXPORT virtual ~Object( void );
-	SYMTAB_EXPORT std::string getFileName() const { return mf->filename(); }
-    SYMTAB_EXPORT bool isForwarded( Offset addr );
-    SYMTAB_EXPORT bool isEEL() const { return false; }
-    SYMTAB_EXPORT bool isText( const Offset addr ) const; 
-    SYMTAB_EXPORT Offset get_base_addr() const { return (Offset)mf->base_addr();} 
-    SYMTAB_EXPORT Module* GetCurrentModule( void )				    { return curModule; }
+    DYNINST_EXPORT virtual ~Object( void );
+	DYNINST_EXPORT std::string getFileName() const { return mf->filename(); }
+    DYNINST_EXPORT bool isForwarded( Offset addr );
+    DYNINST_EXPORT bool isEEL() const { return false; }
+    DYNINST_EXPORT bool isText( const Offset addr ) const; 
+    DYNINST_EXPORT Offset get_base_addr() const { return (Offset)mf->base_addr();} 
+    DYNINST_EXPORT Module* GetCurrentModule( void )				    { return curModule; }
    
-    SYMTAB_EXPORT bool getCatchBlock(ExceptionBlock &b, Offset addr, unsigned size = 0) const;
-    SYMTAB_EXPORT unsigned int GetTextSectionId( void ) const         { return textSectionId;}
-    SYMTAB_EXPORT PIMAGE_NT_HEADERS   GetImageHeader( void ) const    { return peHdr; }
-    SYMTAB_EXPORT PVOID GetMapAddr( void ) const                      { return mf->base_addr(); }
-    SYMTAB_EXPORT Offset getEntryPoint( void ) const                {
+    DYNINST_EXPORT bool getCatchBlock(ExceptionBlock &b, Offset addr, unsigned size = 0) const;
+    DYNINST_EXPORT unsigned int GetTextSectionId( void ) const         { return textSectionId;}
+    DYNINST_EXPORT PIMAGE_NT_HEADERS   GetImageHeader( void ) const    { return peHdr; }
+    DYNINST_EXPORT PVOID GetMapAddr( void ) const                      { return mf->base_addr(); }
+    DYNINST_EXPORT Offset getEntryPoint( void ) const                {
 		if (peHdr) return peHdr->OptionalHeader.AddressOfEntryPoint;
 		return 0;}
     //+ desc.loadAddr(); } //laodAddr is always zero in our fake address space.
     // TODO. Change these later.
-    SYMTAB_EXPORT Offset getLoadAddress() const { return imageBase; }
-	SYMTAB_EXPORT Offset getPreferedBase() const { return preferedBase; }
-    SYMTAB_EXPORT Offset getEntryAddress() const { return getEntryPoint(); }
-    SYMTAB_EXPORT Offset getBaseAddress() const { return get_base_addr(); }
-    SYMTAB_EXPORT Offset getTOCoffset(Offset /*ignored*/) const { return 0; }
-    SYMTAB_EXPORT ObjectType objType() const;
-    SYMTAB_EXPORT const char *interpreter_name() const { return NULL; }
-    SYMTAB_EXPORT dyn_hash_map <std::string, LineInformation> &getLineInfo();
-    SYMTAB_EXPORT void parseTypeInfo();
-    SYMTAB_EXPORT virtual Dyninst::Architecture getArch() const;
-    SYMTAB_EXPORT void    ParseGlobalSymbol(PSYMBOL_INFO pSymInfo);
-    SYMTAB_EXPORT const std::vector<Offset> &getPossibleMains() const   { return possible_mains; }
-    SYMTAB_EXPORT void getModuleLanguageInfo(dyn_hash_map<std::string, supportedLanguages> *mod_langs);
-    SYMTAB_EXPORT bool emitDriver(std::string fName, std::set<Symbol*> &allSymbols, unsigned flag);
-    SYMTAB_EXPORT unsigned int getSecAlign() const {return SecAlignment;}
-    SYMTAB_EXPORT void insertPrereqLibrary(std::string lib);
+    DYNINST_EXPORT Offset getLoadAddress() const { return imageBase; }
+	DYNINST_EXPORT Offset getPreferedBase() const { return preferedBase; }
+    DYNINST_EXPORT Offset getEntryAddress() const { return getEntryPoint(); }
+    DYNINST_EXPORT Offset getBaseAddress() const { return get_base_addr(); }
+    DYNINST_EXPORT Offset getTOCoffset(Offset /*ignored*/) const { return 0; }
+    DYNINST_EXPORT ObjectType objType() const;
+    DYNINST_EXPORT const char *interpreter_name() const { return NULL; }
+    DYNINST_EXPORT dyn_hash_map <std::string, LineInformation> &getLineInfo();
+    DYNINST_EXPORT void parseTypeInfo();
+    DYNINST_EXPORT virtual Dyninst::Architecture getArch() const;
+    DYNINST_EXPORT void    ParseGlobalSymbol(PSYMBOL_INFO pSymInfo);
+    DYNINST_EXPORT const std::vector<Offset> &getPossibleMains() const   { return possible_mains; }
+    DYNINST_EXPORT void getModuleLanguageInfo(dyn_hash_map<std::string, supportedLanguages> *mod_langs);
+    DYNINST_EXPORT bool emitDriver(std::string fName, std::set<Symbol*> &allSymbols, unsigned flag);
+    DYNINST_EXPORT unsigned int getSecAlign() const {return SecAlignment;}
+    DYNINST_EXPORT void insertPrereqLibrary(std::string lib);
     virtual char *mem_image() const 
     {
         assert(mf);
@@ -221,13 +221,13 @@ class Object : public AObject
     void setTrapHeader(Offset ptr);
     Offset trapHeader();
 
-    SYMTAB_EXPORT DWORD ImageOffset2SectionNum(DWORD dwRO);
-    SYMTAB_EXPORT PIMAGE_SECTION_HEADER ImageOffset2Section(DWORD dwRO);
-    SYMTAB_EXPORT PIMAGE_SECTION_HEADER ImageRVA2Section(DWORD dwRVA);
-    SYMTAB_EXPORT DWORD RVA2Offset(DWORD dwRVA);
-    SYMTAB_EXPORT DWORD Offset2RVA(DWORD dwRO);
-    SYMTAB_EXPORT void addReference(Offset, std::string, std::string);
-    SYMTAB_EXPORT std::map<std::string, std::map<Offset, std::string> > & getRefs() { return ref; }
+    DYNINST_EXPORT DWORD ImageOffset2SectionNum(DWORD dwRO);
+    DYNINST_EXPORT PIMAGE_SECTION_HEADER ImageOffset2Section(DWORD dwRO);
+    DYNINST_EXPORT PIMAGE_SECTION_HEADER ImageRVA2Section(DWORD dwRVA);
+    DYNINST_EXPORT DWORD RVA2Offset(DWORD dwRVA);
+    DYNINST_EXPORT DWORD Offset2RVA(DWORD dwRO);
+    DYNINST_EXPORT void addReference(Offset, std::string, std::string);
+    DYNINST_EXPORT std::map<std::string, std::map<Offset, std::string> > & getRefs() { return ref; }
 
     std::vector<std::pair<std::string, IMAGE_IMPORT_DESCRIPTOR> > & getImportDescriptorTable();
     std::map<std::string, std::map<std::string, WORD> > & getHintNameTable();
@@ -235,20 +235,20 @@ class Object : public AObject
 	void setTOCoffset(Offset) {};
 	// Adjusts the data in all the sections to reflect what
 	// the loader will do if the binary is loaded at actualBaseAddress
-	SYMTAB_EXPORT void rebase(Offset off);
-	SYMTAB_EXPORT Region* findRegionByName(const std::string& name) const;
-	SYMTAB_EXPORT void applyRelocs(Region* relocs, Offset delta);
-	SYMTAB_EXPORT virtual void getSegmentsSymReader(std::vector<SymSegment> &);
+	DYNINST_EXPORT void rebase(Offset off);
+	DYNINST_EXPORT Region* findRegionByName(const std::string& name) const;
+	DYNINST_EXPORT void applyRelocs(Region* relocs, Offset delta);
+	DYNINST_EXPORT virtual void getSegmentsSymReader(std::vector<SymSegment> &);
 
 private:
-    SYMTAB_EXPORT void    ParseSymbolInfo( bool );
-    SYMTAB_EXPORT void parseFileLineInfo();
-    SYMTAB_EXPORT void parseLineInfoForAddr(Offset)
+    DYNINST_EXPORT void    ParseSymbolInfo( bool );
+    DYNINST_EXPORT void parseFileLineInfo();
+    DYNINST_EXPORT void parseLineInfoForAddr(Offset)
     {
       parseFileLineInfo();
     }
     
-    SYMTAB_EXPORT void    FindInterestingSections( bool, bool );
+    DYNINST_EXPORT void    FindInterestingSections( bool, bool );
     Region *          findEnclosingRegion(const Offset where);
     void AddTLSFunctions();
 	DWORD* get_dword_ptr(Offset rva);

--- a/symtabAPI/src/Object.C
+++ b/symtabAPI/src/Object.C
@@ -136,7 +136,7 @@ char *AObject::mem_image() const
 	return NULL;
 }
 
-SYMTAB_EXPORT Offset ExceptionBlock::catchStart() const 
+DYNINST_EXPORT Offset ExceptionBlock::catchStart() const 
 {
 	return catchStart_;
 }
@@ -154,7 +154,7 @@ ostream &operator<<(ostream &os, relocationEntry &q) {
  *
  **************************************************/
 
-SYMTAB_EXPORT unsigned AObject::nsymbols () const 
+DYNINST_EXPORT unsigned AObject::nsymbols () const 
 { 
     unsigned n = 0;
     for (dyn_c_hash_map<std::string, std::vector<Symbol *> >::const_iterator i = symbols_.begin();
@@ -165,7 +165,7 @@ SYMTAB_EXPORT unsigned AObject::nsymbols () const
     return n;
 }
 
-SYMTAB_EXPORT bool AObject::get_symbols(string & name, 
+DYNINST_EXPORT bool AObject::get_symbols(string & name, 
       std::vector<Symbol *> &symbols ) 
 {
    dyn_c_hash_map<std::string, std::vector<Symbol *>>::const_accessor ca;
@@ -177,57 +177,57 @@ SYMTAB_EXPORT bool AObject::get_symbols(string & name,
    return true;
 }
 
-SYMTAB_EXPORT char* AObject::code_ptr () const 
+DYNINST_EXPORT char* AObject::code_ptr () const 
 { 
    return code_ptr_; 
 }
 
-SYMTAB_EXPORT Offset AObject::code_off () const 
+DYNINST_EXPORT Offset AObject::code_off () const 
 { 
    return code_off_; 
 }
 
-SYMTAB_EXPORT Offset AObject::code_len () const 
+DYNINST_EXPORT Offset AObject::code_len () const 
 { 
    return code_len_; 
 }
 
-SYMTAB_EXPORT char* AObject::data_ptr () const 
+DYNINST_EXPORT char* AObject::data_ptr () const 
 { 
    return data_ptr_; 
 }
 
-SYMTAB_EXPORT Offset AObject::data_off () const 
+DYNINST_EXPORT Offset AObject::data_off () const 
 { 
    return data_off_; 
 }
 
-SYMTAB_EXPORT Offset AObject::data_len () const 
+DYNINST_EXPORT Offset AObject::data_len () const 
 { 
    return data_len_; 
 }
 
-SYMTAB_EXPORT bool AObject::is_aout() const 
+DYNINST_EXPORT bool AObject::is_aout() const 
 {
    return is_aout_;  
 }
 
-SYMTAB_EXPORT bool AObject::isDynamic() const 
+DYNINST_EXPORT bool AObject::isDynamic() const 
 {
    return is_dynamic_;  
 }
 
-SYMTAB_EXPORT unsigned AObject::no_of_sections() const 
+DYNINST_EXPORT unsigned AObject::no_of_sections() const 
 { 
    return no_of_sections_; 
 }
 
-SYMTAB_EXPORT unsigned AObject::no_of_symbols() const 
+DYNINST_EXPORT unsigned AObject::no_of_symbols() const 
 { 
    return no_of_symbols_;  
 }
 
-SYMTAB_EXPORT bool AObject::getAllExceptions(std::vector<ExceptionBlock *>&excpBlocks) const
+DYNINST_EXPORT bool AObject::getAllExceptions(std::vector<ExceptionBlock *>&excpBlocks) const
 {
    for (unsigned i=0;i<catch_addrs_.size();i++)
       excpBlocks.push_back(new ExceptionBlock(catch_addrs_[i]));
@@ -235,43 +235,43 @@ SYMTAB_EXPORT bool AObject::getAllExceptions(std::vector<ExceptionBlock *>&excpB
    return true;
 }
 
-SYMTAB_EXPORT std::vector<Region *> AObject::getAllRegions() const
+DYNINST_EXPORT std::vector<Region *> AObject::getAllRegions() const
 {
    return regions_;	
 }
 
-SYMTAB_EXPORT Offset AObject::loader_off() const 
+DYNINST_EXPORT Offset AObject::loader_off() const 
 { 
    return loader_off_; 
 }
 
-SYMTAB_EXPORT unsigned AObject::loader_len() const 
+DYNINST_EXPORT unsigned AObject::loader_len() const 
 { 
    return loader_len_; 
 }
 
 
-SYMTAB_EXPORT int AObject::getAddressWidth() const 
+DYNINST_EXPORT int AObject::getAddressWidth() const 
 { 
    return addressWidth_nbytes; 
 }
 
-SYMTAB_EXPORT bool AObject::have_deferred_parsing(void) const
+DYNINST_EXPORT bool AObject::have_deferred_parsing(void) const
 { 
    return deferredParse;
 }
 
-SYMTAB_EXPORT void * AObject::getErrFunc() const 
+DYNINST_EXPORT void * AObject::getErrFunc() const 
 {
    return (void *) err_func_; 
 }
 
-SYMTAB_EXPORT dyn_c_hash_map< string, std::vector< Symbol *> > *AObject::getAllSymbols()
+DYNINST_EXPORT dyn_c_hash_map< string, std::vector< Symbol *> > *AObject::getAllSymbols()
 {
    return &(symbols_);
 }
 
-SYMTAB_EXPORT AObject::~AObject() 
+DYNINST_EXPORT AObject::~AObject() 
 {
     using std::string;
     using std::vector;
@@ -286,7 +286,7 @@ SYMTAB_EXPORT AObject::~AObject()
 }
 
 // explicitly protected
-SYMTAB_EXPORT AObject::AObject(MappedFile *mf_, void (*err_func)(const char *), Symtab* st)
+DYNINST_EXPORT AObject::AObject(MappedFile *mf_, void (*err_func)(const char *), Symtab* st)
 : mf(mf_),
    code_ptr_(0), code_off_(0), code_len_(0),
    data_ptr_(0), data_off_(0), data_len_(0),

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -80,58 +80,58 @@ const char MULTIPLE_WILDCARD_CHARACTER = '*';
 
 class AObject {
 public:
-    SYMTAB_EXPORT unsigned nsymbols () const;
+    DYNINST_EXPORT unsigned nsymbols () const;
     
-    SYMTAB_EXPORT bool get_symbols( std::string & name, std::vector< Symbol *> & symbols);
+    DYNINST_EXPORT bool get_symbols( std::string & name, std::vector< Symbol *> & symbols);
 
-    SYMTAB_EXPORT char*       code_ptr () const; 
-    SYMTAB_EXPORT Offset           code_off () const;
-    SYMTAB_EXPORT Offset           code_len () const;
+    DYNINST_EXPORT char*       code_ptr () const; 
+    DYNINST_EXPORT Offset           code_off () const;
+    DYNINST_EXPORT Offset           code_len () const;
 
-    SYMTAB_EXPORT char*       data_ptr () const;
-    SYMTAB_EXPORT Offset           data_off () const;
-    SYMTAB_EXPORT Offset           data_len () const;
+    DYNINST_EXPORT char*       data_ptr () const;
+    DYNINST_EXPORT Offset           data_off () const;
+    DYNINST_EXPORT Offset           data_len () const;
 
-    SYMTAB_EXPORT bool 	      is_aout  () const;
-    SYMTAB_EXPORT bool        isDynamic() const;
+    DYNINST_EXPORT bool 	      is_aout  () const;
+    DYNINST_EXPORT bool        isDynamic() const;
 
-    SYMTAB_EXPORT unsigned	      no_of_sections () const;
-    SYMTAB_EXPORT unsigned	      no_of_symbols  ()	const;
+    DYNINST_EXPORT unsigned	      no_of_sections () const;
+    DYNINST_EXPORT unsigned	      no_of_symbols  ()	const;
 
-    SYMTAB_EXPORT bool getAllExceptions(std::vector<ExceptionBlock *>&excpBlocks) const;
-    SYMTAB_EXPORT std::vector<Region *> getAllRegions() const;
+    DYNINST_EXPORT bool getAllExceptions(std::vector<ExceptionBlock *>&excpBlocks) const;
+    DYNINST_EXPORT std::vector<Region *> getAllRegions() const;
 
-    SYMTAB_EXPORT Offset loader_off() const;
-    SYMTAB_EXPORT unsigned loader_len() const;
-    SYMTAB_EXPORT int getAddressWidth() const;
+    DYNINST_EXPORT Offset loader_off() const;
+    DYNINST_EXPORT unsigned loader_len() const;
+    DYNINST_EXPORT int getAddressWidth() const;
 
     bool isStaticBinary() const {return is_static_binary_;}
 
-    SYMTAB_EXPORT virtual char *  mem_image() const;
+    DYNINST_EXPORT virtual char *  mem_image() const;
 
-    SYMTAB_EXPORT virtual  bool   needs_function_binding()  const;
-    SYMTAB_EXPORT virtual  bool   get_func_binding_table(std::vector<relocationEntry> &) const;
-    SYMTAB_EXPORT virtual  bool   get_func_binding_table_ptr(const std::vector<relocationEntry> *&) const; 
-    SYMTAB_EXPORT virtual  bool   addRelocationEntry(relocationEntry &re);
-    SYMTAB_EXPORT bool   getSegments(std::vector<Segment> &segs) const;
+    DYNINST_EXPORT virtual  bool   needs_function_binding()  const;
+    DYNINST_EXPORT virtual  bool   get_func_binding_table(std::vector<relocationEntry> &) const;
+    DYNINST_EXPORT virtual  bool   get_func_binding_table_ptr(const std::vector<relocationEntry> *&) const; 
+    DYNINST_EXPORT virtual  bool   addRelocationEntry(relocationEntry &re);
+    DYNINST_EXPORT bool   getSegments(std::vector<Segment> &segs) const;
 
-    SYMTAB_EXPORT bool have_deferred_parsing( void ) const;
+    DYNINST_EXPORT bool have_deferred_parsing( void ) const;
     // for debuggering....
-    SYMTAB_EXPORT const std::ostream &dump_state_info(std::ostream &s);
+    DYNINST_EXPORT const std::ostream &dump_state_info(std::ostream &s);
 
-    SYMTAB_EXPORT void * getErrFunc() const;
-    SYMTAB_EXPORT dyn_c_hash_map< std::string, std::vector< Symbol *> > *getAllSymbols();
+    DYNINST_EXPORT void * getErrFunc() const;
+    DYNINST_EXPORT dyn_c_hash_map< std::string, std::vector< Symbol *> > *getAllSymbols();
     
-    SYMTAB_EXPORT virtual bool hasFrameDebugInfo() {return false;}
-    SYMTAB_EXPORT virtual bool getRegValueAtFrame(Address /*pc*/,
+    DYNINST_EXPORT virtual bool hasFrameDebugInfo() {return false;}
+    DYNINST_EXPORT virtual bool getRegValueAtFrame(Address /*pc*/,
                                                   Dyninst::MachRegister /*reg*/, 
                                                   Dyninst::MachRegisterVal & /*reg_result*/,
                                                   Dyninst::SymtabAPI::MemRegReader * /*reader*/) {return false;}
     
-    SYMTAB_EXPORT virtual Dyninst::Architecture getArch() const { return Arch_none; }
-    SYMTAB_EXPORT bool hasError() const;
-    SYMTAB_EXPORT virtual bool isBigEndianDataEncoding() const { return false; }
-    SYMTAB_EXPORT virtual bool getABIVersion(int & /*major*/, int & /*minor*/) const { return false; }
+    DYNINST_EXPORT virtual Dyninst::Architecture getArch() const { return Arch_none; }
+    DYNINST_EXPORT bool hasError() const;
+    DYNINST_EXPORT virtual bool isBigEndianDataEncoding() const { return false; }
+    DYNINST_EXPORT virtual bool getABIVersion(int & /*major*/, int & /*minor*/) const { return false; }
 
 
     virtual void setTruncateLinePaths(bool value);
@@ -139,13 +139,13 @@ public:
     virtual Region::RegionType getRelType() const { return Region::RT_INVALID; }
 
     // Only implemented for ELF right now
-    SYMTAB_EXPORT virtual void getSegmentsSymReader(std::vector<SymSegment> &) {}
-	SYMTAB_EXPORT virtual void rebase(Offset) {}
+    DYNINST_EXPORT virtual void getSegmentsSymReader(std::vector<SymSegment> &) {}
+	DYNINST_EXPORT virtual void rebase(Offset) {}
     virtual void addModule(SymtabAPI::Module *) {}
 protected:
-    SYMTAB_EXPORT virtual ~AObject();
+    DYNINST_EXPORT virtual ~AObject();
     // explicitly protected
-    SYMTAB_EXPORT AObject(MappedFile *, void (*err_func)(const char *), Symtab*);
+    DYNINST_EXPORT AObject(MappedFile *, void (*err_func)(const char *), Symtab*);
 friend class Module;
     virtual void parseLineInfoForCU(Offset , LineInformation* ) { }
 

--- a/symtabAPI/src/Symbol.C
+++ b/symtabAPI/src/Symbol.C
@@ -61,17 +61,17 @@ Symbol *Symbol::magicEmitElfSymbol() {
                       false);
 }
     
-SYMTAB_EXPORT string Symbol::getMangledName() const 
+DYNINST_EXPORT string Symbol::getMangledName() const 
 {
     return mangledName_;
 }
 
-SYMTAB_EXPORT string Symbol::getPrettyName() const 
+DYNINST_EXPORT string Symbol::getPrettyName() const 
 {
   return P_cplus_demangle(mangledName_, false);
 }
 
-SYMTAB_EXPORT string Symbol::getTypedName() const 
+DYNINST_EXPORT string Symbol::getTypedName() const 
 {
   return P_cplus_demangle(mangledName_, true);
 }
@@ -94,66 +94,66 @@ bool Symbol::setLocalTOC(Offset toc)
     return true;
 }
 
-SYMTAB_EXPORT bool Symbol::setModule(Module *mod) 
+DYNINST_EXPORT bool Symbol::setModule(Module *mod) 
 {
     assert(mod);
     module_ = mod; 
     return true;
 }
 
-SYMTAB_EXPORT bool Symbol::isFunction() const
+DYNINST_EXPORT bool Symbol::isFunction() const
 {
     return (getFunction() != NULL);
 }
 
-SYMTAB_EXPORT bool Symbol::setFunction(Function *func)
+DYNINST_EXPORT bool Symbol::setFunction(Function *func)
 {
     aggregate_ = func;
     return true;
 }
 
-SYMTAB_EXPORT Function * Symbol::getFunction() const
+DYNINST_EXPORT Function * Symbol::getFunction() const
 {
 	if (aggregate_ == NULL) 
 		return NULL;
     return dynamic_cast<Function *>(aggregate_);
 }
 
-SYMTAB_EXPORT bool Symbol::isVariable() const 
+DYNINST_EXPORT bool Symbol::isVariable() const 
 {
     return (getVariable() != NULL);
 }
 
-SYMTAB_EXPORT bool Symbol::setVariable(Variable *var) 
+DYNINST_EXPORT bool Symbol::setVariable(Variable *var) 
 {
     aggregate_ = var;
     return true;
 }
 
-SYMTAB_EXPORT Variable * Symbol::getVariable() const
+DYNINST_EXPORT Variable * Symbol::getVariable() const
 {
     return dynamic_cast<Variable *>(aggregate_);
 }
 
-SYMTAB_EXPORT bool Symbol::setSize(unsigned ns)
+DYNINST_EXPORT bool Symbol::setSize(unsigned ns)
 {
 	size_ = ns;
 	return true;
 }
 
-SYMTAB_EXPORT bool Symbol::setRegion(Region *r)
+DYNINST_EXPORT bool Symbol::setRegion(Region *r)
 {
 	region_ = r;
 	return true;
 }
 
-SYMTAB_EXPORT Symbol::SymbolTag Symbol::tag() const 
+DYNINST_EXPORT Symbol::SymbolTag Symbol::tag() const 
 {
     return tag_;
 }
 
 
-SYMTAB_EXPORT bool Symbol::setSymbolType(SymbolType sType)
+DYNINST_EXPORT bool Symbol::setSymbolType(SymbolType sType)
 {
     if ((sType != ST_UNKNOWN)&&
         (sType != ST_FUNCTION)&&
@@ -173,7 +173,7 @@ SYMTAB_EXPORT bool Symbol::setSymbolType(SymbolType sType)
     return true;
 }
 
-SYMTAB_EXPORT bool Symbol::setVersionFileName(std::string &fileName)
+DYNINST_EXPORT bool Symbol::setVersionFileName(std::string &fileName)
 {
    std::string *fn_p = NULL;
    if (getAnnotation(fn_p, SymbolFileNameAnno)) 
@@ -194,7 +194,7 @@ SYMTAB_EXPORT bool Symbol::setVersionFileName(std::string &fileName)
    return false;
 }
 
-SYMTAB_EXPORT bool Symbol::setVersions(std::vector<std::string> &vers)
+DYNINST_EXPORT bool Symbol::setVersions(std::vector<std::string> &vers)
 {
    std::vector<std::string> *vn_p = NULL;
    if (getAnnotation(vn_p, SymbolVersionNamesAnno)) 
@@ -209,7 +209,7 @@ SYMTAB_EXPORT bool Symbol::setVersions(std::vector<std::string> &vers)
    return true;
 }
 
-SYMTAB_EXPORT bool Symbol::getVersionFileName(std::string &fileName) const
+DYNINST_EXPORT bool Symbol::getVersionFileName(std::string &fileName) const
 {
    std::string *fn_p = NULL;
 
@@ -224,7 +224,7 @@ SYMTAB_EXPORT bool Symbol::getVersionFileName(std::string &fileName) const
    return false;
 }
 
-SYMTAB_EXPORT bool Symbol::getVersions(std::vector<std::string> *&vers) const
+DYNINST_EXPORT bool Symbol::getVersions(std::vector<std::string> *&vers) const
 {
    std::vector<std::string> *vn_p = NULL;
 
@@ -240,7 +240,7 @@ SYMTAB_EXPORT bool Symbol::getVersions(std::vector<std::string> *&vers) const
    return false;
 }
 
-SYMTAB_EXPORT bool Symbol::setMangledName(std::string name)
+DYNINST_EXPORT bool Symbol::setMangledName(std::string name)
 {
    mangledName_ = name;
    setStrIndex(-1);

--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -372,7 +372,7 @@ Variable *Symtab::createVariable(std::string name,
     return var;
 }
 
-SYMTAB_EXPORT bool Symtab::updateRelocations(Address start,
+DYNINST_EXPORT bool Symtab::updateRelocations(Address start,
                                              Address end,
                                              Symbol *oldsym,
                                              Symbol *newsym) {

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -289,22 +289,22 @@ boost::shared_ptr<typeCollection> Symtab::setupStdTypes()
    return stdTypes;
 }
 
-SYMTAB_EXPORT unsigned Symtab::getAddressWidth() const 
+DYNINST_EXPORT unsigned Symtab::getAddressWidth() const 
 {
    return address_width_;
 }
  
-SYMTAB_EXPORT bool Symtab::getABIVersion(int &major, int &minor) const
+DYNINST_EXPORT bool Symtab::getABIVersion(int &major, int &minor) const
 {
    return obj_private->getABIVersion(major, minor);
 }
 
-SYMTAB_EXPORT bool Symtab::isBigEndianDataEncoding() const
+DYNINST_EXPORT bool Symtab::isBigEndianDataEncoding() const
 {
    return obj_private->isBigEndianDataEncoding();
 }
 
-SYMTAB_EXPORT Symtab::Symtab() :
+DYNINST_EXPORT Symtab::Symtab() :
    LookupInterface(),
    AnnotatableSparse(),
    impl{std::unique_ptr<symtab_impl>(new symtab_impl{})}
@@ -312,22 +312,22 @@ SYMTAB_EXPORT Symtab::Symtab() :
     init_debug_symtabAPI();
 }
 
-SYMTAB_EXPORT bool Symtab::isExec() const 
+DYNINST_EXPORT bool Symtab::isExec() const 
 {
     return is_a_out; 
 }
 
-SYMTAB_EXPORT bool Symtab::isExecutable() const
+DYNINST_EXPORT bool Symtab::isExecutable() const
 {
     return obj_private->isExecutable();
 }
 
-SYMTAB_EXPORT bool Symtab::isSharedLibrary() const
+DYNINST_EXPORT bool Symtab::isSharedLibrary() const
 {
     return obj_private->isSharedLibrary();
 }
 
-SYMTAB_EXPORT bool Symtab::isStripped() 
+DYNINST_EXPORT bool Symtab::isStripped() 
 {
 #if defined(os_linux) || defined(os_freebsd)
     Region *sec;
@@ -337,32 +337,32 @@ SYMTAB_EXPORT bool Symtab::isStripped()
 #endif
 }
 
-SYMTAB_EXPORT Offset Symtab::preferedBase() const 
+DYNINST_EXPORT Offset Symtab::preferedBase() const 
 {
     return preferedBase_;
 }
 
-SYMTAB_EXPORT Offset Symtab::imageOffset() const 
+DYNINST_EXPORT Offset Symtab::imageOffset() const 
 {
     return imageOffset_;
 }
 
-SYMTAB_EXPORT Offset Symtab::dataOffset() const 
+DYNINST_EXPORT Offset Symtab::dataOffset() const 
 { 
     return dataOffset_;
 }
 
-SYMTAB_EXPORT Offset Symtab::dataLength() const 
+DYNINST_EXPORT Offset Symtab::dataLength() const 
 {
     return dataLen_;
 } 
 
-SYMTAB_EXPORT Offset Symtab::imageLength() const 
+DYNINST_EXPORT Offset Symtab::imageLength() const 
 {
     return imageLen_;
 }
 
-SYMTAB_EXPORT void Symtab::fixup_code_and_data(Offset newImageOffset,
+DYNINST_EXPORT void Symtab::fixup_code_and_data(Offset newImageOffset,
                                                Offset newImageLength,
                                                Offset newDataOffset,
                                                Offset newDataLength)
@@ -375,34 +375,34 @@ SYMTAB_EXPORT void Symtab::fixup_code_and_data(Offset newImageOffset,
     // Should we update the underlying Object?
 }
 
-SYMTAB_EXPORT const char*  Symtab::getInterpreterName() const 
+DYNINST_EXPORT const char*  Symtab::getInterpreterName() const 
 {
    if (interpreter_name_.length())
       return interpreter_name_.c_str();
    return NULL;
 }
  
-SYMTAB_EXPORT Offset Symtab::getEntryOffset() const 
+DYNINST_EXPORT Offset Symtab::getEntryOffset() const 
 { 
    return entry_address_;
 }
 
-SYMTAB_EXPORT Offset Symtab::getBaseOffset() const 
+DYNINST_EXPORT Offset Symtab::getBaseOffset() const 
 {
    return base_address_;
 }
 
-SYMTAB_EXPORT Offset Symtab::getLoadOffset() const 
+DYNINST_EXPORT Offset Symtab::getLoadOffset() const 
 { 
    return load_address_;
 }
 
-SYMTAB_EXPORT Offset Symtab::getTOCoffset(Function *func) const 
+DYNINST_EXPORT Offset Symtab::getTOCoffset(Function *func) const 
 {
   return getTOCoffset(func ? func->getOffset() : 0); 
 }
 
-SYMTAB_EXPORT Offset Symtab::getTOCoffset(Offset off) const
+DYNINST_EXPORT Offset Symtab::getTOCoffset(Offset off) const
 {
   return obj_private->getTOCoffset(off);
 }
@@ -412,7 +412,7 @@ void Symtab::setTOCOffset(Offset off) {
   return;
 }
 
-SYMTAB_EXPORT string Symtab::getDefaultNamespacePrefix() const
+DYNINST_EXPORT string Symtab::getDefaultNamespacePrefix() const
 {
     return defaultNamespacePrefix;
 }
@@ -1156,13 +1156,13 @@ bool Symtab::isData(const Offset where)  const
    return false;
 }
 
-SYMTAB_EXPORT bool Symtab::getFuncBindingTable(std::vector<relocationEntry> &fbt) const
+DYNINST_EXPORT bool Symtab::getFuncBindingTable(std::vector<relocationEntry> &fbt) const
 {
    fbt = relocation_table_;
    return true;
 }
 
-SYMTAB_EXPORT bool Symtab::findPltEntryByTarget(const Address target_address, relocationEntry &result) const
+DYNINST_EXPORT bool Symtab::findPltEntryByTarget(const Address target_address, relocationEntry &result) const
 {
     /**
      * Object files and static binaries will not have a function binding table
@@ -1186,7 +1186,7 @@ SYMTAB_EXPORT bool Symtab::findPltEntryByTarget(const Address target_address, re
     return true;
 }
 
-SYMTAB_EXPORT bool Symtab::updateFuncBindingTable(Offset stub_addr, Offset plt_addr)
+DYNINST_EXPORT bool Symtab::updateFuncBindingTable(Offset stub_addr, Offset plt_addr)
 {
     int stub_idx = -1, plt_idx = -1;
 
@@ -1206,11 +1206,11 @@ SYMTAB_EXPORT bool Symtab::updateFuncBindingTable(Offset stub_addr, Offset plt_a
     return false;
 }
 
-SYMTAB_EXPORT std::vector<std::string> &Symtab::getDependencies(){
+DYNINST_EXPORT std::vector<std::string> &Symtab::getDependencies(){
     return deps_;
 }
 
-SYMTAB_EXPORT Archive *Symtab::getParentArchive() const {
+DYNINST_EXPORT Archive *Symtab::getParentArchive() const {
     return parentArchive_;
 }
 
@@ -1522,7 +1522,7 @@ void Symtab::parseLineInformation()
     linkedFile->parseFileLineInfo();
 }
 
-SYMTAB_EXPORT bool Symtab::getAddressRanges(std::vector<AddressRange > &ranges,
+DYNINST_EXPORT bool Symtab::getAddressRanges(std::vector<AddressRange > &ranges,
                                             std::string lineSource, unsigned int lineNo)
 {
    unsigned int originalSize = ranges.size();
@@ -1549,7 +1549,7 @@ SYMTAB_EXPORT bool Symtab::getAddressRanges(std::vector<AddressRange > &ranges,
    return false;
 }
 
-SYMTAB_EXPORT bool Symtab::getSourceLines(std::vector<Statement::Ptr> &lines, Offset addressInRange)
+DYNINST_EXPORT bool Symtab::getSourceLines(std::vector<Statement::Ptr> &lines, Offset addressInRange)
 {
    unsigned int originalSize = lines.size();
     Module* m = getContainingModule(addressInRange);
@@ -1565,7 +1565,7 @@ SYMTAB_EXPORT bool Symtab::getSourceLines(std::vector<Statement::Ptr> &lines, Of
 
 }
 
-SYMTAB_EXPORT bool Symtab::getSourceLines(std::vector<LineNoTuple> &lines, Offset addressInRange)
+DYNINST_EXPORT bool Symtab::getSourceLines(std::vector<LineNoTuple> &lines, Offset addressInRange)
 {
     std::vector<Statement::Ptr> tmp;
     getSourceLines(tmp, addressInRange);
@@ -1621,17 +1621,17 @@ bool Symtab::addType(Type *type)
   return true;
 }
 
-SYMTAB_EXPORT void Symtab::getAllstdTypes(vector<boost::shared_ptr<Type>>& v)
+DYNINST_EXPORT void Symtab::getAllstdTypes(vector<boost::shared_ptr<Type>>& v)
 {
    return stdTypes()->getAllTypes(v); 	
 }
 
-SYMTAB_EXPORT void Symtab::getAllbuiltInTypes(vector<boost::shared_ptr<Type>>& v)
+DYNINST_EXPORT void Symtab::getAllbuiltInTypes(vector<boost::shared_ptr<Type>>& v)
 {
    return builtInTypes()->getAllBuiltInTypes(v);
 }
 
-SYMTAB_EXPORT bool Symtab::findType(boost::shared_ptr<Type> &type, std::string name)
+DYNINST_EXPORT bool Symtab::findType(boost::shared_ptr<Type> &type, std::string name)
 {
    parseTypesNow();
 
@@ -1652,7 +1652,7 @@ SYMTAB_EXPORT bool Symtab::findType(boost::shared_ptr<Type> &type, std::string n
    return true;	
 }
 
-SYMTAB_EXPORT boost::shared_ptr<Type> Symtab::findType(unsigned type_id, Type::do_share_t)
+DYNINST_EXPORT boost::shared_ptr<Type> Symtab::findType(unsigned type_id, Type::do_share_t)
 {
 	boost::shared_ptr<Type> t;
    parseTypesNow();
@@ -1690,7 +1690,7 @@ SYMTAB_EXPORT boost::shared_ptr<Type> Symtab::findType(unsigned type_id, Type::d
    return t;	
 }
 
-SYMTAB_EXPORT bool Symtab::findVariableType(boost::shared_ptr<Type>& type, std::string name)
+DYNINST_EXPORT bool Symtab::findVariableType(boost::shared_ptr<Type>& type, std::string name)
 {
    parseTypesNow();
     type = NULL;
@@ -1708,7 +1708,7 @@ SYMTAB_EXPORT bool Symtab::findVariableType(boost::shared_ptr<Type>& type, std::
    return true;	
 }
 
-SYMTAB_EXPORT bool Symtab::findLocalVariable(std::vector<localVar *>&vars, std::string name)
+DYNINST_EXPORT bool Symtab::findLocalVariable(std::vector<localVar *>&vars, std::string name)
 {
    parseTypesNow();
    unsigned origSize = vars.size();
@@ -1724,37 +1724,37 @@ SYMTAB_EXPORT bool Symtab::findLocalVariable(std::vector<localVar *>&vars, std::
    return false;	
 }
 
-SYMTAB_EXPORT bool Symtab::hasRel() const
+DYNINST_EXPORT bool Symtab::hasRel() const
 {
    return hasRel_;
 }
 
-SYMTAB_EXPORT bool Symtab::hasRela() const
+DYNINST_EXPORT bool Symtab::hasRela() const
 {
    return hasRela_;
 }
 
-SYMTAB_EXPORT bool Symtab::hasReldyn() const
+DYNINST_EXPORT bool Symtab::hasReldyn() const
 {
    return hasReldyn_;
 }
 
-SYMTAB_EXPORT bool Symtab::hasReladyn() const
+DYNINST_EXPORT bool Symtab::hasReladyn() const
 {
    return hasReladyn_;
 }
 
-SYMTAB_EXPORT bool Symtab::hasRelplt() const
+DYNINST_EXPORT bool Symtab::hasRelplt() const
 {
    return hasRelplt_;
 }
 
-SYMTAB_EXPORT bool Symtab::hasRelaplt() const
+DYNINST_EXPORT bool Symtab::hasRelaplt() const
 {
    return hasRelaplt_;
 }
 
-SYMTAB_EXPORT bool Symtab::isStaticBinary() const
+DYNINST_EXPORT bool Symtab::isStaticBinary() const
 {
    return isStaticBinary_;
 }
@@ -1765,7 +1765,7 @@ bool Symtab::setDefaultNamespacePrefix(string &str)
    return true;
 }
 
-SYMTAB_EXPORT bool Symtab::emitSymbols(Object *linkedFile,std::string filename, unsigned flag)
+DYNINST_EXPORT bool Symtab::emitSymbols(Object *linkedFile,std::string filename, unsigned flag)
 {
     // Start with all the defined symbols
     std::set<Symbol* > allSyms;
@@ -1779,7 +1779,7 @@ SYMTAB_EXPORT bool Symtab::emitSymbols(Object *linkedFile,std::string filename, 
     return linkedFile->emitDriver(filename, allSyms, flag);
 }
 
-SYMTAB_EXPORT bool Symtab::emit(std::string filename, unsigned flag)
+DYNINST_EXPORT bool Symtab::emit(std::string filename, unsigned flag)
 {
 	Object *obj = getObject();
 	if (!obj)
@@ -1790,12 +1790,12 @@ SYMTAB_EXPORT bool Symtab::emit(std::string filename, unsigned flag)
    return emitSymbols(obj, filename, flag);
 }
 
-SYMTAB_EXPORT void Symtab::addDynLibSubstitution(std::string oldName, std::string newName)
+DYNINST_EXPORT void Symtab::addDynLibSubstitution(std::string oldName, std::string newName)
 {
    dynLibSubs[oldName] = newName;
 }
 
-SYMTAB_EXPORT std::string Symtab::getDynLibSubstitution(std::string name)
+DYNINST_EXPORT std::string Symtab::getDynLibSubstitution(std::string name)
 {
    map<std::string, std::string>::iterator loc = dynLibSubs.find(name);
 
@@ -1805,7 +1805,7 @@ SYMTAB_EXPORT std::string Symtab::getDynLibSubstitution(std::string name)
       return loc->second;
 }
 
-SYMTAB_EXPORT bool Symtab::getSegments(vector<Segment> &segs) const
+DYNINST_EXPORT bool Symtab::getSegments(vector<Segment> &segs) const
 {
    segs = segments_;
 
@@ -1815,7 +1815,7 @@ SYMTAB_EXPORT bool Symtab::getSegments(vector<Segment> &segs) const
    return true;
 }
 
-SYMTAB_EXPORT bool Symtab::getMappedRegions(std::vector<Region *> &mappedRegs) const
+DYNINST_EXPORT bool Symtab::getMappedRegions(std::vector<Region *> &mappedRegs) const
 {
    unsigned origSize = mappedRegs.size();
 
@@ -1831,7 +1831,7 @@ SYMTAB_EXPORT bool Symtab::getMappedRegions(std::vector<Region *> &mappedRegs) c
    return false;
 }
 
-SYMTAB_EXPORT bool Symtab::fixup_RegionAddr(const char* name, Offset memOffset, long memSize)
+DYNINST_EXPORT bool Symtab::fixup_RegionAddr(const char* name, Offset memOffset, long memSize)
 {
     Region *sec;
 
@@ -1876,7 +1876,7 @@ SYMTAB_EXPORT bool Symtab::fixup_RegionAddr(const char* name, Offset memOffset, 
     return true;
 }
 
-SYMTAB_EXPORT bool Symtab::updateRegion(const char* name, void *buffer, unsigned size)
+DYNINST_EXPORT bool Symtab::updateRegion(const char* name, void *buffer, unsigned size)
 {
    Region *sec;
 
@@ -1888,17 +1888,17 @@ SYMTAB_EXPORT bool Symtab::updateRegion(const char* name, void *buffer, unsigned
    return true;
 }
 
-SYMTAB_EXPORT bool Symtab::updateCode(void *buffer, unsigned size)
+DYNINST_EXPORT bool Symtab::updateCode(void *buffer, unsigned size)
 {
   return updateRegion(".text", buffer, size);
 }
 
-SYMTAB_EXPORT bool Symtab::updateData(void *buffer, unsigned size)
+DYNINST_EXPORT bool Symtab::updateData(void *buffer, unsigned size)
 {
   return updateRegion(".data", buffer, size);
 }
 
-SYMTAB_EXPORT Offset Symtab::getFreeOffset(unsigned size) 
+DYNINST_EXPORT Offset Symtab::getFreeOffset(unsigned size) 
 {
    // Look through sections until we find a gap with
    // sufficient space.
@@ -1979,53 +1979,53 @@ SYMTAB_EXPORT Offset Symtab::getFreeOffset(unsigned size)
 #endif	
 }
 
-SYMTAB_EXPORT ObjectType Symtab::getObjectType() const 
+DYNINST_EXPORT ObjectType Symtab::getObjectType() const 
 {
    return object_type_;
 }
 
-SYMTAB_EXPORT Dyninst::Architecture Symtab::getArchitecture() const
+DYNINST_EXPORT Dyninst::Architecture Symtab::getArchitecture() const
 {
    return getObject()->getArch();
 }
 
-SYMTAB_EXPORT char *Symtab::mem_image() const 
+DYNINST_EXPORT char *Symtab::mem_image() const 
 {
    return (char *)mf->base_addr();
 }
 
-SYMTAB_EXPORT std::string Symtab::file() const 
+DYNINST_EXPORT std::string Symtab::file() const 
 {
    assert(mf);
    return mf->filename();
 }
 
-SYMTAB_EXPORT std::string Symtab::name() const 
+DYNINST_EXPORT std::string Symtab::name() const 
 {
   return extract_pathname_tail(mf->filename());
 }
 
-SYMTAB_EXPORT std::string Symtab::memberName() const 
+DYNINST_EXPORT std::string Symtab::memberName() const 
 {
     return member_name_;
 }
 
-SYMTAB_EXPORT unsigned Symtab::getNumberOfRegions() const 
+DYNINST_EXPORT unsigned Symtab::getNumberOfRegions() const 
 {
    return no_of_sections; 
 }
 
-SYMTAB_EXPORT unsigned Symtab::getNumberOfSymbols() const 
+DYNINST_EXPORT unsigned Symtab::getNumberOfSymbols() const 
 {
    return no_of_symbols; 
 }
 
 
-SYMTAB_EXPORT LookupInterface::LookupInterface() 
+DYNINST_EXPORT LookupInterface::LookupInterface() 
 {
 }
 
-SYMTAB_EXPORT LookupInterface::~LookupInterface()
+DYNINST_EXPORT LookupInterface::~LookupInterface()
 {
 }
 
@@ -2068,7 +2068,7 @@ void Symtab::parseTypesNow()
    std::call_once(this->impl->types_parsed, [this](){ this->parseTypes(); });
 }
 
-SYMTAB_EXPORT Offset Symtab::getElfDynamicOffset()
+DYNINST_EXPORT Offset Symtab::getElfDynamicOffset()
 {
 #if defined(os_linux) || defined(os_freebsd)
 	Object *obj = getObject();
@@ -2082,7 +2082,7 @@ SYMTAB_EXPORT Offset Symtab::getElfDynamicOffset()
 #endif
 }
 
-SYMTAB_EXPORT bool Symtab::removeLibraryDependency(std::string lib)
+DYNINST_EXPORT bool Symtab::removeLibraryDependency(std::string lib)
 {
 #if defined(os_windows)
    return false;
@@ -2095,7 +2095,7 @@ SYMTAB_EXPORT bool Symtab::removeLibraryDependency(std::string lib)
 #endif
 }
    
-SYMTAB_EXPORT bool Symtab::addLibraryPrereq(std::string name)
+DYNINST_EXPORT bool Symtab::addLibraryPrereq(std::string name)
 {
    Object *obj = getObject();
 	if (!obj)
@@ -2149,7 +2149,7 @@ SYMTAB_EXPORT bool Symtab::addLibraryPrereq(std::string name)
    return true;
 }
 
-SYMTAB_EXPORT bool Symtab::addSysVDynamic(long name, long value)
+DYNINST_EXPORT bool Symtab::addSysVDynamic(long name, long value)
 {
 #if defined(os_linux) || defined(os_freebsd)
 	Object *obj = getObject();
@@ -2164,7 +2164,7 @@ SYMTAB_EXPORT bool Symtab::addSysVDynamic(long name, long value)
 #endif
 }
 
-SYMTAB_EXPORT bool Symtab::addExternalSymbolReference(Symbol *externalSym, Region *localRegion,
+DYNINST_EXPORT bool Symtab::addExternalSymbolReference(Symbol *externalSym, Region *localRegion,
         relocationEntry localRel)
 {
     // Adjust this to the correct value
@@ -2198,7 +2198,7 @@ SYMTAB_EXPORT bool Symtab::addExternalSymbolReference(Symbol *externalSym, Regio
 
 // on windows we can't specify the trap table's location by adding a dynamic
 // symbol as we don on windows
-SYMTAB_EXPORT bool Symtab::addTrapHeader_win(Address ptr)
+DYNINST_EXPORT bool Symtab::addTrapHeader_win(Address ptr)
 {
 #if defined(os_windows)
    getObject()->setTrapHeader(ptr);
@@ -2215,18 +2215,18 @@ bool Symtab::getExplicitSymtabRefs(std::set<Symtab *> &refs) {
     return (refs.size() != 0);
 }
 
-SYMTAB_EXPORT bool Symtab::addLinkingResource(Archive *library) {
+DYNINST_EXPORT bool Symtab::addLinkingResource(Archive *library) {
     linkingResources_.push_back(library);
 
     return true;
 }
 
-SYMTAB_EXPORT bool Symtab::getLinkingResources(std::vector<Archive *> &libs) {
+DYNINST_EXPORT bool Symtab::getLinkingResources(std::vector<Archive *> &libs) {
     libs = linkingResources_;
     return (linkingResources_.size() != 0);
 }
 
-SYMTAB_EXPORT Address Symtab::getLoadAddress()
+DYNINST_EXPORT Address Symtab::getLoadAddress()
 {
 #if defined(os_linux) || defined(os_freebsd)
    return getObject()->getLoadAddress();
@@ -2235,17 +2235,17 @@ SYMTAB_EXPORT Address Symtab::getLoadAddress()
 #endif
 }
 
-SYMTAB_EXPORT bool Symtab::isDefensiveBinary() const
+DYNINST_EXPORT bool Symtab::isDefensiveBinary() const
 {
     return isDefensiveBinary_;
 }
 
-SYMTAB_EXPORT bool Symtab::canBeShared()
+DYNINST_EXPORT bool Symtab::canBeShared()
 {
    return mf->canBeShared();
 }
 
-SYMTAB_EXPORT Offset Symtab::getInitOffset()
+DYNINST_EXPORT Offset Symtab::getInitOffset()
 {
 #if defined(os_linux) || defined(os_freebsd)
    return getObject()->getInitAddr();
@@ -2255,7 +2255,7 @@ SYMTAB_EXPORT Offset Symtab::getInitOffset()
 
 }
 
-SYMTAB_EXPORT Offset Symtab::getFiniOffset()
+DYNINST_EXPORT Offset Symtab::getFiniOffset()
 {
 #if defined(os_linux) || defined(os_freebsd)
    return getObject()->getFiniAddr();

--- a/symtabAPI/src/relocationEntry-elf-aarch64.C
+++ b/symtabAPI/src/relocationEntry-elf-aarch64.C
@@ -170,7 +170,7 @@ const char *relocationEntry::relType2Str(unsigned long r, unsigned /*addressWidt
     return "?";
 }
 
-SYMTAB_EXPORT unsigned long relocationEntry::getGlobalRelType(unsigned addressWidth, Symbol *sym) {
+DYNINST_EXPORT unsigned long relocationEntry::getGlobalRelType(unsigned addressWidth, Symbol *sym) {
 	//#warning "This functions is not verified yet!"
 
 	//if it is 32bit arch?

--- a/symtabAPI/src/relocationEntry-elf-ppc64.C
+++ b/symtabAPI/src/relocationEntry-elf-ppc64.C
@@ -147,7 +147,7 @@ const char* relocationEntry::relType2Str(unsigned long r, unsigned /*addressWidt
     }
 }
 
-SYMTAB_EXPORT unsigned long relocationEntry::getGlobalRelType(unsigned addressWidth, Symbol *sym) {
+DYNINST_EXPORT unsigned long relocationEntry::getGlobalRelType(unsigned addressWidth, Symbol *sym) {
   if (addressWidth == 4)
     return R_PPC_GLOB_DAT;
 

--- a/symtabAPI/src/relocationEntry-elf-x86.C
+++ b/symtabAPI/src/relocationEntry-elf-x86.C
@@ -118,7 +118,7 @@ const char* relocationEntry::relType2Str(unsigned long r, unsigned addressWidth)
     }
 }
 
-SYMTAB_EXPORT unsigned long relocationEntry::getGlobalRelType(unsigned addressWidth, Symbol *) {
+DYNINST_EXPORT unsigned long relocationEntry::getGlobalRelType(unsigned addressWidth, Symbol *) {
     if( X86_64_WIDTH == addressWidth ) {
         return R_X86_64_GLOB_DAT;
     }else{

--- a/symtabAPI/src/relocationEntry.C
+++ b/symtabAPI/src/relocationEntry.C
@@ -38,7 +38,7 @@ namespace Dyninst  {
 namespace SymtabAPI  {
 
 
-SYMTAB_EXPORT relocationEntry::relocationEntry() :
+DYNINST_EXPORT relocationEntry::relocationEntry() :
    target_addr_(0),
    rel_addr_(0),
    addend_(0),
@@ -50,7 +50,7 @@ SYMTAB_EXPORT relocationEntry::relocationEntry() :
 {
 }
 
-SYMTAB_EXPORT relocationEntry::relocationEntry(Offset ta, Offset ra, std::string n,
+DYNINST_EXPORT relocationEntry::relocationEntry(Offset ta, Offset ra, std::string n,
       Symbol *dynref, unsigned long relType) :
    target_addr_(ta),
    rel_addr_(ra),
@@ -63,7 +63,7 @@ SYMTAB_EXPORT relocationEntry::relocationEntry(Offset ta, Offset ra, std::string
 {
 }
 
-SYMTAB_EXPORT relocationEntry::relocationEntry(Offset ta, Offset ra, Offset add,
+DYNINST_EXPORT relocationEntry::relocationEntry(Offset ta, Offset ra, Offset add,
       std::string n, Symbol *dynref, unsigned long relType) :
    target_addr_(ta),
    rel_addr_(ra),
@@ -76,7 +76,7 @@ SYMTAB_EXPORT relocationEntry::relocationEntry(Offset ta, Offset ra, Offset add,
 {
 }
 
-SYMTAB_EXPORT relocationEntry::relocationEntry(Offset ra, std::string n,
+DYNINST_EXPORT relocationEntry::relocationEntry(Offset ra, std::string n,
       Symbol *dynref, unsigned long relType, Region::RegionType rtype) :
    target_addr_(0),
    rel_addr_(ra),
@@ -89,7 +89,7 @@ SYMTAB_EXPORT relocationEntry::relocationEntry(Offset ra, std::string n,
 {
 }
 
-SYMTAB_EXPORT relocationEntry::relocationEntry(Offset ta, Offset ra, Offset add,
+DYNINST_EXPORT relocationEntry::relocationEntry(Offset ta, Offset ra, Offset add,
         std::string n, Symbol *dynref, unsigned long relType,
         Region::RegionType rtype) :
     target_addr_(ta),
@@ -103,68 +103,68 @@ SYMTAB_EXPORT relocationEntry::relocationEntry(Offset ta, Offset ra, Offset add,
 {
 }
 
-SYMTAB_EXPORT Offset relocationEntry::target_addr() const
+DYNINST_EXPORT Offset relocationEntry::target_addr() const
 {
     return target_addr_;
 }
 
-SYMTAB_EXPORT void relocationEntry::setTargetAddr(const Offset off)
+DYNINST_EXPORT void relocationEntry::setTargetAddr(const Offset off)
 {
     target_addr_ = off;
 }
 
-SYMTAB_EXPORT Offset relocationEntry::rel_addr() const
+DYNINST_EXPORT Offset relocationEntry::rel_addr() const
 {
     return rel_addr_;
 }
 
-SYMTAB_EXPORT void relocationEntry::setRelAddr(const Offset value)
+DYNINST_EXPORT void relocationEntry::setRelAddr(const Offset value)
 {
     rel_addr_ = value;
 }
 
-SYMTAB_EXPORT const std::string &relocationEntry::name() const
+DYNINST_EXPORT const std::string &relocationEntry::name() const
 {
     return name_;
 }
 
-SYMTAB_EXPORT Symbol *relocationEntry::getDynSym() const
+DYNINST_EXPORT Symbol *relocationEntry::getDynSym() const
 {
     return dynref_;
 }
 
-SYMTAB_EXPORT bool relocationEntry::addDynSym(Symbol *dynref)
+DYNINST_EXPORT bool relocationEntry::addDynSym(Symbol *dynref)
 {
     dynref_ = dynref;
     return true;
 }
 
-SYMTAB_EXPORT Region::RegionType relocationEntry::regionType() const
+DYNINST_EXPORT Region::RegionType relocationEntry::regionType() const
 {
 	return rtype_;
 }
 
-SYMTAB_EXPORT unsigned long relocationEntry::getRelType() const
+DYNINST_EXPORT unsigned long relocationEntry::getRelType() const
 {
     return relType_;
 }
 
-SYMTAB_EXPORT Offset relocationEntry::addend() const
+DYNINST_EXPORT Offset relocationEntry::addend() const
 {
         return addend_;
 }
 
-SYMTAB_EXPORT void relocationEntry::setAddend(const Offset value)
+DYNINST_EXPORT void relocationEntry::setAddend(const Offset value)
 {
         addend_ = value;
 }
 
-SYMTAB_EXPORT void relocationEntry::setRegionType(const Region::RegionType value)
+DYNINST_EXPORT void relocationEntry::setRegionType(const Region::RegionType value)
 {
         rtype_ = value;
 }
 
-SYMTAB_EXPORT void relocationEntry::setName(const std::string &newName) {
+DYNINST_EXPORT void relocationEntry::setName(const std::string &newName) {
     name_ = newName;
 }
 


### PR DESCRIPTION
There is no need to have one per toolkit.
    
This also removes the MSVC-specific check because we don't build there
and we don't have any of the visibility compiler switches set for it,
either.