### PR TITLE
Hide ompc_leftmost reducer if not using OpenMP

### DIFF
--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -108,9 +108,12 @@ DwarfWalker::DwarfWalker(Symtab *symtab, ::Dwarf *dbg, std::shared_ptr<ParsedFun
 DwarfWalker::~DwarfWalker() {
 }
 
+#ifdef _OPENMP
 static inline void ompc_leftmost(Module* &out, Module* &in) {
     out = out == NULL ? out : in;
 }
+#endif
+
 #pragma omp declare \
     reduction(leftmost : Module* : ompc_leftmost(omp_out, omp_in)) \
     initializer(omp_priv = NULL)


### PR DESCRIPTION
This causes an unused function warning when USE_OpenMP=OFF.

We could also hide the `#prama omp declare` right after this and remove the CMake check (https://github.com/dyninst/dyninst/blob/master/cmake/DyninstWarnings.cmake#L93).