### PR TITLE
Fix Race Condition in Parsing Line Map for NVIDIA Binaries

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3428,6 +3428,8 @@ LineInformation* Object::parseLineInfoForObject(StringTablePtr strings)
     std::string debug_str_secname = ".debug_str";
     associated_symtab->findRegion(debug_str, debug_str_secname);
 
+    boost::lock_guard<Object> guard(*this);
+
     if (li_for_object) {
         // The line information for this object has been parsed.
         return li_for_object;
@@ -3452,11 +3454,9 @@ LineInformation* Object::parseLineInfoForObject(StringTablePtr strings)
 
     while (1) {
 
-#pragma omp critical (next_lines)
-{
     status = dwarf_next_lines(dbg, off = next_off, &next_off, &cu,
                               &files, &fileCount, &lineBuffer, &lineCount);
-}
+
     if (status != 0) break;
       
 

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -148,7 +148,7 @@ class open_statement {
 };
 
 
-class Object : public AObject, private boost::basic_lockable_adapter<boost::mutex>
+class Object : public AObject, public boost::basic_lockable_adapter<boost::mutex>
 {
   friend class Module;
 

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -148,7 +148,7 @@ class open_statement {
 };
 
 
-class Object : public AObject, public boost::basic_lockable_adapter<boost::mutex>
+class Object : public AObject, private boost::basic_lockable_adapter<boost::mutex>
 {
   friend class Module;
 

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -148,7 +148,7 @@ class open_statement {
 };
 
 
-class Object : public AObject 
+class Object : public AObject, public boost::basic_lockable_adapter<boost::mutex>
 {
   friend class Module;
 


### PR DESCRIPTION
This patch addresses a race condition that occurs when parsing an NVIDIA binary where two modules point to the same object. The NVIDIA binary where the race condition was initially discovered is included in this pull request.

The issue arises when multiple threads attempt to open the object and parse the line map concurrently. This fix ensures proper handling for this specific use case, mitigating the lower-level race condition. However, it is important to note that a potential race condition exists at a higher level.

If two threads call parse on the same module, a race condition occurs as both threads attempt to set the line information for the module. Currently, there is no mechanism to ensure mutual exclusion in this scenario.

This patch addresses the lower-level race condition during object parsing. Specifically, while the object parse line info method is now thread-safe, the module parse line info method remains non-thread-safe. This fix resolves the issue for the specific use case in HPCToolkit, where concurrent calls to parse line info on the same module do not occur. The concurrent parsing on the object level is implicit, as it involves two modules pointing to the same object.

[recursion-sm_87-nvcc118-0.zip](https://github.com/dyninst/dyninst/files/15382254/recursion-sm_87-nvcc118-0.zip)
