### PR TITLE
x86: check that opcode supports VEX/EVEX prefix if it is present

### DIFF
--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -10161,7 +10161,7 @@ int ia32_decode_opcode(unsigned int capa, const unsigned char *addr, ia32_instru
     assert(gotit != NULL);
     instruct.legacy_type = gotit->legacyType;
 
-    if(pref.vex_present && !vextab && false)
+    if(pref.vex_present && !vextab)
     {
 #ifdef VEX_DEBUG
         printf("ERROR: This instruction doesn't support VEX prefixes.\n");


### PR DESCRIPTION
Without checking Dyninst recognizes invalid combinations of VEX/EVEX prefixes and opcodes as valid instructions.

An example:

```
_start:
    .byte 0x62, 0x61, 0x64, 0x20, 0x65, 0x78, 0x63
```

Objdump:

```
0000000000001000 <_start>:
    1000:	62                   	.byte 0x62
    1001:	61                   	(bad)
    1002:	64 20 65 78          	and    %ah,%fs:0x78(%rbp)
```

Dyninst without this change:

```
"_start" :
1000: "pcmpgtw {k0},0x63(%rax),%mm7
```

Which is not a valid instruction. VEX/EVEX prefixed instructions can't operate on MMX registers.

The `&& false` part was introduced in 39caf8e245 and most probably is some debugging change that slipped into the main code by accident.