### PR TITLE
x86: only group opcodes from groupMap2 can be VEX-prefixed

### DIFF
--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -9949,7 +9949,6 @@ int ia32_decode_opcode(unsigned int capa, const unsigned char *addr, ia32_instru
                 {
                     idx = gotit->tabidx;
                     unsigned int reg  = (addr[0] >> 3) & 7;
-                    vextab = true;
                     if(idx < Grp12)
                         switch(idx)
                         {
@@ -9972,6 +9971,7 @@ int ia32_decode_opcode(unsigned int capa, const unsigned char *addr, ia32_instru
                         unsigned int mod = addr[0] >> 6;
                         gotit = &groupMap2[idx-Grp12][mod==3][reg];
                         nxtab = gotit->otable;
+                        vextab = true;
                     }
                     break;
                 }


### PR DESCRIPTION
Currently Dyninst allows all group map opcodes to have VEX prefix, which is not correct.

An example:

```
_start:
    .byte 0x62, 0x61, 0x6c, 0x29, 0x0, 0x6f, 0x75
```

Objdump:

```
0000000000001000 <_start>:
    1000:	62 61 6c 29 00       	(bad)
    1005:	6f                   	outsl  %ds:(%rsi),(%dx)
    1006:	75                   	.byte 0x75
```

Dyninst without this change:

```
"_start" :
1000: "verw {k1},0x75(%rdi)"
```

Instruction `verw` doesn't support VEX or EVEX prefixes.

This change requires #1746 to have an actual effect.