### PR TITLE
x86: correctly detect 3DNow instruction length

### DIFF
--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -9486,6 +9486,13 @@ ia32_instruction &ia32_decode(unsigned int capa, const unsigned char *addr, ia32
 
     /* Do the operand decoding */
     ia32_decode_operands(pref, *gotit, addr, instruct, instruct.mac, mode_64);
+
+    if(gotit->otable == t_3dnow)
+    {
+      // 3DNow has opcode as a suffix. Skip it.
+      instruct.size++;
+    }
+
     /* Decode the memory accesses if requested */
     if(capa & IA32_DECODE_MEMACCESS) 
     {
@@ -10017,6 +10024,15 @@ int ia32_decode_opcode(unsigned int capa, const unsigned char *addr, ia32_instru
             case t_3dnow:
                 // 3D now opcodes are given as suffix: ModRM [SIB] [displacement] opcode
                 // Right now we don't care what the actual opcode is, so there's no table
+                if(pref.vex_present)
+                {
+#ifdef VEX_PEDANTIC
+                    assert(!"3DNow! can't be VEX-prefixed!\n");
+#endif
+                    instruct.legacy_type = ILLEGAL;
+                    instruct.entry = gotit;
+                    return -1;
+                }
                 nxtab = t_done;
                 break;
             case t_vexl:


### PR DESCRIPTION
3DNow instructions have their opcode as one byte at the very end. It needs to be consumed when we are decoding the instruction. Dyninst doesn't really support 3DNow instruction set, but with this change we at least remain in sync with the instruction stream.

An example:

```
_start:
    .byte 0xf, 0xf, 0xe2, 0x9a, 0xf, 0xf, 0xc5, 0x9a, 0xf, 0xf, 0xf2, 0x9e, 0xf, 0xf, 0xfd, 0x9e
```

Objdump:

```
0000000000001000 <_start>:
    1000:	0f 0f e2 9a          	pfsub  %mm2,%mm4
    1004:	0f 0f c5 9a          	pfsub  %mm5,%mm0
    1008:	0f 0f f2 9e          	pfadd  %mm2,%mm6
    100c:	0f 0f fd 9e          	pfadd  %mm5,%mm7
```

Dyninst without this change:

```
"_start" :
1000: "[FIXME: GENERIC 3DNow INSN] %mm2,%mm4
```

Dyninst with this change:

```
"_start" :
1000: "[FIXME: GENERIC 3DNow INSN] %mm2,%mm4"
1004: "[FIXME: GENERIC 3DNow INSN] %mm5,%mm0"
1008: "[FIXME: GENERIC 3DNow INSN] %mm2,%mm6"
100c: "[FIXME: GENERIC 3DNow INSN] %mm5,%mm7"
```