### PR TITLE
x86: handle flag RF

### DIFF
--- a/instructionAPI/src/Operation.C
+++ b/instructionAPI/src/Operation.C
@@ -498,6 +498,9 @@ namespace Dyninst
                                 case x86::iif_:
                                     otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::if_ : x86_64::if_));
                                     break;
+                                case x86::irf:
+                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::rf : x86_64::rf));
+                                    break;
                                 default:
                                     assert(0);
                             }
@@ -534,6 +537,9 @@ namespace Dyninst
                                     break;
                                 case x86::iif_:
                                     otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::if_ : x86_64::if_));
+                                    break;
+                                case x86::irf:
+                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::rf : x86_64::rf));
                                     break;
                                 default:
                                     fprintf(stderr, "ERROR: unhandled entry %s\n",


### PR DESCRIPTION
The only instruction supported by Dyninst that references flag RF is RSM. An attempt to getReadSet or getWriteSet for it fails an assertion.

Sample code:

```
_start:
    rsm
```

Dyninst without change:

```
ERROR: unhandled entry x86::rf
code_sample: /home/batuzovk/projects/dyninst-upstream/instructionAPI/src/Operation.C:541: Dyninst::InstructionAPI::Operation::SetUpNonOperandData()::<lambda()>: Assertion `0' failed.
Aborted
```