### PR TITLE
Handle ELF files that don't contain code

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -674,6 +674,13 @@ bool Object::loaded_elf(Offset &txtaddr, Offset &dataddr,
         }
 
         if (strcmp(name, TEXT_NAME) == 0) {
+            // NOBITS .text section means that we are probably dealing with
+            // debug symbols being split into a separate ELF file.
+            // This file doesn't contain code for us to parse.
+            if (scn.sh_type() == SHT_NOBITS) {
+                log_elferror(err_func_, "section .text can't be NOBITS");
+                return false;
+            }
             text_addr_ = scn.sh_addr();
             text_size_ = scn.sh_size();
 
@@ -2679,6 +2686,12 @@ int read_except_table_gcc3(
     unsigned char lpstart_format, ttype_format, table_format;
     unsigned long value, table_end, region_start, region_size, landingpad_base;
     unsigned long catch_block, action, augmentor_len;
+
+    // An attempt to read data from NOBITS section will result in
+    // NULL pointer dereference
+    if (!eh_frame->isValid() || eh_frame->sh_type() == SHT_NOBITS) {
+        return false;
+    }
 
     Dwarf_Off offset = 0, next_offset, saved_cur_offset;
     int res = 0;


### PR DESCRIPTION
When debug info is being split into a separate file, the resulting file has ELF format. Users may accidentally pass this file as an input to Dyninst. Usually these files' names end with .debug and are easy to distinguish from actual libraries, but lbunity, for example, names its debug file libunity.sym.so. Dyninst shouldn't crash on it.

Debug files have full set of sections you'd expect to see in a normal ELF file, but most of them are NOBITS. An attempt to read data from NOBITS section results in NULL pointer dereference. This happens in `read_except_table_gcc3` in particular.

This patch adds checks for NOBITS sections in two places: in `read_except_table_gcc3` where SIGSEGV happened, and when handling `.text` section to fail debug files early and avoid other potential segmentation faults that were not found yet.

To trigger mentioned SIGSEGV you need a separate debug file that has `.eh_frame` and `.gcc_except_table` sections. The debug file for libc.so.6 fits the requirements.