### PR TITLE
x86: support XOP horizontal add/sub instructions

### DIFF
--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -2023,6 +2023,21 @@ DYNINST_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_vrndscalesd, "vrndscalesd")
   (e_vdbpsadbw, "vdbpsadbw")
   (e_vphsubsw, "vphsubsw")
+  (e_vphaddbw, "vphaddbw")
+  (e_vphaddbd, "vphaddbd")
+  (e_vphaddbq, "vphaddbq")
+  (e_vphaddwd, "vphaddwd")
+  (e_vphaddwq, "vphaddwq")
+  (e_vphadddq, "vphadddq")
+  (e_vphaddubw, "vphaddubw")
+  (e_vphaddubd, "vphaddubd")
+  (e_vphaddubq, "vphaddubq")
+  (e_vphadduwd, "vphadduwd")
+  (e_vphadduwq, "vphadduwq")
+  (e_vphaddudq, "vphaddudq")
+  (e_vphsubbw, "vphsubbw")
+  (e_vphsubwd, "vphsubwd")
+  (e_vphsubdq, "vphsubdq")
 
  (e_fp_generic, "[FIXME: GENERIC FPU INSN]")
  (e_3dnow_generic, "[FIXME: GENERIC 3DNow INSN]")
@@ -8991,45 +9006,45 @@ static struct ia32_entry XOP9[256] =
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		/* C0 */
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
+		{ e_vphaddbw, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+		{ e_vphaddbd, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+		{ e_vphaddbq, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
+		{ e_vphaddwd, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+		{ e_vphaddwq, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
 		/* C8 */
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
+		{ e_vphadddq, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		/* D0 */
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
+		{ e_vphaddubw, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+		{ e_vphaddubd, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+		{ e_vphaddubq, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
+		{ e_vphadduwd, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+		{ e_vphadduwq, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
 		/* D8 */
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
+		{ e_vphaddudq, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		/* E0 */
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
+		{ e_vphsubbw, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+		{ e_vphsubwd, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+		{ e_vphsubdq, t_done, 0, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
 		{ e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },


### PR DESCRIPTION
Support decoding of XOP instructions from horizontal add/sub group. Previously there were only IDs for them, and empty decoding tables.

Code sample for testing purposes:

```
_start:
    vphaddbw %xmm3, %xmm1
    vphaddbw 0x123(%rbx,%rcx,4), %xmm1
    vphaddbd %xmm3, %xmm1
    vphaddbd 0x123(%rbx,%rcx,4), %xmm1
    vphaddbq %xmm3, %xmm1
    vphaddbq 0x123(%rbx,%rcx,4), %xmm1
    vphaddwd %xmm3, %xmm1
    vphaddwd 0x123(%rbx,%rcx,4), %xmm1
    vphaddwq %xmm3, %xmm1
    vphaddwq 0x123(%rbx,%rcx,4), %xmm1
    vphadddq %xmm3, %xmm1
    vphadddq 0x123(%rbx,%rcx,4), %xmm1
    vphaddubw %xmm3, %xmm1
    vphaddubw 0x123(%rbx,%rcx,4), %xmm1
    vphaddubd %xmm3, %xmm1
    vphaddubd 0x123(%rbx,%rcx,4), %xmm1
    vphaddubq %xmm3, %xmm1
    vphaddubq 0x123(%rbx,%rcx,4), %xmm1
    vphadduwd %xmm3, %xmm1
    vphadduwd 0x123(%rbx,%rcx,4), %xmm1
    vphadduwq %xmm3, %xmm1
    vphadduwq 0x123(%rbx,%rcx,4), %xmm1
    vphaddudq %xmm3, %xmm1
    vphaddudq 0x123(%rbx,%rcx,4), %xmm1
    vphsubbw %xmm3, %xmm1
    vphsubbw 0x123(%rbx,%rcx,4), %xmm1
    vphsubwd %xmm3, %xmm1
    vphsubwd 0x123(%rbx,%rcx,4), %xmm1
    vphsubdq %xmm3, %xmm1
    vphsubdq 0x123(%rbx,%rcx,4), %xmm1
```

With this change Dyninst text disassemble output (from examples/disassemble) matches source assembler and output of objdump.

There is a duplication of `vextab = true;` between this PR and #1752 . Once one of them is merged I'll remove this line in the other.