### PR TITLE
x86: handle UD0 and UD1 instructions

### DIFF
--- a/common/h/mnemonics/x86_entryIDs.h
+++ b/common/h/mnemonics/x86_entryIDs.h
@@ -11,7 +11,6 @@ e_movsd_sse, /* pseudo mnemonic */
 e_pextrd_pextrq, /* pseudo mnemonic */
 e_pinsrd_pinsrq, /* pseudo mnemonic */
 e_prefetch_w, /* pseudo mnemonic */
-e_ud2grp10 , /* pseudo mnemonic */
 e_ret_far, /* pseudo mnemonic */
 e_ret_near, /* pseudo mnemonic */
 e_lcall, /* pseudo mnemonic */

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -189,7 +189,7 @@ enum {
   SSEE0, SSEE1, SSEE2, SSEE3, SSEE4, SSEE5, SSEE6, SSEE7,
   SSEE8, SSEE9, SSEEA, SSEEB, SSEEC, SSEED, SSEEE, SSEEF,
   SSEF0, SSEF1, SSEF2, SSEF3, SSEF4, SSEF5, SSEF6, SSEF7,
-  SSEF8, SSEF9, SSEFA, SSEFB, SSEFC, SSEFD, SSEFE, SSEFF
+  SSEF8, SSEF9, SSEFA, SSEFB, SSEFC, SSEFD, SSEFE
 };
 /** END_DYNINST_TABLE_DEF */
 
@@ -1404,8 +1404,9 @@ DYNINST_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = map_list_of
   (e_test, "test")
   (e_ucomisd, "ucomisd")
   (e_ucomiss, "ucomiss")
+  (e_ud0, "ud0")
+  (e_ud1, "ud1")
   (e_ud2, "ud2")
-  (e_ud2grp10, "ud2grp10")
   (e_unpckhpd, "unpckhpd")
   (e_unpckhps, "unpckhps")
   (e_unpcklpd, "unpcklpd")
@@ -2739,7 +2740,7 @@ static ia32_entry twoByteMap[256] = {
   { e_movzx, t_done, 0, true, { Gv, Ew, Zz }, 0, s1W2R, 0 },
   /* B8 */
   { e_No_Entry, t_sse, SSEB8, 0, { Zz, Zz, Zz }, 0, 0, 0 },
-  { e_ud2grp10, t_ill, 0, 0, { Zz, Zz, Zz }, 0, sNONE, 0 },
+  { e_ud1, t_done, 0, true, { Gv, Ev, Zz }, 0, sNONE, 0 },
   { e_No_Entry, t_grp, Grp8, true, { Zz, Zz, Zz }, 0, 0, 0 },
   { e_btc, t_done, 0, true, { Ev, Gv, Zz }, 0, s1RW2R, 0 },
   { e_bsf, t_done, 0, true, { Gv, Ev, Zz }, 0, s1W2R, 0 },
@@ -2817,7 +2818,7 @@ static ia32_entry twoByteMap[256] = {
   { e_No_Entry, t_sse, SSEFC, true, { Zz, Zz, Zz }, 0, 0, 0 },
   { e_No_Entry, t_sse, SSEFD, true, { Zz, Zz, Zz }, 0, 0, 0 },
   { e_No_Entry, t_sse, SSEFE, true, { Zz, Zz, Zz }, 0, 0, 0 },
-  { e_No_Entry, t_sse, SSEFF, false, { Zz, Zz, Zz }, 0, 0, 0 }
+  { e_ud0, t_done, 0, true, { Gv, Ev, Zz }, 0, sNONE, 0 },
 };
 
 /**
@@ -4866,12 +4867,6 @@ static ia32_entry sseMap[][4] = {
     { e_paddd, t_done, 0, true, { Pq, Qq, Zz }, 0, s1RW2R, 0 },
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
     { e_paddd, t_sse_mult, SSEFE_66, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
-    { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-  },
-  { /* SSEFF */
-    { e_ud0, t_done, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-    { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
-    { e_ud0, t_done, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
   }
 };

--- a/dataflowAPI/src/convertOpcodes.C
+++ b/dataflowAPI/src/convertOpcodes.C
@@ -915,10 +915,10 @@ X86InstructionKind RoseInsnX86Factory::convertKind(entryID opcode, prefixEntryID
         case e_ucomiss:
             return x86_ucomiss;
         case e_ud0:
-            return x86_unknown_instruction;
-        case e_ud2:
             return x86_ud2;
-        case e_ud2grp10:
+        case e_ud1:
+            return x86_ud2;
+        case e_ud2:
             return x86_ud2;
         case e_unpckhpd:
             return x86_unpckhpd;


### PR DESCRIPTION
Intel manual define 3 different UD instructions: UD0, UD1, and UD2. UD2 is fully supported by Dyninst, UD0 and UD1 are not.

Code sample to test the change:

```
_start:
    ud0 %eax, %edx
    ud0 (%eax), %edx
    ud1 %eax, %edx
    ud1 (%eax), %edx
    ud0 %rax, %rdx
    ud0 (%rax), %rdx
    ud1 %rax, %rdx
    ud1 (%rax), %rdx
    ud2 
```

Objdump:

```
0000000000001000 <_start>:
    1000:	0f ff d0             	ud0    %eax,%edx
    1003:	67 0f ff 10          	ud0    (%eax),%edx
    1007:	0f b9 d0             	ud1    %eax,%edx
    100a:	67 0f b9 10          	ud1    (%eax),%edx
    100e:	48 0f ff d0          	ud0    %rax,%rdx
    1012:	48 0f ff 10          	ud0    (%rax),%rdx
    1016:	48 0f b9 d0          	ud1    %rax,%rdx
    101a:	48 0f b9 10          	ud1    (%rax),%rdx
    101e:	0f 0b                	ud2
```

Dyninst without changes:

```
"_start" :
1000: "[INVALID] "
1002: "shl $0x1,0xf(%rdi)"
1005: "call (%rax)"
```

Dyninst with changes:

```
"_start" :
1000: "ud0 %eax,%edx"
1003: "ud0 (%eax),%edx"
1007: "ud1 %eax,%edx"
100a: "ud1 (%eax),%edx"
100e: "ud0 %rax,%rdx"
1012: "ud0 (%rax),%rdx"
1016: "ud1 %rax,%rdx"
101a: "ud1 (%rax),%rdx"
101e: "ud2 
```

Notes:

* I've removed forwarding of UD0 instruction to SSE table because it can cause things like VEX-encoded UD0, which shouldn't exist.
* I convert all of them to x86_ud Rose operation. There is x86_unknown_instruction as well, which seem to do the same.