### PR TITLE
[WIP] Implement parsing of PE files using pe-parse library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ include(DyninstLibIberty)
 include(DyninstThread_DB)
 include(DyninstValgrind)
 include(DyninstOpenMP)
+include(DyninstPeParse)
 
 add_subdirectory(common)
 add_subdirectory(elf)

--- a/cmake/DyninstConfig.cmake.in
+++ b/cmake/DyninstConfig.cmake.in
@@ -6,6 +6,7 @@ list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/Modules"
 include(DyninstBoost)
 include(DyninstElfUtils)
 include(DyninstTBB)
+include(DyninstPeParse)
 
 set(CMAKE_MODULE_PATH ${_DYNINST_module_path_save})
 unset(_DYNINST_module_path_save)

--- a/symtabAPI/CMakeLists.txt
+++ b/symtabAPI/CMakeLists.txt
@@ -72,7 +72,8 @@ if(DYNINST_OS_UNIX)
     src/LinkMap.C
     src/emitElf.C
     src/emitElfStatic.C
-    src/dwarfWalker.C)
+    src/dwarfWalker.C
+    src/Object-pe.C)
 
   if(DYNINST_ARCH_x86_64 OR DYNINST_ARCH_i386)
     list(APPEND _sources src/emitElfStatic-x86.C src/relocationEntry-elf-x86.C)
@@ -96,7 +97,7 @@ dyninst_library(
   DEFINES SYMTAB_LIB
   DYNINST_DEPS common dynElf dynDwarf
   PRIVATE_DEPS OpenMP::OpenMP_CXX Dyninst::Boost
-  PUBLIC_DEPS Dyninst::ElfUtils
+  PUBLIC_DEPS Dyninst::ElfUtils Dyninst::PeParse
 )
 # cmake-format: on
 

--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -192,6 +192,8 @@ class DYNINST_EXPORT InlinedFunction : public FunctionBase
    friend class Symtab;
    friend class DwarfWalker;
    friend class Object;
+   friend class ObjectELF;
+   friend class ObjectPE;
   public:
    InlinedFunction(FunctionBase *parent);
    virtual ~InlinedFunction();

--- a/symtabAPI/h/Region.h
+++ b/symtabAPI/h/Region.h
@@ -46,6 +46,8 @@ class Symtab;
 
 class DYNINST_EXPORT Region : public AnnotatableSparse {
    friend class Object;
+   friend class ObjectELF;
+   friend class ObjectPE;
    friend class Symtab;
    friend class SymtabTranslatorBase;
    friend class SymtabTranslatorBin;
@@ -95,7 +97,15 @@ class DYNINST_EXPORT Region : public AnnotatableSparse {
    Region(const Region &reg);
    Region& operator=(const Region &reg);
    std::ostream& operator<< (std::ostream &os);
-   bool operator== (const Region &reg);
+   bool operator== (const Region &reg) const;
+   bool operator< (const Region &reg) const;
+
+   struct less {
+      bool operator()(const Region * r1, const Region * r2)
+      {
+         return *r1 < *r2;
+      }
+   };
 
    ~Region();
 

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -90,6 +90,8 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    friend class Aggregate;
    friend class relocationEntry;
    friend class Object;
+   friend class ObjectELF;
+   friend class ObjectPE;
 
    // Hide implementation details that are complex or add large dependencies
    const std::unique_ptr<symtab_impl> impl;

--- a/symtabAPI/h/symutil.h
+++ b/symtabAPI/h/symutil.h
@@ -70,7 +70,9 @@ typedef enum {
    obj_Unknown,
    obj_SharedLib,
    obj_Executable,
-   obj_RelocatableFile
+   obj_RelocatableFile,
+   obj_PEExecutable,
+   obj_PESharedLib
 } ObjectType;
 
 typedef enum { 

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -848,7 +848,7 @@ bool ObjectELF::loaded_elf(Offset &txtaddr, Offset &dataddr,
         }
     }
 
-    loadAddress_ = 0x0;
+    preferedBase_ = loadAddress_ = 0x0;
 #if defined(os_linux) || defined(os_freebsd)
     /**
    * If the virtual address of the first PT_LOAD element in the
@@ -860,7 +860,7 @@ bool ObjectELF::loaded_elf(Offset &txtaddr, Offset &dataddr,
         Elf_X_Phdr &phdr = elfHdr->get_phdr(i);
 
         if (phdr.p_type() == PT_LOAD) {
-            loadAddress_ = phdr.p_vaddr();
+            preferedBase_ = loadAddress_ = phdr.p_vaddr();
             break;
         }
     }

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -178,6 +178,8 @@ public:
 
   bool addRelocationEntry(relocationEntry &re) override;
 
+  virtual Offset getPreferedBase() const { return preferedBase_; }
+
   //getLoadAddress may return 0 on shared objects
   virtual Offset getLoadAddress() const { return loadAddress_; }
 
@@ -354,6 +356,7 @@ public:
   unsigned opd_size_;
 
   bool      dwarvenDebugInfo;    // is DWARF debug info present?
+  Offset   preferedBase_;
   Offset   loadAddress_;      // The object may specify a load address
                                //   Set to 0 if it may load anywhere
   Offset entryAddress_;

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -82,6 +82,7 @@ class pdElfShdr;
 class Symtab;
 class Region;
 class Object;
+class ObjectELF;
 class InlinedFunction;
 
 class open_statement {
@@ -148,18 +149,18 @@ class open_statement {
 };
 
 
-class Object : public AObject 
+class ObjectELF : public Object 
 {
   friend class Module;
 
   // declared but not implemented; no copying allowed
-  Object(const Object &);
-  const Object& operator=(const Object &);
+  ObjectELF(const ObjectELF &);
+  const ObjectELF& operator=(const ObjectELF &);
 
 public:
 
-  Object(MappedFile *, bool, void (*)(const char *) = log_msg, bool alloc_syms = true, Symtab* st = NULL);
-  virtual ~Object();
+  ObjectELF(MappedFile *, bool, void (*)(const char *) = log_msg, bool alloc_syms = true, Symtab* st = NULL);
+  virtual ~ObjectELF();
 
   bool emitDriver(std::string fName, std::set<Symbol *> &allSymbols, unsigned flag);
     
@@ -178,11 +179,11 @@ public:
   bool addRelocationEntry(relocationEntry &re) override;
 
   //getLoadAddress may return 0 on shared objects
-  Offset getLoadAddress() const { return loadAddress_; }
+  virtual Offset getLoadAddress() const { return loadAddress_; }
 
-  Offset getEntryAddress() const { return entryAddress_; }
+  virtual Offset getEntryAddress() const { return entryAddress_; }
   // To be changed later - Giri
-  Offset getBaseAddress() const { return 0; }
+  virtual Offset getBaseAddress() const { return 0; }
   static bool truncateLineFilenames;
 
   void insertPrereqLibrary(std::string libname);
@@ -196,7 +197,7 @@ public:
   }
 
   DYNINST_EXPORT ObjectType objType() const;
-  const char *interpreter_name() const;
+  virtual const char *interpreter_name() const;
 
 
   // On most platforms, the TOC offset doesn't exist and is thus null. 
@@ -210,7 +211,7 @@ public:
   void setTOCoffset(Offset off);
 
   const std::ostream &dump_state_info(std::ostream &s);
-  bool isEEL() { return EEL; }
+  virtual bool isEEL() const { return EEL; }
 
 	//to determine if a mutation falls in the text section of
 	// a shared library
@@ -286,6 +287,8 @@ public:
     DYNINST_EXPORT bool isDebugOnly() const;
     DYNINST_EXPORT bool isLinuxKernelModule() const;
 
+    bool   getSegments(std::vector<Segment> &segs) const;
+
     std::vector<relocationEntry> &getPLTRelocs() { return fbt_; }
     std::vector<relocationEntry> &getDynRelocs() { return relocation_table_; }
 
@@ -295,7 +298,7 @@ public:
     virtual void setTruncateLinePaths(bool value) override;
     virtual bool getTruncateLinePaths() override;
     
-    Elf_X * getElfHandle() { return elfHdr; }
+    void *getElfHandle() { return elfHdr; }
 
     unsigned gotSize() const { return got_size_; }
     Offset gotAddr() const { return got_addr_; }
@@ -411,6 +414,7 @@ public:
   void parse_opd(Elf_X_Shdr *);
  public:
   void parseDwarfFileLineInfo();
+  void parseDwarfTypes( Symtab *);
   void parseLineInfoForAddr(Offset addr_to_find);
 
   bool hasDebugInfo();

--- a/symtabAPI/src/Object-pe.C
+++ b/symtabAPI/src/Object-pe.C
@@ -1,0 +1,396 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ * 
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ * 
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include "symtabAPI/src/Object-pe.h"
+#include <pe-parse/parse.h>
+
+#include <iostream>
+
+using namespace Dyninst;
+using namespace Dyninst::SymtabAPI;
+
+Region::perm_t ObjectPE::getRegionPerms(std::uint32_t flags)
+{
+    if((flags & peparse::IMAGE_SCN_MEM_EXECUTE) && (flags & peparse::IMAGE_SCN_MEM_WRITE))
+        return Region::RP_RWX;
+    else if(flags & peparse::IMAGE_SCN_MEM_EXECUTE)
+        return Region::RP_RX;
+    else if(flags & peparse::IMAGE_SCN_MEM_WRITE)
+        return Region::RP_RW;
+    else
+        return Region::RP_R;
+}
+
+Region::RegionType ObjectPE::getRegionType(std::uint32_t flags){
+    /**
+     * It's possible for a PE sections to contain an actually executed code
+     * without being labeled as a code section. So we check for both permission and section type
+     */
+    std::uint32_t exec_flags = ( peparse::IMAGE_SCN_CNT_CODE | peparse::IMAGE_SCN_MEM_EXECUTE );
+    std::uint32_t data_flags = ( peparse::IMAGE_SCN_CNT_INITIALIZED_DATA | peparse::IMAGE_SCN_CNT_UNINITIALIZED_DATA );
+    if((flags & exec_flags) && (flags & peparse::IMAGE_SCN_CNT_INITIALIZED_DATA))
+        return Region::RT_TEXTDATA;
+    else if(flags & exec_flags)
+        return Region::RT_TEXT;
+    else if (flags & data_flags)
+        return Region::RT_DATA;
+    else
+        return Region::RT_OTHER;
+}
+
+void ObjectPE::log_error(const std::string &msg)
+{
+	if (err_func_) {
+		std::string full_msg = msg + std::string(": ") + peparse::GetPEErrString() + std::string("\n");
+		err_func_(full_msg.c_str());
+	}
+}
+
+ObjectPE::ObjectPE(MappedFile *mf_,
+                   bool defensive,
+                   void (*err_func)(const char *),
+                   bool alloc_syms,
+                   Symtab *st) :
+    Object(mf_, err_func, st)
+{
+    (void)defensive;
+    (void)alloc_syms;
+    parsed_pe_ = peparse::ParsePEFromPointer((unsigned char *)mf_->base_addr(), mf_->size());
+    if (!parsed_pe_) {
+        has_error = true;
+        log_error("Error while parsing PE file");
+        return;
+    }
+
+    parse_object();
+}
+
+void ObjectPE::parse_object()
+{
+    no_of_sections_ = parsed_pe_->peHeader.nt.FileHeader.NumberOfSections;
+    no_of_symbols_ = parsed_pe_->peHeader.nt.FileHeader.NumberOfSymbols;
+    addressWidth_nbytes = getArchWidth();
+
+    peparse::VA entry_addr = -1;
+    if (!peparse::GetEntryPoint(parsed_pe_, entry_addr)) {
+        log_error("Error while getting entry point");
+    }
+    entryAddress_ = entry_addr;
+    if (parsed_pe_->peHeader.nt.FileHeader.Machine == peparse::IMAGE_FILE_MACHINE_AMD64) {
+        preferedBase_ = loadAddress_ = parsed_pe_->peHeader.nt.OptionalHeader64.ImageBase;
+    } else {
+        preferedBase_ = loadAddress_ = parsed_pe_->peHeader.nt.OptionalHeader.ImageBase;
+    }
+
+    if (parsed_pe_->peHeader.nt.FileHeader.Characteristics & peparse::IMAGE_FILE_DLL) {
+        is_aout_ = false;
+    } else {
+        is_aout_ = true;
+    }
+
+    /* Iterate over section */
+    peparse::iterSec section_iterator =
+        [](void *N, const peparse::VA &, const std::string &name,
+           const peparse::image_section_header &header,
+           const peparse::bounded_buffer *) -> int {
+            ObjectPE *obj = static_cast<ObjectPE*>(N);
+            int reg_num = obj->regions_.size();
+            char *sec_ptr = (char *)obj->mf->base_addr() + header.PointerToRawData;
+            Offset sec_off = header.PointerToRawData;
+            Offset sec_len = std::max(header.SizeOfRawData, header.Misc.VirtualSize);
+            if (header.Characteristics & peparse::IMAGE_SCN_CNT_CODE) {
+                obj->code_ptr_ = sec_ptr;
+                obj->code_off_ = sec_off;
+                obj->code_len_ = sec_len;
+            } else if (header.Characteristics & peparse::IMAGE_SCN_CNT_INITIALIZED_DATA) {
+                obj->data_ptr_ = sec_ptr;
+                obj->data_off_ = sec_off;
+                obj->data_len_ = sec_len;
+            } else {
+                /* ... */
+            }
+            obj->regions_.push_back(new Region(reg_num, name, header.PointerToRawData,
+                                    header.SizeOfRawData, obj->loadAddress_ + header.VirtualAddress, sec_len,
+                                    sec_ptr, getRegionPerms(header.Characteristics),
+                                    getRegionType(header.Characteristics)));
+            return 0;
+        };
+    peparse::IterSec(parsed_pe_, section_iterator, this);
+
+    Region::less cmp;
+    std::sort(regions_.begin(), regions_.end(), cmp);
+
+    /* Iterate over symbols */
+
+    // Microsoft documentation says that COFF debugging information is deprecated
+    // and COFF symbol table should be empty.
+    //
+    // See https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
+    //
+    // That said, some compilers make it non-empty (e.g. Linux to MinGW GCC
+    // cross-compiler generates non-empty COFF symbol table). Also, according to
+    // another part of Microsoft documentation, binaries compiled with /DEBUG
+    // do have a non-empty COFF symbol table.
+    //
+    // See https://learn.microsoft.com/en-us/cpp/build/reference/symbols?view=msvc-170
+    peparse::iterSymbol symbol_iterator =
+        [](void *N, const std::string &name, const uint32_t &value,
+                const int16_t &sec_num, const uint16_t &type,
+                const uint8_t &storage, const uint8_t &num_aux) -> int {
+            ObjectPE *obj = static_cast<ObjectPE*>(N);
+            static_cast<void>(num_aux);
+            static_cast<void>(storage);
+            if (sec_num <= 0)
+            {
+                /**
+                 * Negative values and zero are reserved for special types of symbols:
+                 *  0  for an undefined (extern) symbol;
+                 *  -1 for an absolute symbol (that is, its value is a constant, not an address);
+                 *  -2 for a debugging symbol.
+                 *
+                 * See http://www.delorie.com/djgpp/doc/coff/symtab.html
+                 *
+                 * We are not interested in such types of symbols.
+                 */
+                return 0;
+            }
+            // The section numbering begins with 1, not 0
+            Region *sec = obj->regions_[sec_num - 1];
+            if (!sec) return 0; // Ignore symbols that don't belong to any valid section
+
+            /**
+             * Microsoft documentation sais that the information if the symbol is a function or not
+             * is stored in the MSB of 2-byte field.
+             *
+             * See https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
+             *
+             * This is incorrect. That information is stored in the high 4 bits of the LSB. The examples
+             * given in their documentation are correct though: 0x20 is used for functions.
+             *
+             * See http://www.delorie.com/djgpp/doc/coff/symtab.html for correct COFF symbol table
+             * description.
+             */
+            Symbol::SymbolType sym_type = (((type >> 4) & 0xf) == peparse::IMAGE_SYM_DTYPE_FUNCTION) ? Symbol::ST_FUNCTION : Symbol::ST_OBJECT;
+            Symbol *sym = new Symbol(name, sym_type, Symbol::SL_GLOBAL, Symbol::SV_DEFAULT,
+                    sec->getMemOffset() + value, NULL, sec);
+            sym->setDynamic(true);
+            {
+                dyn_c_hash_map<std::string,std::vector<Symbol*>>::accessor a;
+                if(!obj->symbols_.insert(a, {name, {sym}}))
+                    a->second.push_back(sym);
+            }
+            {
+                dyn_c_hash_map<Offset,std::vector<Symbol*>>::accessor a2;
+                if(!obj->symsByOffset_.insert(a2, {sym->getOffset(), {sym}}))
+                    a2->second.push_back(sym);
+            }
+            return 0;
+        };
+    peparse::IterSymbols(parsed_pe_, symbol_iterator, this);
+
+    peparse::iterExp export_iterator =
+        [](void *N, const peparse::VA &addr, const std::string &,
+           const std::string &sym_name) -> int {
+            ObjectPE *obj = static_cast<ObjectPE*>(N);
+            Region *sec = obj->findEnclosingRegion((Offset)(addr));
+            std::string tmpstr = sym_name;
+            if (!sec) return 0; // Ignore symbols that don't belong to any valid section
+            Symbol *sym = new Symbol(sym_name, Symbol::ST_FUNCTION, Symbol::SL_GLOBAL, Symbol::SV_DEFAULT,
+                    addr, NULL, sec);
+            sym->setDynamic(true);
+            {
+                dyn_c_hash_map<std::string,std::vector<Symbol*>>::accessor a;
+                if(!obj->symbols_.insert(a, {sym_name, {sym}}))
+                    a->second.push_back(sym);
+            }
+            {
+                dyn_c_hash_map<Offset,std::vector<Symbol*>>::accessor a2;
+                if(!obj->symsByOffset_.insert(a2, {sym->getOffset(), {sym}}))
+                    a2->second.push_back(sym);
+            }
+            return 0;
+        };
+    peparse::IterExpVA(parsed_pe_, export_iterator, this);
+
+    /* Iterate over relocations */
+    peparse::iterReloc relocation_iterator =
+        [](void *N, const peparse::VA &ra, const peparse::reloc_type &rel_type) -> int {
+            ObjectPE *obj = static_cast<ObjectPE*>(N);
+            Region *sec = obj->findEnclosingRegion((Offset)ra);
+            if (!sec) return 0; // TODO
+            const uint8_t *ptr = (const uint8_t *)sec->getPtrToRawData() + ((Offset)ra - (Offset)sec->getMemOffset());
+            Offset ta = ObjectPE::readRelocTarget(ptr, rel_type);
+            sec->addRelocationEntry(relocationEntry(ta, ra, 0, "", NULL, (unsigned long)rel_type, Region::RT_REL));
+            return 0;
+        };
+    peparse::IterRelocs(parsed_pe_, relocation_iterator, this);
+
+    no_of_symbols_ = nsymbols();
+
+#if 0
+    loader_off_ = ;
+    loader_len_ = ;
+#endif
+}
+
+Offset ObjectPE::getPreferedBase() const
+{
+    return preferedBase_;
+}
+
+void ObjectPE::getDependencies(std::vector<std::string> &deps)
+{
+    deps.clear();
+    /* TODO */
+}
+
+Offset ObjectPE::getBaseAddress() const
+{
+    return 0; /* ELF can so should we? */
+}
+
+Offset ObjectPE::getEntryAddress() const
+{
+    return entryAddress_;
+}
+
+Offset ObjectPE::getLoadAddress() const
+{
+    return loadAddress_;
+}
+
+ObjectType ObjectPE::objType() const
+{
+    return is_aout() ? obj_PEExecutable : obj_PESharedLib;
+}
+
+bool ObjectPE::isOnlyExecutable() const
+{
+    return is_aout_;
+}
+
+bool ObjectPE::isExecutable() const
+{
+    /**
+     * This method is used only to check whether we should consider an entry point
+     * as a function hint. A DLL may have a valid entry point that is not covered by
+     * a symbol, so we want to always consider it as a hint.
+     */
+    return true;
+}
+
+bool ObjectPE::isOnlySharedLibrary() const
+{
+    return !is_aout_;
+}
+
+bool ObjectPE::isSharedLibrary() const
+{
+    return !is_aout_;
+}
+
+Dyninst::Architecture ObjectPE::getArch() const
+{
+    if (!parsed_pe_) return Arch_none;
+    switch (parsed_pe_->peHeader.nt.FileHeader.Machine) {
+        case peparse::IMAGE_FILE_MACHINE_AMD64:
+            return Arch_x86_64;
+        case peparse::IMAGE_FILE_MACHINE_I386:
+            return Arch_x86;
+        case peparse::IMAGE_FILE_MACHINE_ARM:
+        case peparse::IMAGE_FILE_MACHINE_ARMNT:
+            return Arch_aarch32;
+        case peparse::IMAGE_FILE_MACHINE_ARM64:
+            return Arch_aarch64;
+        case peparse::IMAGE_FILE_MACHINE_UNKNOWN:
+        case peparse::IMAGE_FILE_MACHINE_ALPHA:
+        case peparse::IMAGE_FILE_MACHINE_ALPHA64:
+        case peparse::IMAGE_FILE_MACHINE_CEE:
+        case peparse::IMAGE_FILE_MACHINE_CEF:
+        case peparse::IMAGE_FILE_MACHINE_EBC:
+        case peparse::IMAGE_FILE_MACHINE_IA64:
+        case peparse::IMAGE_FILE_MACHINE_M32R:
+        case peparse::IMAGE_FILE_MACHINE_MIPS16:
+        case peparse::IMAGE_FILE_MACHINE_MIPSFPU:
+        case peparse::IMAGE_FILE_MACHINE_MIPSFPU16:
+        case peparse::IMAGE_FILE_MACHINE_POWERPC:
+        case peparse::IMAGE_FILE_MACHINE_POWERPCFP:
+        case peparse::IMAGE_FILE_MACHINE_R10000:
+        case peparse::IMAGE_FILE_MACHINE_RISCV32:
+        case peparse::IMAGE_FILE_MACHINE_RISCV64:
+        case peparse::IMAGE_FILE_MACHINE_RISCV128:
+        case peparse::IMAGE_FILE_MACHINE_SH3:
+        case peparse::IMAGE_FILE_MACHINE_SH3DSP:
+        case peparse::IMAGE_FILE_MACHINE_SH4:
+        case peparse::IMAGE_FILE_MACHINE_SH5:
+        case peparse::IMAGE_FILE_MACHINE_THUMB:
+        case peparse::IMAGE_FILE_MACHINE_TRICORE:
+        case peparse::IMAGE_FILE_MACHINE_WCEMIPSV2:
+        default:
+            return Arch_none;
+    }
+}
+
+int ObjectPE::getArchWidth() const
+{
+    switch (getArch()) {
+        case Arch_x86:
+        case Arch_aarch32:
+            return 4;
+        case Arch_x86_64:
+        case Arch_aarch64:
+            return 8;
+        case Arch_none:
+        default:
+            return -1;
+    }
+}
+
+Offset ObjectPE::readRelocTarget(const void *ptr, peparse::reloc_type type)
+{
+    switch (type) {
+        case peparse::RELOC_ABSOLUTE:
+            return 0;
+        case peparse::RELOC_HIGH:
+            return (uint32_t)(*(const uint16_t *)ptr) << 16;
+        case peparse::RELOC_LOW:
+            return *(const uint16_t *)ptr;
+        case peparse::RELOC_HIGHLOW:
+            return *(const uint32_t *)ptr;
+        case peparse::RELOC_HIGHADJ:
+            return readRelocTarget(ptr, peparse::RELOC_HIGH) | readRelocTarget((const uint8_t *)ptr + 2, peparse::RELOC_LOW);
+        case peparse::RELOC_DIR64:
+            return *(const uint64_t *)ptr;
+        case peparse::RELOC_MIPS_JMPADDR:
+        case peparse::RELOC_MIPS_JMPADDR16:
+        default:
+            std::cout << "Unsupported relocation in PE file\n";
+            return 0;
+    }
+}

--- a/symtabAPI/src/Object-pe.h
+++ b/symtabAPI/src/Object-pe.h
@@ -71,6 +71,9 @@ private:
     static Region::RegionType getRegionType(std::uint32_t flags);
 
     static Offset readRelocTarget(const void *ptr, peparse::reloc_type type);
+    static void writeRelocTarget(void *ptr, peparse::reloc_type type, Offset val);
+
+    void rebase(Offset new_base);
 
     int getArchWidth() const;
 

--- a/symtabAPI/src/Object-pe.h
+++ b/symtabAPI/src/Object-pe.h
@@ -1,0 +1,88 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ * 
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ * 
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#if !defined(_Object_pe_h_)
+#define _Object_pe_h_
+
+#include "symtabAPI/src/Object.h"
+#include <pe-parse/parse.h>
+
+namespace Dyninst {
+namespace SymtabAPI {
+
+class ObjectPE : public Object {
+    friend class Symtab;
+
+public:
+    ObjectPE(MappedFile *, bool, void(*)(const char *) = log_msg, bool = true, Symtab * = NULL);
+
+    Offset getPreferedBase() const;
+    void getDependencies(std::vector<std::string> &deps);
+    Offset getEntryAddress() const;
+    Offset getBaseAddress() const;
+    Offset getLoadAddress() const;
+    ObjectType objType() const;
+
+    DYNINST_EXPORT bool isOnlyExecutable() const;
+    DYNINST_EXPORT bool isExecutable() const;
+    DYNINST_EXPORT bool isSharedLibrary() const;
+    DYNINST_EXPORT bool isOnlySharedLibrary() const;
+    DYNINST_EXPORT Dyninst::Architecture getArch() const;
+
+    void insertPrereqLibrary(std::string) {} // TODO
+    bool emitDriver(std::string, std::set<Symbol *> &, unsigned ) { return false; } // TODO
+    void getModuleLanguageInfo(dyn_hash_map<std::string, supportedLanguages> *) {} // TODO
+
+private:
+    ObjectPE(const ObjectPE &);
+    const ObjectPE& operator=(const ObjectPE &);
+
+    void log_error(const std::string &);
+    void parse_object();
+
+    static Region::perm_t getRegionPerms(std::uint32_t flags);
+    static Region::RegionType getRegionType(std::uint32_t flags);
+
+    static Offset readRelocTarget(const void *ptr, peparse::reloc_type type);
+
+    int getArchWidth() const;
+
+    peparse::parsed_pe *parsed_pe_;
+
+    Offset entryAddress_;
+
+    Offset preferedBase_;
+    Offset loadAddress_;
+};
+
+} // namespace SymtabAPI
+} // namespace Dyninst
+
+#endif /* !defined(_Object_pe_h_) */

--- a/symtabAPI/src/Object.C
+++ b/symtabAPI/src/Object.C
@@ -111,27 +111,27 @@ bool Dyninst::SymtabAPI::symbol_compare(const Symbol *s1, const Symbol *s2)
 }
 
 
-bool AObject::needs_function_binding() const 
+bool Object::needs_function_binding() const 
 {
     return false;
 }
 
-bool AObject::get_func_binding_table(std::vector<relocationEntry> &) const 
+bool Object::get_func_binding_table(std::vector<relocationEntry> &) const 
 {
     return false;
 }
 
-bool AObject::get_func_binding_table_ptr(const std::vector<relocationEntry> *&) const 
+bool Object::get_func_binding_table_ptr(const std::vector<relocationEntry> *&) const 
 {
     return false;
 }
 
-bool AObject::addRelocationEntry(relocationEntry &)
+bool Object::addRelocationEntry(relocationEntry &)
 {
     return true;
 }
 
-char *AObject::mem_image() const
+char *Object::mem_image() const
 {
 	return NULL;
 }
@@ -154,7 +154,7 @@ ostream &operator<<(ostream &os, relocationEntry &q) {
  *
  **************************************************/
 
-DYNINST_EXPORT unsigned AObject::nsymbols () const 
+DYNINST_EXPORT unsigned Object::nsymbols () const 
 { 
     unsigned n = 0;
     for (dyn_c_hash_map<std::string, std::vector<Symbol *> >::const_iterator i = symbols_.begin();
@@ -165,7 +165,7 @@ DYNINST_EXPORT unsigned AObject::nsymbols () const
     return n;
 }
 
-DYNINST_EXPORT bool AObject::get_symbols(string & name, 
+DYNINST_EXPORT bool Object::get_symbols(string & name, 
       std::vector<Symbol *> &symbols ) 
 {
    dyn_c_hash_map<std::string, std::vector<Symbol *>>::const_accessor ca;
@@ -177,57 +177,57 @@ DYNINST_EXPORT bool AObject::get_symbols(string & name,
    return true;
 }
 
-DYNINST_EXPORT char* AObject::code_ptr () const 
+DYNINST_EXPORT char* Object::code_ptr () const 
 { 
    return code_ptr_; 
 }
 
-DYNINST_EXPORT Offset AObject::code_off () const 
+DYNINST_EXPORT Offset Object::code_off () const 
 { 
    return code_off_; 
 }
 
-DYNINST_EXPORT Offset AObject::code_len () const 
+DYNINST_EXPORT Offset Object::code_len () const 
 { 
    return code_len_; 
 }
 
-DYNINST_EXPORT char* AObject::data_ptr () const 
+DYNINST_EXPORT char* Object::data_ptr () const 
 { 
    return data_ptr_; 
 }
 
-DYNINST_EXPORT Offset AObject::data_off () const 
+DYNINST_EXPORT Offset Object::data_off () const 
 { 
    return data_off_; 
 }
 
-DYNINST_EXPORT Offset AObject::data_len () const 
+DYNINST_EXPORT Offset Object::data_len () const 
 { 
    return data_len_; 
 }
 
-DYNINST_EXPORT bool AObject::is_aout() const 
+DYNINST_EXPORT bool Object::is_aout() const 
 {
    return is_aout_;  
 }
 
-DYNINST_EXPORT bool AObject::isDynamic() const 
+DYNINST_EXPORT bool Object::isDynamic() const 
 {
    return is_dynamic_;  
 }
 
-DYNINST_EXPORT unsigned AObject::no_of_sections() const 
+DYNINST_EXPORT unsigned Object::no_of_sections() const 
 { 
    return no_of_sections_; 
 }
 
-DYNINST_EXPORT unsigned AObject::no_of_symbols() const 
+DYNINST_EXPORT unsigned Object::no_of_symbols() const 
 { 
    return no_of_symbols_;  
 }
 
-DYNINST_EXPORT bool AObject::getAllExceptions(std::vector<ExceptionBlock *>&excpBlocks) const
+DYNINST_EXPORT bool Object::getAllExceptions(std::vector<ExceptionBlock *>&excpBlocks) const
 {
    for (unsigned i=0;i<catch_addrs_.size();i++)
       excpBlocks.push_back(new ExceptionBlock(catch_addrs_[i]));
@@ -235,43 +235,43 @@ DYNINST_EXPORT bool AObject::getAllExceptions(std::vector<ExceptionBlock *>&excp
    return true;
 }
 
-DYNINST_EXPORT std::vector<Region *> AObject::getAllRegions() const
+DYNINST_EXPORT std::vector<Region *> Object::getAllRegions() const
 {
    return regions_;	
 }
 
-DYNINST_EXPORT Offset AObject::loader_off() const 
+DYNINST_EXPORT Offset Object::loader_off() const 
 { 
    return loader_off_; 
 }
 
-DYNINST_EXPORT unsigned AObject::loader_len() const 
+DYNINST_EXPORT unsigned Object::loader_len() const 
 { 
    return loader_len_; 
 }
 
 
-DYNINST_EXPORT int AObject::getAddressWidth() const 
+DYNINST_EXPORT int Object::getAddressWidth() const 
 { 
    return addressWidth_nbytes; 
 }
 
-DYNINST_EXPORT bool AObject::have_deferred_parsing(void) const
+DYNINST_EXPORT bool Object::have_deferred_parsing(void) const
 { 
    return deferredParse;
 }
 
-DYNINST_EXPORT void * AObject::getErrFunc() const 
+DYNINST_EXPORT void * Object::getErrFunc() const 
 {
    return (void *) err_func_; 
 }
 
-DYNINST_EXPORT dyn_c_hash_map< string, std::vector< Symbol *> > *AObject::getAllSymbols()
+DYNINST_EXPORT dyn_c_hash_map< string, std::vector< Symbol *> > *Object::getAllSymbols()
 {
    return &(symbols_);
 }
 
-DYNINST_EXPORT AObject::~AObject() 
+DYNINST_EXPORT Object::~Object() 
 {
     using std::string;
     using std::vector;
@@ -286,7 +286,7 @@ DYNINST_EXPORT AObject::~AObject()
 }
 
 // explicitly protected
-DYNINST_EXPORT AObject::AObject(MappedFile *mf_, void (*err_func)(const char *), Symtab* st)
+DYNINST_EXPORT Object::Object(MappedFile *mf_, void (*err_func)(const char *), Symtab* st)
 : mf(mf_),
    code_ptr_(0), code_off_(0), code_len_(0),
    data_ptr_(0), data_off_(0), data_len_(0),
@@ -299,6 +299,22 @@ DYNINST_EXPORT AObject::AObject(MappedFile *mf_, void (*err_func)(const char *),
   deferredParse(false), parsedAllLineInfo(false), err_func_(err_func), addressWidth_nbytes(4),
   associated_symtab(st)
 {
+}
+
+Object *Dyninst::SymtabAPI::parseObjectFile(MappedFile *mf,
+                                            bool is_defensive,
+                                            void (*err)(const char *),
+                                            bool alloc_syms,
+                                            Symtab *symtab)
+{
+    const char *mfa = (const char *)mf->base_addr();
+    if (mfa[0] == 'M' && mfa[1] == 'Z') {
+        return new ObjectPE(mf, is_defensive, err, alloc_syms, symtab);
+    } else if (mfa[1] == 'E' && mfa[2] == 'L' && mfa[3] == 'F') {
+        return new ObjectELF(mf, is_defensive, err, alloc_syms, symtab);
+    } else {
+        return NULL;
+    }
 }
 
 SymbolIter::SymbolIter( Object & obj ) 
@@ -359,16 +375,16 @@ Symbol *SymbolIter::currval()
    return ((symbolIterator->second)[ currentPositionInVector ]);
 }
 
-bool AObject::hasError() const
+bool Object::hasError() const
 {
   return has_error;
 }
 
-void AObject::setTruncateLinePaths(bool)
+void Object::setTruncateLinePaths(bool)
 {
 }
 
-bool AObject::getTruncateLinePaths()
+bool Object::getTruncateLinePaths()
 {
    return false;
 }

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -140,7 +140,7 @@ public:
     virtual bool getTruncateLinePaths();
     virtual Region::RegionType getRelType() const { return Region::RT_INVALID; }
 
-    virtual Offset getPreferedBase() const { return 0; }
+    virtual Offset getPreferedBase() const = 0;
     virtual bool hasReldyn() const { return false; }
     virtual bool hasReladyn() const { return false; }
     virtual bool hasRelplt() const { return false; }

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -55,6 +55,8 @@
 #include "common/src/MappedFile.h"
 #include "common/src/lprintf.h"
 
+#include "dwarfHandle.h"
+
 namespace Dyninst{
 namespace SymtabAPI{
 
@@ -69,7 +71,7 @@ const char WILDCARD_CHARACTER = '?';
 const char MULTIPLE_WILDCARD_CHARACTER = '*';
 
 /************************************************************************
- * class AObject
+ * class Object
  *
  *  WHAT IS THIS CLASS????  COMMENTS????
  *  Looks like it has a dictionary hash of symbols, as well as
@@ -78,7 +80,7 @@ const char MULTIPLE_WILDCARD_CHARACTER = '*';
  *   section....
 ************************************************************************/
 
-class AObject {
+class Object {
 public:
     DYNINST_EXPORT unsigned nsymbols () const;
     
@@ -113,7 +115,7 @@ public:
     DYNINST_EXPORT virtual  bool   get_func_binding_table(std::vector<relocationEntry> &) const;
     DYNINST_EXPORT virtual  bool   get_func_binding_table_ptr(const std::vector<relocationEntry> *&) const; 
     DYNINST_EXPORT virtual  bool   addRelocationEntry(relocationEntry &re);
-    DYNINST_EXPORT bool   getSegments(std::vector<Segment> &segs) const;
+    DYNINST_EXPORT virtual  bool   getSegments(std::vector<Segment> &) const { return false; }
 
     DYNINST_EXPORT bool have_deferred_parsing( void ) const;
     // for debuggering....
@@ -138,14 +140,74 @@ public:
     virtual bool getTruncateLinePaths();
     virtual Region::RegionType getRelType() const { return Region::RT_INVALID; }
 
+    virtual Offset getPreferedBase() const { return 0; }
+    virtual bool hasReldyn() const { return false; }
+    virtual bool hasReladyn() const { return false; }
+    virtual bool hasRelplt() const { return false; }
+    virtual bool hasRelaplt() const { return false; }
+    virtual bool hasDebugInfo() { return false; }
+    virtual void getDependencies(std::vector<std::string> &deps) { deps.clear(); }
+    virtual const char *interpreter_name() const { return NULL; }
+    virtual Offset getEntryAddress() const = 0;
+    virtual Offset getBaseAddress() const = 0;
+    virtual Offset getLoadAddress() const = 0;
+    virtual bool isEEL() const { return false; }
+    virtual ObjectType objType() const = 0;
+    virtual void getModuleLanguageInfo(dyn_hash_map<std::string, supportedLanguages> *mod_langs) = 0;
+
+    virtual void insertPrereqLibrary(std::string libname) = 0;
+    virtual bool removePrereqLibrary(std::string ) { return false; }
+    virtual void insertDynamicEntry(long, long) { }
+
+    virtual Offset getInitAddr() const { return 0; }
+    virtual Offset getFiniAddr() const { return 0; }
+    virtual Offset getDynamicAddr() const { return 0; }
+
+    virtual void *getElfHandle() { return NULL; }
+    virtual LineInformation* parseLineInfoForObject(StringTablePtr) { return NULL; }
+
+    DYNINST_EXPORT virtual bool isOnlyExecutable() const { return false; }
+    DYNINST_EXPORT virtual bool isExecutable() const { return false; }
+    DYNINST_EXPORT virtual bool isSharedLibrary() const { return false; }
+    DYNINST_EXPORT virtual bool isOnlySharedLibrary() const { return false; }
+    DYNINST_EXPORT virtual bool isDebugOnly() const { return false; }
+    DYNINST_EXPORT virtual bool isLinuxKernelModule() const { return false; }
+
+    virtual bool convertDebugOffset(Offset, Offset &) { return false; }
+
+    virtual Offset getTOCoffset(Offset) const { return 0; }
+    virtual void setTOCoffset(Offset) { }
+
+    virtual bool emitDriver(std::string fName, std::set<Symbol *> &allSymbols, unsigned flag) = 0;
+    virtual void parseFileLineInfo() { }
+    virtual void parseTypeInfo() { }
+
+    Region *findEnclosingRegion(const Offset off)
+    {
+      auto rgn = std::lower_bound(regions_.begin(), regions_.end(), off,
+          [](const Region *r, const Offset &value)
+          {
+            return r->getMemOffset() <= value;
+          });
+      if (rgn != regions_.begin()) {
+        rgn--;
+      } else {
+        rgn = regions_.end();
+      }
+      return rgn != regions_.end() ? *rgn : NULL;
+    }
+
+    Dyninst::DwarfDyninst::DwarfHandle::ptr dwarf;
+
+
     // Only implemented for ELF right now
     DYNINST_EXPORT virtual void getSegmentsSymReader(std::vector<SymSegment> &) {}
-	DYNINST_EXPORT virtual void rebase(Offset) {}
+	  DYNINST_EXPORT virtual void rebase(Offset) {}
     virtual void addModule(SymtabAPI::Module *) {}
 protected:
-    DYNINST_EXPORT virtual ~AObject();
+    DYNINST_EXPORT virtual ~Object();
     // explicitly protected
-    DYNINST_EXPORT AObject(MappedFile *, void (*err_func)(const char *), Symtab*);
+    DYNINST_EXPORT Object(MappedFile *, void (*err_func)(const char *), Symtab*);
 friend class Module;
     virtual void parseLineInfoForCU(Offset , LineInformation* ) { }
 
@@ -204,8 +266,8 @@ private:
     friend class Symtab;
 
     // declared but not implemented; no copying allowed
-    AObject(const AObject &obj);
-    const AObject& operator=(const AObject &obj);
+    Object(const Object &obj);
+    const Object& operator=(const Object &obj);
 };
 
 }//namepsace Symtab
@@ -217,6 +279,7 @@ private:
 
 #if defined(os_linux) || defined(os_freebsd)
 #include "Object-elf.h"
+#include "Object-pe.h"
 #elif defined(os_windows)
 #include "Object-nt.h"
 #else
@@ -255,6 +318,8 @@ class SymbolIter {
    
    SymbolIter & operator = ( const SymbolIter & ); // explicitly disallowed
 }; /* end class SymbolIter() */
+
+Object *parseObjectFile(MappedFile *, bool, void(*)(const char *) = log_msg, bool = true, Symtab * = NULL);
 
 }//namepsace SymtabAPI
 }//namespace Dyninst

--- a/symtabAPI/src/Region.C
+++ b/symtabAPI/src/Region.C
@@ -104,7 +104,7 @@ Region& Region::operator=(const Region &reg)
     return *this;
 }
 
-bool Region::operator==(const Region &reg)
+bool Region::operator==(const Region &reg) const
 {
 
 	if (rels_.size() != reg.rels_.size()) return false;
@@ -140,6 +140,11 @@ ostream& Region::operator<< (ostream &os)
                 << " Permissions=" << permissions_
                         << " region type " << rType_
                 << " }" << endl;
+}
+
+bool Region::operator<(const Region &reg) const
+{
+   return memOff_ < reg.memOff_;
 }
 
 Region::~Region() 

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -816,8 +816,8 @@ Symtab::Symtab(std::string filename, bool defensive_bin, bool &err) : Symtab()
       return;
    }
 
-   obj_private = new Object(mf, defensive_bin, 
-                            symtab_log_perror, true, this);
+   obj_private = parseObjectFile(mf, defensive_bin, 
+                                 symtab_log_perror, true, this);
    if (obj_private->hasError()) {
       create_printf("%s[%d]: WARNING: creating symtab for %s, " 
                     "Object ctor failed\n", FILE__, __LINE__, 
@@ -857,8 +857,8 @@ Symtab::Symtab(unsigned char *mem_image, size_t image_size,
       return;
    }
 
-   obj_private = new Object(mf, defensive_bin, 
-                            symtab_log_perror, true, this);
+   obj_private = parseObjectFile(mf, defensive_bin, 
+                                 symtab_log_perror, true, this);
    if (obj_private->hasError()) {
      err = true;
      return;
@@ -900,23 +900,12 @@ bool Symtab::extractInfo(Object *linkedFile)
      * members are imprecise. These members should probably be deprecated in
      * favor of the getCodeRegions and getDataRegions functions.
      */
-#if defined(os_windows)
-	preferedBase_ = linkedFile->getPreferedBase();
-#else
-	preferedBase_ = 0;
-#endif
     imageOffset_ = linkedFile->code_off();
     dataOffset_ = linkedFile->data_off();
-
-#if defined(os_windows)
-	preferedBase_ = linkedFile->getPreferedBase();
-#else
-	preferedBase_ = 0;
-#endif
-
+	 preferedBase_ = linkedFile->getPreferedBase();
     imageLen_ = linkedFile->code_len();
     dataLen_ = linkedFile->data_len();
-    
+
     if (0 == imageLen_ || 0 == linkedFile->code_ptr()) 
     {
        if (0 == linkedFile->code_ptr()) {
@@ -941,15 +930,16 @@ bool Symtab::extractInfo(Object *linkedFile)
 
     hasRel_ = false;
     hasRela_ = false;
-    hasReldyn_ = false;
-    hasReladyn_ = false;
-    hasRelplt_ = false;
-    hasRelaplt_ = false;
+    hasReldyn_ = linkedFile->hasReldyn();
+    hasReladyn_ = linkedFile->hasReladyn();
+    hasRelplt_ = linkedFile->hasRelplt();
+    hasRelaplt_ = linkedFile->hasRelaplt();
+
     regions_ = linkedFile->getAllRegions();
 
     for (unsigned index=0;index<regions_.size();index++)
-      {
-      regions_[index]->setSymtab(this);
+    {
+        regions_[index]->setSymtab(this);
 
         if ( regions_[index]->isLoadable() ) 
         {
@@ -977,13 +967,6 @@ bool Symtab::extractInfo(Object *linkedFile)
         {
             hasRela_ = true;
         }
-
-#if defined(os_linux) || defined(os_freebsd)
-        hasReldyn_ = linkedFile->hasReldyn();
-	hasReladyn_ = linkedFile->hasReladyn();
-        hasRelplt_ = linkedFile->hasRelplt();
-        hasRelaplt_ = linkedFile->hasRelaplt();
-#endif	
 
     }
     // sort regions_ & codeRegions_ vectors
@@ -1052,9 +1035,7 @@ bool Symtab::extractInfo(Object *linkedFile)
     // determined before this step).
     
     // Also identifies aliases (multiple names with equal addresses)
-#if !defined(os_windows)
     linkedFile->getDependencies(deps_);
-#endif
 
     
     linkedFile->getAllExceptions(excpBlocks);

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -241,7 +241,7 @@ namespace Dyninst {
 
             bool isStripped;
             int library_adjust;
-            Object *object;
+            ObjectELF *object;
 
             void (*err_func_)(const char*);
 

--- a/symtabAPI/src/parseDwarf.C
+++ b/symtabAPI/src/parseDwarf.C
@@ -64,14 +64,14 @@ std::string convertCharToString(char *ptr)
   return str;	
 }
 
-bool Object::hasFrameDebugInfo()
+bool ObjectELF::hasFrameDebugInfo()
 {
    dwarf->frame_dbg();
    assert(dwarf->frameParser());
    return dwarf->frameParser()->hasFrameDebugInfo();
 }
 
-bool Object::getRegValueAtFrame(Address pc, 
+bool ObjectELF::getRegValueAtFrame(Address pc, 
 		Dyninst::MachRegister reg, 
 		Dyninst::MachRegisterVal &reg_result,
 		MemRegReader *reader)


### PR DESCRIPTION
This change adds support for parsing PE (Windows .EXE and .DLL) files. Compared to previous implementation it is not tied to any specific platform. With it you can parse PE files on Linux machine. It supports both 32- and 64-bit PE files. It detects file type based on "magic" bytes at the beginning, so you can feed .EXE/.DLL files to disassemble from Dyninst examples and it will work. The implementation is based on [pe-parse](https://github.com/trailofbits/pe-parse) library.

This change is marked as WIP because it requires tidying up before it can be merged. But before I do it I'd like to hear some feedback on few topics

* Windows builds. This change does not update anything related to Windows builds, and it is in obvious conflict with existing Object-nt.C. I tried to make Dyninst build on Windows machine, but the build was broken in more than one ways. Some of them require non-trivial effort and time to fix, but at the same time it doesn't seem to be used by anyone. For example, [P_cplus_demangle](https://github.com/dyninst/dyninst/blob/9daa8a09db09f8de153e351a6a18dd7ebcda1881/common/src/ntHeaders.h#L217-L234) in ntHeaders.h is missing semicolon in line 221 and closing brace in line 226. Those will obviously cause compilation error. They were introduced in 41ef642f3a, more than 3 years ago. Yet no one raised an issue about it. I have nearly zero motivation to spend efforts on something that is not used by anyone, but if you say that Windows build needs to work, then I'll try to fix it and incorporate this change into it.
* The change requires splitting into parts. It is too big for single review. There is an obvious split "refactoring or AObject" and "PE parsing", but this might not be enough. If you have any ideas how to further split the second part, I'll be glad to hear them.
* Possible change to AObject/Object interface. Currently I've dumped everything from ELF and PE together, but I'm sure there is a lot of trimming to do there.