### PR TITLE
Refactroing of AObject class

### DIFF
--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -192,6 +192,7 @@ class DYNINST_EXPORT InlinedFunction : public FunctionBase
    friend class Symtab;
    friend class DwarfWalker;
    friend class Object;
+   friend class ObjectELF;
   public:
    InlinedFunction(FunctionBase *parent);
    virtual ~InlinedFunction();

--- a/symtabAPI/h/Region.h
+++ b/symtabAPI/h/Region.h
@@ -46,6 +46,7 @@ class Symtab;
 
 class DYNINST_EXPORT Region : public AnnotatableSparse {
    friend class Object;
+   friend class ObjectELF;
    friend class Symtab;
    friend class SymtabTranslatorBase;
    friend class SymtabTranslatorBin;

--- a/symtabAPI/h/Symbol.h
+++ b/symtabAPI/h/Symbol.h
@@ -75,7 +75,6 @@ class DYNINST_EXPORT Symbol : public AnnotatableSparse
 {
    friend class typeCommon;
    friend class Symtab;
-   friend class AObject;
    friend class Object;
    friend class Aggregate;
    friend class relocationEntry;

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -90,6 +90,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    friend class Aggregate;
    friend class relocationEntry;
    friend class Object;
+   friend class ObjectELF;
 
    // Hide implementation details that are complex or add large dependencies
    const std::unique_ptr<symtab_impl> impl;

--- a/symtabAPI/src/Function.C
+++ b/symtabAPI/src/Function.C
@@ -241,14 +241,17 @@ void FunctionBase::expandLocation(const VariableLocation &loc,
    }
 
    using namespace Dyninst::DwarfDyninst;
-   auto obj = getModule()->exec()->getObject();
-   DwarfFrameParser::Ptr frameParser =
-		   DwarfFrameParser::create(*obj->dwarf->frame_dbg(), obj->dwarf->origFile()->e_elfp(), obj->getArch());
-
    std::vector<VariableLocation> FDEs;
-   Dyninst::DwarfDyninst::FrameErrors_t err;
-   if(!frameParser) return;
-   frameParser->getRegsForFunction(std::make_pair(loc.lowPC, loc.hiPC), Dyninst::CFA, FDEs, err);
+   Object *obj = getModule()->exec()->getObject();
+   ObjectELF *obj_elf = dynamic_cast<ObjectELF *>(obj);
+   if (obj_elf) {
+      DwarfFrameParser::Ptr frameParser =
+            DwarfFrameParser::create(*obj_elf->dwarf->frame_dbg(), obj_elf->dwarf->origFile()->e_elfp(), obj_elf->getArch());
+
+      Dyninst::DwarfDyninst::FrameErrors_t err;
+      if(!frameParser) return;
+      frameParser->getRegsForFunction(std::make_pair(loc.lowPC, loc.hiPC), Dyninst::CFA, FDEs, err);
+   }
 
    if (FDEs.empty()) {
       // Odd, but happens

--- a/symtabAPI/src/Object.C
+++ b/symtabAPI/src/Object.C
@@ -111,27 +111,27 @@ bool Dyninst::SymtabAPI::symbol_compare(const Symbol *s1, const Symbol *s2)
 }
 
 
-bool AObject::needs_function_binding() const 
+bool Object::needs_function_binding() const 
 {
     return false;
 }
 
-bool AObject::get_func_binding_table(std::vector<relocationEntry> &) const 
+bool Object::get_func_binding_table(std::vector<relocationEntry> &) const 
 {
     return false;
 }
 
-bool AObject::get_func_binding_table_ptr(const std::vector<relocationEntry> *&) const 
+bool Object::get_func_binding_table_ptr(const std::vector<relocationEntry> *&) const 
 {
     return false;
 }
 
-bool AObject::addRelocationEntry(relocationEntry &)
+bool Object::addRelocationEntry(relocationEntry &)
 {
     return true;
 }
 
-char *AObject::mem_image() const
+char *Object::mem_image() const
 {
 	return NULL;
 }
@@ -154,7 +154,7 @@ ostream &operator<<(ostream &os, relocationEntry &q) {
  *
  **************************************************/
 
-DYNINST_EXPORT unsigned AObject::nsymbols () const 
+DYNINST_EXPORT unsigned Object::nsymbols () const 
 { 
     unsigned n = 0;
     for (dyn_c_hash_map<std::string, std::vector<Symbol *> >::const_iterator i = symbols_.begin();
@@ -165,7 +165,7 @@ DYNINST_EXPORT unsigned AObject::nsymbols () const
     return n;
 }
 
-DYNINST_EXPORT bool AObject::get_symbols(string & name, 
+DYNINST_EXPORT bool Object::get_symbols(string & name, 
       std::vector<Symbol *> &symbols ) 
 {
    dyn_c_hash_map<std::string, std::vector<Symbol *>>::const_accessor ca;
@@ -177,57 +177,57 @@ DYNINST_EXPORT bool AObject::get_symbols(string & name,
    return true;
 }
 
-DYNINST_EXPORT char* AObject::code_ptr () const 
+DYNINST_EXPORT char* Object::code_ptr () const 
 { 
    return code_ptr_; 
 }
 
-DYNINST_EXPORT Offset AObject::code_off () const 
+DYNINST_EXPORT Offset Object::code_off () const 
 { 
    return code_off_; 
 }
 
-DYNINST_EXPORT Offset AObject::code_len () const 
+DYNINST_EXPORT Offset Object::code_len () const 
 { 
    return code_len_; 
 }
 
-DYNINST_EXPORT char* AObject::data_ptr () const 
+DYNINST_EXPORT char* Object::data_ptr () const 
 { 
    return data_ptr_; 
 }
 
-DYNINST_EXPORT Offset AObject::data_off () const 
+DYNINST_EXPORT Offset Object::data_off () const 
 { 
    return data_off_; 
 }
 
-DYNINST_EXPORT Offset AObject::data_len () const 
+DYNINST_EXPORT Offset Object::data_len () const 
 { 
    return data_len_; 
 }
 
-DYNINST_EXPORT bool AObject::is_aout() const 
+DYNINST_EXPORT bool Object::is_aout() const 
 {
    return is_aout_;  
 }
 
-DYNINST_EXPORT bool AObject::isDynamic() const 
+DYNINST_EXPORT bool Object::isDynamic() const 
 {
    return is_dynamic_;  
 }
 
-DYNINST_EXPORT unsigned AObject::no_of_sections() const 
+DYNINST_EXPORT unsigned Object::no_of_sections() const 
 { 
    return no_of_sections_; 
 }
 
-DYNINST_EXPORT unsigned AObject::no_of_symbols() const 
+DYNINST_EXPORT unsigned Object::no_of_symbols() const 
 { 
    return no_of_symbols_;  
 }
 
-DYNINST_EXPORT bool AObject::getAllExceptions(std::vector<ExceptionBlock *>&excpBlocks) const
+DYNINST_EXPORT bool Object::getAllExceptions(std::vector<ExceptionBlock *>&excpBlocks) const
 {
    for (unsigned i=0;i<catch_addrs_.size();i++)
       excpBlocks.push_back(new ExceptionBlock(catch_addrs_[i]));
@@ -235,43 +235,43 @@ DYNINST_EXPORT bool AObject::getAllExceptions(std::vector<ExceptionBlock *>&excp
    return true;
 }
 
-DYNINST_EXPORT std::vector<Region *> AObject::getAllRegions() const
+DYNINST_EXPORT std::vector<Region *> Object::getAllRegions() const
 {
    return regions_;	
 }
 
-DYNINST_EXPORT Offset AObject::loader_off() const 
+DYNINST_EXPORT Offset Object::loader_off() const 
 { 
    return loader_off_; 
 }
 
-DYNINST_EXPORT unsigned AObject::loader_len() const 
+DYNINST_EXPORT unsigned Object::loader_len() const 
 { 
    return loader_len_; 
 }
 
 
-DYNINST_EXPORT int AObject::getAddressWidth() const 
+DYNINST_EXPORT int Object::getAddressWidth() const 
 { 
    return addressWidth_nbytes; 
 }
 
-DYNINST_EXPORT bool AObject::have_deferred_parsing(void) const
+DYNINST_EXPORT bool Object::have_deferred_parsing(void) const
 { 
    return deferredParse;
 }
 
-DYNINST_EXPORT void * AObject::getErrFunc() const 
+DYNINST_EXPORT void * Object::getErrFunc() const 
 {
    return (void *) err_func_; 
 }
 
-DYNINST_EXPORT dyn_c_hash_map< string, std::vector< Symbol *> > *AObject::getAllSymbols()
+DYNINST_EXPORT dyn_c_hash_map< string, std::vector< Symbol *> > *Object::getAllSymbols()
 {
    return &(symbols_);
 }
 
-DYNINST_EXPORT AObject::~AObject() 
+DYNINST_EXPORT Object::~Object() 
 {
     using std::string;
     using std::vector;
@@ -286,7 +286,7 @@ DYNINST_EXPORT AObject::~AObject()
 }
 
 // explicitly protected
-DYNINST_EXPORT AObject::AObject(MappedFile *mf_, void (*err_func)(const char *), Symtab* st)
+DYNINST_EXPORT Object::Object(MappedFile *mf_, void (*err_func)(const char *), Symtab* st)
 : mf(mf_),
    code_ptr_(0), code_off_(0), code_len_(0),
    data_ptr_(0), data_off_(0), data_len_(0),
@@ -299,6 +299,20 @@ DYNINST_EXPORT AObject::AObject(MappedFile *mf_, void (*err_func)(const char *),
   deferredParse(false), parsedAllLineInfo(false), err_func_(err_func), addressWidth_nbytes(4),
   associated_symtab(st)
 {
+}
+
+Object *Dyninst::SymtabAPI::parseObjectFile(MappedFile *mf,
+                                            bool is_defensive,
+                                            void (*err)(const char *),
+                                            bool alloc_syms,
+                                            Symtab *symtab)
+{
+    const char *mfa = (const char *)mf->base_addr();
+    if (mfa[1] == 'E' && mfa[2] == 'L' && mfa[3] == 'F') {
+        return new ObjectELF(mf, is_defensive, err, alloc_syms, symtab);
+    } else {
+        return NULL;
+    }
 }
 
 SymbolIter::SymbolIter( Object & obj ) 
@@ -359,16 +373,16 @@ Symbol *SymbolIter::currval()
    return ((symbolIterator->second)[ currentPositionInVector ]);
 }
 
-bool AObject::hasError() const
+bool Object::hasError() const
 {
   return has_error;
 }
 
-void AObject::setTruncateLinePaths(bool)
+void Object::setTruncateLinePaths(bool)
 {
 }
 
-bool AObject::getTruncateLinePaths()
+bool Object::getTruncateLinePaths()
 {
    return false;
 }

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -69,7 +69,7 @@ const char WILDCARD_CHARACTER = '?';
 const char MULTIPLE_WILDCARD_CHARACTER = '*';
 
 /************************************************************************
- * class AObject
+ * class Object
  *
  *  WHAT IS THIS CLASS????  COMMENTS????
  *  Looks like it has a dictionary hash of symbols, as well as
@@ -78,7 +78,8 @@ const char MULTIPLE_WILDCARD_CHARACTER = '*';
  *   section....
 ************************************************************************/
 
-class AObject {
+class Object : public boost::basic_lockable_adapter<boost::mutex>
+{
 public:
     DYNINST_EXPORT unsigned nsymbols () const;
     
@@ -113,7 +114,7 @@ public:
     DYNINST_EXPORT virtual  bool   get_func_binding_table(std::vector<relocationEntry> &) const;
     DYNINST_EXPORT virtual  bool   get_func_binding_table_ptr(const std::vector<relocationEntry> *&) const; 
     DYNINST_EXPORT virtual  bool   addRelocationEntry(relocationEntry &re);
-    DYNINST_EXPORT bool   getSegments(std::vector<Segment> &segs) const;
+    DYNINST_EXPORT virtual  bool   getSegments(std::vector<Segment> &) const { return false; }
 
     DYNINST_EXPORT bool have_deferred_parsing( void ) const;
     // for debuggering....
@@ -138,14 +139,56 @@ public:
     virtual bool getTruncateLinePaths();
     virtual Region::RegionType getRelType() const { return Region::RT_INVALID; }
 
+    virtual Offset getPreferedBase() const { return 0; }
+    virtual bool hasReldyn() const { return false; }
+    virtual bool hasReladyn() const { return false; }
+    virtual bool hasRelplt() const { return false; }
+    virtual bool hasRelaplt() const { return false; }
+    virtual bool hasDebugInfo() { return false; }
+    virtual void getDependencies(std::vector<std::string> &deps) { deps.clear(); }
+    virtual const char *interpreter_name() const { return NULL; }
+    virtual Offset getEntryAddress() const = 0;
+    virtual Offset getBaseAddress() const = 0;
+    virtual Offset getLoadAddress() const = 0;
+    virtual bool isEEL() const { return false; }
+    virtual ObjectType objType() const = 0;
+    virtual void getModuleLanguageInfo(dyn_hash_map<std::string, supportedLanguages> *mod_langs) = 0;
+
+    virtual void insertPrereqLibrary(std::string libname) = 0;
+    virtual bool removePrereqLibrary(std::string ) { return false; }
+    virtual void insertDynamicEntry(long, long) { }
+
+    virtual Offset getInitAddr() const { return 0; }
+    virtual Offset getFiniAddr() const { return 0; }
+    virtual Offset getDynamicAddr() const { return 0; }
+
+    virtual void *getElfHandle() { return NULL; }
+    virtual LineInformation* parseLineInfoForObject(StringTablePtr) { return NULL; }
+
+    DYNINST_EXPORT virtual bool isOnlyExecutable() const { return false; }
+    DYNINST_EXPORT virtual bool isExecutable() const { return false; }
+    DYNINST_EXPORT virtual bool isSharedLibrary() const { return false; }
+    DYNINST_EXPORT virtual bool isOnlySharedLibrary() const { return false; }
+    DYNINST_EXPORT virtual bool isDebugOnly() const { return false; }
+    DYNINST_EXPORT virtual bool isLinuxKernelModule() const { return false; }
+
+    virtual bool convertDebugOffset(Offset, Offset &) { return false; }
+
+    virtual Offset getTOCoffset(Offset) const { return 0; }
+    virtual void setTOCoffset(Offset) { }
+
+    virtual bool emitDriver(std::string fName, std::set<Symbol *> &allSymbols, unsigned flag) = 0;
+    virtual void parseFileLineInfo() { }
+    virtual void parseTypeInfo() { }
+
     // Only implemented for ELF right now
     DYNINST_EXPORT virtual void getSegmentsSymReader(std::vector<SymSegment> &) {}
-	DYNINST_EXPORT virtual void rebase(Offset) {}
+	  DYNINST_EXPORT virtual void rebase(Offset) {}
     virtual void addModule(SymtabAPI::Module *) {}
 protected:
-    DYNINST_EXPORT virtual ~AObject();
+    DYNINST_EXPORT virtual ~Object();
     // explicitly protected
-    DYNINST_EXPORT AObject(MappedFile *, void (*err_func)(const char *), Symtab*);
+    DYNINST_EXPORT Object(MappedFile *, void (*err_func)(const char *), Symtab*);
 friend class Module;
     virtual void parseLineInfoForCU(Offset , LineInformation* ) { }
 
@@ -204,8 +247,8 @@ private:
     friend class Symtab;
 
     // declared but not implemented; no copying allowed
-    AObject(const AObject &obj);
-    const AObject& operator=(const AObject &obj);
+    Object(const Object &obj);
+    const Object& operator=(const Object &obj);
 };
 
 }//namepsace Symtab
@@ -255,6 +298,8 @@ class SymbolIter {
    
    SymbolIter & operator = ( const SymbolIter & ); // explicitly disallowed
 }; /* end class SymbolIter() */
+
+Object *parseObjectFile(MappedFile *, bool, void(*)(const char *) = log_msg, bool = true, Symtab * = NULL);
 
 }//namepsace SymtabAPI
 }//namespace Dyninst

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -143,7 +143,7 @@ namespace Dyninst {
 
         template<class ElfTypes = ElfTypes64> class emitElf : public ElfTypes {
         public:
-            emitElf(Elf_X *pX, bool i, Object *pObject, void (*pFunction)(const char *), Symtab *pSymtab);
+            emitElf(Elf_X *pX, bool i, ObjectELF *pObject, void (*pFunction)(const char *), Symtab *pSymtab);
 
             typedef typename ElfTypes::Elf_Ehdr Elf_Ehdr;
             typedef typename ElfTypes::Elf_Phdr Elf_Phdr;
@@ -241,7 +241,7 @@ namespace Dyninst {
 
             bool isStripped;
             int library_adjust;
-            Object *object;
+            ObjectELF *object;
 
             void (*err_func_)(const char*);
 

--- a/symtabAPI/src/parseDwarf.C
+++ b/symtabAPI/src/parseDwarf.C
@@ -64,14 +64,14 @@ std::string convertCharToString(char *ptr)
   return str;	
 }
 
-bool Object::hasFrameDebugInfo()
+bool ObjectELF::hasFrameDebugInfo()
 {
    dwarf->frame_dbg();
    assert(dwarf->frameParser());
    return dwarf->frameParser()->hasFrameDebugInfo();
 }
 
-bool Object::getRegValueAtFrame(Address pc, 
+bool ObjectELF::getRegValueAtFrame(Address pc, 
 		Dyninst::MachRegister reg, 
 		Dyninst::MachRegisterVal &reg_result,
 		MemRegReader *reader)


### PR DESCRIPTION
This change is made in preparation for implementation of PE files parsing support.

The base class AObject is renamed to Object and its interface is expanded.

Derived classes now have different names depending on the type of the object files they represent, e.g. ObjectELF

All non-specific parsing operations were changed to work with the basic class.

A new function that selects derived class based on magic bytes is implemented. It can only select ObjectELF for now.