### PR TITLE
Fix vector segmentation fault introduced in #1733

### DIFF
--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -443,8 +443,8 @@ void RoseInsnAMDGPUFactory::massageOperands(const Instruction &insn,
     case amdgpu_gfx940_op_S_SWAPPC_B64: {
         assert(operands.size() == 4);
         operands.reserve(6);
-        operands[4] = operands[2];
-        operands[5] = operands[3];
+        operands.push_back(operands[2]);
+        operands.push_back(operands[3]);
         MultiRegisterAST::Ptr src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[1].getValue());
         const std::vector<RegisterAST::Ptr> & src_reg_asts = src_regs->getRegs();
         operands[3] = Operand(src_reg_asts[1]);
@@ -462,7 +462,7 @@ void RoseInsnAMDGPUFactory::massageOperands(const Instruction &insn,
     case amdgpu_gfx940_op_S_SETPC_B64: {
         assert(operands.size() == 2);
         operands.reserve(3);
-        operands[2] = operands[1];
+        operands.push_back(operands[1]);
         MultiRegisterAST::Ptr src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
         const std::vector<RegisterAST::Ptr> & src_reg_asts = src_regs->getRegs();
         operands[1] = Operand(src_reg_asts[1]);
@@ -476,8 +476,7 @@ void RoseInsnAMDGPUFactory::massageOperands(const Instruction &insn,
     case amdgpu_gfx940_op_S_GETPC_B64: {
         assert(operands.size() == 2);
         operands.reserve(3);
-
-        operands[2] = Operand(InstructionAPI::Immediate::makeImmediate(Result(u64,_addr+4)),false,false);
+        operands.push_back(Operand(InstructionAPI::Immediate::makeImmediate(Result(u64,_addr+4)),false,false));
         MultiRegisterAST::Ptr dst_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
         const std::vector<RegisterAST::Ptr> & dst_reg_asts = dst_regs->getRegs();
         operands[1] = Operand(dst_reg_asts[1]);


### PR DESCRIPTION
The use of reserve instead of resize for the operand vector somehow cause Dyninst to segmentation fault on test cases with GETPC, SETPC and SWAPPC.
