### PR TITLE
warning fix: ambiguous-reversed-operator

### DIFF
--- a/dataflowAPI/src/SymEvalPolicy.h
+++ b/dataflowAPI/src/SymEvalPolicy.h
@@ -111,7 +111,7 @@ struct Handle {
     ~Handle() { if (v_) delete v_; }
   
   template <size_t Len2>
-  bool operator==(const Handle<Len2> &rhs) {
+  bool operator==(const Handle<Len2> &rhs) const {
     return ((Len == Len2) && (*(var()) == *(rhs.var())));
   }
 

--- a/symtabAPI/h/Aggregate.h
+++ b/symtabAPI/h/Aggregate.h
@@ -103,7 +103,7 @@ class DYNINST_EXPORT Aggregate
       bool setSize(unsigned size);
       bool setOffset(unsigned offset);
       
-	  bool operator==(const Aggregate &a);
+	  bool operator==(const Aggregate &a) const;
 
 	  friend std::ostream& operator<<(std::ostream &os, Aggregate const& a) {
 		  a.print(os);

--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -95,7 +95,7 @@ class DYNINST_EXPORT FunctionBase
    bool getLocalVariables(std::vector<localVar *>&vars);
    bool getParams(std::vector<localVar *>&params);
 
-   bool operator==(const FunctionBase &);
+   bool operator==(const FunctionBase &) const;
 
    FunctionBase *getInlinedParent();
    const InlineCollection &getInlines();

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -58,7 +58,7 @@ namespace Dyninst { namespace SymtabAPI {
     Module();
     Module(supportedLanguages lang, Offset adr, std::string fullNm, Symtab *img);
     Module(const Module &mod);
-    bool operator==(Module &mod);
+    bool operator==(const Module &mod) const;
 
     const std::string &fileName() const;
     const std::string &fullName() const;

--- a/symtabAPI/h/Region.h
+++ b/symtabAPI/h/Region.h
@@ -95,7 +95,7 @@ class DYNINST_EXPORT Region : public AnnotatableSparse {
    Region(const Region &reg);
    Region& operator=(const Region &reg);
    std::ostream& operator<< (std::ostream &os);
-   bool operator== (const Region &reg);
+   bool operator== (const Region &reg) const;
 
    ~Region();
 

--- a/symtabAPI/h/Variable.h
+++ b/symtabAPI/h/Variable.h
@@ -66,7 +66,7 @@ class DYNINST_EXPORT Variable : public Aggregate, public AnnotatableSparse {
    void setType(Type* t) { setType(t->reshare()); }
    boost::shared_ptr<Type> getType(Type::do_share_t);
    Type* getType() { return getType(Type::share).get(); }
-   bool operator==(const Variable &v);
+   bool operator==(const Variable &v) const;
 
    friend std::ostream &operator<<(std::ostream &os, Variable const& v) {
 	   v.print(os);
@@ -128,7 +128,7 @@ class DYNINST_EXPORT localVar : public AnnotatableSparse
 	int  getLineNum();
 	std::string &getFileName();
 	std::vector<VariableLocation> &getLocationLists();
-	bool operator==(const localVar &l);
+	bool operator==(const localVar &l) const;
 };
 
 }

--- a/symtabAPI/src/Aggregate.C
+++ b/symtabAPI/src/Aggregate.C
@@ -274,7 +274,7 @@ void Aggregate::print(std::ostream &os) const {
   os << " }";
 }
 
-bool Aggregate::operator==(const Aggregate &a)
+bool Aggregate::operator==(const Aggregate &a) const
 {
 	if (symbols_.size() != a.symbols_.size()) return false;
 	if (module_ && !a.module_) return false;

--- a/symtabAPI/src/Function.C
+++ b/symtabAPI/src/Function.C
@@ -399,7 +399,7 @@ std::string Function::getName() const
     return getFirstSymbol()->getMangledName();
 }
 
-bool FunctionBase::operator==(const FunctionBase &f)
+bool FunctionBase::operator==(const FunctionBase &f) const
 {
 	if (retType_ && !f.retType_)
 		return false;
@@ -411,7 +411,7 @@ bool FunctionBase::operator==(const FunctionBase &f)
 			return false;
 		}
 
-	return ((Aggregate &)(*this)) == ((const Aggregate &)f);
+	return ((const Aggregate &)(*this)) == ((const Aggregate &)f);
 }
 
 InlinedFunction::InlinedFunction(FunctionBase *parent) :

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -372,7 +372,7 @@ std::vector<Function*> Module::getAllFunctions() const
     return funcs;
 }
 
-bool Module::operator==(Module &mod) 
+bool Module::operator==(const Module &mod) const
 {
    if (exec_ && !mod.exec_) return false;
    if (!exec_ && mod.exec_) return false;

--- a/symtabAPI/src/Region.C
+++ b/symtabAPI/src/Region.C
@@ -104,7 +104,7 @@ Region& Region::operator=(const Region &reg)
     return *this;
 }
 
-bool Region::operator==(const Region &reg)
+bool Region::operator==(const Region &reg) const
 {
 
 	if (rels_.size() != reg.rels_.size()) return false;

--- a/symtabAPI/src/Variable.C
+++ b/symtabAPI/src/Variable.C
@@ -84,7 +84,7 @@ void Variable::print(std::ostream &os) const {
 	os  << 	"}";
 }
 
-bool Variable::operator==(const Variable &v)
+bool Variable::operator==(const Variable &v) const
 {
 	if (type_ && !v.type_)
 		return false;
@@ -95,7 +95,7 @@ bool Variable::operator==(const Variable &v)
 		{
 			return false;
 		}
-	return ((Aggregate &)(*this)) == ((const Aggregate &)v);
+	return ((const Aggregate &)(*this)) == ((const Aggregate &)v);
 }
 
 bool Variable::removeSymbol(Symbol *sym) 
@@ -297,7 +297,7 @@ std::vector<Dyninst::VariableLocation> &localVar::getLocationLists()
    return locs_;
 }
 
-bool localVar::operator==(const localVar &l)
+bool localVar::operator==(const localVar &l) const
 {
 	if (type_ && !l.type_) return false;
 	if (!type_ && l.type_) return false;


### PR DESCRIPTION
In C++20 and later the signature of operator== should be T::operator==(const T&) const otherwise it is ambiguous as these versions also look for matches with the arguments reversed and if only one is const then there is not a best match.