### PR TITLE
fix issues with calloc calls (order/overflow)

### DIFF
--- a/common/h/Annotatable.h
+++ b/common/h/Annotatable.h
@@ -172,7 +172,7 @@ class DYNINST_EXPORT AnnotatableDense
 
 		 if (annotations->data == NULL) 
 		 {
-			annotations->data = (anno_list_t *) calloc(sizeof(anno_list_t), (size));
+			annotations->data = (anno_list_t *) calloc(size, sizeof(anno_list_t));
 			annotations->max = size;
 			for (unsigned i=0; i<size; i++)
 				annotations->data[i] = NULL;
@@ -224,7 +224,7 @@ class DYNINST_EXPORT AnnotatableDense
 				  annotations = (aInfo *) malloc(sizeof(aInfo));
 				  unsigned size = rhs.annotations->max;
 				  annotations->max = size;
-				  annotations->data = (anno_list_t *)calloc(sizeof(anno_list_t), (size));
+				  annotations->data = (anno_list_t *)calloc(size, sizeof(anno_list_t));
 				  memcpy(annotations->data, rhs.annotations->data, size * sizeof(anno_list_t));
 			  }  else  {
 				  annotations = NULL;

--- a/dynC_API/src/C.y
+++ b/dynC_API/src/C.y
@@ -444,8 +444,12 @@ func_call: DYNINST BACKTICK IDENTIFIER '(' param_list ')'
           if(verbose) printf("break_ ()");
           $$ = new BPatch_breakPointExpr();
        }else{
-          char *errString = (char *)calloc(strlen($3), sizeof(char));
-          sprintf(errString, "%s not found!\n", $3);
+          const char fmt[] = "%s not found!\n";
+          // output size is bytes of fmt (which includes null terminator),
+          //     replacing %s (-2) with length of $3 (+strlen($3))
+          size_t errStringSize = sizeof(fmt) / sizeof(fmt[0]) - 2 + strlen($3);
+          char *errString = (char *)calloc(errStringSize, sizeof(char));
+          snprintf(errString, errStringSize, fmt, $3);
           yyerror(errString);
           $$ = new BPatch_nullExpr();
           free(errString);

--- a/dynC_API/src/dynC.tab.C
+++ b/dynC_API/src/dynC.tab.C
@@ -2026,8 +2026,12 @@ yyreduce:
           if(verbose) printf("break_ ()");
           (yyval.snippet) = new BPatch_breakPointExpr();
        }else{
-          char *errString = (char *)calloc(strlen((yyvsp[-3].sval)), sizeof(char));
-          sprintf(errString, "%s not found!\n", (yyvsp[-3].sval));
+          const char fmt[] = "%s not found!\n";
+          // output size is bytes of fmt (which includes null terminator),
+          //     replacing %s (-2) with length of $3 (+strlen($3))
+          size_t errStringSize = sizeof(fmt) / sizeof(fmt[0]) - 2 + strlen((yyvsp[-3].sval));
+          char *errString = (char *)calloc(errStringSize, sizeof(char));
+          snprintf(errString, errStringSize, fmt, (yyvsp[-3].sval));
           yyerror(errString);
           (yyval.snippet) = new BPatch_nullExpr();
           free(errString);


### PR DESCRIPTION
- fix order of calloc arguments that gcc 14 warns about: the correct order is number of elements, then size of elements

- fix buffer in one of the calloc calls: the number of elements calculations did not incorporate 13-bytes of output