### PR TITLE
update versions of github workflow actions

### DIFF
--- a/.github/workflows/libabigail.yaml
+++ b/.github/workflows/libabigail.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload Libs
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v4.4
       with:
         name: release-libs
         path: /opt/dyninst-env/install/dyninst/lib
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload Libs
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v4.4
       with:
         name: latest-libs
         path: /opt/dyninst-env/install/dyninst/lib
@@ -38,7 +38,7 @@ jobs:
          /bin/bash build.sh         
          
     - name: Upload results
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v4.4
       with:
         name: pr-libs
         path: /opt/dyninst-env/install/dyninst/lib
@@ -71,13 +71,13 @@ jobs:
 
     steps:
     - name: Download Previous Version
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4.1.8
       with:
         name: ${{ matrix.artifacts[1] }}
         path: previous/
 
     - name: Download Pull Request Version
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4.1.8
       with:
         name: ${{ matrix.artifacts[0] }}
         path: current/


### PR DESCRIPTION
- update download-artifact to 4.1.8 (eliminates security warning from dependabot that doesn't apply)

- update upload-artifact to 4.4 to be compatible with download

This is a correct fix for the dependabot suggested fix in #1773.  That patch does not update the upload-artifact and both need to be updated to be compatible. This workflow is not enabled and is untested,