### PR TITLE
Remove elfutils from public dependencies

### DIFF
--- a/cmake/DyninstConfig.cmake.in
+++ b/cmake/DyninstConfig.cmake.in
@@ -4,7 +4,6 @@ list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/Modules"
      "${CMAKE_CURRENT_LIST_DIR}/tpls")
 
 include(DyninstBoost)
-include(DyninstElfUtils)
 include(DyninstTBB)
 
 set(CMAKE_MODULE_PATH ${_DYNINST_module_path_save})

--- a/cmake/DyninstLibrary.cmake
+++ b/cmake/DyninstLibrary.cmake
@@ -93,20 +93,29 @@ function(dyninst_library _target)
       SOURCE_FILES # Both public and private
       DEFINES
       DYNINST_DEPS
+      DYNINST_INTERNAL_DEPS
       PUBLIC_DEPS
       PRIVATE_DEPS)
   # cmake-format: on
-  cmake_parse_arguments(PARSE_ARGV 0 _target "FORCE_STATIC" "" "${_keywords}")
+  cmake_parse_arguments(PARSE_ARGV 0 _target "FORCE_STATIC;INTERNAL_LIBRARY" "" "${_keywords}")
 
-  add_library(${_target} SHARED ${_target_PUBLIC_HEADER_FILES}
+  if(_target_INTERNAL_LIBRARY)
+    # Internal libraries never create actual library files (.so, .a, etc.)
+    set(_lib_type OBJECT)
+  else()
+    set(_lib_type SHARED)
+  endif()
+
+  add_library(${_target} ${_lib_type} ${_target_PUBLIC_HEADER_FILES}
                                 ${_target_PRIVATE_HEADER_FILES} ${_target_SOURCE_FILES})
 
-  # Depending on another Dyninst library is always public
-  target_link_libraries(${_target} PUBLIC ${_target_DYNINST_DEPS})
+  if(_target_INTERNAL_LIBRARY)
+    set_target_properties(${_target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  endif()
 
   set(_all_targets ${_target})
 
-  if(_target_FORCE_STATIC OR ENABLE_STATIC_LIBS)
+  if(NOT _target_INTERNAL_LIBRARY AND (_target_FORCE_STATIC OR ENABLE_STATIC_LIBS))
     list(APPEND _all_targets ${_target}_static)
     add_library(
       ${_target}_static STATIC ${_target_PUBLIC_HEADER_FILES}
@@ -128,6 +137,12 @@ function(dyninst_library _target)
 
   foreach(t ${_all_targets})
     message(STATUS "Adding library '${t}'")
+
+    # Depending on another Dyninst library is always public
+    target_link_libraries(${t} PUBLIC ${_target_DYNINST_DEPS})
+
+    # Internal library dependencies are NOT public
+    target_link_libraries(${t} PRIVATE ${_target_DYNINST_INTERNAL_DEPS})
 
     target_link_options(${t} PRIVATE $<$<COMPILE_LANGUAGE:C>:${DYNINST_LINK_FLAGS}>
                         $<$<COMPILE_LANGUAGE:CXX>:${DYNINST_CXX_LINK_FLAGS}>)

--- a/cmake/DyninstLibrary.cmake
+++ b/cmake/DyninstLibrary.cmake
@@ -96,8 +96,10 @@ function(dyninst_library _target)
       DYNINST_INTERNAL_DEPS
       PUBLIC_DEPS
       PRIVATE_DEPS)
-  # cmake-format: on
+  
   cmake_parse_arguments(PARSE_ARGV 0 _target "FORCE_STATIC;INTERNAL_LIBRARY" "" "${_keywords}")
+  
+  # cmake-format: on
 
   if(_target_INTERNAL_LIBRARY)
     # Internal libraries never create actual library files (.so, .a, etc.)
@@ -107,7 +109,7 @@ function(dyninst_library _target)
   endif()
 
   add_library(${_target} ${_lib_type} ${_target_PUBLIC_HEADER_FILES}
-                                ${_target_PRIVATE_HEADER_FILES} ${_target_SOURCE_FILES})
+                         ${_target_PRIVATE_HEADER_FILES} ${_target_SOURCE_FILES})
 
   if(_target_INTERNAL_LIBRARY)
     set_target_properties(${_target} PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/dwarf/CMakeLists.txt
+++ b/dwarf/CMakeLists.txt
@@ -22,7 +22,7 @@ dyninst_library(
   SOURCE_FILES ${_sources}
   DEFINES DYNDWARF_LIB
   DYNINST_DEPS dynElf common
-  PUBLIC_DEPS Dyninst::Boost_headers
-  PRIVATE_DEPS Dyninst::ElfUtils
+  PRIVATE_DEPS Dyninst::Boost_headers Dyninst::ElfUtils
+  INTERNAL_LIBRARY
 )
 # cmake-format: on

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -297,7 +297,8 @@ dyninst_library(
   dyninstAPI
   PUBLIC_HEADER_FILES ${_public_headers}
   SOURCE_FILES ${_sources}
-  DYNINST_DEPS common instructionAPI stackwalk pcontrol patchAPI parseAPI symtabAPI 
+  DYNINST_DEPS common instructionAPI stackwalk pcontrol patchAPI parseAPI symtabAPI
+  DYNINST_INTERNAL_DEPS dynDwarf dynElf
   PUBLIC_DEPS Dyninst::Boost_headers
   PRIVATE_DEPS Dyninst::ElfUtils Threads::Threads
 )

--- a/elf/CMakeLists.txt
+++ b/elf/CMakeLists.txt
@@ -19,7 +19,7 @@ dyninst_library(
   SOURCE_FILES ${_sources}
   DEFINES DYNELF_LIB
   DYNINST_DEPS common
-  PRIVATE_DEPS Dyninst::Boost_headers
-  PUBLIC_DEPS Dyninst::ElfUtils
+  PRIVATE_DEPS Dyninst::Boost_headers Dyninst::ElfUtils
+  INTERNAL_LIBRARY
 )
 # cmake-format: on

--- a/stackwalk/CMakeLists.txt
+++ b/stackwalk/CMakeLists.txt
@@ -70,7 +70,8 @@ dyninst_library(
   PUBLIC_HEADER_FILES ${_public_headers}
   PRIVATE_HEADER_FILES ${_private_headers}
   SOURCE_FILES ${_sources}
-  DYNINST_DEPS common dynDwarf dynElf instructionAPI pcontrol ${SYMREADER}
+  DYNINST_DEPS common instructionAPI pcontrol ${SYMREADER}
+  DYNINST_INTERNAL_DEPS dynDwarf dynElf
   PUBLIC_DEPS Dyninst::Boost_headers
   PRIVATE_DEPS Dyninst::ElfUtils
 )

--- a/symtabAPI/CMakeLists.txt
+++ b/symtabAPI/CMakeLists.txt
@@ -94,9 +94,9 @@ dyninst_library(
   PRIVATE_HEADER_FILES ${_private_headers}
   SOURCE_FILES ${_sources}
   DEFINES SYMTAB_LIB
-  DYNINST_DEPS common dynElf dynDwarf
-  PRIVATE_DEPS OpenMP::OpenMP_CXX Dyninst::Boost
-  PUBLIC_DEPS Dyninst::ElfUtils
+  DYNINST_DEPS common
+  DYNINST_INTERNAL_DEPS dynDwarf dynElf
+  PRIVATE_DEPS OpenMP::OpenMP_CXX Dyninst::Boost Dyninst::ElfUtils
 )
 # cmake-format: on
 


### PR DESCRIPTION
It's only used internally, so it shouldn't be exported. This will also make supporting other files formats (e.g., Windows PE) easier since we can properly hide those details.

This will cause link failures for consumers that explicitly pass `-ldyn{Dwarf,Elf}`. I'll run the consumers workflow to check for this, but I'm fairly certain I'll need to send patches to systemtap and TAU.

This will also cause a couple of failures in dyninst/external-tests because it tries to compile the dyn{Elf,Dwarf} headers. I'll post a PR to remove those tests.