### PR TITLE
GitHub CI: fix spelling of Ubuntu 24.04 name

### DIFF
--- a/.github/actions/os-versions/action.yaml
+++ b/.github/actions/os-versions/action.yaml
@@ -15,7 +15,7 @@ runs:
       run: |
         set -ex
         declare -a names=(
-                          ubuntu-20.04 ubuntu-22.04 ubuntu 24.04
+                          ubuntu-20.04 ubuntu-22.04 ubuntu-24.04
                           ubuntu-24.10
                           
                           fedora-37 fedora-38 fedora-39 fedora-40

--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -354,6 +354,7 @@ jobs:
           ./configure -dyninst=/dyninst/install
           make -j2
 
+  # Part of the Barcelona Supercomputing Performance Tools (https://github.com/bsc-performance-tools).
   extrae:
     runs-on: ubuntu-latest
     needs: get-oses


### PR DESCRIPTION
This was introduced by d9fc07182.

I also fixed the action failures for ubuntu-24.10 and fedora-4{0,1} due to incorrect access permissions on those packages.