### PR TITLE
Check for valid subrange bounds in DwarfWalker::parseSubrange()

### DIFF
--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -1254,6 +1254,10 @@ bool DwarfWalker::parseSubrange() {
    Dwarf_Die e = entry();
    auto subrange = parseSubrange(&e);
 
+   if(!subrange) {
+     return false;
+   }
+
    boost::shared_ptr<Type> rangeType = tc()->addOrUpdateType(subrange);
    dwarf_printf("(0x%lx) Created subrange type: ID 0x%d, pointer %p (tc %p)\n", id(),
                 rangeType->getID(), (void *)rangeType.get(), (void *)tc());


### PR DESCRIPTION
Fixes #1787

The underyling problem in #1787 is that the upper bound of the subrange is computed from a formal function parameter. It's not clear if that idiom is specific to Fortran, but it's something that should be added to subrange [parsing](https://github.com/dyninst/dyninst/blob/master/dwarf/src/dwarf_subrange.cpp#L61).