### PR TITLE
Fix Boost not found error on RHEL 9

### DIFF
--- a/cmake/tpls/DyninstBoost.cmake
+++ b/cmake/tpls/DyninstBoost.cmake
@@ -17,8 +17,12 @@
 
 include_guard(GLOBAL)
 
-# Need at least 1.71 for a usable BoostConfig.cmake
 set(_min_version 1.71.0)
+
+# Silence a warning about CMake 3.30 removing the FindBoost module
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 
 # Use multithreaded libraries
 set(Boost_USE_MULTITHREADED ON)
@@ -26,6 +30,7 @@ set(Boost_USE_MULTITHREADED ON)
 # Don't use libraries linked statically to the C++ runtime
 set(Boost_USE_STATIC_RUNTIME OFF)
 
+# Follow convention with custom Find modules
 if(Boost_ROOT_DIR)
   set(Boost_NO_SYSTEM_PATHS ON)
   set(Boost_ROOT ${Boost_ROOT_DIR})
@@ -36,15 +41,7 @@ set(Boost_NO_WARN_NEW_VERSIONS ON)
 
 # Library components that need to be linked against
 set(_boost_components atomic chrono date_time filesystem thread timer)
-find_package(
-  Boost
-  ${_min_version}
-  QUIET
-  REQUIRED
-  HINTS
-  ${PATH_BOOST}
-  ${BOOST_ROOT}
-  COMPONENTS ${_boost_components})
+find_package(Boost ${_min_version} QUIET REQUIRED COMPONENTS ${_boost_components})
 
 # Don't let Boost variables seep through
 mark_as_advanced(Boost_DIR)


### PR DESCRIPTION
Currently Dyninst can only find Boost if it has a `BoostConfig.cmake` (implied by the `find_package(... HINTS ...)` keyword). Some notable distros, specifically RHEL 9.x, have a new enough Boost to build Dyninst but do not package `BoostConfig.cmake`, which breaks the build.

This PR removes the `HINTS` syntax and allows using the `FindBoost.cmake` module shipped with CMake, which supports common variables like `BOOST_ROOT`, works without `BoostConfig.cmake`, and supports older versions of Boost.