### PR TITLE
Remove addressSpace::findJumpTargetFuncByAddr

### DIFF
--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -940,46 +940,6 @@ void AddressSpace::getAllModules(std::vector<mapped_module *> &mods){
    }
 }
 
-//Acts like findTargetFuncByAddr, but also finds the function if addr
-// is an indirect jump to a function.
-//I know this is an odd function, but darn I need it.
-func_instance *AddressSpace::findJumpTargetFuncByAddr(Address addr) {
-
-   Address addr2 = 0;
-   func_instance *f = findOneFuncByAddr(addr);
-   if (f)
-      return f;
-
-   if (!findObject(addr)) return NULL;
-
-   using namespace Dyninst::InstructionAPI;
-   InstructionDecoder decoder((const unsigned char*)getPtrToInstruction(addr),
-                              InstructionDecoder::maxInstructionLength,
-                              getArch());
-   Instruction curInsn = decoder.decode();
-    
-   Expression::Ptr target = curInsn.getControlFlowTarget();
-   RegisterAST thePC = RegisterAST::makePC(getArch());
-   target->bind(&thePC, Result(u32, addr));
-   Result cft = target->eval();
-   if(cft.defined)
-   {
-      switch(cft.type)
-      {
-         case u32:
-            addr2 = cft.val.u32val;
-            break;
-         case s32:
-            addr2 = cft.val.s32val;
-            break;
-         default:
-            assert(!"Not implemented for non-32 bit CFTs yet!");
-            break;
-      }
-   }
-   return findOneFuncByAddr(addr2);
-}
-
 AstNodePtr AddressSpace::trampGuardAST() {
    if (!trampGuardBase_) {
       // Don't have it yet....

--- a/dyninstAPI/src/addressSpace.h
+++ b/dyninstAPI/src/addressSpace.h
@@ -271,10 +271,6 @@ class AddressSpace : public InstructionSource {
 
 	// Fast lookups across all mapped_objects
 	func_instance *findFuncByEntry(const block_instance *block);
-
-    //findJumpTargetFuncByAddr Acts like findFunc, but if it fails,
-    // checks if 'addr' is a jump to a function.
-    func_instance *findJumpTargetFuncByAddr(Address addr);
     
     // true if the addrs are in the same object and region within the object
     bool sameRegion(Dyninst::Address addr1, Dyninst::Address addr2);


### PR DESCRIPTION
It was added by fb2612c0fac in 2007, but never used.