### PR TITLE
Use correct semantics when constructing AST for return instructions

### DIFF
--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -169,7 +169,7 @@ namespace Dyninst { namespace InstructionAPI {
     void appendOperand(Expression::Ptr e, bool isRead, bool isWritten, bool isImplicit = false,
                        bool trueP = false, bool falseP = false) const;
     void copyRaw(size_t size, const unsigned char* raw);
-    Expression::Ptr makeReturnExpression() const;
+
     mutable std::list<Operand> m_Operands;
     mutable Operation m_InsnOp;
     bool m_Valid;

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -326,9 +326,6 @@ namespace Dyninst { namespace InstructionAPI {
     if(getCategory() == c_NoCategory || isCompare() || isPrefetch()) {
       return Expression::Ptr();
     }
-    if(isReturn()) {
-      return makeReturnExpression();
-    }
     DECODE_OPERANDS();
     if(m_Successors.empty()) {
       return Expression::Ptr();
@@ -415,14 +412,6 @@ namespace Dyninst { namespace InstructionAPI {
   DYNINST_EXPORT bool Instruction::isLegalInsn() const { return (m_InsnOp.getID() != e_No_Entry); }
 
   DYNINST_EXPORT Architecture Instruction::getArch() const { return arch_decoded_from; }
-
-  Expression::Ptr Instruction::makeReturnExpression() const {
-    Expression::Ptr stackPtr =
-        Expression::Ptr(new RegisterAST(MachRegister::getStackPointer(arch_decoded_from), 0,
-                                        MachRegister::getStackPointer(arch_decoded_from).size()));
-    Expression::Ptr retLoc = Expression::Ptr(new Dereference(stackPtr, u32));
-    return retLoc;
-  }
 
   DYNINST_EXPORT InsnCategory Instruction::getCategory() const {
     if(m_InsnOp.isVectorInsn)

--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -2999,12 +2999,15 @@ Expression::Ptr InstructionDecoder_aarch64::makeMemRefExPair2(){
                     insn_in_progress->appendOperand(makePstateExpr(), isPstateRead, isPstateWritten, true);
             }
 
-            if(insn_in_progress->getCategory() == c_ReturnInsn) {
+            if(insn_in_progress->getOperation().getID() == aarch64_op_ret) {
               /*********************************************************************
                *  Arm A64 Instruction Set Architecture Armv8. March 2021
                *
                *  The conventional return sequence is to use `ret {Xn}` where the
                *  register is optional (in which case it is assumed to be X30).
+               *
+               *  There is no representation for `retaa` and `retab`, yet.
+               *
                *********************************************************************/
               auto res = [this]() -> std::pair<Expression::Ptr,bool> {
                 if(this->insn_in_progress->m_Operands.size()) {

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -320,17 +320,19 @@ namespace Dyninst
             std::mem_fn(*curFn)(this);
         }
 
-        if(insn_in_progress->getCategory() == c_ReturnInsn) {
-          /*********************************************************************
-           *  Power ISA Version 3.1, Book I. May 2020. 2.4 Branch Instructions
-           *
-           *  The conventional return sequence is to use `bclr` (Branch
-           *  Conditional to Link Register) with BH=0b00.
-           *********************************************************************/
-          insn_in_progress->addSuccessor(makeRegisterExpression(ppc32::lr), false, true, false, false, true);
-        }
-        if(current->op == power_op_bclr && bcIsConditional) {
+        // bclr is either a conventional branch or used as a return from a procedure
+        if(current->op == power_op_bclr) {
+          if(bcIsConditional) {
             insn_in_progress->addSuccessor(makeFallThroughExpr(), false, false, false, true);
+          } else {
+            /*********************************************************************
+             *  Power ISA Version 3.1, Book I. May 2020. 2.4 Branch Instructions
+             *
+             *  The conventional return sequence is to use `bclr` (Branch
+             *  Conditional to Link Register) with BH=0b00.
+             *********************************************************************/
+            insn_in_progress->addSuccessor(makeRegisterExpression(ppc32::lr), false, true, false, false, true);
+          }
         }
         if(current->op == power_op_bcctr)
         {

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -319,17 +319,18 @@ namespace Dyninst
         {
             std::mem_fn(*curFn)(this);
         }
-        if(current->op == power_op_bclr)
-        {
-	  // blrl is in practice a return-and-link, not a call-through-LR
-	  // so we'll treat it as such
-            insn_in_progress->addSuccessor(makeRegisterExpression(ppc32::lr),
-                                           /*field<31,31>(insn) == 1*/ false, true, 
-					   bcIsConditional, false);
-            if(bcIsConditional)
-            {
-                insn_in_progress->addSuccessor(makeFallThroughExpr(), false, false, false, true);
-            }
+
+        if(insn_in_progress->getCategory() == c_ReturnInsn) {
+          /*********************************************************************
+           *  Power ISA Version 3.1, Book I. May 2020. 2.4 Branch Instructions
+           *
+           *  The conventional return sequence is to use `bclr` (Branch
+           *  Conditional to Link Register) with BH=0b00.
+           *********************************************************************/
+          insn_in_progress->addSuccessor(makeRegisterExpression(ppc32::lr), false, true, false, false, true);
+        }
+        if(current->op == power_op_bclr && bcIsConditional) {
+            insn_in_progress->addSuccessor(makeFallThroughExpr(), false, false, false, true);
         }
         if(current->op == power_op_bcctr)
         {

--- a/instructionAPI/src/InstructionDecoder-x86.C
+++ b/instructionAPI/src/InstructionDecoder-x86.C
@@ -1845,7 +1845,8 @@ namespace Dyninst
             sGetImplicitOPs(decodedInstruction->getEntry()->impl_dec);
         InstructionDecoder::buffer b(insn_to_complete->ptr(), insn_to_complete->size());
 
-        if(insn_to_complete->getCategory() == c_ReturnInsn) {
+        if (decodedInstruction->getEntry()->getID() == e_ret_near ||
+            decodedInstruction->getEntry()->getID() == e_ret_far) {
           /************************************************************************
            *  AMD64 Architecture Programmer’s Manual Volume 3. Version 3.33. Nov 2021
            *


### PR DESCRIPTION
Instruction::makeReturnInstruction always assumes a 32-bit unsigned value is read from the top of the stack. This is not true for Aarch64 and ppc64le (and probably not for RISCV). In fact, ppc and x86 (kind of) already create AST for return instructions, but it gets ignored by Instruction::getControlFlowTarget.