### PR TITLE
Clean up Operand, Operator, and Instruction classes from InstructionAPI

### DIFF
--- a/instructionAPI/doc/API/Instruction.tex
+++ b/instructionAPI/doc/API/Instruction.tex
@@ -158,8 +158,7 @@ bool isWritten(Expression::Ptr candidate) const
 bool readsMemory() const
 \end{apient}
 \apidesc{
-    Returns \code{true} if the instruction reads at least one memory address as
-    data.
+    Returns \code{true} if the instruction reads from at least one memory address.
 
     If any operand containing a \code{Dereference} object is read, the
     instruction reads the memory at that address. Also, on platforms where a
@@ -171,8 +170,7 @@ bool readsMemory() const
 bool writesMemory() const
 \end{apient}
 \apidesc{
-    Returns \code{true} if the instruction writes at least one memory address as
-    data.
+    Returns \code{true} if the instruction writes to at least one memory address.
 
     If any operand containing a \code{Dereference} object is write, the
     instruction writes the memory at that address. Also, on platforms where a

--- a/instructionAPI/doc/API/Instruction.tex
+++ b/instructionAPI/doc/API/Instruction.tex
@@ -72,6 +72,14 @@ were decoded.
 }
 
 \begin{apient}
+std::vector<Operand> getDisplayOrderedOperands() const
+\end{apient}
+\apidesc{
+  Returns a vector of non-implicit operands in printed order.
+}
+
+
+\begin{apient}
 Operand getOperand(int index) const
 \end{apient}
 \apidesc{

--- a/instructionAPI/doc/API/Operand.tex
+++ b/instructionAPI/doc/API/Operand.tex
@@ -23,6 +23,8 @@ Operand(Expression::Ptr val, bool read, bool written)
     \code{val} is a reference-counted pointer to the \code{Expression} that will
     be contained in the \code{Operand} being constructed. \code{read} is true if
     this operand is read. \code{written} is true if this operand is written.
+    
+    An instruction can be true predicated, false predicated, or not predicated at all.
 }
 
 \begin{apient}

--- a/instructionAPI/doc/API/Operation.tex
+++ b/instructionAPI/doc/API/Operation.tex
@@ -26,7 +26,27 @@ As an example, the \code{CMP} operation on IA32/AMD64 processors has the followi
 \end{itemize}
 
 Operations are constructed by the \code{InstructionDecoder} as part of the
-process of constructing an Instruction. 
+process of constructing an Instruction.
+
+OpCode = operation + encoding
+\begin{itemize}
+\item hex value
+\item information on how to decode operands
+\item operation encoded
+\end{itemize}
+
+Operation = what an instruction does
+\begin{itemize}
+\item read/write semantics on explicit operands
+\item register implicit read/write lists, including flags
+\item string/enum representation of the operation
+\end{itemize}
+
+Some use cases include
+
+OpCode + raw instruction -> Operation + ExpressionPtrs
+Operation + ExpressionPtrs -> Instruction + Operands
+
 
 \begin{apient}
 const Operation::registerSet & implicitReads () const

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -51,35 +51,9 @@ namespace Dyninst
   namespace InstructionAPI
   {
       class InstructionDecoder;
-    /// The %Instruction class is a generic instruction representation that contains operands,
-    /// read/write semantic information about those operands, and information about
-    /// what other registers and memory locations are affected by the operation the instruction performs.
-    ///
-    /// The purpose of an %Instruction object is to join an %Operation with a sequence of %Operands, and provide
-    /// an interface for some common summary analyses (namely, the read/write sets, memory access information,
-    /// and control flow information).
-    ///
-    /// The %Operation contains knowledge about its mnemonic and sufficient semantic
-    /// details to answer the following questions:
-    ///   - What %Operands are read/written?
-    ///   - What registers are implicitly read/written?
-    ///   - What memory locations are implicitly read/written?
-    ///   - What are the possible control flow successors of this instruction?
-    ///
-    /// Each %Operand is an AST built from %RegisterAST and %Immediate leaves.  For each %Operand, you may determine:
-    ///   - Registers read
-    ///   - Registers written
-    ///   - Whether memory is read or written
-    ///   - Which memory addresses are read or written, given the state of all relevant registers
-    ///
-    /// Instructions should be constructed from an \c unsigned \c char* pointing to machine language, using the
-    /// %InstructionDecoder class.  See InstructionDecoder for more details.
-    ///
+
     class Instruction
     {
-        /// Component version information corresponding to \c libInstructionAPI.so.(major).(minor).(maintenance)
-        /// Note that \c maintenance may be absent from the binary (in which case, it will be zero in the interface).
-
         DYNINST_EXPORT static void version(int& major, int& minor, int& maintenance);
       union raw_insn_T
       {
@@ -108,22 +82,6 @@ namespace Dyninst
             CFT(Expression::Ptr t, bool call, bool indir, bool cond, bool ft) :
                     target(t), isCall(call), isIndirect(indir), isConditional(cond), isFallthrough(ft) {}
         };
-      /// \param what Opcode of the instruction
-      /// \param operandSource Contains the %Expressions to be transformed into %Operands
-      /// \param size Contains the number of bytes occupied by the corresponding machine instruction
-      /// \param raw Contains a pointer to the buffer from which this instruction object
-      /// was decoded.
-      ///
-      /// Construct an %Instruction from an %Operation and a collection of %Expressions.  This
-      /// method is not intended to be used except by the %InstructionDecoder class, which serves as a
-      /// factory class for producing %Instruction objects.  While an %Instruction object may be built
-      /// "by hand" if desired, using the decoding interface ensures that the operation and operands
-      /// are a sensible combination, and that the size reported is based on the actual size of a legal
-      /// encoding of the machine instruction represented.
-      /// In the course of constructing an %Instruction, the %Expressions in \c operandSource
-      /// will be transformed to %Operand objects.  This transformation will map the semantic information about
-      /// which operands are read and written
-      /// in the %Operation object \c what to the value computations in \c operandSource.
 
       DYNINST_EXPORT Instruction(Operation what, size_t size, const unsigned char* raw,
                                      Dyninst::Architecture arch);
@@ -135,147 +93,55 @@ namespace Dyninst
       DYNINST_EXPORT const Instruction& operator=(const Instruction& rhs);
 
 
-      /// \return The %Operation used by the %Instruction
-      ///
-      /// See Operation for details of the %Operation interface.
       DYNINST_EXPORT Operation& getOperation();
       DYNINST_EXPORT const Operation& getOperation() const;
 
-      /// The vector \c operands has the instruction's operands appended to it
-      /// in the same order that they were decoded.
       DYNINST_EXPORT void getOperands(std::vector<Operand>& operands) const;
 
       /// Returns a vector of non-implicit operands in printed order
       DYNINST_EXPORT std::vector<Operand> getDisplayOrderedOperands() const;
 
-      /// The \c getOperand method returns the operand at position \c index, or
-      /// an empty operand if \c index does not correspond to a valid operand in this
-      /// instruction.
       DYNINST_EXPORT Operand getOperand(int index) const;
 
       DYNINST_EXPORT Operand getPredicateOperand() const;
       DYNINST_EXPORT bool hasPredicateOperand() const;
 
-      /// Returns a pointer to the buffer from which this instruction
-      /// was decoded.
       DYNINST_EXPORT unsigned char rawByte(unsigned int index) const;
 
-      /// Returns the size of the corresponding machine instruction, in bytes.
       DYNINST_EXPORT size_t size() const;
 
-      /// Returns a pointer to the raw byte representation of the corresponding
-      /// machine instruction.
       DYNINST_EXPORT const void* ptr() const;
-
-      /// \param regsWritten Insert the set of registers written by the instruction into \c regsWritten.
-      ///
-      /// The list of registers returned in \c regsWritten includes registers that are explicitly written as destination
-      /// operands (like the destination of a move).  It also includes registers
-      /// that are implicitly written (like the
-      /// stack pointer in a push or pop instruction).  It does not include
-      /// any registers used only in computing the effective address of a write.
-      /// \c pop \c *eax, for example, writes to \c esp, reads \c esp, and reads \c eax,
-      /// but despite the fact that \c *eax is the destination operand, \c eax is not
-      /// itself written.
-      ///
-      /// For both the write set and the read set (below), it is possible to determine whether a register
-      /// is accessed implicitly or explicitly by examining the %Operands.  An explicitly accessed register appears
-      /// as an operand that is written or read; also, any registers used in any address calculations are explicitly
-      /// read.  Any element of the write set or read set that is not explicitly written or read is implicitly
-      /// written or read.
 
       DYNINST_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
 
-      /// \param regsRead Insert the set of registers read by the instruction into \c regsRead.
-      ///
-      /// If an operand is used to compute an effective address, the registers
-      /// involved are read but not written, regardless of the effect on the operand.
       DYNINST_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
 
-      /// \param candidate Subexpression to search for among the values read by this %Instruction object.
-      ///
-      /// Returns true if \c candidate is read by this %Instruction.
       DYNINST_EXPORT bool isRead(Expression::Ptr candidate) const;
 
-      /// \param candidate Subexpression to search for among the values written by this %Instruction object.
-      ///
-      /// Returns true if \c candidate is written by this %Instruction.
       DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) const;
 
-
-      /// \return Returns true if the instruction reads at least one memory address as data.
-      ///
-      /// If any operand containing a  %Dereference object is read, the instruction
-      /// reads the memory at that address.
-      /// Also, on platforms where a stack pop is guaranteed to read memory,
-      /// \c readsMemory will return true for a pop operation.
       DYNINST_EXPORT bool readsMemory() const;
 
       DYNINST_EXPORT ArchSpecificFormatter& getFormatter() const;
 
-      /// \return Returns true if the instruction writes at least one memory address.
-      ///
-      /// If any operand containing a  %Dereference object is written, the instruction
-      /// writes the memory at that address.
-      /// Also, on platforms where a stack push is guaranteed to write memory,
-      /// \c writesMemory will return true for a push operation.
       DYNINST_EXPORT bool writesMemory() const;
 
-      /// \param memAccessors Addresses read by this instruction are inserted into \c memAccessors
-      ///
-      /// The addresses read are in the form of %Expressions, which may be evaluated once all of the
-      /// registers that they use have had their values set.
-      /// Note that this method returns ASTs representing address computations, and not address accesses.  For instance,
-      /// an instruction accessing memory through a register dereference would return a %Expression tree containing
-      /// just the register that determines the address being accessed, not a tree representing a dereference of that register.
       DYNINST_EXPORT void getMemoryReadOperands(std::set<Expression::Ptr>& memAccessors) const;
 
-      /// \param memAccessors Addresses written by this instruction are inserted into \c memAccessors
-      ///
-      /// The addresses written are in the same form as those returned by \c getMemoryReadOperands above.
       DYNINST_EXPORT void getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const;
 
-      /// \return An expression evaluating to the non-fallthrough control flow targets, if any, of this instruction.
-      ///
-      /// When called on an explicitly control-flow altering instruction, returns the
-      /// non-fallthrough control flow destination.  When called on any other instruction,
-      /// returns \c NULL.
-      ///
-      /// For direct absolute branch instructions, \c getControlFlowTarget will return an immediate value.
-      /// For direct relative branch instructions, \c getControlFlowTarget will return the expression
-      /// \c PC + offset.
-      /// In the case of indirect branches and calls, it returns a dereference of a register (or possibly
-      /// a dereference of a more complicated expression).  In this case,
-      /// data flow analysis will often allow the determination of the possible targets of the
-      /// instruction.  We do not do analysis beyond the single-instruction level
-      /// in the %Instruction API; if other code performs this type of analysis,
-      /// it may update the information in the %Dereference object using the setValue method in the %Expression interface.
-      /// More details about this may be found in Expression and Dereference.
       DYNINST_EXPORT Expression::Ptr getControlFlowTarget() const;
 
-      /// \return False if control flow will unconditionally go to the result of
-      /// \c getControlFlowTarget after executing this instruction.
       DYNINST_EXPORT bool allowsFallThrough() const;
 
-      /// \return The instruction as a string of assembly language
-      ///
-      /// \c format is principally a helper function; %Instructions are meant to be written to
-      /// output streams via \c operator<<.  \c format is included in the public interface for
-      /// diagnostic purposes.
       DYNINST_EXPORT std::string format(Address addr = 0) const;
 
-      /// Returns true if this %Instruction object is valid.  Invalid instructions indicate that
-      /// an %InstructionDecoder has reached the end of its assigned range, and that decoding should terminate.
       DYNINST_EXPORT bool isValid() const;
 
-      /// Returns true if this %Instruction object represents a legal instruction, as specified by the architecture
-      /// used to decode this instruction.
       DYNINST_EXPORT bool isLegalInsn() const;
 
       DYNINST_EXPORT Architecture getArch() const;
 
-      /// Currently, the valid categories are c_CallInsn, c_ReturnInsn, c_BranchInsn, c_CompareInsn,
-      /// and c_NoCategory, as defined in %InstructionCategories.h.
       DYNINST_EXPORT InsnCategory getCategory() const;
 
       typedef std::list<CFT>::const_iterator cftConstIter;

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -79,9 +79,7 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT Instruction(Operation what, size_t size, const unsigned char* raw,
                                Dyninst::Architecture arch);
     DYNINST_EXPORT Instruction();
-
     DYNINST_EXPORT virtual ~Instruction();
-
     DYNINST_EXPORT Instruction(const Instruction& o);
     DYNINST_EXPORT const Instruction& operator=(const Instruction& rhs);
 
@@ -89,46 +87,38 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT const Operation& getOperation() const;
 
     DYNINST_EXPORT void getOperands(std::vector<Operand>& operands) const;
+    DYNINST_EXPORT Operand getOperand(int index) const;
 
     DYNINST_EXPORT std::vector<Operand> getDisplayOrderedOperands() const;
-
-    DYNINST_EXPORT Operand getOperand(int index) const;
 
     DYNINST_EXPORT Operand getPredicateOperand() const;
     DYNINST_EXPORT bool hasPredicateOperand() const;
 
     DYNINST_EXPORT unsigned char rawByte(unsigned int index) const;
+    DYNINST_EXPORT const void* ptr() const;
 
     DYNINST_EXPORT size_t size() const;
 
-    DYNINST_EXPORT const void* ptr() const;
-
     DYNINST_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
-
     DYNINST_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
 
     DYNINST_EXPORT bool isRead(Expression::Ptr candidate) const;
-
     DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) const;
 
     DYNINST_EXPORT bool readsMemory() const;
-
-    DYNINST_EXPORT ArchSpecificFormatter& getFormatter() const;
-
     DYNINST_EXPORT bool writesMemory() const;
 
     DYNINST_EXPORT void getMemoryReadOperands(std::set<Expression::Ptr>& memAccessors) const;
-
     DYNINST_EXPORT void getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const;
 
     DYNINST_EXPORT Expression::Ptr getControlFlowTarget() const;
 
     DYNINST_EXPORT bool allowsFallThrough() const;
 
+    DYNINST_EXPORT ArchSpecificFormatter& getFormatter() const;
     DYNINST_EXPORT std::string format(Address addr = 0) const;
 
     DYNINST_EXPORT bool isValid() const;
-
     DYNINST_EXPORT bool isLegalInsn() const;
 
     DYNINST_EXPORT Architecture getArch() const;
@@ -136,9 +126,7 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT InsnCategory getCategory() const;
 
     typedef std::list<CFT>::const_iterator cftConstIter;
-
     DYNINST_EXPORT cftConstIter cft_begin() const { return m_Successors.begin(); }
-
     DYNINST_EXPORT cftConstIter cft_end() const { return m_Successors.end(); }
 
     DYNINST_EXPORT bool operator<(const Instruction& rhs) const {

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -50,8 +50,6 @@ namespace Dyninst
 {
   namespace InstructionAPI
   {
-      class InstructionDecoder;
-
     class Instruction
     {
         DYNINST_EXPORT static void version(int& major, int& minor, int& maintenance);

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -96,7 +96,6 @@ namespace Dyninst
 
       DYNINST_EXPORT void getOperands(std::vector<Operand>& operands) const;
 
-      /// Returns a vector of non-implicit operands in printed order
       DYNINST_EXPORT std::vector<Operand> getDisplayOrderedOperands() const;
 
       DYNINST_EXPORT Operand getOperand(int index) const;

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -47,7 +47,6 @@
 
 namespace Dyninst { namespace InstructionAPI {
   class Instruction {
-    DYNINST_EXPORT static void version(int& major, int& minor, int& maintenance);
 
     union raw_insn_T {
 #if defined(__powerpc__) || defined(__powerpc64__)

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -168,7 +168,6 @@ namespace Dyninst { namespace InstructionAPI {
     unsigned int m_size;
     Architecture arch_decoded_from;
     mutable std::list<CFT> m_Successors;
-    static int numInsnsAllocated;
     // formatter is a non-owning pointer to a singleton object
     ArchSpecificFormatter* formatter;
   };

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -31,166 +31,160 @@
 #if !defined(INSTRUCTION_H)
 #define INSTRUCTION_H
 
-
-#include <stddef.h>
-#include <string>
-#include <string.h>
-#include <vector>
-#include <set>
-#include <list>
-#include "Expression.h"
-#include "Operation_impl.h"
-#include "Operand.h"
-#include "InstructionCategories.h"
 #include "ArchSpecificFormatters.h"
-
+#include "Expression.h"
+#include "InstructionCategories.h"
+#include "Operand.h"
+#include "Operation_impl.h"
 #include "util.h"
 
-namespace Dyninst
-{
-  namespace InstructionAPI
-  {
-    class Instruction
-    {
-        DYNINST_EXPORT static void version(int& major, int& minor, int& maintenance);
-      union raw_insn_T
-      {
+#include <list>
+#include <set>
+#include <stddef.h>
+#include <string.h>
+#include <string>
+#include <vector>
+
+namespace Dyninst { namespace InstructionAPI {
+  class Instruction {
+    DYNINST_EXPORT static void version(int& major, int& minor, int& maintenance);
+
+    union raw_insn_T {
 #if defined(__powerpc__) || defined(__powerpc64__)
-	unsigned int small_insn;
+      unsigned int small_insn;
 #else
-	uintptr_t small_insn;
+      uintptr_t small_insn;
 #endif
-	unsigned char* large_insn;
-      };
-    public:
-        friend class InstructionDecoder_x86;
-        friend class InstructionDecoder_power;
-        friend class InstructionDecoder_aarch64;
-        friend class InstructionDecoder_amdgpu_gfx908;
-        friend class InstructionDecoder_amdgpu_gfx90a;
-        friend class InstructionDecoder_amdgpu_gfx940;
-
-        struct CFT
-        {
-            Expression::Ptr target;
-            bool isCall;
-            bool isIndirect;
-            bool isConditional;
-            bool isFallthrough;
-            CFT(Expression::Ptr t, bool call, bool indir, bool cond, bool ft) :
-                    target(t), isCall(call), isIndirect(indir), isConditional(cond), isFallthrough(ft) {}
-        };
-
-      DYNINST_EXPORT Instruction(Operation what, size_t size, const unsigned char* raw,
-                                     Dyninst::Architecture arch);
-      DYNINST_EXPORT Instruction();
-
-      DYNINST_EXPORT virtual ~Instruction();
-
-      DYNINST_EXPORT Instruction(const Instruction& o);
-      DYNINST_EXPORT const Instruction& operator=(const Instruction& rhs);
-
-
-      DYNINST_EXPORT Operation& getOperation();
-      DYNINST_EXPORT const Operation& getOperation() const;
-
-      DYNINST_EXPORT void getOperands(std::vector<Operand>& operands) const;
-
-      DYNINST_EXPORT std::vector<Operand> getDisplayOrderedOperands() const;
-
-      DYNINST_EXPORT Operand getOperand(int index) const;
-
-      DYNINST_EXPORT Operand getPredicateOperand() const;
-      DYNINST_EXPORT bool hasPredicateOperand() const;
-
-      DYNINST_EXPORT unsigned char rawByte(unsigned int index) const;
-
-      DYNINST_EXPORT size_t size() const;
-
-      DYNINST_EXPORT const void* ptr() const;
-
-      DYNINST_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
-
-      DYNINST_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
-
-      DYNINST_EXPORT bool isRead(Expression::Ptr candidate) const;
-
-      DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) const;
-
-      DYNINST_EXPORT bool readsMemory() const;
-
-      DYNINST_EXPORT ArchSpecificFormatter& getFormatter() const;
-
-      DYNINST_EXPORT bool writesMemory() const;
-
-      DYNINST_EXPORT void getMemoryReadOperands(std::set<Expression::Ptr>& memAccessors) const;
-
-      DYNINST_EXPORT void getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const;
-
-      DYNINST_EXPORT Expression::Ptr getControlFlowTarget() const;
-
-      DYNINST_EXPORT bool allowsFallThrough() const;
-
-      DYNINST_EXPORT std::string format(Address addr = 0) const;
-
-      DYNINST_EXPORT bool isValid() const;
-
-      DYNINST_EXPORT bool isLegalInsn() const;
-
-      DYNINST_EXPORT Architecture getArch() const;
-
-      DYNINST_EXPORT InsnCategory getCategory() const;
-
-      typedef std::list<CFT>::const_iterator cftConstIter;
-      DYNINST_EXPORT cftConstIter cft_begin() const {
-          return m_Successors.begin();
-      }
-        DYNINST_EXPORT cftConstIter cft_end() const {
-            return m_Successors.end();
-        }
-        DYNINST_EXPORT bool operator<(const Instruction& rhs) const
-        {
-            if(m_size < rhs.m_size) return true;
-            if(m_size <= sizeof(m_RawInsn.small_insn)) {
-                return m_RawInsn.small_insn < rhs.m_RawInsn.small_insn;
-            }
-            return memcmp(m_RawInsn.large_insn, rhs.m_RawInsn.large_insn, m_size) < 0;
-        }
-        DYNINST_EXPORT bool operator==(const Instruction& rhs) const {
-            if(m_size != rhs.m_size) return false;
-            if(m_size <= sizeof(m_RawInsn.small_insn)) {
-                return m_RawInsn.small_insn == rhs.m_RawInsn.small_insn;
-            }
-            return memcmp(m_RawInsn.large_insn, rhs.m_RawInsn.large_insn, m_size) == 0;
-        }
-        DYNINST_EXPORT void updateMnemonic(std::string new_mnemonic) {
-                m_InsnOp.updateMnemonic(new_mnemonic);
-            }
-
-
-      typedef boost::shared_ptr<Instruction> Ptr;
-
-    private:
-      void updateSize(const unsigned int new_size) {m_size = new_size;}
-      void decodeOperands() const;
-      void addSuccessor(Expression::Ptr e, bool isCall, bool isIndirect, bool isConditional, bool isFallthrough, bool isImplicit = false) const;
-      void appendOperand(Expression::Ptr e, bool isRead, bool isWritten, bool isImplicit = false, bool trueP = false, bool falseP = false) const;
-      void copyRaw(size_t size, const unsigned char* raw);
-      Expression::Ptr makeReturnExpression() const;
-      mutable std::list<Operand> m_Operands;
-      mutable Operation m_InsnOp;
-      bool m_Valid;
-      raw_insn_T m_RawInsn;
-      unsigned int m_size;
-      Architecture arch_decoded_from;
-      mutable std::list<CFT> m_Successors;
-      static int numInsnsAllocated;
-      // formatter is a non-owning pointer to a singleton object
-      ArchSpecificFormatter* formatter;
+      unsigned char* large_insn;
     };
-  }
-}
 
+  public:
+    friend class InstructionDecoder_x86;
+    friend class InstructionDecoder_power;
+    friend class InstructionDecoder_aarch64;
+    friend class InstructionDecoder_amdgpu_gfx908;
+    friend class InstructionDecoder_amdgpu_gfx90a;
+    friend class InstructionDecoder_amdgpu_gfx940;
 
+    struct CFT {
+      Expression::Ptr target;
+      bool isCall;
+      bool isIndirect;
+      bool isConditional;
+      bool isFallthrough;
 
-#endif //!defined(INSTRUCTION_H)
+      CFT(Expression::Ptr t, bool call, bool indir, bool cond, bool ft)
+          : target(t), isCall(call), isIndirect(indir), isConditional(cond), isFallthrough(ft) {}
+    };
+
+    DYNINST_EXPORT Instruction(Operation what, size_t size, const unsigned char* raw,
+                               Dyninst::Architecture arch);
+    DYNINST_EXPORT Instruction();
+
+    DYNINST_EXPORT virtual ~Instruction();
+
+    DYNINST_EXPORT Instruction(const Instruction& o);
+    DYNINST_EXPORT const Instruction& operator=(const Instruction& rhs);
+
+    DYNINST_EXPORT Operation& getOperation();
+    DYNINST_EXPORT const Operation& getOperation() const;
+
+    DYNINST_EXPORT void getOperands(std::vector<Operand>& operands) const;
+
+    DYNINST_EXPORT std::vector<Operand> getDisplayOrderedOperands() const;
+
+    DYNINST_EXPORT Operand getOperand(int index) const;
+
+    DYNINST_EXPORT Operand getPredicateOperand() const;
+    DYNINST_EXPORT bool hasPredicateOperand() const;
+
+    DYNINST_EXPORT unsigned char rawByte(unsigned int index) const;
+
+    DYNINST_EXPORT size_t size() const;
+
+    DYNINST_EXPORT const void* ptr() const;
+
+    DYNINST_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
+
+    DYNINST_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
+
+    DYNINST_EXPORT bool isRead(Expression::Ptr candidate) const;
+
+    DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) const;
+
+    DYNINST_EXPORT bool readsMemory() const;
+
+    DYNINST_EXPORT ArchSpecificFormatter& getFormatter() const;
+
+    DYNINST_EXPORT bool writesMemory() const;
+
+    DYNINST_EXPORT void getMemoryReadOperands(std::set<Expression::Ptr>& memAccessors) const;
+
+    DYNINST_EXPORT void getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const;
+
+    DYNINST_EXPORT Expression::Ptr getControlFlowTarget() const;
+
+    DYNINST_EXPORT bool allowsFallThrough() const;
+
+    DYNINST_EXPORT std::string format(Address addr = 0) const;
+
+    DYNINST_EXPORT bool isValid() const;
+
+    DYNINST_EXPORT bool isLegalInsn() const;
+
+    DYNINST_EXPORT Architecture getArch() const;
+
+    DYNINST_EXPORT InsnCategory getCategory() const;
+
+    typedef std::list<CFT>::const_iterator cftConstIter;
+
+    DYNINST_EXPORT cftConstIter cft_begin() const { return m_Successors.begin(); }
+
+    DYNINST_EXPORT cftConstIter cft_end() const { return m_Successors.end(); }
+
+    DYNINST_EXPORT bool operator<(const Instruction& rhs) const {
+      if(m_size < rhs.m_size)
+        return true;
+      if(m_size <= sizeof(m_RawInsn.small_insn)) {
+        return m_RawInsn.small_insn < rhs.m_RawInsn.small_insn;
+      }
+      return memcmp(m_RawInsn.large_insn, rhs.m_RawInsn.large_insn, m_size) < 0;
+    }
+
+    DYNINST_EXPORT bool operator==(const Instruction& rhs) const {
+      if(m_size != rhs.m_size)
+        return false;
+      if(m_size <= sizeof(m_RawInsn.small_insn)) {
+        return m_RawInsn.small_insn == rhs.m_RawInsn.small_insn;
+      }
+      return memcmp(m_RawInsn.large_insn, rhs.m_RawInsn.large_insn, m_size) == 0;
+    }
+
+    DYNINST_EXPORT void updateMnemonic(std::string new_mnemonic) { m_InsnOp.updateMnemonic(new_mnemonic); }
+
+    typedef boost::shared_ptr<Instruction> Ptr;
+
+  private:
+    void updateSize(const unsigned int new_size) { m_size = new_size; }
+
+    void decodeOperands() const;
+    void addSuccessor(Expression::Ptr e, bool isCall, bool isIndirect, bool isConditional, bool isFallthrough,
+                      bool isImplicit = false) const;
+    void appendOperand(Expression::Ptr e, bool isRead, bool isWritten, bool isImplicit = false,
+                       bool trueP = false, bool falseP = false) const;
+    void copyRaw(size_t size, const unsigned char* raw);
+    Expression::Ptr makeReturnExpression() const;
+    mutable std::list<Operand> m_Operands;
+    mutable Operation m_InsnOp;
+    bool m_Valid;
+    raw_insn_T m_RawInsn;
+    unsigned int m_size;
+    Architecture arch_decoded_from;
+    mutable std::list<CFT> m_Successors;
+    static int numInsnsAllocated;
+    // formatter is a non-owning pointer to a singleton object
+    ArchSpecificFormatter* formatter;
+  };
+}}
+
+#endif //! defined(INSTRUCTION_H)

--- a/instructionAPI/h/Operand.h
+++ b/instructionAPI/h/Operand.h
@@ -64,7 +64,6 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT bool isWritten() const { return m_isWritten; }
 
     DYNINST_EXPORT bool isImplicit() const { return m_isImplicit; }
-    DYNINST_EXPORT void setImplicit(bool i) { m_isImplicit = i; }
 
     DYNINST_EXPORT bool readsMemory() const;
     DYNINST_EXPORT bool writesMemory() const;

--- a/instructionAPI/h/Operand.h
+++ b/instructionAPI/h/Operand.h
@@ -44,44 +44,23 @@ namespace Dyninst
 {
   namespace InstructionAPI
   {
-    /// An %Operand object contains an AST built from %RegisterAST and %Immediate leaves,
-    /// and information about whether the %Operand
-    /// is read, written, or both. This allows us to determine which of the registers
-    /// that appear in the %Operand are read and which are written, as well as whether
-    /// any memory accesses are reads, writes, or both.
-    /// An %Operand, given full knowledge of the values of the leaves of the AST, and knowledge of
-    /// the logic associated with the tree's internal nodes, can determine the
-    /// result of any computations that are encoded in it.  It will rarely be the case
-    /// that an %Instruction is built with its %Operands' state fully specified.  This mechanism is
-    /// instead intended to allow a user to fill in knowledge about the state of the processor
-    /// at the time the %Instruction is executed.
-    
     class Operand
     {
     public:
         typedef boost::shared_ptr<Operand> Ptr;
-      /// \brief Create an operand from a %Expression and flags describing whether the %ValueComputation
-      /// is read, written or both.
-      /// \param val Reference-counted pointer to the %Expression that will be contained in the %Operand being constructed
-      /// \param read True if this operand is read
-      /// \param written True if this operand is written
-      // An instruction can be true predicated, false predicated, or not predicated at all
+
       explicit Operand(Expression::Ptr val = {}, bool read = false, bool written = false, bool implicit = false,
               bool trueP = false, bool falseP = false) noexcept :
           op_value(val), m_isRead(read), m_isWritten(written), m_isImplicit(implicit), m_isTruePredicate(trueP), m_isFalsePredicate(falseP) {}
 
-      /// \brief Get the registers read by this operand
-      /// \param regsRead Has the registers read inserted into it
       DYNINST_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
-      /// \brief Get the registers written by this operand
-      /// \param regsWritten Has the registers written  inserted into it
+
       DYNINST_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
 
       DYNINST_EXPORT RegisterAST::Ptr getPredicate() const;
 
-      /// Returns true if this operand is read
       DYNINST_EXPORT bool isRead(Expression::Ptr candidate) const;
-      /// Returns true if this operand is written
+
       DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) const;
 
       DYNINST_EXPORT bool isRead() const { return m_isRead; }
@@ -93,23 +72,16 @@ namespace Dyninst
       DYNINST_EXPORT bool isTruePredicate() const { return m_isTruePredicate; }
       DYNINST_EXPORT bool isFalsePredicate() const { return m_isFalsePredicate; }
       
-      /// Returns true if this operand reads memory
       DYNINST_EXPORT bool readsMemory() const;
-      /// Returns true if this operand writes memory
+
       DYNINST_EXPORT bool writesMemory() const;
-      /// \brief Inserts the effective addresses read by this operand into memAccessors
-      /// \param memAccessors If this is a memory read operand, insert the \c %Expression::Ptr representing
-      /// the address being read into \c memAccessors.
+
       DYNINST_EXPORT void addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const;
-      /// \brief Inserts the effective addresses written by this operand into memAccessors
-      /// \param memAccessors If this is a memory write operand, insert the \c %Expression::Ptr representing
-      /// the address being written into \c memAccessors.
+
       DYNINST_EXPORT void addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const;
-      /// \brief Return a printable string representation of the operand.
-      /// \return The operand in a disassembly format
+
       DYNINST_EXPORT std::string format(Architecture arch, Address addr = 0) const;
 
-      /// The \c getValue method returns an %Expression::Ptr to the AST contained by the operand.
       DYNINST_EXPORT Expression::Ptr getValue() const;
       
     private:

--- a/instructionAPI/h/Operand.h
+++ b/instructionAPI/h/Operand.h
@@ -29,16 +29,16 @@
  */
 
 #if !defined(OPERAND_H)
-#  define OPERAND_H
+#define OPERAND_H
 
-#  include "BinaryFunction.h"
-#  include "Expression.h"
-#  include "Immediate.h"
-#  include "Register.h"
-#  include "util.h"
+#include "BinaryFunction.h"
+#include "Expression.h"
+#include "Immediate.h"
+#include "Register.h"
+#include "util.h"
 
-#  include <set>
-#  include <string>
+#include <set>
+#include <string>
 
 namespace Dyninst { namespace InstructionAPI {
   class Operand {

--- a/instructionAPI/h/Operand.h
+++ b/instructionAPI/h/Operand.h
@@ -1,103 +1,99 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #if !defined(OPERAND_H)
-#define OPERAND_H
+#  define OPERAND_H
 
-#include "Expression.h"
-#include "Register.h"
-#include "BinaryFunction.h"
-#include "Immediate.h"
-#include <set>
-#include <string>
+#  include "BinaryFunction.h"
+#  include "Expression.h"
+#  include "Immediate.h"
+#  include "Register.h"
+#  include "util.h"
 
-#include "util.h"
+#  include <set>
+#  include <string>
 
-namespace Dyninst
-{
-  namespace InstructionAPI
-  {
-    class Operand
-    {
-    public:
-        typedef boost::shared_ptr<Operand> Ptr;
+namespace Dyninst { namespace InstructionAPI {
+  class Operand {
+  public:
+    typedef boost::shared_ptr<Operand> Ptr;
 
-      explicit Operand(Expression::Ptr val = {}, bool read = false, bool written = false, bool implicit = false,
-              bool trueP = false, bool falseP = false) noexcept :
-          op_value(val), m_isRead(read), m_isWritten(written), m_isImplicit(implicit), m_isTruePredicate(trueP), m_isFalsePredicate(falseP) {}
+    explicit Operand(Expression::Ptr val = {}, bool read = false, bool written = false, bool implicit = false,
+                     bool trueP = false, bool falseP = false) noexcept
+        : op_value(val), m_isRead(read), m_isWritten(written), m_isImplicit(implicit),
+          m_isTruePredicate(trueP), m_isFalsePredicate(falseP) {}
 
-      DYNINST_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
+    DYNINST_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
 
-      DYNINST_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
+    DYNINST_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
 
-      DYNINST_EXPORT RegisterAST::Ptr getPredicate() const;
+    DYNINST_EXPORT RegisterAST::Ptr getPredicate() const;
 
-      DYNINST_EXPORT bool isRead(Expression::Ptr candidate) const;
+    DYNINST_EXPORT bool isRead(Expression::Ptr candidate) const;
 
-      DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) const;
+    DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) const;
 
-      DYNINST_EXPORT bool isRead() const { return m_isRead; }
-      DYNINST_EXPORT bool isWritten() const { return m_isWritten; }
+    DYNINST_EXPORT bool isRead() const { return m_isRead; }
 
-      DYNINST_EXPORT bool isImplicit() const { return m_isImplicit; }
-      DYNINST_EXPORT void setImplicit(bool i) { m_isImplicit = i; }
+    DYNINST_EXPORT bool isWritten() const { return m_isWritten; }
 
-      DYNINST_EXPORT bool isTruePredicate() const { return m_isTruePredicate; }
-      DYNINST_EXPORT bool isFalsePredicate() const { return m_isFalsePredicate; }
-      
-      DYNINST_EXPORT bool readsMemory() const;
+    DYNINST_EXPORT bool isImplicit() const { return m_isImplicit; }
 
-      DYNINST_EXPORT bool writesMemory() const;
+    DYNINST_EXPORT void setImplicit(bool i) { m_isImplicit = i; }
 
-      DYNINST_EXPORT void addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const;
+    DYNINST_EXPORT bool isTruePredicate() const { return m_isTruePredicate; }
 
-      DYNINST_EXPORT void addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const;
+    DYNINST_EXPORT bool isFalsePredicate() const { return m_isFalsePredicate; }
 
-      DYNINST_EXPORT std::string format(Architecture arch, Address addr = 0) const;
+    DYNINST_EXPORT bool readsMemory() const;
 
-      DYNINST_EXPORT Expression::Ptr getValue() const;
-      
-    private:
-      Expression::Ptr op_value{};
-      bool m_isRead{};
-      bool m_isWritten{};
-      bool m_isImplicit{};
+    DYNINST_EXPORT bool writesMemory() const;
 
-      // Used for GPU instructions with predicates
-      bool m_isTruePredicate{};
-      bool m_isFalsePredicate{};
-    };
-  }
-}
+    DYNINST_EXPORT void addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const;
 
+    DYNINST_EXPORT void addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const;
 
+    DYNINST_EXPORT std::string format(Architecture arch, Address addr = 0) const;
 
+    DYNINST_EXPORT Expression::Ptr getValue() const;
 
-#endif //!defined(OPERAND_H)
+  private:
+    Expression::Ptr op_value{};
+    bool m_isRead{};
+    bool m_isWritten{};
+    bool m_isImplicit{};
+
+    // Used for GPU instructions with predicates
+    bool m_isTruePredicate{};
+    bool m_isFalsePredicate{};
+  };
+}}
+
+#endif //! defined(OPERAND_H)

--- a/instructionAPI/h/Operand.h
+++ b/instructionAPI/h/Operand.h
@@ -51,33 +51,25 @@ namespace Dyninst { namespace InstructionAPI {
           m_isTruePredicate(trueP), m_isFalsePredicate(falseP) {}
 
     DYNINST_EXPORT void getReadSet(std::set<RegisterAST::Ptr>& regsRead) const;
-
     DYNINST_EXPORT void getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const;
 
     DYNINST_EXPORT RegisterAST::Ptr getPredicate() const;
+    DYNINST_EXPORT bool isTruePredicate() const { return m_isTruePredicate; }
+    DYNINST_EXPORT bool isFalsePredicate() const { return m_isFalsePredicate; }
 
     DYNINST_EXPORT bool isRead(Expression::Ptr candidate) const;
-
     DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) const;
 
     DYNINST_EXPORT bool isRead() const { return m_isRead; }
-
     DYNINST_EXPORT bool isWritten() const { return m_isWritten; }
 
     DYNINST_EXPORT bool isImplicit() const { return m_isImplicit; }
-
     DYNINST_EXPORT void setImplicit(bool i) { m_isImplicit = i; }
 
-    DYNINST_EXPORT bool isTruePredicate() const { return m_isTruePredicate; }
-
-    DYNINST_EXPORT bool isFalsePredicate() const { return m_isFalsePredicate; }
-
     DYNINST_EXPORT bool readsMemory() const;
-
     DYNINST_EXPORT bool writesMemory() const;
 
     DYNINST_EXPORT void addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const;
-
     DYNINST_EXPORT void addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const;
 
     DYNINST_EXPORT std::string format(Architecture arch, Address addr = 0) const;

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -78,7 +78,6 @@ namespace Dyninst { namespace InstructionAPI {
     friend class InstructionDecoder_amdgpu_gfx908;
     friend class InstructionDecoder_amdgpu_gfx90a;
     friend class InstructionDecoder_amdgpu_gfx940;
-    friend class Instruction; // to make use of the update size function
 
   public:
     DYNINST_EXPORT Operation(NS_x86::ia32_entry* e, NS_x86::ia32_prefixes* p = NULL,

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -42,22 +42,6 @@
 #include <stddef.h>
 #include <string>
 
-// OpCode = operation + encoding
-// contents:
-// hex value
-// information on how to decode operands
-// operation encoded
-
-// Operation = what an instruction does
-// contents:
-// read/write semantics on explicit operands
-// register implicit read/write lists, including flags
-// string/enum representation of the operation
-
-// Use cases:
-// OpCode + raw instruction -> Operation + ExpressionPtrs
-// Operation + ExpressionPtrs -> Instruction + Operands
-
 namespace NS_x86 {
   struct ia32_entry;
   class ia32_prefixes;

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -97,7 +97,6 @@ namespace Dyninst { namespace InstructionAPI {
     mutable VCSet otherEffAddrsRead;
     mutable VCSet otherEffAddrsWritten;
 
-  protected:
     mutable entryID operationID;
     Architecture archDecodedFrom;
     prefixEntryID prefixID;

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -1,28 +1,28 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
@@ -31,19 +31,19 @@
 #if !defined(DYN_OPERATION_H)
 #define DYN_OPERATION_H
 
-#include "Register.h"
 #include "Expression.h"
-#include "entryIDs.h"
+#include "Register.h"
 #include "Result.h"
-#include <stddef.h>
-#include <string>
-#include <set>
-#include <mutex>
-
+#include "entryIDs.h"
 #include "util.h"
+
+#include <boost/flyweight.hpp>
 #include <boost/thread/lockable_adapter.hpp>
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/flyweight.hpp>
+#include <mutex>
+#include <set>
+#include <stddef.h>
+#include <string>
 
 // OpCode = operation + encoding
 // contents:
@@ -62,77 +62,68 @@
 // Operation + ExpressionPtrs -> Instruction + Operands
 
 namespace NS_x86 {
-struct ia32_entry;
-class ia32_prefixes;
+  struct ia32_entry;
+  class ia32_prefixes;
 }
 class ia32_locations;
 
-namespace Dyninst
-{
-  namespace InstructionAPI
-  {
-    class Operation : public boost::lockable_adapter<boost::recursive_mutex>
-    {
-    public:
-      typedef std::set<RegisterAST::Ptr> registerSet;
-      typedef std::set<Expression::Ptr> VCSet;
-      friend class InstructionDecoder_power; // for editing mnemonics after creation
-      friend class InstructionDecoder_aarch64;
-      friend class InstructionDecoder_amdgpu_gfx908;
-      friend class InstructionDecoder_amdgpu_gfx90a;
-      friend class InstructionDecoder_amdgpu_gfx940;
-      friend class Instruction; // to make use of the update size function
-      
-    public:
-      DYNINST_EXPORT Operation(NS_x86::ia32_entry* e, NS_x86::ia32_prefixes* p = NULL, ia32_locations* l = NULL,
-                                  Architecture arch = Arch_none);
-      DYNINST_EXPORT Operation(const Operation& o);
-      DYNINST_EXPORT Operation();
-      DYNINST_EXPORT Operation(entryID id, std::string m, Architecture arch);
+namespace Dyninst { namespace InstructionAPI {
 
-      DYNINST_EXPORT const Operation& operator=(const Operation& o);
-      
-      DYNINST_EXPORT const registerSet& implicitReads();
-      DYNINST_EXPORT const registerSet& implicitWrites();
+  class Operation : public boost::lockable_adapter<boost::recursive_mutex> {
+  public:
+    typedef std::set<RegisterAST::Ptr> registerSet;
+    typedef std::set<Expression::Ptr> VCSet;
+    friend class InstructionDecoder_power; // for editing mnemonics after creation
+    friend class InstructionDecoder_aarch64;
+    friend class InstructionDecoder_amdgpu_gfx908;
+    friend class InstructionDecoder_amdgpu_gfx90a;
+    friend class InstructionDecoder_amdgpu_gfx940;
+    friend class Instruction; // to make use of the update size function
 
-      DYNINST_EXPORT const VCSet& getImplicitMemReads();
-      DYNINST_EXPORT const VCSet& getImplicitMemWrites();
+  public:
+    DYNINST_EXPORT Operation(NS_x86::ia32_entry* e, NS_x86::ia32_prefixes* p = NULL,
+                             ia32_locations* l = NULL, Architecture arch = Arch_none);
+    DYNINST_EXPORT Operation(const Operation& o);
+    DYNINST_EXPORT Operation();
+    DYNINST_EXPORT Operation(entryID id, std::string m, Architecture arch);
 
-      DYNINST_EXPORT std::string format() const;
+    DYNINST_EXPORT const Operation& operator=(const Operation& o);
 
-      DYNINST_EXPORT entryID getID() const;
-      DYNINST_EXPORT prefixEntryID getPrefixID() const;
+    DYNINST_EXPORT const registerSet& implicitReads();
+    DYNINST_EXPORT const registerSet& implicitWrites();
 
-      DYNINST_EXPORT bool isRead(Expression::Ptr candidate);
-      DYNINST_EXPORT bool isWritten(Expression::Ptr candidate);
+    DYNINST_EXPORT const VCSet& getImplicitMemReads();
+    DYNINST_EXPORT const VCSet& getImplicitMemWrites();
 
-      void updateMnemonic(std::string new_mnemonic){
-        mnemonic = new_mnemonic;
-      }
+    DYNINST_EXPORT std::string format() const;
 
-      bool isVectorInsn;
+    DYNINST_EXPORT entryID getID() const;
+    DYNINST_EXPORT prefixEntryID getPrefixID() const;
 
-    private:
-        std::once_flag data_initialized;
-      void SetUpNonOperandData();
-      
-      mutable registerSet otherRead;
-      mutable registerSet otherWritten;
-      mutable VCSet otherEffAddrsRead;
-      mutable VCSet otherEffAddrsWritten;
+    DYNINST_EXPORT bool isRead(Expression::Ptr candidate);
+    DYNINST_EXPORT bool isWritten(Expression::Ptr candidate);
 
-    protected:
-        mutable entryID operationID;
-      Architecture archDecodedFrom;
-      prefixEntryID prefixID;
-      Result_Type addrWidth;
-      int segPrefix;
-      mutable std::string mnemonic;
+    void updateMnemonic(std::string new_mnemonic) { mnemonic = new_mnemonic; }
 
-      
-    };
-  }
-}
+    bool isVectorInsn;
 
+  private:
+    std::once_flag data_initialized;
+    void SetUpNonOperandData();
 
-#endif //!defined(DYN_OPERATION_H)
+    mutable registerSet otherRead;
+    mutable registerSet otherWritten;
+    mutable VCSet otherEffAddrsRead;
+    mutable VCSet otherEffAddrsWritten;
+
+  protected:
+    mutable entryID operationID;
+    Architecture archDecodedFrom;
+    prefixEntryID prefixID;
+    Result_Type addrWidth;
+    int segPrefix;
+    mutable std::string mnemonic;
+  };
+}}
+
+#endif //! defined(DYN_OPERATION_H)

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -37,9 +37,6 @@
 #include "entryIDs.h"
 #include "util.h"
 
-#include <boost/flyweight.hpp>
-#include <boost/thread/lockable_adapter.hpp>
-#include <boost/thread/recursive_mutex.hpp>
 #include <mutex>
 #include <set>
 #include <stddef.h>
@@ -67,9 +64,10 @@ namespace NS_x86 {
 }
 class ia32_locations;
 
+
 namespace Dyninst { namespace InstructionAPI {
 
-  class Operation : public boost::lockable_adapter<boost::recursive_mutex> {
+  class Operation {
   public:
     typedef std::set<RegisterAST::Ptr> registerSet;
     typedef std::set<Expression::Ptr> VCSet;

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -84,7 +84,7 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT bool isRead(Expression::Ptr candidate);
     DYNINST_EXPORT bool isWritten(Expression::Ptr candidate);
 
-    void updateMnemonic(std::string new_mnemonic) { mnemonic = new_mnemonic; }
+    void updateMnemonic(std::string new_mnemonic) { mnemonic = std::move(new_mnemonic); }
 
     bool isVectorInsn;
 

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -92,31 +92,24 @@ namespace Dyninst
 
       DYNINST_EXPORT const Operation& operator=(const Operation& o);
       
-      DYNINST_EXPORT const registerSet& implicitReads() ;
+      DYNINST_EXPORT const registerSet& implicitReads();
+      DYNINST_EXPORT const registerSet& implicitWrites();
 
-      DYNINST_EXPORT const registerSet& implicitWrites() ;
+      DYNINST_EXPORT const VCSet& getImplicitMemReads();
+      DYNINST_EXPORT const VCSet& getImplicitMemWrites();
 
       DYNINST_EXPORT std::string format() const;
 
       DYNINST_EXPORT entryID getID() const;
-
       DYNINST_EXPORT prefixEntryID getPrefixID() const;
 
-
-      DYNINST_EXPORT bool isRead(Expression::Ptr candidate) ;
-
-      DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) ;
-
-      DYNINST_EXPORT const VCSet& getImplicitMemReads() ;
-
-      DYNINST_EXPORT const VCSet& getImplicitMemWrites() ;
+      DYNINST_EXPORT bool isRead(Expression::Ptr candidate);
+      DYNINST_EXPORT bool isWritten(Expression::Ptr candidate);
 
       void updateMnemonic(std::string new_mnemonic){
         mnemonic = new_mnemonic;
       }
 
-
-      DYNINST_EXPORT const VCSet& getImplicitMemWrites() const;
       bool isVectorInsn;
 
     private:

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -71,31 +71,6 @@ namespace Dyninst
 {
   namespace InstructionAPI
   {
-    /// An %Operation object represents a family of opcodes (operation encodings)
-    /// that perform the same task (e.g. the \c MOV family).  It includes
-    /// information about the number of operands, their read/write semantics,
-    /// the implicit register reads and writes, and the control flow behavior
-    /// of a particular assembly language operation.  It additionally provides
-    /// access to the assembly mnemonic, which allows any semantic details that
-    /// are not encoded in the %Instruction representation to be added by higher
-    /// layers of analysis.
-    ///
-    /// As an example, the \c CMP operation on IA32/AMD64 processors has the following
-    /// properties:
-    ///   - %Operand 1 is read, but not written
-    ///   - %Operand 2 is read, but not written
-    ///   - The following flags are written:
-    ///     - Overflow
-    ///     - Sign
-    ///     - Zero
-    ///     - Parity
-    ///     - Carry
-    ///     - Auxiliary
-    ///   - No other registers are read, and no implicit memory operations are performed
-    ///
-    /// %Operations are constructed by the %InstructionDecoder as part of the process
-    /// of constructing an %Instruction.
-    
     class Operation : public boost::lockable_adapter<boost::recursive_mutex>
     {
     public:
@@ -117,27 +92,23 @@ namespace Dyninst
 
       DYNINST_EXPORT const Operation& operator=(const Operation& o);
       
-      /// Returns the set of registers implicitly read (i.e. those not included in the operands, but read anyway)
       DYNINST_EXPORT const registerSet& implicitReads() ;
-      /// Returns the set of registers implicitly written (i.e. those not included in the operands, but written anyway)
+
       DYNINST_EXPORT const registerSet& implicitWrites() ;
-      /// Returns the mnemonic for the operation.  Like \c instruction::format, this is exposed for debugging
-      /// and will be replaced with stream operators in the public interface.
+
       DYNINST_EXPORT std::string format() const;
-      /// Returns the entry ID corresponding to this operation.  Entry IDs are enumerated values that correspond
-      /// to assembly mnemonics.
+
       DYNINST_EXPORT entryID getID() const;
-      /// Returns the prefix entry ID corresponding to this operation, if any.
-      /// Prefix IDs are enumerated values that correspond to assembly prefix mnemonics.
+
       DYNINST_EXPORT prefixEntryID getPrefixID() const;
 
-      /// Returns true if the expression represented by \c candidate is read implicitly.
+
       DYNINST_EXPORT bool isRead(Expression::Ptr candidate) ;
-      /// Returns true if the expression represented by \c candidate is written implicitly.
+
       DYNINST_EXPORT bool isWritten(Expression::Ptr candidate) ;
-      /// Returns the set of memory locations implicitly read.
+
       DYNINST_EXPORT const VCSet& getImplicitMemReads() ;
-      /// Returns the set of memory locations implicitly written.
+
       DYNINST_EXPORT const VCSet& getImplicitMemWrites() ;
 
       void updateMnemonic(std::string new_mnemonic){

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -28,8 +28,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#define INSIDE_INSTRUCTION_API
-
 #include "../h/Instruction.h"
 #include "../h/InstructionCategories.h"
 #include "../h/Register.h"

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -361,37 +361,6 @@ namespace Dyninst { namespace InstructionAPI {
       formattedOperands.push_back(currOperand->format(getArch(), addr));
     }
 
-#if defined(DEBUG_READ_WRITE)
-    std::set<RegisterAST::Ptr> tmp;
-    getReadSet(tmp);
-    cout << "Read set:" << endl;
-    for(std::set<RegisterAST::Ptr>::iterator i = tmp.begin(); i != tmp.end(); ++i) {
-      cout << (*i)->format() << " ";
-    }
-    cout << endl;
-    tmp.clear();
-    getWriteSet(tmp);
-    cout << "Write set:" << endl;
-    for(std::set<RegisterAST::Ptr>::iterator i = tmp.begin(); i != tmp.end(); ++i) {
-      cout << (*i)->format() << " ";
-    }
-    cout << endl;
-    std::set<Expression::Ptr> mem;
-    getMemoryReadOperands(mem);
-    cout << "Read mem:" << endl;
-    for(std::set<Expression::Ptr>::iterator i = mem.begin(); i != mem.end(); ++i) {
-      cout << (*i)->format() << " ";
-    }
-    cout << endl;
-    mem.clear();
-    getMemoryWriteOperands(mem);
-    cout << "Write mem:" << endl;
-    for(std::set<Expression::Ptr>::iterator i = mem.begin(); i != mem.end(); ++i) {
-      cout << (*i)->format() << " ";
-    }
-    cout << endl;
-#endif // defined(DEBUG_READ_WRITE)
-
     return opstr + formatter->getInstructionString(formattedOperands);
   }
 

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -1,28 +1,28 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
@@ -30,620 +30,492 @@
 
 #define INSIDE_INSTRUCTION_API
 
-#include <stdio.h>
-#include <string>
-#include <signal.h>
-#include "../h/InstructionCategories.h"
 #include "../h/Instruction.h"
+#include "../h/InstructionCategories.h"
 #include "../h/Register.h"
-#include "Operation_impl.h"
-#include "InstructionDecoder.h"
 #include "Dereference.h"
-#include <boost/iterator/indirect_iterator.hpp>
-#include <iostream>
-#include <sstream>
-#include <iomanip>
-#include <set>
-#include <functional>
-#include <algorithm>
-
+#include "InstructionDecoder.h"
+#include "Operation_impl.h"
 #include "common/src/arch-x86.h"
 #include "dyninstversion.h"
+
+#include <algorithm>
+#include <boost/iterator/indirect_iterator.hpp>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <set>
+#include <signal.h>
+#include <sstream>
+#include <stdio.h>
+#include <string>
 
 using namespace std;
 using namespace NS_x86;
 
 #include "ArchSpecificFormatters.h"
 
-#define DECODE_OPERANDS() \
-    do { \
-        if (arch_decoded_from != Arch_cuda && arch_decoded_from != Arch_amdgpu_gfx908 && arch_decoded_from != Arch_amdgpu_gfx90a && arch_decoded_from != Arch_amdgpu_gfx940 && m_Operands.empty()) { \
-            decodeOperands(); \
-        }\
-    }while(0) 
+#define DECODE_OPERANDS()                                                                          \
+  do {                                                                                             \
+    if(arch_decoded_from != Arch_cuda && arch_decoded_from != Arch_amdgpu_gfx908 &&                \
+       arch_decoded_from != Arch_amdgpu_gfx90a && arch_decoded_from != Arch_amdgpu_gfx940 &&       \
+       m_Operands.empty()) {                                                                       \
+      decodeOperands();                                                                            \
+    }                                                                                              \
+  } while(0)
 
-namespace Dyninst
-{
-    namespace InstructionAPI
-    {
+namespace Dyninst { namespace InstructionAPI {
 
-        int Instruction::numInsnsAllocated = 0;
-        DYNINST_EXPORT Instruction::Instruction(Operation what,
-                size_t size, const unsigned char* raw,
-                Dyninst::Architecture arch)
-            : m_InsnOp(what), m_Valid(what.getID() != e_No_Entry), arch_decoded_from(arch),
-            formatter(&ArchSpecificFormatter::getFormatter(arch))
-        {
-            copyRaw(size, raw);
+  int Instruction::numInsnsAllocated = 0;
+
+  DYNINST_EXPORT Instruction::Instruction(Operation what, size_t size, const unsigned char* raw,
+                                          Dyninst::Architecture arch)
+      : m_InsnOp(what), m_Valid(what.getID() != e_No_Entry), arch_decoded_from(arch),
+        formatter(&ArchSpecificFormatter::getFormatter(arch)) {
+    copyRaw(size, raw);
 
 #if defined(DEBUG_INSN_ALLOCATIONS)
-            numInsnsAllocated++;
-            if((numInsnsAllocated % 1000) == 0)
-            {
-                fprintf(stderr, "Instruction CTOR, %d insns allocated\n", numInsnsAllocated);
-            }
-#endif    
-        }
-
-        void Instruction::copyRaw(size_t size, const unsigned char* raw)
-        {
-
-            if(raw)
-            {
-                m_size = size;
-                m_RawInsn.small_insn = 0;
-                if(size <= sizeof(m_RawInsn.small_insn))
-                {
-                    memcpy(&m_RawInsn.small_insn, raw, size);
-                }
-                else
-                {
-                    m_RawInsn.large_insn = new unsigned char[size];
-                    memcpy(m_RawInsn.large_insn, raw, size);
-                }
-            }
-            else
-            {
-                m_size = 0;
-                m_RawInsn.small_insn = 0;
-            }
-        }
-
-        void Instruction::decodeOperands() const
-        {
-        if (!m_Valid) return;
-            //m_Operands.reserve(5);
-            InstructionDecoder dec(ptr(), size(), arch_decoded_from);
-            dec.doDelayedDecode(this);
-        }
-
-        DYNINST_EXPORT Instruction::Instruction() :
-            m_Valid(false), m_size(0), arch_decoded_from(Arch_none), formatter(nullptr)
-        {
-#if defined(DEBUG_INSN_ALLOCATIONS)
-            numInsnsAllocated++;
-            if((numInsnsAllocated % 1000) == 0)
-            {
-                fprintf(stderr, "Instruction CTOR, %d insns allocated\n", numInsnsAllocated);
-            }
+    numInsnsAllocated++;
+    if((numInsnsAllocated % 1000) == 0) {
+      fprintf(stderr, "Instruction CTOR, %d insns allocated\n", numInsnsAllocated);
+    }
 #endif
-        }
+  }
 
-        DYNINST_EXPORT Instruction::~Instruction()
-        {
+  void Instruction::copyRaw(size_t size, const unsigned char* raw) {
+    if(raw) {
+      m_size = size;
+      m_RawInsn.small_insn = 0;
+      if(size <= sizeof(m_RawInsn.small_insn)) {
+        memcpy(&m_RawInsn.small_insn, raw, size);
+      } else {
+        m_RawInsn.large_insn = new unsigned char[size];
+        memcpy(m_RawInsn.large_insn, raw, size);
+      }
+    } else {
+      m_size = 0;
+      m_RawInsn.small_insn = 0;
+    }
+  }
 
-            if(m_size > sizeof(m_RawInsn.small_insn))
-            {
-                delete[] m_RawInsn.large_insn;
-            }
+  void Instruction::decodeOperands() const {
+    if(!m_Valid)
+      return;
+    // m_Operands.reserve(5);
+    InstructionDecoder dec(ptr(), size(), arch_decoded_from);
+    dec.doDelayedDecode(this);
+  }
 
+  DYNINST_EXPORT Instruction::Instruction()
+      : m_Valid(false), m_size(0), arch_decoded_from(Arch_none), formatter(nullptr) {
 #if defined(DEBUG_INSN_ALLOCATIONS)
-            numInsnsAllocated--;
-            if((numInsnsAllocated % 1000) == 0)
-            {
-                fprintf(stderr, "Instruction DTOR, %d insns allocated\n", numInsnsAllocated);
-            }
-#endif      
-        }
-
-        DYNINST_EXPORT Instruction::Instruction(const Instruction& o) :
-            m_Operands(o.m_Operands),
-            m_InsnOp(o.m_InsnOp),
-            m_Valid(o.m_Valid),
-            arch_decoded_from(o.arch_decoded_from),
-            formatter(o.formatter)
-
-        {
-            m_size = o.m_size;
-            if(o.m_size > sizeof(m_RawInsn.small_insn))
-            {
-                m_RawInsn.large_insn = new unsigned char[o.m_size];
-                memcpy(m_RawInsn.large_insn, o.m_RawInsn.large_insn, m_size);
-            }
-            else
-            {
-                m_RawInsn.small_insn = o.m_RawInsn.small_insn;
-            }
-
-            m_Successors = o.m_Successors;
-
-#if defined(DEBUG_INSN_ALLOCATIONS)
-            numInsnsAllocated++;
-            if((numInsnsAllocated % 1000) == 0)
-            {
-                fprintf(stderr, "Instruction COPY CTOR, %d insns allocated\n", numInsnsAllocated);
-            }
+    numInsnsAllocated++;
+    if((numInsnsAllocated % 1000) == 0) {
+      fprintf(stderr, "Instruction CTOR, %d insns allocated\n", numInsnsAllocated);
+    }
 #endif
-        }
+  }
 
-        DYNINST_EXPORT const Instruction& Instruction::operator=(const Instruction& rhs)
-        {
-            m_Operands = rhs.m_Operands;
-            //m_Operands.reserve(rhs.m_Operands.size());
-            //std::copy(rhs.m_Operands.begin(), rhs.m_Operands.end(), std::back_inserter(m_Operands));
-            if(m_size > sizeof(m_RawInsn.small_insn))
-            {
-                delete[] m_RawInsn.large_insn;
-            }
+  DYNINST_EXPORT Instruction::~Instruction() {
 
-            m_size = rhs.m_size;
-            if(rhs.m_size > sizeof(m_RawInsn.small_insn))
-            {
-                m_RawInsn.large_insn = new unsigned char[rhs.m_size];
-                memcpy(m_RawInsn.large_insn, rhs.m_RawInsn.large_insn, m_size);
-            }
-            else
-            {
-                m_RawInsn.small_insn = rhs.m_RawInsn.small_insn;
-            }
+    if(m_size > sizeof(m_RawInsn.small_insn)) {
+      delete[] m_RawInsn.large_insn;
+    }
 
+#if defined(DEBUG_INSN_ALLOCATIONS)
+    numInsnsAllocated--;
+    if((numInsnsAllocated % 1000) == 0) {
+      fprintf(stderr, "Instruction DTOR, %d insns allocated\n", numInsnsAllocated);
+    }
+#endif
+  }
 
-            m_InsnOp = rhs.m_InsnOp;
-            m_Valid = rhs.m_Valid;
-            formatter = rhs.formatter;
-            arch_decoded_from = rhs.arch_decoded_from;
-            m_Successors = rhs.m_Successors;
-            return *this;
-        }    
+  DYNINST_EXPORT Instruction::Instruction(const Instruction& o)
+      : m_Operands(o.m_Operands), m_InsnOp(o.m_InsnOp), m_Valid(o.m_Valid),
+        arch_decoded_from(o.arch_decoded_from), formatter(o.formatter)
 
-        DYNINST_EXPORT bool Instruction::isValid() const
-        {
-            return m_Valid;
-        }
+  {
+    m_size = o.m_size;
+    if(o.m_size > sizeof(m_RawInsn.small_insn)) {
+      m_RawInsn.large_insn = new unsigned char[o.m_size];
+      memcpy(m_RawInsn.large_insn, o.m_RawInsn.large_insn, m_size);
+    } else {
+      m_RawInsn.small_insn = o.m_RawInsn.small_insn;
+    }
 
-        DYNINST_EXPORT Operation& Instruction::getOperation()
-        {
-            return m_InsnOp;
-        }
-        DYNINST_EXPORT const Operation& Instruction::getOperation() const
-        {
-            return m_InsnOp;
-        }
+    m_Successors = o.m_Successors;
 
-        DYNINST_EXPORT void Instruction::getOperands(std::vector<Operand>& operands) const
-        {
+#if defined(DEBUG_INSN_ALLOCATIONS)
+    numInsnsAllocated++;
+    if((numInsnsAllocated % 1000) == 0) {
+      fprintf(stderr, "Instruction COPY CTOR, %d insns allocated\n", numInsnsAllocated);
+    }
+#endif
+  }
 
-            DECODE_OPERANDS();
-            std::copy(m_Operands.begin(), m_Operands.end(), std::back_inserter(operands));
-        }
+  DYNINST_EXPORT const Instruction& Instruction::operator=(const Instruction& rhs) {
+    m_Operands = rhs.m_Operands;
+    // m_Operands.reserve(rhs.m_Operands.size());
+    // std::copy(rhs.m_Operands.begin(), rhs.m_Operands.end(), std::back_inserter(m_Operands));
+    if(m_size > sizeof(m_RawInsn.small_insn)) {
+      delete[] m_RawInsn.large_insn;
+    }
 
-        DYNINST_EXPORT std::vector<Operand> Instruction::getDisplayOrderedOperands() const
-        {
-            DECODE_OPERANDS();
+    m_size = rhs.m_size;
+    if(rhs.m_size > sizeof(m_RawInsn.small_insn)) {
+      m_RawInsn.large_insn = new unsigned char[rhs.m_size];
+      memcpy(m_RawInsn.large_insn, rhs.m_RawInsn.large_insn, m_size);
+    } else {
+      m_RawInsn.small_insn = rhs.m_RawInsn.small_insn;
+    }
 
-            std::vector<Operand> operands;
-            auto operandsInserter{std::back_inserter(operands)};
-            auto isNotImplicitPred = [](const Operand & x){return !x.isImplicit();};
+    m_InsnOp = rhs.m_InsnOp;
+    m_Valid = rhs.m_Valid;
+    formatter = rhs.formatter;
+    arch_decoded_from = rhs.arch_decoded_from;
+    m_Successors = rhs.m_Successors;
+    return *this;
+  }
 
-            if (formatter->operandPrintOrderReversed())  {
-                copy_if(m_Operands.crbegin(), m_Operands.crend(), operandsInserter, isNotImplicitPred);
-            }  else  {
-                copy_if(m_Operands.cbegin(), m_Operands.cend(), operandsInserter, isNotImplicitPred);
-            }
+  DYNINST_EXPORT bool Instruction::isValid() const { return m_Valid; }
 
-            return operands;
-        }
+  DYNINST_EXPORT Operation& Instruction::getOperation() { return m_InsnOp; }
 
-        DYNINST_EXPORT Operand Instruction::getOperand(int index) const
-        {
-            DECODE_OPERANDS();
-            if(index < 0 || index >= (int)(m_Operands.size()))
-            {
-                // Out of range = empty operand
-                return Operand(Expression::Ptr(), false, false);
-            }
-            std::list<Operand>::const_iterator found = m_Operands.begin();
-            std::advance(found, index);
-            return *found;
-        }
+  DYNINST_EXPORT const Operation& Instruction::getOperation() const { return m_InsnOp; }
 
-        DYNINST_EXPORT const void* Instruction::ptr() const
-        {
-            if(m_size > sizeof(m_RawInsn.small_insn))
-            {
-                return m_RawInsn.large_insn;
-            }
-            else
-            {
-                return reinterpret_cast<const void*>(&m_RawInsn.small_insn);
-            }
-        }
-        DYNINST_EXPORT unsigned char Instruction::rawByte(unsigned int index) const
-        {
-            if(index >= m_size) return 0;
-            if(m_size > sizeof(m_RawInsn.small_insn))
-            {
-                return m_RawInsn.large_insn[index];
-            }
-            else
-            {
-                return reinterpret_cast<const unsigned char*>(&m_RawInsn.small_insn)[index];
-            }
-        }
+  DYNINST_EXPORT void Instruction::getOperands(std::vector<Operand>& operands) const {
+    DECODE_OPERANDS();
+    std::copy(m_Operands.begin(), m_Operands.end(), std::back_inserter(operands));
+  }
 
-        DYNINST_EXPORT size_t Instruction::size() const
-        {
-            return m_size;
+  DYNINST_EXPORT std::vector<Operand> Instruction::getDisplayOrderedOperands() const {
+    DECODE_OPERANDS();
 
-        }
+    std::vector<Operand> operands;
+    auto operandsInserter{std::back_inserter(operands)};
+    auto isNotImplicitPred = [](const Operand& x) { return !x.isImplicit(); };
 
-        DYNINST_EXPORT void Instruction::getReadSet(std::set<RegisterAST::Ptr>& regsRead) const
-        {
-            DECODE_OPERANDS();
-            for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
-                    curOperand != m_Operands.end();
-                    ++curOperand)
-            {
-                curOperand->getReadSet(regsRead);
-            }
-            std::copy(m_InsnOp.implicitReads().begin(), m_InsnOp.implicitReads().end(),
-                    std::inserter(regsRead, regsRead.begin()));
+    if(formatter->operandPrintOrderReversed()) {
+      copy_if(m_Operands.crbegin(), m_Operands.crend(), operandsInserter, isNotImplicitPred);
+    } else {
+      copy_if(m_Operands.cbegin(), m_Operands.cend(), operandsInserter, isNotImplicitPred);
+    }
 
-        }
+    return operands;
+  }
 
-        DYNINST_EXPORT void Instruction::getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const
-        { 
-            DECODE_OPERANDS();
-            for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
-                    curOperand != m_Operands.end();
-                    ++curOperand)
-            {
-                curOperand->getWriteSet(regsWritten);
-            }
-            std::copy(m_InsnOp.implicitWrites().begin(), m_InsnOp.implicitWrites().end(),
-                    std::inserter(regsWritten, regsWritten.begin()));
+  DYNINST_EXPORT Operand Instruction::getOperand(int index) const {
+    DECODE_OPERANDS();
+    if(index < 0 || index >= (int)(m_Operands.size())) {
+      // Out of range = empty operand
+      return Operand(Expression::Ptr(), false, false);
+    }
+    std::list<Operand>::const_iterator found = m_Operands.begin();
+    std::advance(found, index);
+    return *found;
+  }
 
-        }
+  DYNINST_EXPORT const void* Instruction::ptr() const {
+    if(m_size > sizeof(m_RawInsn.small_insn)) {
+      return m_RawInsn.large_insn;
+    } else {
+      return reinterpret_cast<const void*>(&m_RawInsn.small_insn);
+    }
+  }
 
-        DYNINST_EXPORT bool Instruction::isRead(Expression::Ptr candidate) const
-        {
-            DECODE_OPERANDS();
-            for(std::list<Operand >::const_iterator curOperand = m_Operands.begin();
-                    curOperand != m_Operands.end();
-                    ++curOperand)
-            {
-                // Check if the candidate is read as an explicit operand
-                if(curOperand->isRead(candidate))
-                {
-                    return true;
-                }
-            }
-            // Check if the candidate is read as an implicit operand
-            return m_InsnOp.isRead(candidate);
-        }
+  DYNINST_EXPORT unsigned char Instruction::rawByte(unsigned int index) const {
+    if(index >= m_size)
+      return 0;
+    if(m_size > sizeof(m_RawInsn.small_insn)) {
+      return m_RawInsn.large_insn[index];
+    } else {
+      return reinterpret_cast<const unsigned char*>(&m_RawInsn.small_insn)[index];
+    }
+  }
 
-        DYNINST_EXPORT bool Instruction::isWritten(Expression::Ptr candidate) const
-        {
-            DECODE_OPERANDS();
+  DYNINST_EXPORT size_t Instruction::size() const { return m_size; }
 
-            for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
-                    curOperand != m_Operands.end();
-                    ++curOperand)
-            {
-                if(curOperand->isWritten(candidate))
-                {
-                    return true;
-                }
-            }
-            return m_InsnOp.isWritten(candidate);
-        }
+  DYNINST_EXPORT void Instruction::getReadSet(std::set<RegisterAST::Ptr>& regsRead) const {
+    DECODE_OPERANDS();
+    for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
+        curOperand != m_Operands.end(); ++curOperand) {
+      curOperand->getReadSet(regsRead);
+    }
+    std::copy(m_InsnOp.implicitReads().begin(), m_InsnOp.implicitReads().end(),
+              std::inserter(regsRead, regsRead.begin()));
+  }
 
-        DYNINST_EXPORT bool Instruction::readsMemory() const
-        {
-            DECODE_OPERANDS();
-            if(getCategory() == c_PrefetchInsn)
-            {
-                return false;
-            }
-            for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
-                    curOperand != m_Operands.end();
-                    ++curOperand)
-            {
-                if(curOperand->readsMemory())
-                {
-                    return true;
-                }
-            }
-            return !m_InsnOp.getImplicitMemReads().empty();
-        }
+  DYNINST_EXPORT void Instruction::getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const {
+    DECODE_OPERANDS();
+    for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
+        curOperand != m_Operands.end(); ++curOperand) {
+      curOperand->getWriteSet(regsWritten);
+    }
+    std::copy(m_InsnOp.implicitWrites().begin(), m_InsnOp.implicitWrites().end(),
+              std::inserter(regsWritten, regsWritten.begin()));
+  }
 
-        DYNINST_EXPORT bool Instruction::writesMemory() const
-        {
-            DECODE_OPERANDS();
-            for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
-                    curOperand != m_Operands.end();
-                    ++curOperand)
-            {
-                if(curOperand->writesMemory())
-                {
-                    return true;
-                }
-            }
-            return !m_InsnOp.getImplicitMemWrites().empty();
-        }
+  DYNINST_EXPORT bool Instruction::isRead(Expression::Ptr candidate) const {
+    DECODE_OPERANDS();
+    for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
+        curOperand != m_Operands.end(); ++curOperand) {
+      // Check if the candidate is read as an explicit operand
+      if(curOperand->isRead(candidate)) {
+        return true;
+      }
+    }
+    // Check if the candidate is read as an implicit operand
+    return m_InsnOp.isRead(candidate);
+  }
 
-        DYNINST_EXPORT void Instruction::getMemoryReadOperands(std::set<Expression::Ptr>& memAccessors) const
-        {
-            DECODE_OPERANDS();
-            for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
-                    curOperand != m_Operands.end();
-                    ++curOperand)
-            {
-                curOperand->addEffectiveReadAddresses(memAccessors);
-            }  
-            std::copy(m_InsnOp.getImplicitMemReads().begin(), m_InsnOp.getImplicitMemReads().end(), std::inserter(memAccessors,
-                        memAccessors.begin()));
-        }
+  DYNINST_EXPORT bool Instruction::isWritten(Expression::Ptr candidate) const {
+    DECODE_OPERANDS();
 
-        DYNINST_EXPORT void Instruction::getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const
-        {
-            DECODE_OPERANDS();
-            for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
-                    curOperand != m_Operands.end();
-                    ++curOperand)
-            {
-                curOperand->addEffectiveWriteAddresses(memAccessors);
-            }  
-            std::copy(m_InsnOp.getImplicitMemWrites().begin(), m_InsnOp.getImplicitMemWrites().end(), std::inserter(memAccessors,
-                        memAccessors.begin()));
-        }
+    for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
+        curOperand != m_Operands.end(); ++curOperand) {
+      if(curOperand->isWritten(candidate)) {
+        return true;
+      }
+    }
+    return m_InsnOp.isWritten(candidate);
+  }
 
-        DYNINST_EXPORT Operand Instruction::getPredicateOperand() const
-        {
-            DECODE_OPERANDS();
-            for(auto const &op : m_Operands) {
-                if (op.isTruePredicate() || op.isFalsePredicate()) {
-                    return op;
-                }
-            }
+  DYNINST_EXPORT bool Instruction::readsMemory() const {
+    DECODE_OPERANDS();
+    if(getCategory() == c_PrefetchInsn) {
+      return false;
+    }
+    for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
+        curOperand != m_Operands.end(); ++curOperand) {
+      if(curOperand->readsMemory()) {
+        return true;
+      }
+    }
+    return !m_InsnOp.getImplicitMemReads().empty();
+  }
 
-            return Operand(Expression::Ptr(), false, false);
-        }
-        DYNINST_EXPORT bool Instruction::hasPredicateOperand() const
-        {
-            DECODE_OPERANDS();
-            for(auto const &op : m_Operands) {
-                if (op.isTruePredicate() || op.isFalsePredicate()) {
-                    return true;
-                }
-            }
+  DYNINST_EXPORT bool Instruction::writesMemory() const {
+    DECODE_OPERANDS();
+    for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
+        curOperand != m_Operands.end(); ++curOperand) {
+      if(curOperand->writesMemory()) {
+        return true;
+      }
+    }
+    return !m_InsnOp.getImplicitMemWrites().empty();
+  }
 
-            return false;
-        }
+  DYNINST_EXPORT void
+  Instruction::getMemoryReadOperands(std::set<Expression::Ptr>& memAccessors) const {
+    DECODE_OPERANDS();
+    for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
+        curOperand != m_Operands.end(); ++curOperand) {
+      curOperand->addEffectiveReadAddresses(memAccessors);
+    }
+    std::copy(m_InsnOp.getImplicitMemReads().begin(), m_InsnOp.getImplicitMemReads().end(),
+              std::inserter(memAccessors, memAccessors.begin()));
+  }
 
-        DYNINST_EXPORT Expression::Ptr Instruction::getControlFlowTarget() const
-        {
-            // We assume control flow transfer instructions have the PC as
-            // an implicit write, and that we have decoded the control flow
-            // target's full location as the first and only operand.
-            // If this is not the case, we'll squawk for the time being...
-            if(getCategory() == c_NoCategory ||
-                    getCategory() == c_CompareInsn ||
-                    getCategory() == c_PrefetchInsn)
-            {
-                return Expression::Ptr();
-            }
-            if(getCategory() == c_ReturnInsn)
-            {
-                return makeReturnExpression();
-            }
-            DECODE_OPERANDS();
-            if(m_Successors.empty())
-            {
-                return Expression::Ptr();
-            }
-            return m_Successors.front().target;
-        }
+  DYNINST_EXPORT void
+  Instruction::getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const {
+    DECODE_OPERANDS();
+    for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
+        curOperand != m_Operands.end(); ++curOperand) {
+      curOperand->addEffectiveWriteAddresses(memAccessors);
+    }
+    std::copy(m_InsnOp.getImplicitMemWrites().begin(), m_InsnOp.getImplicitMemWrites().end(),
+              std::inserter(memAccessors, memAccessors.begin()));
+  }
 
-        DYNINST_EXPORT ArchSpecificFormatter& Instruction::getFormatter() const {
-            return *formatter;
-        }
+  DYNINST_EXPORT Operand Instruction::getPredicateOperand() const {
+    DECODE_OPERANDS();
+    for(auto const& op : m_Operands) {
+      if(op.isTruePredicate() || op.isFalsePredicate()) {
+        return op;
+      }
+    }
 
-        DYNINST_EXPORT std::string Instruction::format(Address addr) const
-        {
-            // if Arch_none, this is an error and the formatter is nullptr,
-            // so return an error string (could also abort or except)
-            if (arch_decoded_from == Arch_none)  {
-                return "ERROR_NO_ARCH_SET_FOR_INSTRUCTION";
-            }
+    return Operand(Expression::Ptr(), false, false);
+  }
 
-            DECODE_OPERANDS();
-            //remove this once ArchSpecificFormatter is extended for all architectures
+  DYNINST_EXPORT bool Instruction::hasPredicateOperand() const {
+    DECODE_OPERANDS();
+    for(auto const& op : m_Operands) {
+      if(op.isTruePredicate() || op.isFalsePredicate()) {
+        return true;
+      }
+    }
 
-            std::string opstr = m_InsnOp.format();
-            opstr += " ";
-            std::list<Operand>::const_iterator currOperand;
-            std::vector<std::string> formattedOperands;
-            for(currOperand = m_Operands.begin();
-                    currOperand != m_Operands.end();
-                    ++currOperand)
-            {
-                /* If this operand is implicit, don't put it in the list of operands. */
-                if(currOperand->isImplicit())
-                    continue;
+    return false;
+  }
 
-                formattedOperands.push_back(currOperand->format(getArch(), addr));
-            }
+  DYNINST_EXPORT Expression::Ptr Instruction::getControlFlowTarget() const {
+    // We assume control flow transfer instructions have the PC as
+    // an implicit write, and that we have decoded the control flow
+    // target's full location as the first and only operand.
+    // If this is not the case, we'll squawk for the time being...
+    if(getCategory() == c_NoCategory || getCategory() == c_CompareInsn ||
+       getCategory() == c_PrefetchInsn) {
+      return Expression::Ptr();
+    }
+    if(getCategory() == c_ReturnInsn) {
+      return makeReturnExpression();
+    }
+    DECODE_OPERANDS();
+    if(m_Successors.empty()) {
+      return Expression::Ptr();
+    }
+    return m_Successors.front().target;
+  }
 
-#if defined(DEBUG_READ_WRITE)      
-            std::set<RegisterAST::Ptr> tmp;
-            getReadSet(tmp);
-            cout << "Read set:" << endl;
-            for(std::set<RegisterAST::Ptr>::iterator i = tmp.begin();
-                    i != tmp.end();
-                    ++i)
-            {
-                cout << (*i)->format() << " ";
-            }
-            cout << endl;
-            tmp.clear();
-            getWriteSet(tmp);
-            cout << "Write set:" << endl;
-            for(std::set<RegisterAST::Ptr>::iterator i = tmp.begin();
-                    i != tmp.end();
-                    ++i)
-            {
-                cout << (*i)->format() << " ";
-            }
-            cout << endl;
-            std::set<Expression::Ptr> mem;
-            getMemoryReadOperands(mem);
-            cout << "Read mem:" << endl;
-            for(std::set<Expression::Ptr>::iterator i = mem.begin();
-                    i != mem.end();
-                    ++i)
-            {
-                cout << (*i)->format() << " ";
-            }
-            cout << endl;
-            mem.clear();
-            getMemoryWriteOperands(mem);
-            cout << "Write mem:" << endl;
-            for(std::set<Expression::Ptr>::iterator i = mem.begin();
-                    i != mem.end();
-                    ++i)
-            {
-                cout << (*i)->format() << " ";
-            }
-            cout << endl;
+  DYNINST_EXPORT ArchSpecificFormatter& Instruction::getFormatter() const { return *formatter; }
+
+  DYNINST_EXPORT std::string Instruction::format(Address addr) const {
+    // if Arch_none, this is an error and the formatter is nullptr,
+    // so return an error string (could also abort or except)
+    if(arch_decoded_from == Arch_none) {
+      return "ERROR_NO_ARCH_SET_FOR_INSTRUCTION";
+    }
+
+    DECODE_OPERANDS();
+    // remove this once ArchSpecificFormatter is extended for all architectures
+
+    std::string opstr = m_InsnOp.format();
+    opstr += " ";
+    std::list<Operand>::const_iterator currOperand;
+    std::vector<std::string> formattedOperands;
+    for(currOperand = m_Operands.begin(); currOperand != m_Operands.end(); ++currOperand) {
+      /* If this operand is implicit, don't put it in the list of operands. */
+      if(currOperand->isImplicit())
+        continue;
+
+      formattedOperands.push_back(currOperand->format(getArch(), addr));
+    }
+
+#if defined(DEBUG_READ_WRITE)
+    std::set<RegisterAST::Ptr> tmp;
+    getReadSet(tmp);
+    cout << "Read set:" << endl;
+    for(std::set<RegisterAST::Ptr>::iterator i = tmp.begin(); i != tmp.end(); ++i) {
+      cout << (*i)->format() << " ";
+    }
+    cout << endl;
+    tmp.clear();
+    getWriteSet(tmp);
+    cout << "Write set:" << endl;
+    for(std::set<RegisterAST::Ptr>::iterator i = tmp.begin(); i != tmp.end(); ++i) {
+      cout << (*i)->format() << " ";
+    }
+    cout << endl;
+    std::set<Expression::Ptr> mem;
+    getMemoryReadOperands(mem);
+    cout << "Read mem:" << endl;
+    for(std::set<Expression::Ptr>::iterator i = mem.begin(); i != mem.end(); ++i) {
+      cout << (*i)->format() << " ";
+    }
+    cout << endl;
+    mem.clear();
+    getMemoryWriteOperands(mem);
+    cout << "Write mem:" << endl;
+    for(std::set<Expression::Ptr>::iterator i = mem.begin(); i != mem.end(); ++i) {
+      cout << (*i)->format() << " ";
+    }
+    cout << endl;
 #endif // defined(DEBUG_READ_WRITE)
 
-            return opstr + formatter->getInstructionString(formattedOperands);
-        }
+    return opstr + formatter->getInstructionString(formattedOperands);
+  }
 
-        DYNINST_EXPORT bool Instruction::allowsFallThrough() const
-        {
-            switch(m_InsnOp.getID())
-            {
-                case e_ret_far:
-                case e_ret_near:
-                case e_iret:
-                case e_jmp:
-                case e_hlt:
-                case e_sysret:
-                case e_sysexit:
-                case e_call:
-                case e_syscall:
-                case amdgpu_gfx908_op_S_SETPC_B64:
-                case amdgpu_gfx908_op_S_SWAPPC_B64:
-                case amdgpu_gfx90a_op_S_SETPC_B64:
-                case amdgpu_gfx90a_op_S_SWAPPC_B64:
-                case amdgpu_gfx940_op_S_SETPC_B64:
-                case amdgpu_gfx940_op_S_SWAPPC_B64:
-                    return false;
-                case e_jae:
-                case e_jb:
-                case e_jb_jnaej_j:
-                case e_jbe:
-                case e_jcxz_jec:
-                case e_jl:
-                case e_jle:
-                case e_jnb_jae_j:
-                case e_ja:
-                case e_jge:
-                case e_jg:
-                case e_jno:
-                case e_jnp:
-                case e_jns:
-                case e_jne:
-                case e_jo:
-                case e_jp:
-                case e_js:
-                case e_je:
-                    return true;
-                default:
-                    {
-                        DECODE_OPERANDS();
-                        for(cftConstIter targ = m_Successors.begin();
-                                targ != m_Successors.end();
-                                ++targ)
-                        {
-                            if(targ->isFallthrough) return true;
-                        }
-                        return m_Successors.empty();
-                    }
-            }
-            // can't happen but make the compiler happy
-            return false;
+  DYNINST_EXPORT bool Instruction::allowsFallThrough() const {
+    switch(m_InsnOp.getID()) {
+      case e_ret_far:
+      case e_ret_near:
+      case e_iret:
+      case e_jmp:
+      case e_hlt:
+      case e_sysret:
+      case e_sysexit:
+      case e_call:
+      case e_syscall:
+      case amdgpu_gfx908_op_S_SETPC_B64:
+      case amdgpu_gfx908_op_S_SWAPPC_B64:
+      case amdgpu_gfx90a_op_S_SETPC_B64:
+      case amdgpu_gfx90a_op_S_SWAPPC_B64:
+      case amdgpu_gfx940_op_S_SETPC_B64:
+      case amdgpu_gfx940_op_S_SWAPPC_B64: return false;
+      case e_jae:
+      case e_jb:
+      case e_jb_jnaej_j:
+      case e_jbe:
+      case e_jcxz_jec:
+      case e_jl:
+      case e_jle:
+      case e_jnb_jae_j:
+      case e_ja:
+      case e_jge:
+      case e_jg:
+      case e_jno:
+      case e_jnp:
+      case e_jns:
+      case e_jne:
+      case e_jo:
+      case e_jp:
+      case e_js:
+      case e_je: return true;
+      default: {
+        DECODE_OPERANDS();
+        for(cftConstIter targ = m_Successors.begin(); targ != m_Successors.end(); ++targ) {
+          if(targ->isFallthrough)
+            return true;
         }
-        DYNINST_EXPORT bool Instruction::isLegalInsn() const
-        {
-            return (m_InsnOp.getID() != e_No_Entry);
-        }
-
-        DYNINST_EXPORT Architecture Instruction::getArch() const {
-            return arch_decoded_from;
-        }
-
-        Expression::Ptr Instruction::makeReturnExpression() const
-        {
-            Expression::Ptr stackPtr = Expression::Ptr(new RegisterAST(MachRegister::getStackPointer(arch_decoded_from),
-                        0, MachRegister::getStackPointer(arch_decoded_from).size()));
-            Expression::Ptr retLoc = Expression::Ptr(new Dereference(stackPtr, u32));
-            return retLoc;
-        }
-        DYNINST_EXPORT InsnCategory Instruction::getCategory() const
-        {
-            if(m_InsnOp.isVectorInsn) return c_VectorInsn;
-            InsnCategory c = entryToCategory(m_InsnOp.getID());
-            if(c == c_BranchInsn && (arch_decoded_from == Arch_ppc32 || arch_decoded_from == Arch_ppc64))
-            {
-                DECODE_OPERANDS();
-                for(cftConstIter cft = cft_begin();
-                        cft != cft_end();
-                        ++cft)
-                {
-                    if(cft->isCall)
-                    {
-                        return c_CallInsn;
-                    }
-                }
-                if(m_InsnOp.getID() == power_op_bclr)
-                {
-                    return c_ReturnInsn;
-                }
-            }
-            return c;
-        }
-        void Instruction::addSuccessor(Expression::Ptr e, 
-                bool isCall, 
-                bool isIndirect, 
-                bool isConditional, 
-                bool isFallthrough,
-		bool isImplicit) const
-        {
-            CFT c(e, isCall, isIndirect, isConditional, isFallthrough);
-            m_Successors.push_back(c);
-            if (!isFallthrough) appendOperand(e, true, false, isImplicit);
-        }
-
-        void Instruction::appendOperand(Expression::Ptr e, 
-                bool isRead, bool isWritten, bool isImplicit, bool trueP, bool falseP) const
-        {
-            m_Operands.push_back(Operand(e, isRead, isWritten, isImplicit, trueP, falseP));
-        }
-
-
+        return m_Successors.empty();
+      }
     }
-}
+    // can't happen but make the compiler happy
+    return false;
+  }
 
+  DYNINST_EXPORT bool Instruction::isLegalInsn() const { return (m_InsnOp.getID() != e_No_Entry); }
+
+  DYNINST_EXPORT Architecture Instruction::getArch() const { return arch_decoded_from; }
+
+  Expression::Ptr Instruction::makeReturnExpression() const {
+    Expression::Ptr stackPtr =
+        Expression::Ptr(new RegisterAST(MachRegister::getStackPointer(arch_decoded_from), 0,
+                                        MachRegister::getStackPointer(arch_decoded_from).size()));
+    Expression::Ptr retLoc = Expression::Ptr(new Dereference(stackPtr, u32));
+    return retLoc;
+  }
+
+  DYNINST_EXPORT InsnCategory Instruction::getCategory() const {
+    if(m_InsnOp.isVectorInsn)
+      return c_VectorInsn;
+    InsnCategory c = entryToCategory(m_InsnOp.getID());
+    if(c == c_BranchInsn && (arch_decoded_from == Arch_ppc32 || arch_decoded_from == Arch_ppc64)) {
+      DECODE_OPERANDS();
+      for(cftConstIter cft = cft_begin(); cft != cft_end(); ++cft) {
+        if(cft->isCall) {
+          return c_CallInsn;
+        }
+      }
+      if(m_InsnOp.getID() == power_op_bclr) {
+        return c_ReturnInsn;
+      }
+    }
+    return c;
+  }
+
+  void Instruction::addSuccessor(Expression::Ptr e, bool isCall, bool isIndirect,
+                                 bool isConditional, bool isFallthrough, bool isImplicit) const {
+    CFT c(e, isCall, isIndirect, isConditional, isFallthrough);
+    m_Successors.push_back(c);
+    if(!isFallthrough)
+      appendOperand(e, true, false, isImplicit);
+  }
+
+  void Instruction::appendOperand(Expression::Ptr e, bool isRead, bool isWritten, bool isImplicit,
+                                  bool trueP, bool falseP) const {
+    m_Operands.push_back(Operand(e, isRead, isWritten, isImplicit, trueP, falseP));
+  }
+
+}}

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -64,20 +64,11 @@ using namespace NS_x86;
 
 namespace Dyninst { namespace InstructionAPI {
 
-  int Instruction::numInsnsAllocated = 0;
-
   DYNINST_EXPORT Instruction::Instruction(Operation what, size_t size, const unsigned char* raw,
                                           Dyninst::Architecture arch)
       : m_InsnOp(what), m_Valid(what.getID() != e_No_Entry), arch_decoded_from(arch),
         formatter(&ArchSpecificFormatter::getFormatter(arch)) {
     copyRaw(size, raw);
-
-#if defined(DEBUG_INSN_ALLOCATIONS)
-    numInsnsAllocated++;
-    if((numInsnsAllocated % 1000) == 0) {
-      fprintf(stderr, "Instruction CTOR, %d insns allocated\n", numInsnsAllocated);
-    }
-#endif
   }
 
   void Instruction::copyRaw(size_t size, const unsigned char* raw) {
@@ -106,12 +97,6 @@ namespace Dyninst { namespace InstructionAPI {
 
   DYNINST_EXPORT Instruction::Instruction()
       : m_Valid(false), m_size(0), arch_decoded_from(Arch_none), formatter(nullptr) {
-#if defined(DEBUG_INSN_ALLOCATIONS)
-    numInsnsAllocated++;
-    if((numInsnsAllocated % 1000) == 0) {
-      fprintf(stderr, "Instruction CTOR, %d insns allocated\n", numInsnsAllocated);
-    }
-#endif
   }
 
   DYNINST_EXPORT Instruction::~Instruction() {
@@ -119,13 +104,6 @@ namespace Dyninst { namespace InstructionAPI {
     if(m_size > sizeof(m_RawInsn.small_insn)) {
       delete[] m_RawInsn.large_insn;
     }
-
-#if defined(DEBUG_INSN_ALLOCATIONS)
-    numInsnsAllocated--;
-    if((numInsnsAllocated % 1000) == 0) {
-      fprintf(stderr, "Instruction DTOR, %d insns allocated\n", numInsnsAllocated);
-    }
-#endif
   }
 
   DYNINST_EXPORT Instruction::Instruction(const Instruction& o)
@@ -142,13 +120,6 @@ namespace Dyninst { namespace InstructionAPI {
     }
 
     m_Successors = o.m_Successors;
-
-#if defined(DEBUG_INSN_ALLOCATIONS)
-    numInsnsAllocated++;
-    if((numInsnsAllocated % 1000) == 0) {
-      fprintf(stderr, "Instruction COPY CTOR, %d insns allocated\n", numInsnsAllocated);
-    }
-#endif
   }
 
   DYNINST_EXPORT const Instruction& Instruction::operator=(const Instruction& rhs) {

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -67,17 +67,6 @@ namespace Dyninst
     namespace InstructionAPI
     {
 
-        static const int IAPI_major_version = DYNINST_MAJOR_VERSION;
-        static const int IAPI_minor_version = DYNINST_MINOR_VERSION;
-        static const int IAPI_maintenance_version = DYNINST_PATCH_VERSION;
-
-        void Instruction::version(int& major, int& minor, int& maintenance)
-        {
-            major = IAPI_major_version;
-            minor = IAPI_minor_version;
-            maintenance = IAPI_maintenance_version;
-        }
-
         int Instruction::numInsnsAllocated = 0;
         DYNINST_EXPORT Instruction::Instruction(Operation what,
                 size_t size, const unsigned char* raw,

--- a/instructionAPI/src/InstructionDecoder-x86.C
+++ b/instructionAPI/src/InstructionDecoder-x86.C
@@ -28,8 +28,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#define INSIDE_INSTRUCTION_API
-
 #include "InstructionDecoder-x86.h"
 #include "Expression.h"
 #include "common/src/arch-x86.h"

--- a/instructionAPI/src/Operand.C
+++ b/instructionAPI/src/Operand.C
@@ -1,180 +1,159 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "../h/Operand.h"
-#include "../h/Dereference.h"
-#include "../h/Register.h"
-#include "../h/MultiRegister.h"
-#include "../h/Immediate.h"
-#include "../h/Expression.h"
 #include "../h/BinaryFunction.h"
+#include "../h/Dereference.h"
+#include "../h/Expression.h"
+#include "../h/Immediate.h"
+#include "../h/MultiRegister.h"
+#include "../h/Operand.h"
+#include "../h/Register.h"
 #include "../h/Result.h"
+
 #include <iostream>
 
 using namespace std;
 
-namespace Dyninst
-{
-    namespace InstructionAPI
-    {
-        DYNINST_EXPORT void Operand::getReadSet(std::set<RegisterAST::Ptr>& regsRead) const
-        {
-            std::set<InstructionAST::Ptr> useSet;
-            // This thing returns something only for RegisterAST Expression
-            op_value->getUses(useSet);
-            std::set<InstructionAST::Ptr>::const_iterator curUse;
-            for(curUse = useSet.begin(); curUse != useSet.end(); ++curUse)
-            {
-                RegisterAST::Ptr tmp = boost::dynamic_pointer_cast<RegisterAST>(*curUse);
-                if(tmp) 
-                {
-                    if(m_isRead || !(*tmp == *op_value))
-                        regsRead.insert(tmp);
-                }else{
-                
-                    MultiRegisterAST::Ptr multitmp = boost::dynamic_pointer_cast<MultiRegisterAST>(*curUse);
-                    if(tmp)
-                    {
-                        for (auto reg : multitmp->getRegs()){
-                            if(m_isRead || !(*reg == *op_value))
-                                regsRead.insert(reg);
-                        } 
-                    }
+namespace Dyninst { namespace InstructionAPI {
 
-                }
-            }
-        }
-        DYNINST_EXPORT void Operand::getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const
-        {
-            if(m_isWritten) 
-            {
-                RegisterAST::Ptr op_as_reg = boost::dynamic_pointer_cast<RegisterAST>(op_value);
-                if(op_as_reg){
-                    regsWritten.insert(op_as_reg);
-                }else
-                {
-                  
-                    MultiRegisterAST::Ptr op_as_multireg = boost::dynamic_pointer_cast<MultiRegisterAST>(op_value);
-                    if(op_as_reg)
-                    {
-                        for (auto reg : op_as_multireg->getRegs()){
-                            regsWritten.insert(reg);
-                        } 
-                
-                    }
-                }
-            }
-        }
+  DYNINST_EXPORT void Operand::getReadSet(std::set<RegisterAST::Ptr>& regsRead) const {
+    std::set<InstructionAST::Ptr> useSet;
+    // This thing returns something only for RegisterAST Expression
+    op_value->getUses(useSet);
+    std::set<InstructionAST::Ptr>::const_iterator curUse;
+    for(curUse = useSet.begin(); curUse != useSet.end(); ++curUse) {
+      RegisterAST::Ptr tmp = boost::dynamic_pointer_cast<RegisterAST>(*curUse);
+      if(tmp) {
+        if(m_isRead || !(*tmp == *op_value))
+          regsRead.insert(tmp);
+      } else {
 
-        DYNINST_EXPORT RegisterAST::Ptr Operand::getPredicate() const
-        {
-            RegisterAST::Ptr op_as_reg = boost::dynamic_pointer_cast<RegisterAST>(op_value);
-            if (m_isTruePredicate || m_isFalsePredicate) {
-                return op_as_reg;
-            }
-            return nullptr;
+        MultiRegisterAST::Ptr multitmp = boost::dynamic_pointer_cast<MultiRegisterAST>(*curUse);
+        if(tmp) {
+          for(auto reg : multitmp->getRegs()) {
+            if(m_isRead || !(*reg == *op_value))
+              regsRead.insert(reg);
+          }
         }
-
-        DYNINST_EXPORT bool Operand::isRead(Expression::Ptr candidate) const
-        {
-            // The whole expression of a read, any subexpression of a write
-            return op_value->isUsed(candidate) && (m_isRead || !(*candidate == *op_value));
-        }
-        DYNINST_EXPORT bool Operand::isWritten(Expression::Ptr candidate) const
-        {
-            // Whole expression of a write
-            return m_isWritten && (*op_value == *candidate);
-        }    
-        DYNINST_EXPORT bool Operand::readsMemory() const
-        {
-            return (boost::dynamic_pointer_cast<Dereference>(op_value) && m_isRead);
-        }
-        DYNINST_EXPORT bool Operand::writesMemory() const
-        {
-            return (boost::dynamic_pointer_cast<Dereference>(op_value) && m_isWritten);
-        }
-        DYNINST_EXPORT void Operand::addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const
-        {
-            if(m_isRead && boost::dynamic_pointer_cast<Dereference>(op_value))
-            {
-                std::vector<Expression::Ptr> tmp;
-                op_value->getChildren(tmp);
-                for(std::vector<Expression::Ptr>::const_iterator curKid = tmp.begin();
-                        curKid != tmp.end();
-                        ++curKid)
-                {
-                    memAccessors.insert(*curKid);
-                }
-            }
-        }
-        DYNINST_EXPORT void Operand::addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const
-        {
-            if(m_isWritten && boost::dynamic_pointer_cast<Dereference>(op_value))
-            {
-                std::vector<Expression::Ptr> tmp;
-                op_value->getChildren(tmp);
-                for(std::vector<Expression::Ptr>::const_iterator curKid = tmp.begin();
-                        curKid != tmp.end();
-                        ++curKid)
-                {
-                    memAccessors.insert(*curKid);
-                }
-            }
-        }
-
-
-        DYNINST_EXPORT std::string Operand::format(Architecture arch, Address addr) const
-        {
-            if(!op_value) return "ERROR: format() called on empty operand!";
-            if (addr) {
-                Expression::Ptr thePC = Expression::Ptr(new RegisterAST(MachRegister::getPC(arch)));
-                op_value->bind(thePC.get(), Result(u32, addr));
-                Result res = op_value->eval();
-                if (res.defined) {
-                    char hex[20];
-                    snprintf(hex, 20, "0x%lx", res.convert<uintmax_t>());
-                    return string(hex);
-                }
-            }
-            auto s = op_value->format(arch);
-            if (!s.compare(0, 2, "##"))  {
-                s.replace(0, 2, "0x0(");	// fix-up ##X to indirection syntax 0x0(X)
-                s += ')';
-            }
-            return s;
-        }
-
-        DYNINST_EXPORT Expression::Ptr Operand::getValue() const
-        {
-            return op_value;
-        }
+      }
     }
-}
+  }
 
+  DYNINST_EXPORT void Operand::getWriteSet(std::set<RegisterAST::Ptr>& regsWritten) const {
+    if(m_isWritten) {
+      RegisterAST::Ptr op_as_reg = boost::dynamic_pointer_cast<RegisterAST>(op_value);
+      if(op_as_reg) {
+        regsWritten.insert(op_as_reg);
+      } else {
+
+        MultiRegisterAST::Ptr op_as_multireg =
+            boost::dynamic_pointer_cast<MultiRegisterAST>(op_value);
+        if(op_as_reg) {
+          for(auto reg : op_as_multireg->getRegs()) {
+            regsWritten.insert(reg);
+          }
+        }
+      }
+    }
+  }
+
+  DYNINST_EXPORT RegisterAST::Ptr Operand::getPredicate() const {
+    RegisterAST::Ptr op_as_reg = boost::dynamic_pointer_cast<RegisterAST>(op_value);
+    if(m_isTruePredicate || m_isFalsePredicate) {
+      return op_as_reg;
+    }
+    return nullptr;
+  }
+
+  DYNINST_EXPORT bool Operand::isRead(Expression::Ptr candidate) const {
+    // The whole expression of a read, any subexpression of a write
+    return op_value->isUsed(candidate) && (m_isRead || !(*candidate == *op_value));
+  }
+
+  DYNINST_EXPORT bool Operand::isWritten(Expression::Ptr candidate) const {
+    // Whole expression of a write
+    return m_isWritten && (*op_value == *candidate);
+  }
+
+  DYNINST_EXPORT bool Operand::readsMemory() const {
+    return (boost::dynamic_pointer_cast<Dereference>(op_value) && m_isRead);
+  }
+
+  DYNINST_EXPORT bool Operand::writesMemory() const {
+    return (boost::dynamic_pointer_cast<Dereference>(op_value) && m_isWritten);
+  }
+
+  DYNINST_EXPORT void
+  Operand::addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const {
+    if(m_isRead && boost::dynamic_pointer_cast<Dereference>(op_value)) {
+      std::vector<Expression::Ptr> tmp;
+      op_value->getChildren(tmp);
+      for(std::vector<Expression::Ptr>::const_iterator curKid = tmp.begin(); curKid != tmp.end();
+          ++curKid) {
+        memAccessors.insert(*curKid);
+      }
+    }
+  }
+
+  DYNINST_EXPORT void
+  Operand::addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const {
+    if(m_isWritten && boost::dynamic_pointer_cast<Dereference>(op_value)) {
+      std::vector<Expression::Ptr> tmp;
+      op_value->getChildren(tmp);
+      for(std::vector<Expression::Ptr>::const_iterator curKid = tmp.begin(); curKid != tmp.end();
+          ++curKid) {
+        memAccessors.insert(*curKid);
+      }
+    }
+  }
+
+  DYNINST_EXPORT std::string Operand::format(Architecture arch, Address addr) const {
+    if(!op_value)
+      return "ERROR: format() called on empty operand!";
+    if(addr) {
+      Expression::Ptr thePC = Expression::Ptr(new RegisterAST(MachRegister::getPC(arch)));
+      op_value->bind(thePC.get(), Result(u32, addr));
+      Result res = op_value->eval();
+      if(res.defined) {
+        char hex[20];
+        snprintf(hex, 20, "0x%lx", res.convert<uintmax_t>());
+        return string(hex);
+      }
+    }
+    auto s = op_value->format(arch);
+    if(!s.compare(0, 2, "##")) {
+      s.replace(0, 2, "0x0("); // fix-up ##X to indirection syntax 0x0(X)
+      s += ')';
+    }
+    return s;
+  }
+
+  DYNINST_EXPORT Expression::Ptr Operand::getValue() const { return op_value; }
+}}

--- a/instructionAPI/src/Operation.C
+++ b/instructionAPI/src/Operation.C
@@ -1,28 +1,28 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
@@ -30,527 +30,466 @@
 
 #define INSIDE_INSTRUCTION_API
 
-#include "common/src/vgannotations.h"
-
 #include "Operation_impl.h"
-#include "common/src/arch-x86.h"
-#include "entryIDs.h"
 #include "Register.h"
+#include "common/src/arch-x86.h"
+#include "common/src/vgannotations.h"
+#include "concurrent.h"
+#include "entryIDs.h"
+#include "registers/x86_64_regs.h"
+#include "registers/x86_regs.h"
+
+#include <boost/make_shared.hpp>
 #include <map>
 #include <mutex>
-#include "concurrent.h"
-#include "registers/x86_regs.h"
-#include "registers/x86_64_regs.h"
-#include <boost/make_shared.hpp>
 
 using namespace NS_x86;
 #include "BinaryFunction.h"
 #include "Immediate.h"
 
-namespace Dyninst
-{
-    namespace InstructionAPI
-    {
-        RegisterAST::Ptr makeRegFromID(MachRegister regID, unsigned int low, unsigned int high)
-        {
-            return boost::make_shared<RegisterAST>(regID, low, high);
-        }
-        RegisterAST::Ptr makeRegFromID(MachRegister regID)
-        {
-            return boost::make_shared<RegisterAST>(regID, 0, regID.size() * 8);
-        }
+namespace Dyninst { namespace InstructionAPI {
 
-        Operation::Operation(entryID id, std::string m, Architecture arch)
-            : operationID(id), archDecodedFrom(arch), prefixID(prefix_none)
-        {
-            switch(archDecodedFrom)
-            {
-                case Arch_x86:
-                case Arch_ppc32:
-                    addrWidth = u32;
-                    break;
-                default:
-                    addrWidth = u64;
-                    break;
-            }
-            segPrefix = 0;
-            isVectorInsn = false;
-            mnemonic = m;
-        }
+  RegisterAST::Ptr makeRegFromID(MachRegister regID, unsigned int low, unsigned int high) {
+    return boost::make_shared<RegisterAST>(regID, low, high);
+  }
 
-        static bool getVectorizationInfo(ia32_entry* e)
-        {
-            for(int i = 0; i < 3; i++)
-            {
-                switch(e->operands[i].admet)
-                {
-                    case am_V:
-                    case am_W:
-                    case am_P:
-                    case am_Q:
-                    case am_HK:
-                    case am_H:
-                    case am_X:
-                    case am_XH:
-                    case am_XU:
-                    case am_XV:
-                    case am_XW:
-                    case am_Y:
-                    case am_YH:
-                    case am_YU:
-                    case am_YV:
-                    case am_YW:
-                    case am_VK:
-                    case am_WK:
+  RegisterAST::Ptr makeRegFromID(MachRegister regID) {
+    return boost::make_shared<RegisterAST>(regID, 0, regID.size() * 8);
+  }
 
-                        return true;
-                    default:
-                        break;
-                }
-            }
-            return false;
-        }
+  Operation::Operation(entryID id, std::string m, Architecture arch)
+      : operationID(id), archDecodedFrom(arch), prefixID(prefix_none) {
+    switch(archDecodedFrom) {
+      case Arch_x86:
+      case Arch_ppc32: addrWidth = u32; break;
+      default: addrWidth = u64; break;
+    }
+    segPrefix = 0;
+    isVectorInsn = false;
+    mnemonic = m;
+  }
 
-        Operation::Operation(ia32_entry* e, ia32_prefixes* p, ia32_locations* l, Architecture arch) :
-            archDecodedFrom(arch), prefixID(prefix_none)
-        {
-            segPrefix = 0;
-            isVectorInsn = getVectorizationInfo(e);
-            operationID = e->getID(l);
-            // Defaults for no size prefix
-            switch(archDecodedFrom)
-            {
-                case Arch_x86:
-                case Arch_ppc32:
-                    addrWidth = u32;
-                    break;
-                default:
-                    addrWidth = u64;
-                    break;
-            }
-            if(p && p->getCount())
-            {
-                if (p->getPrefix(0) == PREFIX_REP) prefixID = prefix_rep;
-                if (p->getPrefix(0) == PREFIX_REPNZ) prefixID = prefix_repnz;
-                segPrefix = p->getPrefix(1);
-                if(p->getAddrSzPrefix())
-                {
-                    addrWidth = u16;
-                }
-            }
-        }
+  static bool getVectorizationInfo(ia32_entry* e) {
+    for(int i = 0; i < 3; i++) {
+      switch(e->operands[i].admet) {
+        case am_V:
+        case am_W:
+        case am_P:
+        case am_Q:
+        case am_HK:
+        case am_H:
+        case am_X:
+        case am_XH:
+        case am_XU:
+        case am_XV:
+        case am_XW:
+        case am_Y:
+        case am_YH:
+        case am_YU:
+        case am_YV:
+        case am_YW:
+        case am_VK:
+        case am_WK: return true;
+        default: break;
+      }
+    }
+    return false;
+  }
 
-        Operation::Operation(const Operation& o)
-        {
-            operationID = o.operationID;
-            archDecodedFrom = o.archDecodedFrom;
-            prefixID = o.prefixID;
-            addrWidth = o.addrWidth;
-            segPrefix = o.segPrefix;
-            isVectorInsn = o.isVectorInsn;
-            mnemonic = o.mnemonic;
-        }
-        const Operation& Operation::operator=(const Operation& o)
-        {
-            operationID = o.operationID;
-            archDecodedFrom = o.archDecodedFrom;
-            prefixID = o.prefixID;
-            addrWidth = o.addrWidth;
-            segPrefix = o.segPrefix;
-            isVectorInsn = o.isVectorInsn;
-            mnemonic = o.mnemonic;
-            return *this;
-        }
-        Operation::Operation()
-        {
-            operationID = e_No_Entry;
-            archDecodedFrom = Arch_none;
-            prefixID = prefix_none;
-            addrWidth = u64;
-            segPrefix = 0;
-            isVectorInsn = false;
-        }
+  Operation::Operation(ia32_entry* e, ia32_prefixes* p, ia32_locations* l, Architecture arch)
+      : archDecodedFrom(arch), prefixID(prefix_none) {
+    segPrefix = 0;
+    isVectorInsn = getVectorizationInfo(e);
+    operationID = e->getID(l);
+    // Defaults for no size prefix
+    switch(archDecodedFrom) {
+      case Arch_x86:
+      case Arch_ppc32: addrWidth = u32; break;
+      default: addrWidth = u64; break;
+    }
+    if(p && p->getCount()) {
+      if(p->getPrefix(0) == PREFIX_REP)
+        prefixID = prefix_rep;
+      if(p->getPrefix(0) == PREFIX_REPNZ)
+        prefixID = prefix_repnz;
+      segPrefix = p->getPrefix(1);
+      if(p->getAddrSzPrefix()) {
+        addrWidth = u16;
+      }
+    }
+  }
 
-        const Operation::registerSet&  Operation::implicitReads()
-        {
-            SetUpNonOperandData();
+  Operation::Operation(const Operation& o) {
+    operationID = o.operationID;
+    archDecodedFrom = o.archDecodedFrom;
+    prefixID = o.prefixID;
+    addrWidth = o.addrWidth;
+    segPrefix = o.segPrefix;
+    isVectorInsn = o.isVectorInsn;
+    mnemonic = o.mnemonic;
+  }
 
-            return otherRead;
-        }
-        const Operation::registerSet&  Operation::implicitWrites()
-        {
-            SetUpNonOperandData();
+  const Operation& Operation::operator=(const Operation& o) {
+    operationID = o.operationID;
+    archDecodedFrom = o.archDecodedFrom;
+    prefixID = o.prefixID;
+    addrWidth = o.addrWidth;
+    segPrefix = o.segPrefix;
+    isVectorInsn = o.isVectorInsn;
+    mnemonic = o.mnemonic;
+    return *this;
+  }
 
-            return otherWritten;
-        }
-        bool Operation::isRead(Expression::Ptr candidate)
-        {
+  Operation::Operation() {
+    operationID = e_No_Entry;
+    archDecodedFrom = Arch_none;
+    prefixID = prefix_none;
+    addrWidth = u64;
+    segPrefix = 0;
+    isVectorInsn = false;
+  }
 
-            SetUpNonOperandData();
+  const Operation::registerSet& Operation::implicitReads() {
+    SetUpNonOperandData();
 
-            for(registerSet::const_iterator r = otherRead.begin();
-                    r != otherRead.end();
-                    ++r)
-            {
-                if(*candidate == *(*r))
-                {
-                    return true;
-                }
-            }
-            for(VCSet::const_iterator e = otherEffAddrsRead.begin();
-                    e != otherEffAddrsRead.end();
-                    ++e)
-            {
-                if(*candidate == *(*e))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-        const Operation::VCSet& Operation::getImplicitMemReads()
-        {
-            SetUpNonOperandData();
-            return otherEffAddrsRead;
-        }
-        const Operation::VCSet& Operation::getImplicitMemWrites()
-        {
-            SetUpNonOperandData();
-            return otherEffAddrsWritten;
-        }
+    return otherRead;
+  }
 
-        bool Operation::isWritten(Expression::Ptr candidate)
-        {
+  const Operation::registerSet& Operation::implicitWrites() {
+    SetUpNonOperandData();
 
-            SetUpNonOperandData();
+    return otherWritten;
+  }
 
-            for(registerSet::const_iterator r = otherWritten.begin();
-                    r != otherWritten.end();
-                    ++r)
-            {
-                if(*candidate == *(*r))
-                {
-                    return true;
-                }
-            }
-            for(VCSet::const_iterator e = otherEffAddrsWritten.begin();
-                    e != otherEffAddrsWritten.end();
-                    ++e)
-            {
-                if(*candidate == *(*e))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
+  bool Operation::isRead(Expression::Ptr candidate) {
 
-        std::string Operation::format() const
-        {
-            if(mnemonic != "")
-            {
-                return mnemonic;
-            }
-            dyn_hash_map<prefixEntryID, std::string>::const_iterator foundPrefix = prefixEntryNames_IAPI.find(prefixID);
-            dyn_hash_map<entryID, std::string>::const_iterator found = entryNames_IAPI.find(operationID);
-            std::string result;
-            if(foundPrefix != prefixEntryNames_IAPI.end())
-            {
-                result += (foundPrefix->second + " ");
-            }
-            if(found != entryNames_IAPI.end())
-            {
-                result += found->second;
-            }
-            else
-            {
-                result += "[INVALID]";
-            }
-            return result;
-        }
+    SetUpNonOperandData();
 
-        entryID Operation::getID() const
-        {
-            return operationID;
-        }
+    for(registerSet::const_iterator r = otherRead.begin(); r != otherRead.end(); ++r) {
+      if(*candidate == *(*r)) {
+        return true;
+      }
+    }
+    for(VCSet::const_iterator e = otherEffAddrsRead.begin(); e != otherEffAddrsRead.end(); ++e) {
+      if(*candidate == *(*e)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
-        prefixEntryID Operation::getPrefixID() const
-        {
-            return prefixID;
-        }
+  const Operation::VCSet& Operation::getImplicitMemReads() {
+    SetUpNonOperandData();
+    return otherEffAddrsRead;
+  }
 
-        struct OperationMaps
-        {
-            typedef dyn_c_hash_map<entryID, Operation::registerSet > reg_info_t;
-            typedef dyn_c_hash_map<entryID, Operation::VCSet > mem_info_t;
-            public:
-            OperationMaps(Architecture arch)
-            {
-                thePC.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getPC(arch))));
-                pcAndSP.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getPC(arch))));
-                pcAndSP.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getStackPointer(arch))));
-                stackPointer.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getStackPointer(arch))));
-                stackPointerAsExpr.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getStackPointer(arch))));
-                framePointer.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getFramePointer(arch))));
-                spAndBP.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getStackPointer(arch))));
-                spAndBP.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getFramePointer(arch))));
-                si.insert(RegisterAST::Ptr(new RegisterAST(arch == Arch_x86_64 ? x86_64::rsi : x86::esi)));
-                di.insert(RegisterAST::Ptr(new RegisterAST(arch == Arch_x86_64 ? x86_64::rdi : x86::edi)));
-                si_and_di.insert(RegisterAST::Ptr(new RegisterAST(arch == Arch_x86_64 ? x86_64::rsi : x86::esi)));
-                si_and_di.insert(RegisterAST::Ptr(new RegisterAST(arch == Arch_x86_64 ? x86_64::rdi : x86::edi)));
+  const Operation::VCSet& Operation::getImplicitMemWrites() {
+    SetUpNonOperandData();
+    return otherEffAddrsWritten;
+  }
 
-                nonOperandRegisterReads.insert(make_pair(e_call, pcAndSP));
-                nonOperandRegisterReads.insert(make_pair(e_ret_near, stackPointer));
-                nonOperandRegisterReads.insert(make_pair(e_ret_far, stackPointer));
-                nonOperandRegisterReads.insert(make_pair(e_leave, framePointer));
-                nonOperandRegisterReads.insert(make_pair(e_enter, spAndBP));
+  bool Operation::isWritten(Expression::Ptr candidate) {
 
-                nonOperandRegisterWrites.insert(make_pair(e_call, pcAndSP));
-                nonOperandRegisterWrites.insert(make_pair(e_ret_near, pcAndSP));
-                nonOperandRegisterWrites.insert(make_pair(e_ret_far, pcAndSP));
-                nonOperandRegisterWrites.insert(make_pair(e_leave, spAndBP));
-                nonOperandRegisterWrites.insert(make_pair(e_enter, spAndBP));
+    SetUpNonOperandData();
 
-                nonOperandRegisterWrites.insert(make_pair(e_loop, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_loope, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_loopne, thePC));
+    for(registerSet::const_iterator r = otherWritten.begin(); r != otherWritten.end(); ++r) {
+      if(*candidate == *(*r)) {
+        return true;
+      }
+    }
+    for(VCSet::const_iterator e = otherEffAddrsWritten.begin(); e != otherEffAddrsWritten.end();
+        ++e) {
+      if(*candidate == *(*e)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
-                nonOperandRegisterWrites.insert(make_pair(e_jb, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jb_jnaej_j, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jbe, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jcxz_jec, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jl, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jle, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jmp, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jae, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jnb_jae_j, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_ja, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jge, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jg, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jno, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jnp, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jns, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jne, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jo, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_jp, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_js, thePC));
-                nonOperandRegisterWrites.insert(make_pair(e_je, thePC));
+  std::string Operation::format() const {
+    if(mnemonic != "") {
+      return mnemonic;
+    }
+    dyn_hash_map<prefixEntryID, std::string>::const_iterator foundPrefix =
+        prefixEntryNames_IAPI.find(prefixID);
+    dyn_hash_map<entryID, std::string>::const_iterator found = entryNames_IAPI.find(operationID);
+    std::string result;
+    if(foundPrefix != prefixEntryNames_IAPI.end()) {
+      result += (foundPrefix->second + " ");
+    }
+    if(found != entryNames_IAPI.end()) {
+      result += found->second;
+    } else {
+      result += "[INVALID]";
+    }
+    return result;
+  }
 
-                nonOperandMemoryReads.insert(make_pair(e_pop, stackPointerAsExpr));
-                nonOperandMemoryReads.insert(make_pair(e_popal, stackPointerAsExpr));
-                nonOperandMemoryReads.insert(make_pair(e_popaw, stackPointerAsExpr));
-                nonOperandMemoryWrites.insert(make_pair(e_push, stackPointerAsExpr));
-                nonOperandMemoryWrites.insert(make_pair(e_pushal, stackPointerAsExpr));
-                nonOperandMemoryWrites.insert(make_pair(e_call, stackPointerAsExpr));
-                nonOperandMemoryReads.insert(make_pair(e_ret_near, stackPointerAsExpr));
-                nonOperandMemoryReads.insert(make_pair(e_ret_far, stackPointerAsExpr));
-                nonOperandMemoryReads.insert(make_pair(e_leave, stackPointerAsExpr));
+  entryID Operation::getID() const { return operationID; }
 
-                nonOperandRegisterWrites.insert(make_pair(e_cmpsb, si_and_di));
-                nonOperandRegisterWrites.insert(make_pair(e_cmpsd, si_and_di));
-                nonOperandRegisterWrites.insert(make_pair(e_cmpsw, si_and_di));
-                nonOperandRegisterWrites.insert(make_pair(e_movsb, si_and_di));
-                nonOperandRegisterWrites.insert(make_pair(e_movsd, si_and_di));
-                nonOperandRegisterWrites.insert(make_pair(e_movsw, si_and_di));
-                nonOperandRegisterWrites.insert(make_pair(e_insb, di));
-                nonOperandRegisterWrites.insert(make_pair(e_insd, di));
-                nonOperandRegisterWrites.insert(make_pair(e_insw, di));
-                nonOperandRegisterWrites.insert(make_pair(e_stosb, di));
-                nonOperandRegisterWrites.insert(make_pair(e_stosd, di));
-                nonOperandRegisterWrites.insert(make_pair(e_stosw, di));
-                nonOperandRegisterWrites.insert(make_pair(e_scasb, di));
-                nonOperandRegisterWrites.insert(make_pair(e_scasd, di));
-                nonOperandRegisterWrites.insert(make_pair(e_scasw, di));
-                nonOperandRegisterWrites.insert(make_pair(e_lodsb, di));
-                nonOperandRegisterWrites.insert(make_pair(e_lodsd, di));
-                nonOperandRegisterWrites.insert(make_pair(e_lodsw, di));
-                nonOperandRegisterWrites.insert(make_pair(e_outsb, di));
-                nonOperandRegisterWrites.insert(make_pair(e_outsd, di));
-                nonOperandRegisterWrites.insert(make_pair(e_outsw, di));
+  prefixEntryID Operation::getPrefixID() const { return prefixID; }
 
+  struct OperationMaps {
+    typedef dyn_c_hash_map<entryID, Operation::registerSet> reg_info_t;
+    typedef dyn_c_hash_map<entryID, Operation::VCSet> mem_info_t;
 
-            }
-            Operation::registerSet thePC;
-            Operation::registerSet pcAndSP;
-            Operation::registerSet stackPointer;
-            Operation::VCSet stackPointerAsExpr;
-            Operation::registerSet framePointer;
-            Operation::registerSet spAndBP;
-            Operation::registerSet si;
-            Operation::registerSet di;
-            Operation::registerSet si_and_di;
+  public:
+    OperationMaps(Architecture arch) {
+      thePC.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getPC(arch))));
+      pcAndSP.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getPC(arch))));
+      pcAndSP.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getStackPointer(arch))));
+      stackPointer.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getStackPointer(arch))));
+      stackPointerAsExpr.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getStackPointer(arch))));
+      framePointer.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getFramePointer(arch))));
+      spAndBP.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getStackPointer(arch))));
+      spAndBP.insert(RegisterAST::Ptr(new RegisterAST(MachRegister::getFramePointer(arch))));
+      si.insert(RegisterAST::Ptr(new RegisterAST(arch == Arch_x86_64 ? x86_64::rsi : x86::esi)));
+      di.insert(RegisterAST::Ptr(new RegisterAST(arch == Arch_x86_64 ? x86_64::rdi : x86::edi)));
+      si_and_di.insert(RegisterAST::Ptr(new RegisterAST(arch == Arch_x86_64 ? x86_64::rsi : x86::esi)));
+      si_and_di.insert(RegisterAST::Ptr(new RegisterAST(arch == Arch_x86_64 ? x86_64::rdi : x86::edi)));
 
-            reg_info_t nonOperandRegisterReads;
-            reg_info_t nonOperandRegisterWrites;
+      nonOperandRegisterReads.insert(make_pair(e_call, pcAndSP));
+      nonOperandRegisterReads.insert(make_pair(e_ret_near, stackPointer));
+      nonOperandRegisterReads.insert(make_pair(e_ret_far, stackPointer));
+      nonOperandRegisterReads.insert(make_pair(e_leave, framePointer));
+      nonOperandRegisterReads.insert(make_pair(e_enter, spAndBP));
 
-            mem_info_t nonOperandMemoryReads;
-            mem_info_t nonOperandMemoryWrites;
-        };
-        OperationMaps op_data_32(Arch_x86);
-        OperationMaps op_data_64(Arch_x86_64);
-        const OperationMaps& op_data(Architecture arch)
-        {
-            switch(arch)
-            {
-                case Arch_x86:
-                    return op_data_32;
-                case Arch_x86_64:
-                    return op_data_64;
-                default:
-                    return op_data_32;
-            }
-        }
-        void Operation::SetUpNonOperandData()
-        {
-            if (archDecodedFrom != Arch_x86 && archDecodedFrom != Arch_x86_64) return;
-            std::call_once(data_initialized, [&]() {
-                    if (prefixID == prefix_rep || prefixID == prefix_repnz) 	{
-                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::df : x86_64::df));
-                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::ecx : x86_64::rcx));
-                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::ecx : x86_64::rcx));
-                    if(prefixID == prefix_repnz)
-                    {
-                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::zf : x86_64::zf));
-                    }
-                    }
-                    switch(segPrefix)
-                    {
-                    case PREFIX_SEGCS:
-                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::cs : x86_64::cs));
-                    break;
-                    case PREFIX_SEGDS:
-                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::ds : x86_64::ds));
-                    break;
-                    case PREFIX_SEGES:
-                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::es : x86_64::es));
-                    break;
-                    case PREFIX_SEGFS:
-                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::fs : x86_64::fs));
-                    break;
-                    case PREFIX_SEGGS:
-                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::gs : x86_64::gs));
-                    break;
-                    case PREFIX_SEGSS:
-                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::ss : x86_64::ss));
-                    break;
-                    }
+      nonOperandRegisterWrites.insert(make_pair(e_call, pcAndSP));
+      nonOperandRegisterWrites.insert(make_pair(e_ret_near, pcAndSP));
+      nonOperandRegisterWrites.insert(make_pair(e_ret_far, pcAndSP));
+      nonOperandRegisterWrites.insert(make_pair(e_leave, spAndBP));
+      nonOperandRegisterWrites.insert(make_pair(e_enter, spAndBP));
 
-                    OperationMaps::reg_info_t::const_accessor a, b;
-                    if (op_data(archDecodedFrom).nonOperandRegisterReads.find(a, operationID)) {
-                        otherRead.insert(a->second.begin(), a->second.end());
-                    }
-                    if (op_data(archDecodedFrom).nonOperandRegisterWrites.find(b, operationID)) {
-                        otherWritten.insert(b->second.begin(), b->second.end());
-                    }
-                    OperationMaps::mem_info_t::const_accessor c, d;
-                    if (op_data(archDecodedFrom).nonOperandMemoryReads.find(c, operationID)) {
-                        otherEffAddrsRead.insert(c->second.begin(), c->second.end());
-                    }
-                    if (operationID == e_push) {
-                        BinaryFunction::funcT::Ptr adder(new BinaryFunction::addResult());
-                        // special case for push: we write at the new value of the SP.
-                        Result dummy(addrWidth, 0);
-                        Expression::Ptr push_addr(new BinaryFunction(
-                                    *(op_data(archDecodedFrom).stackPointerAsExpr.begin()),
-                                    Immediate::makeImmediate(Result(s8, -(dummy.size()))),
-                                    addrWidth,
-                                    adder));
+      nonOperandRegisterWrites.insert(make_pair(e_loop, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_loope, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_loopne, thePC));
 
-                        otherEffAddrsWritten.insert(push_addr);
+      nonOperandRegisterWrites.insert(make_pair(e_jb, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jb_jnaej_j, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jbe, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jcxz_jec, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jl, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jle, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jmp, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jae, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jnb_jae_j, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_ja, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jge, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jg, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jno, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jnp, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jns, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jne, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jo, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_jp, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_js, thePC));
+      nonOperandRegisterWrites.insert(make_pair(e_je, thePC));
 
-                    } else {
-                        if (op_data(archDecodedFrom).nonOperandMemoryWrites.find(d, operationID)) {
-                            otherEffAddrsWritten.insert(d->second.begin(), d->second.end());
-                        }
-                    }
+      nonOperandMemoryReads.insert(make_pair(e_pop, stackPointerAsExpr));
+      nonOperandMemoryReads.insert(make_pair(e_popal, stackPointerAsExpr));
+      nonOperandMemoryReads.insert(make_pair(e_popaw, stackPointerAsExpr));
+      nonOperandMemoryWrites.insert(make_pair(e_push, stackPointerAsExpr));
+      nonOperandMemoryWrites.insert(make_pair(e_pushal, stackPointerAsExpr));
+      nonOperandMemoryWrites.insert(make_pair(e_call, stackPointerAsExpr));
+      nonOperandMemoryReads.insert(make_pair(e_ret_near, stackPointerAsExpr));
+      nonOperandMemoryReads.insert(make_pair(e_ret_far, stackPointerAsExpr));
+      nonOperandMemoryReads.insert(make_pair(e_leave, stackPointerAsExpr));
 
-                    dyn_hash_map<entryID, flagInfo>::const_iterator found = ia32_instruction::getFlagTable().find(operationID);
-                    if (found != ia32_instruction::getFlagTable().end()) {
-                        for (unsigned i = 0; i < found->second.readFlags.size(); i++) {
-                            switch (found->second.readFlags[i]) {
-                                case x86::icf:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::cf : x86_64::cf));
-                                    break;
-                                case x86::ipf:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::pf : x86_64::pf));
-                                    break;
-                                case x86::iaf:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::af : x86_64::af));
-                                    break;
-                                case x86::izf:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::zf : x86_64::zf));
-                                    break;
-                                case x86::isf:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::sf : x86_64::sf));
-                                    break;
-                                case x86::itf:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::tf : x86_64::tf));
-                                    break;
-                                case x86::idf:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::df : x86_64::df));
-                                    break;
-                                case x86::iof:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::of : x86_64::of));
-                                    break;
-                                case x86::int_:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::nt_ : x86_64::nt_));
-                                    break;
-                                case x86::iif_:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::if_ : x86_64::if_));
-                                    break;
-                                case x86::irf:
-                                    otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::rf : x86_64::rf));
-                                    break;
-                                default:
-                                    assert(0);
-                            }
-                        }
-
-                        for (unsigned j = 0; j < found->second.writtenFlags.size(); j++) {
-                            switch (found->second.writtenFlags[j]) {
-                                case x86::icf:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::cf : x86_64::cf));
-                                    break;
-                                case x86::ipf:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::pf : x86_64::pf));
-                                    break;
-                                case x86::iaf:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::af : x86_64::af));
-                                    break;
-                                case x86::izf:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::zf : x86_64::zf));
-                                    break;
-                                case x86::isf:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::sf : x86_64::sf));
-                                    break;
-                                case x86::itf:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::tf : x86_64::tf));
-                                    break;
-                                case x86::idf:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::df : x86_64::df));
-                                    break;
-                                case x86::iof:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::of : x86_64::of));
-                                    break;
-                                case x86::int_:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::nt_ : x86_64::nt_));
-                                    break;
-                                case x86::iif_:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::if_ : x86_64::if_));
-                                    break;
-                                case x86::irf:
-                                    otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::rf : x86_64::rf));
-                                    break;
-                                default:
-                                    fprintf(stderr, "ERROR: unhandled entry %s\n",
-                                            found->second.writtenFlags[j].name().c_str());
-                                    assert(0);
-                            }
-                        }
-                    }
-            });
-            return;
-        }
+      nonOperandRegisterWrites.insert(make_pair(e_cmpsb, si_and_di));
+      nonOperandRegisterWrites.insert(make_pair(e_cmpsd, si_and_di));
+      nonOperandRegisterWrites.insert(make_pair(e_cmpsw, si_and_di));
+      nonOperandRegisterWrites.insert(make_pair(e_movsb, si_and_di));
+      nonOperandRegisterWrites.insert(make_pair(e_movsd, si_and_di));
+      nonOperandRegisterWrites.insert(make_pair(e_movsw, si_and_di));
+      nonOperandRegisterWrites.insert(make_pair(e_insb, di));
+      nonOperandRegisterWrites.insert(make_pair(e_insd, di));
+      nonOperandRegisterWrites.insert(make_pair(e_insw, di));
+      nonOperandRegisterWrites.insert(make_pair(e_stosb, di));
+      nonOperandRegisterWrites.insert(make_pair(e_stosd, di));
+      nonOperandRegisterWrites.insert(make_pair(e_stosw, di));
+      nonOperandRegisterWrites.insert(make_pair(e_scasb, di));
+      nonOperandRegisterWrites.insert(make_pair(e_scasd, di));
+      nonOperandRegisterWrites.insert(make_pair(e_scasw, di));
+      nonOperandRegisterWrites.insert(make_pair(e_lodsb, di));
+      nonOperandRegisterWrites.insert(make_pair(e_lodsd, di));
+      nonOperandRegisterWrites.insert(make_pair(e_lodsw, di));
+      nonOperandRegisterWrites.insert(make_pair(e_outsb, di));
+      nonOperandRegisterWrites.insert(make_pair(e_outsd, di));
+      nonOperandRegisterWrites.insert(make_pair(e_outsw, di));
     }
 
-}
+    Operation::registerSet thePC;
+    Operation::registerSet pcAndSP;
+    Operation::registerSet stackPointer;
+    Operation::VCSet stackPointerAsExpr;
+    Operation::registerSet framePointer;
+    Operation::registerSet spAndBP;
+    Operation::registerSet si;
+    Operation::registerSet di;
+    Operation::registerSet si_and_di;
+
+    reg_info_t nonOperandRegisterReads;
+    reg_info_t nonOperandRegisterWrites;
+
+    mem_info_t nonOperandMemoryReads;
+    mem_info_t nonOperandMemoryWrites;
+  };
+
+  OperationMaps op_data_32(Arch_x86);
+  OperationMaps op_data_64(Arch_x86_64);
+
+  const OperationMaps& op_data(Architecture arch) {
+    switch(arch) {
+      case Arch_x86: return op_data_32;
+      case Arch_x86_64: return op_data_64;
+      default: return op_data_32;
+    }
+  }
+
+  void Operation::SetUpNonOperandData() {
+    if(archDecodedFrom != Arch_x86 && archDecodedFrom != Arch_x86_64)
+      return;
+    std::call_once(data_initialized, [&]() {
+      if(prefixID == prefix_rep || prefixID == prefix_repnz) {
+        otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::df : x86_64::df));
+        otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::ecx : x86_64::rcx));
+        otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::ecx : x86_64::rcx));
+        if(prefixID == prefix_repnz) {
+          otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::zf : x86_64::zf));
+        }
+      }
+      switch(segPrefix) {
+        case PREFIX_SEGCS:
+          otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::cs : x86_64::cs));
+          break;
+        case PREFIX_SEGDS:
+          otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::ds : x86_64::ds));
+          break;
+        case PREFIX_SEGES:
+          otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::es : x86_64::es));
+          break;
+        case PREFIX_SEGFS:
+          otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::fs : x86_64::fs));
+          break;
+        case PREFIX_SEGGS:
+          otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::gs : x86_64::gs));
+          break;
+        case PREFIX_SEGSS:
+          otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::ss : x86_64::ss));
+          break;
+      }
+
+      OperationMaps::reg_info_t::const_accessor a, b;
+      if(op_data(archDecodedFrom).nonOperandRegisterReads.find(a, operationID)) {
+        otherRead.insert(a->second.begin(), a->second.end());
+      }
+      if(op_data(archDecodedFrom).nonOperandRegisterWrites.find(b, operationID)) {
+        otherWritten.insert(b->second.begin(), b->second.end());
+      }
+      OperationMaps::mem_info_t::const_accessor c, d;
+      if(op_data(archDecodedFrom).nonOperandMemoryReads.find(c, operationID)) {
+        otherEffAddrsRead.insert(c->second.begin(), c->second.end());
+      }
+      if(operationID == e_push) {
+        BinaryFunction::funcT::Ptr adder(new BinaryFunction::addResult());
+        // special case for push: we write at the new value of the SP.
+        Result dummy(addrWidth, 0);
+        Expression::Ptr push_addr(new BinaryFunction(
+            *(op_data(archDecodedFrom).stackPointerAsExpr.begin()),
+            Immediate::makeImmediate(Result(s8, -(dummy.size()))), addrWidth, adder));
+
+        otherEffAddrsWritten.insert(push_addr);
+
+      } else {
+        if(op_data(archDecodedFrom).nonOperandMemoryWrites.find(d, operationID)) {
+          otherEffAddrsWritten.insert(d->second.begin(), d->second.end());
+        }
+      }
+
+      dyn_hash_map<entryID, flagInfo>::const_iterator found =
+          ia32_instruction::getFlagTable().find(operationID);
+      if(found != ia32_instruction::getFlagTable().end()) {
+        for(unsigned i = 0; i < found->second.readFlags.size(); i++) {
+          switch(found->second.readFlags[i]) {
+            case x86::icf:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::cf : x86_64::cf));
+              break;
+            case x86::ipf:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::pf : x86_64::pf));
+              break;
+            case x86::iaf:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::af : x86_64::af));
+              break;
+            case x86::izf:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::zf : x86_64::zf));
+              break;
+            case x86::isf:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::sf : x86_64::sf));
+              break;
+            case x86::itf:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::tf : x86_64::tf));
+              break;
+            case x86::idf:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::df : x86_64::df));
+              break;
+            case x86::iof:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::of : x86_64::of));
+              break;
+            case x86::int_:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::nt_ : x86_64::nt_));
+              break;
+            case x86::iif_:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::if_ : x86_64::if_));
+              break;
+            case x86::irf:
+              otherRead.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::rf : x86_64::rf));
+              break;
+            default: assert(0);
+          }
+        }
+
+        for(unsigned j = 0; j < found->second.writtenFlags.size(); j++) {
+          switch(found->second.writtenFlags[j]) {
+            case x86::icf:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::cf : x86_64::cf));
+              break;
+            case x86::ipf:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::pf : x86_64::pf));
+              break;
+            case x86::iaf:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::af : x86_64::af));
+              break;
+            case x86::izf:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::zf : x86_64::zf));
+              break;
+            case x86::isf:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::sf : x86_64::sf));
+              break;
+            case x86::itf:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::tf : x86_64::tf));
+              break;
+            case x86::idf:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::df : x86_64::df));
+              break;
+            case x86::iof:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::of : x86_64::of));
+              break;
+            case x86::int_:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::nt_ : x86_64::nt_));
+              break;
+            case x86::iif_:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::if_ : x86_64::if_));
+              break;
+            case x86::irf:
+              otherWritten.insert(makeRegFromID((archDecodedFrom == Arch_x86) ? x86::rf : x86_64::rf));
+              break;
+            default:
+              fprintf(stderr, "ERROR: unhandled entry %s\n", found->second.writtenFlags[j].name().c_str());
+              assert(0);
+          }
+        }
+      }
+    });
+    return;
+  }
+}}

--- a/instructionAPI/src/Operation.C
+++ b/instructionAPI/src/Operation.C
@@ -28,8 +28,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#define INSIDE_INSTRUCTION_API
-
 #include "Operation_impl.h"
 #include "Register.h"
 #include "common/src/arch-x86.h"


### PR DESCRIPTION
These classes will need non-trivial modifications for the move to Capstone. This makes them easier to work with.