### PR TITLE
Add category helpers to Instruction class

### DIFF
--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -2435,11 +2435,11 @@ void StackAnalysis::handleDefault(Instruction insn, Block *block,
 }
 
 bool StackAnalysis::isCall(Instruction insn) {
-   return insn.getCategory() == c_CallInsn;
+   return insn.isCall();
 }
 
 bool StackAnalysis::isJump(Instruction insn) {
-   return insn.getCategory() == c_BranchInsn;
+   return insn.isBranch();
 }
 
 bool StackAnalysis::handleNormalCall(Instruction insn, Block *block,
@@ -2788,7 +2788,7 @@ bool StackAnalysis::handleThunkCall(Instruction insn, Block *block,
 
    // We know that we're not a normal call, so it depends on whether the CFT is
    // "next instruction" or not.
-   if (insn.getCategory() != c_CallInsn || !insn.getControlFlowTarget()) {
+   if (!insn.isCall() || !insn.getControlFlowTarget()) {
       return false;
    }
 

--- a/dyninstAPI/src/BPatch_basicBlock.C
+++ b/dyninstAPI/src/BPatch_basicBlock.C
@@ -358,7 +358,7 @@ bool isStore(Instruction i)
 }
 bool isPrefetch(Instruction i)
 {
-  return i.getCategory() == c_PrefetchInsn;
+  return i.isPrefetch();
 }
 
 struct funcPtrPredicate : public insnPredicate

--- a/dyninstAPI/src/Relocation/CFG/RelocBlock.C
+++ b/dyninstAPI/src/Relocation/CFG/RelocBlock.C
@@ -317,9 +317,7 @@ void RelocBlock::createCFWidget() {
 
    InstructionAPI::Instruction insn = elements_.back()->insn();
    if (insn.isValid()) {
-      if (insn.getCategory() == c_CallInsn ||
-          insn.getCategory() == c_ReturnInsn ||
-          insn.getCategory() == c_BranchInsn) {
+      if (insn.isCall() || insn.isReturn() || insn.isBranch()) {
          hasCF = true;
       }
    }

--- a/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
@@ -289,14 +289,8 @@ bool adhocMovementTransformer::isPCRelData(Widget::Ptr ptr,
                                            Instruction insn,
                                            Address &target) {
   target = 0;
-  switch(insn.getCategory())
-  {
-      case c_CallInsn:
-      case c_BranchInsn:
-      case c_ReturnInsn:
-          return false;
-      default:
-	  break;
+  if(insn.isCall() || insn.isBranch() || insn.isReturn()) {
+    return false;
   }
   if (insn.getControlFlowTarget()) return false;
 
@@ -411,7 +405,7 @@ bool adhocMovementTransformer::isGetPC(Widget::Ptr ptr,
   // Check for call to thunk.
   // TODO: need a return register parameter.
 
-   if (insn.getCategory() != InstructionAPI::c_CallInsn) return false;
+   if (!insn.isCall()) return false;
 
   // Okay: checking for call + size
   Expression::Ptr CFT = insn.getControlFlowTarget();
@@ -479,7 +473,7 @@ bool adhocMovementTransformer::isGetPC(Widget::Ptr ptr,
 
     if(firstInsn.isValid() && firstInsn.getOperation().getID() == e_mov
        && firstInsn.readsMemory() && !firstInsn.writesMemory()
-       && secondInsn.isValid() && secondInsn.getCategory() == c_ReturnInsn) {
+       && secondInsn.isValid() && secondInsn.isReturn()) {
 
       thunkVisitor visitor;
       relocation_cerr << "Checking operand "

--- a/dyninstAPI/src/Relocation/Transformers/Movement-analysis.C
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-analysis.C
@@ -138,7 +138,7 @@ bool PCSensitiveTransformer::process(RelocBlock *reloc, RelocGraph *g) {
             extSens_++;
             thunk_++;
             continue;
-        } else if (insn.getCategory() == c_CallInsn && exceptionSensitive(addr+insn.size(), block)) {
+        } else if (insn.isCall() && exceptionSensitive(addr+insn.size(), block)) {
             extSens = true;
             sensitivity_cerr << "\tException sensitive @ " << hex << addr << dec << endl;
         }
@@ -406,7 +406,7 @@ bool PCSensitiveTransformer::insnIsThunkCall(Instruction insn,
                                              Address addr,
                                              Absloc &destination) {
   // Should be able to handle this much more efficiently by following the CFG
-  if (insn.getCategory() != c_CallInsn) {
+  if (!insn.isCall()) {
     return false;
   }
   Expression::Ptr CFT = insn.getControlFlowTarget();
@@ -450,7 +450,7 @@ bool PCSensitiveTransformer::insnIsThunkCall(Instruction insn,
 
     if(firstInsn.isValid() && firstInsn.getOperation().getID() == e_mov
        && firstInsn.readsMemory() && !firstInsn.writesMemory()
-       && secondInsn.isValid() && secondInsn.getCategory() == c_ReturnInsn) {
+       && secondInsn.isValid() && secondInsn.isReturn()) {
 
       // Check to be sure we're reading memory
       std::set<RegisterAST::Ptr> reads;

--- a/dyninstAPI/src/StackMod/StackAccess.C
+++ b/dyninstAPI/src/StackMod/StackAccess.C
@@ -287,7 +287,7 @@ bool getAccesses(ParseAPI::Function *func,
     // If this instruction is a call, check if any stack pointers are possibly
     // being passed as parameters.  If so, we don't know what the callee will
     // access through that pointer and need to return false.
-    if (insn.getCategory() == InstructionAPI::c_CallInsn) {
+    if (insn.isCall()) {
         // Check parameter registers for stack pointers
         ABI *abi = ABI::getABI(word_size);
         const bitArray &callParamRegs = abi->getParameterRegisters();

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -2211,7 +2211,7 @@ bool AstDynamicTargetNode::generateCode_phase2(codeGen &gen,
        return false;
 
    InstructionAPI::Instruction insn = gen.point()->block()->getInsn(gen.point()->block()->last());
-   if (insn.getCategory() == c_ReturnInsn) {
+   if (insn.isReturn()) {
       // if this is a return instruction our AST reads the top stack value
       if (retReg == Dyninst::Null_Register) {
          retReg = allocateAndKeep(gen, noCost);

--- a/dyninstAPI/src/hybridInstrumentation.C
+++ b/dyninstAPI/src/hybridInstrumentation.C
@@ -751,7 +751,7 @@ bool HybridAnalysis::parseAfterCallAndInstrument(BPatch_point *callPoint,
             using namespace InstructionAPI;
             Address curFallThroughAddr = (*cIter)->getCallFallThroughAddr();
             if ((*cIter)->getInsnAtPoint().isValid() &&
-                c_BranchInsn != (*cIter)->getInsnAtPoint().getCategory() &&
+                !(*cIter)->getInsnAtPoint().isBranch() &&
                 BPatch_defensiveMode == (*cIter)->llpoint()->func()->obj()->hybridMode() &&
                 ! hasEdge((*cIter)->getFunction(), 
                           (Address)((*cIter)->llpoint()->block()->start()), 

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -729,8 +729,7 @@ int image::findMain()
             while( numCalls < 4 && curInsn && curInsn->isValid() &&
                     bytesSeen < eReg->getMemSize())
             {
-                InsnCategory category = curInsn->getCategory();
-                if( category == c_CallInsn ) {
+                if( curInsn->isCall() ) {
                     numCalls++;
                 }
 

--- a/dyninstAPI/src/mapped_object.C
+++ b/dyninstAPI/src/mapped_object.C
@@ -1211,8 +1211,8 @@ bool mapped_object::parseNewEdges(const std::vector<edgeStub> &stubs)
             stubs[idx].src->getInsns(insns);
             InstructionAPI::Instruction cf = insns[stubs[idx].src->last()];
             assert(cf.isValid());
-            switch (cf.getCategory()) {
-            case c_CallInsn:
+
+            if(cf.isCall()) {
                 if (stubs[idx].trg == stubs[idx].src->end())
                 {
                     edgeType = CALL_FT;
@@ -1221,13 +1221,13 @@ bool mapped_object::parseNewEdges(const std::vector<edgeStub> &stubs)
                 {
                     edgeType = CALL;
                 }
-                break;
-            case c_ReturnInsn:
+            } else
+            if(cf.isReturn()) {
                 //edgeType = RET;
                 // The above doesn't work according to Nate
                 edgeType = INDIRECT;
-                break;
-            case c_BranchInsn:
+            } else
+            if(cf.isBranch()) {
                 if (cf.readsMemory())
                 {
                     edgeType = INDIRECT;
@@ -1244,10 +1244,9 @@ bool mapped_object::parseNewEdges(const std::vector<edgeStub> &stubs)
                 {
                     edgeType = COND_TAKEN;
                 }
-                break;
-            default:
+            }
+            else {
                 edgeType = FALLTHROUGH;
-                break;
             }
         }
 

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -124,6 +124,15 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT Architecture getArch() const;
 
     DYNINST_EXPORT InsnCategory getCategory() const;
+    DYNINST_EXPORT bool isCall() const { return getCategory() == c_CallInsn; }
+    DYNINST_EXPORT bool isReturn() const { return getCategory() == c_ReturnInsn; }
+    DYNINST_EXPORT bool isBranch() const { return getCategory() == c_BranchInsn; }
+    DYNINST_EXPORT bool isCompare() const { return getCategory() == c_CompareInsn; }
+    DYNINST_EXPORT bool isPrefetch() const { return getCategory() == c_PrefetchInsn; }
+    DYNINST_EXPORT bool isSysEnter() const { return getCategory() == c_SysEnterInsn; }
+    DYNINST_EXPORT bool isSyscall() const { return getCategory() == c_SyscallInsn; }
+    DYNINST_EXPORT bool isVector() const { return getCategory() == c_VectorInsn; }
+    DYNINST_EXPORT bool isGPUKernelExit() const { return getCategory() == c_GPUKernelExitInsn; }
 
     typedef std::list<CFT>::const_iterator cftConstIter;
     DYNINST_EXPORT cftConstIter cft_begin() const { return m_Successors.begin(); }

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -251,7 +251,7 @@ namespace Dyninst { namespace InstructionAPI {
 
   DYNINST_EXPORT bool Instruction::readsMemory() const {
     DECODE_OPERANDS();
-    if(getCategory() == c_PrefetchInsn) {
+    if(isPrefetch()) {
       return false;
     }
     for(std::list<Operand>::const_iterator curOperand = m_Operands.begin();
@@ -323,11 +323,10 @@ namespace Dyninst { namespace InstructionAPI {
     // an implicit write, and that we have decoded the control flow
     // target's full location as the first and only operand.
     // If this is not the case, we'll squawk for the time being...
-    if(getCategory() == c_NoCategory || getCategory() == c_CompareInsn ||
-       getCategory() == c_PrefetchInsn) {
+    if(getCategory() == c_NoCategory || isCompare() || isPrefetch()) {
       return Expression::Ptr();
     }
-    if(getCategory() == c_ReturnInsn) {
+    if(isReturn()) {
       return makeReturnExpression();
     }
     DECODE_OPERANDS();

--- a/parseAPI/src/IA_aarch64.C
+++ b/parseAPI/src/IA_aarch64.C
@@ -131,7 +131,7 @@ bool IA_aarch64::isTailCall(const Function* context, EdgeTypeEnum type, unsigned
     Function *callee = _obj->findFuncByEntry(_cr, addr);
     Block *target = _obj->findBlockByEntry(_cr, addr);
 
-    if(curInsn().getCategory() == c_BranchInsn &&
+    if(curInsn().isBranch() &&
        valid &&
        callee && 
        callee != context &&
@@ -152,7 +152,7 @@ bool IA_aarch64::isTailCall(const Function* context, EdgeTypeEnum type, unsigned
       return true;
     }    
 
-    if (curInsn().getCategory() == c_BranchInsn &&
+    if (curInsn().isBranch() &&
             valid &&
             !callee) {
     if (knownTargets.find(addr) != knownTargets.end()) {
@@ -231,7 +231,7 @@ bool IA_aarch64::isReturnAddrSave(Address&) const
 
 bool IA_aarch64::isReturn(Dyninst::ParseAPI::Function *, Dyninst::ParseAPI::Block*) const
 {
-    return curInsn().getCategory() == c_ReturnInsn;
+    return curInsn().isReturn();
 }
 
 bool IA_aarch64::isFakeCall() const

--- a/parseAPI/src/IA_amdgpu.C
+++ b/parseAPI/src/IA_amdgpu.C
@@ -118,7 +118,7 @@ bool IA_amdgpu::isReturnAddrSave(Address& ) const
 
 bool IA_amdgpu::isReturn(Dyninst::ParseAPI::Function * , Dyninst::ParseAPI::Block*) const
 {
-    return curInsn().getCategory() == c_ReturnInsn;
+    return curInsn().isReturn();
 }
 
 bool IA_amdgpu::isFakeCall() const

--- a/parseAPI/src/IA_power.C
+++ b/parseAPI/src/IA_power.C
@@ -133,7 +133,7 @@ bool IA_power::isTailCall(const Function* context, EdgeTypeEnum type, unsigned i
         callee = preambleCallee;
         target = preambleTarget;
     }
-    if(curInsn().getCategory() == c_BranchInsn &&
+    if(curInsn().isBranch() &&
        valid &&
        callee && 
        callee != context &&
@@ -154,7 +154,7 @@ bool IA_power::isTailCall(const Function* context, EdgeTypeEnum type, unsigned i
       return true;
     }    
 
-    if (curInsn().getCategory() == c_BranchInsn &&
+    if (curInsn().isBranch() &&
             valid &&
             !callee) {
     if (knownTargets.find(addr) != knownTargets.end()) {
@@ -165,7 +165,7 @@ bool IA_power::isTailCall(const Function* context, EdgeTypeEnum type, unsigned i
     }
 
     if(allInsns.size() < 2) {
-      if(context->addr() == _curBlk->start() && curInsn().getCategory() == c_BranchInsn)
+      if(context->addr() == _curBlk->start() && curInsn().isBranch())
       {
 	parsing_printf("\tjump as only insn in entry block, TAIL CALL\n");
 	tailCalls[type] = true;
@@ -312,7 +312,7 @@ bool IA_power::isReturnAddrSave(Address& retAddr) const
 bool IA_power::isReturn(Dyninst::ParseAPI::Function * context, Dyninst::ParseAPI::Block* currBlk) const
 {
   /* Check for leaf node or lw - mflr - blr pattern */
-  if (curInsn().getCategory() != c_ReturnInsn) {
+  if (curInsn().isReturn()) {
 	parsing_printf(" Not BLR - returning false \n");
 	return false;
    }

--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -278,7 +278,7 @@ void IndirectControlFlowAnalyzer::FindAllThunks() {
 	InsnAdapter::IA_IAPI* insnBlock = InsnAdapter::IA_IAPI::makePlatformIA_IAPI(b->obj()->cs()->getArch(), dec, b->start(), b->obj() , b->region(), b->obj()->cs(), b);
 	Address cur = b->start();
 	while (cur < b->end()) {
-        if (insnBlock->getInstruction().getCategory() == c_CallInsn && insnBlock->isThunk()) {
+        if (insnBlock->getInstruction().isCall() && insnBlock->isThunk()) {
             bool valid;
             Address addr;
             boost::tie(valid, addr) = insnBlock->getCFT();

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -946,7 +946,7 @@ Parser::finalize(Function *f)
         Block *b = f->entry();
         Block::Insns insns;
         b->getInsns(insns);
-        if (insns.size() == 1 && insns.begin()->second.getCategory() == c_BranchInsn) {
+        if (insns.size() == 1 && insns.begin()->second.isBranch()) {
             Block::edgelist targets;
             b->copy_targets(targets);
             for (auto e : targets) {
@@ -1796,7 +1796,7 @@ Parser::parse_frame_one_iteration(ParseFrame &frame, bool recursive) {
                             false)
                         );
                 break;
-            } else if(ah->getInstruction().getCategory()==c_GPUKernelExitInsn) {
+            } else if(ah->getInstruction().isGPUKernelExit()) {
                 // this is special treatment for non-returning instruction
                 // examples are amdgpu_op_s_endpgm and amddgpu_op_s_endpgm_saved
                 //cout << "calling endblock for non-returning instruction " << std::hex <<ah->getAddr() << endl; 


### PR DESCRIPTION
getCategory() assumes there is only one category per instruction, but that restriction will be removed when using the Capstone decoder and the function deprecated. These helpers will make it easier for users to check behavior without having to know how it's being tracked in Instruction.

This makes IA_IAPI::hasCFT() more expensive, but it will be much cheaper as we move more architectures to Capstone.