### PR TITLE
Add instruction class for software interrupts

### DIFF
--- a/dataflowAPI/src/liveness.C
+++ b/dataflowAPI/src/liveness.C
@@ -548,8 +548,7 @@ ReadWriteInfo LivenessAnalyzer::calcRWSets(Instruction curInsn, Block *blk, Addr
     }
   }
   else {
-    auto is_interrupt = Dyninst::InstructionAPI::isSoftwareInterrupt(curInsn);
-    if (is_interrupt || curInsn.isSyscall()) {
+    if (curInsn.isInterrupt() || curInsn.isSyscall()) {
       ret.read |= (abi->getSyscallReadRegisters());
       ret.written |= (abi->getSyscallWrittenRegisters());
     }

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -131,6 +131,7 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT bool isPrefetch() const { return getCategory() == c_PrefetchInsn; }
     DYNINST_EXPORT bool isSysEnter() const { return getCategory() == c_SysEnterInsn; }
     DYNINST_EXPORT bool isSyscall() const { return getCategory() == c_SyscallInsn; }
+    DYNINST_EXPORT bool isInterrupt() const { return getCategory() == c_InterruptInsn; }
     DYNINST_EXPORT bool isVector() const { return getCategory() == c_VectorInsn; }
     DYNINST_EXPORT bool isGPUKernelExit() const { return getCategory() == c_GPUKernelExitInsn; }
 

--- a/instructionAPI/h/InstructionCategories.h
+++ b/instructionAPI/h/InstructionCategories.h
@@ -47,6 +47,7 @@ namespace Dyninst
       c_PrefetchInsn,
       c_SysEnterInsn,
       c_SyscallInsn,
+      c_InterruptInsn,     // software interrupt
       c_VectorInsn,
       c_GPUKernelExitInsn,
       c_NoCategory

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -36,6 +36,7 @@
 #include "Operation_impl.h"
 #include "common/src/arch-x86.h"
 #include "dyninstversion.h"
+#include "interrupts.h"
 
 #include <algorithm>
 #include <boost/iterator/indirect_iterator.hpp>
@@ -438,6 +439,9 @@ namespace Dyninst { namespace InstructionAPI {
       if(m_InsnOp.getID() == power_op_bclr) {
         return c_ReturnInsn;
       }
+    }
+    if(isSoftwareInterrupt(*this)) {
+      return c_InterruptInsn;
     }
     return c;
   }

--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -468,8 +468,7 @@ bool IA_IAPI::isCall() const
 
 bool IA_IAPI::isInterruptOrSyscall() const
 {
-    auto is_interrupt = Dyninst::InstructionAPI::isSoftwareInterrupt(curInsn());
-    return is_interrupt || curInsn().isSyscall();
+    return curInsn().isInterrupt() || curInsn().isSyscall();
 }
 
 bool IA_IAPI::isSysEnter() const


### PR DESCRIPTION
@kupsch I *think* the name here should be fine. We don't really model hardware interrupts, but I want to add another category for halt/abort/reset instructions for the port to Capstone. These are kind of handled in [`IA_IAPI::isAbort`](https://github.com/dyninst/dyninst/blob/master/parseAPI/src/IA_IAPI.C#L320). I'm not sure what that category should be called, but c_HardwarInterruptInsn doesn't seem like a good one since it might suggest we also model UART-like interrupts.