### PR TITLE
Add hasControlFlowTarget to Instruction class

### DIFF
--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -2459,7 +2459,7 @@ bool StackAnalysis::handleNormalCall(Instruction insn, Block *block,
       }
    }
 
-   if (!insn.getControlFlowTarget()) return false;
+   if (!insn.hasControlFlowTarget()) return false;
 
    // Must be a thunk based on parsing.
    if (off != block->lastInsnAddr()) return false;
@@ -2788,7 +2788,7 @@ bool StackAnalysis::handleThunkCall(Instruction insn, Block *block,
 
    // We know that we're not a normal call, so it depends on whether the CFT is
    // "next instruction" or not.
-   if (!insn.isCall() || !insn.getControlFlowTarget()) {
+   if (!insn.isCall() || !insn.hasControlFlowTarget()) {
       return false;
    }
 

--- a/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
@@ -251,8 +251,7 @@ static Address PCValue(Address addr, Instruction insn) {
 bool adhocMovementTransformer::isPCDerefCF(Widget::Ptr ptr,
                                            Instruction insn,
                                            Address &target) {
-   Expression::Ptr cf = insn.getControlFlowTarget();
-   if (!cf) return false;
+   if (!insn.hasControlFlowTarget()) return false;
    
 //   Architecture fixme = insn->getArch();
 //   if (fixme == Arch_ppc32) fixme = Arch_ppc64;
@@ -271,7 +270,8 @@ bool adhocMovementTransformer::isPCDerefCF(Widget::Ptr ptr,
 	// Bind succeeded, eval to get target address
 	Result res = exp->eval();
 	if (!res.defined) {
-	  cerr << "ERROR: failed bind/eval at " << std::hex << ptr->addr() << endl;if (insn.getControlFlowTarget()) return false;
+	  cerr << "ERROR: failed bind/eval at " << std::hex << ptr->addr() << endl;
+	  if (insn.hasControlFlowTarget()) return false;
 	}
 	assert(res.defined);
 	target = res.convert<Address>();
@@ -292,7 +292,7 @@ bool adhocMovementTransformer::isPCRelData(Widget::Ptr ptr,
   if(insn.isCall() || insn.isBranch() || insn.isReturn()) {
     return false;
   }
-  if (insn.getControlFlowTarget()) return false;
+  if (insn.hasControlFlowTarget()) return false;
 
 
   Expression::Ptr thePC(new RegisterAST(MachRegister::getPC(insn.getArch())));

--- a/instructionAPI/doc/API/Instruction.tex
+++ b/instructionAPI/doc/API/Instruction.tex
@@ -239,6 +239,21 @@ if any, of this instruction.
 }
 
 \begin{apient}
+bool hasControlFlowTarget() const
+\end{apient}
+\apidesc{
+    Checks if the instruction has a control flow target.
+    
+    For an Instruction object `insn`, these are equivalent:
+    
+    `if(ins.hasControlFlowTarget())`
+    `if(ins.getControlFlowTarget())`
+    
+    but the first does not do any expression evaluation and
+    can be substantially cheaper.
+}
+
+\begin{apient}
 bool allowsFallThrough() const
 \end{apient}
 \apidesc{

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -112,6 +112,7 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT void getMemoryWriteOperands(std::set<Expression::Ptr>& memAccessors) const;
 
     DYNINST_EXPORT Expression::Ptr getControlFlowTarget() const;
+    DYNINST_EXPORT bool hasControlFlowTarget() const { return m_Successors.empty(); }
 
     DYNINST_EXPORT bool allowsFallThrough() const;
 


### PR DESCRIPTION
Checks if the instruction has a control flow target. For an Instruction object insn, these are equivalent:

  if(ins.hasControlFlowTarget())
  if(ins.getControlFlowTarget())

but the first does not do any expression evaluation and can be substantially cheaper.