### PR TITLE
Separate operand interface in Instruction class

### DIFF
--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -520,8 +520,7 @@ void AssignmentConverter::convert(const Instruction &I,
         // SGPR_PAIR[0] = PC & 0xffffffff
         // SGPR_PARI[1] = PC >> 32
         //
-        std::vector<Operand> operands;
-        I.getOperands(operands);
+        auto operands = I.getAllOperands();
         assert(operands.size() == 2);
         MultiRegisterAST::Ptr pc_reg  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
         const std::vector<RegisterAST::Ptr> & pc_regasts = pc_reg->getRegs();
@@ -560,8 +559,7 @@ void AssignmentConverter::convert(const Instruction &I,
                 block,
                 pc);
 
-        std::vector<Operand> operands;
-        I.getOperands(operands);
+        auto operands = I.getAllOperands();
         assert(operands.size() == 2);
         MultiRegisterAST::Ptr pc_reg  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
         const std::vector<RegisterAST::Ptr> & pc_regasts = pc_reg->getRegs();
@@ -576,8 +574,7 @@ void AssignmentConverter::convert(const Instruction &I,
     case amdgpu_gfx908_op_S_SWAPPC_B64:
     case amdgpu_gfx90a_op_S_SWAPPC_B64: 
     case amdgpu_gfx940_op_S_SWAPPC_B64: {
-        std::vector<Operand> operands;
-        I.getOperands(operands);
+        auto operands = I.getAllOperands();
         assert(operands.size() == 4);
 
         MultiRegisterAST::Ptr pc_src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[1].getValue());
@@ -628,9 +625,7 @@ void AssignmentConverter::convert(const Instruction &I,
     case amdgpu_gfx908_op_S_ADD_U32:
     case amdgpu_gfx90a_op_S_ADD_U32: 
     case amdgpu_gfx940_op_S_ADD_U32: {
-        std::vector<Operand> operands;
-        I.getOperands(operands);
-
+        auto operands = I.getAllOperands();
 
         assert(operands.size() == 4);
 
@@ -679,8 +674,7 @@ void AssignmentConverter::convert(const Instruction &I,
     case amdgpu_gfx908_op_S_ADDC_U32:
     case amdgpu_gfx90a_op_S_ADDC_U32: 
     case amdgpu_gfx940_op_S_ADDC_U32: {
-        std::vector<Operand> operands;
-        I.getOperands(operands);
+        auto operands = I.getAllOperands();
         assert(operands.size() == 5);
 
         RegisterAST::Ptr dst_sgpr = boost::dynamic_pointer_cast<RegisterAST>(operands[0].getValue());
@@ -715,8 +709,7 @@ void AssignmentConverter::convert(const Instruction &I,
     // SP = SP - 4 
     // *SP = <register>
  
-    std::vector<Operand> operands;
-    I.getOperands(operands);
+    auto operands = I.getAllOperands();
 
     // According to the InstructionAPI, the first operand will be the argument, the second will be ESP.
     assert(operands.size() == 2);
@@ -789,8 +782,7 @@ void AssignmentConverter::convert(const Instruction &I,
 
     // As with push, eSP shows up as operand 1. 
 
-    std::vector<Operand> operands;
-    I.getOperands(operands);
+    auto operands = I.getAllOperands();
 
     // According to the InstructionAPI, the first operand will be the explicit register, the second will be ESP.
     assert(operands.size() == 2);
@@ -883,8 +875,7 @@ void AssignmentConverter::convert(const Instruction &I,
   case e_xchg: {
     // xchg defines two abslocs, and uses them as appropriate...
 
-    std::vector<Operand> operands;
-    I.getOperands(operands);
+    auto operands = I.getAllOperands();
 
     // According to the InstructionAPI, the first operand will be the argument, the second will be ESP.
     assert(operands.size() == 2);
@@ -922,8 +913,7 @@ void AssignmentConverter::convert(const Instruction &I,
 
 
   case power_op_stwu: {
-    std::vector<Operand> operands;
-    I.getOperands(operands);
+    auto operands = I.getAllOperands();
 
     // stwu <a>, <b>, <c>
     // <a> = R1

--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -83,8 +83,7 @@ SgAsmInstruction *RoseInsnFactory::convert(const Instruction &insn, uint64_t add
   }
 
    //std::cerr << "no special handling by opcode, checking if we should mangle operands..." << std::endl;
-  std::vector<InstructionAPI::Operand> operands;
-  insn.getOperands(operands);
+  auto operands = insn.getAllOperands();
   massageOperands(insn, operands);
   int i = 0;
   //std::cerr << "converting insn " << insn.format(addr) << std::endl;

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -767,8 +767,7 @@ StackAnalysis::Height StackAnalysis::getStackCleanAmount(Function *func_) {
       if (what != e_ret_near) continue;
 
       int val;
-      std::vector<Operand> ops;
-      insn.getOperands(ops);
+      std::vector<Operand> ops = insn.getAllOperands();
       if (ops.size() == 1) {
          val = 0;
       } else {
@@ -1140,8 +1139,7 @@ private:
 
 void StackAnalysis::handleXor(Instruction insn, Block *block,
                               const Offset off, TransferFuncs &xferFuncs) {
-   std::vector<Operand> operands;
-   insn.getOperands(operands);
+   auto operands = insn.getAllOperands();
    STACKANALYSIS_ASSERT(operands.size() == 2);
 
    // Handle the case where a register is being zeroed out.
@@ -1292,8 +1290,7 @@ void StackAnalysis::handleXor(Instruction insn, Block *block,
 
 void StackAnalysis::handleDiv(Instruction insn,
                               TransferFuncs &xferFuncs) {
-   std::vector<Operand> operands;
-   insn.getOperands(operands);
+   auto operands = insn.getAllOperands();
    STACKANALYSIS_ASSERT(operands.size() == 3);
 
    Expression::Ptr quotient = operands[1].getValue();
@@ -1324,8 +1321,7 @@ void StackAnalysis::handleMul(Instruction insn,
    //     -- reg1 = reg2/mem2 * imm3
    //   3. mul reg1, reg2, reg3/mem3
    //     -- reg1:reg2 = reg2 * reg3/mem3
-   std::vector<Operand> operands;
-   insn.getOperands(operands);
+   auto operands = insn.getAllOperands();
    STACKANALYSIS_ASSERT(operands.size() == 2 || operands.size() == 3);
 
    Expression::Ptr target = operands[0].getValue();
@@ -1500,8 +1496,7 @@ void StackAnalysis::handlePushPop(Instruction insn, Block *block,
 void StackAnalysis::handleReturn(Instruction insn,
                                  TransferFuncs &xferFuncs) {
    long delta = 0;
-   std::vector<Operand> operands;
-   insn.getOperands(operands);
+   auto operands = insn.getAllOperands();
    if (operands.size() < 2) {
       delta = word_size;
    } else {
@@ -1556,8 +1551,7 @@ void StackAnalysis::handleAddSub(Instruction insn, Block *block,
    //      a. If it can, mem1 is handled with a delta.
    //      b. Otherwise, nothing happens.
 
-   std::vector<Operand> operands;
-   insn.getOperands(operands);
+   auto operands = insn.getAllOperands();
    STACKANALYSIS_ASSERT(operands.size() == 2);
 
    std::set<RegisterAST::Ptr> readSet;
@@ -2000,8 +1994,7 @@ void StackAnalysis::handleMov(Instruction insn, Block *block,
    //    b. Otherwise, we ignore the store.
 
    // Extract operands
-   std::vector<Operand> operands;
-   insn.getOperands(operands);
+   auto operands = insn.getAllOperands();
    STACKANALYSIS_ASSERT(operands.size() == 2);
 
    // Extract written/read register sets
@@ -2150,8 +2143,7 @@ void StackAnalysis::handleZeroExtend(Instruction insn, Block *block,
    STACKANALYSIS_ASSERT(!insn.writesMemory());
 
    // Extract operands
-   std::vector<Operand> operands;
-   insn.getOperands(operands);
+   auto operands = insn.getAllOperands();
    STACKANALYSIS_ASSERT(operands.size() == 2);
 
    // Extract written/read register sets
@@ -2217,8 +2209,7 @@ void StackAnalysis::handleSignExtend(Instruction insn, Block *block,
    STACKANALYSIS_ASSERT(!insn.writesMemory());
 
    // Extract operands
-   std::vector<Operand> operands;
-   insn.getOperands(operands);
+   auto operands = insn.getAllOperands();
    STACKANALYSIS_ASSERT(operands.size() == 2);
 
    // Extract written/read register sets

--- a/dyninstAPI/src/BPatch_memoryAccessAdapter.C
+++ b/dyninstAPI/src/BPatch_memoryAccessAdapter.C
@@ -180,9 +180,7 @@ BPatch_memoryAccess* BPatch_memoryAccessAdapter::convert(Instruction insn,
   }
   assert(nac < 3);
   return bmap;
-#elif defined(DYNINST_HOST_ARCH_POWER)
-    std::vector<Operand> operands;
-    insn.getOperands(operands);
+    auto operands = insn.getAllOperands();
     for(std::vector<Operand>::iterator op = operands.begin();
         op != operands.end();
        ++op)
@@ -221,9 +219,9 @@ BPatch_memoryAccess* BPatch_memoryAccessAdapter::convert(Instruction insn,
         }
     }
     return NULL;
-#elif defined(DYNINST_HOST_ARCH_AARCH64) 
-    std::vector<Operand> operands;
-    insn.getOperands(operands);
+
+#elif defined(DYNINST_HOST_ARCH_AARCH64)
+    auto operands = insn.getAllOperands();
     for(std::vector<Operand>::iterator op = operands.begin();
         op != operands.end();
        ++op)

--- a/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
@@ -323,8 +323,7 @@ bool adhocMovementTransformer::isPCRelData(Widget::Ptr ptr,
   // Didn't use the PC to read memory; thus we have to grind through
   // all the operands. We didn't do this directly because the 
   // memory-topping deref stops eval...
-  vector<Operand> operands;
-  insn.getOperands(operands);
+  auto operands = insn.getAllOperands();
   for (vector<Operand>::iterator iter = operands.begin();
        iter != operands.end(); ++iter) {
     // If we can bind the PC, then we're in the operand

--- a/dyninstAPI/src/StackMod/StackAccess.C
+++ b/dyninstAPI/src/StackMod/StackAccess.C
@@ -100,8 +100,7 @@ bool isDebugType(StackAccess::StackAccessType t)
 
 int getAccessSize(InstructionAPI::Instruction insn)
 {
-    std::vector<InstructionAPI::Operand> operands;
-    insn.getOperands(operands);
+    auto operands = insn.getAllOperands();
     int accessSize = 0;
     for (unsigned i = 0; i < operands.size(); i++) {
         InstructionAPI::Expression::Ptr value = operands[i].getValue();
@@ -620,8 +619,7 @@ bool getMemoryOffset(ParseAPI::Function *func,
     InstructionAPI::RegisterAST* regAST = new InstructionAPI::RegisterAST(reg);
     InstructionAPI::RegisterAST::Ptr regASTPtr = InstructionAPI::RegisterAST::Ptr(regAST);
 
-    std::vector<InstructionAPI::Operand> operands;
-    insn.getOperands(operands);
+    auto operands = insn.getAllOperands();
 
     signed long disp = 0;  // Stack height of access
     signed long offset = 0;  // Offset from the base register used in the access

--- a/instructionAPI/doc/API/Instruction.tex
+++ b/instructionAPI/doc/API/Instruction.tex
@@ -82,6 +82,39 @@ const Operation & getOperation() const
 }
 
 \begin{apient}
+std::vector<Operand> getAllOperands() const
+\end{apient}
+\apidesc{
+Returns the operands in the order that they were decoded.
+
+For the instruction \code{add rax, rcx}, the operands are \code{rax},
+\code{rcx}, and \code{EFLAGS}. \code{EFLAGS} is included because it
+is implicitly modified to update the overflow and carry flags.   
+}
+
+\begin{apient}
+std::vector<Operand> getImplicitOperands() const
+\end{apient}
+\apidesc{
+Returns the *implicit* operands in the order that they were decoded.
+
+For the instruction \code{add rax, rcx}, the implicit operand is
+\code{EFLAGS} because it is implicitly modified to update the
+overflow and carry flags.
+}
+
+\begin{apient}
+std::vector<Operand> getExplicitOperands() const
+\end{apient}
+\apidesc{
+Returns the *explicit* operands in the order that they were decoded.
+
+For the instruction \code{add rax, rcx}, the explitic operands are \code{rax}
+and \code{rcx}. \code{EFLAGS} is not included because it is *implicitly*
+modified to update the overflow and carry flags.
+}
+
+\begin{apient}
 void getOperands(std::vector<Operand> & operands) const
 \end{apient}
 \apidesc{

--- a/instructionAPI/doc/API/Instruction.tex
+++ b/instructionAPI/doc/API/Instruction.tex
@@ -118,9 +118,9 @@ modified to update the overflow and carry flags.
 void getOperands(std::vector<Operand> & operands) const
 \end{apient}
 \apidesc{
-The vector operands has the instruction's operands appended to it in the same
-order that they
-were decoded.
+DEPRECATED
+
+Use `getAllOperands()`.
 }
 
 \begin{apient}

--- a/instructionAPI/doc/examples/Visitor-regexample.C
+++ b/instructionAPI/doc/examples/Visitor-regexample.C
@@ -23,8 +23,7 @@ class PrintVisitor : public Visitor {
 
 void printRegisters(Instruction::Ptr insn) {
    PrintVisitor pv;
-   std::vector<Operand> operands;
-   insn->getOperands(operands);
+   auto operands = insn.getAllOperands();
    // c++11x allows auto to determine the type of a variable;
    // if not using c++11x, use 'std::vector<Operand>::iterator' instead.
    // For gcc, use the -std=c++0x argument.

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -86,6 +86,9 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT Operation& getOperation();
     DYNINST_EXPORT const Operation& getOperation() const;
 
+    DYNINST_EXPORT std::vector<Operand> getAllOperands() const;
+    DYNINST_EXPORT std::vector<Operand> getExplicitOperands() const;
+    DYNINST_EXPORT std::vector<Operand> getImplicitOperands() const;
     DYNINST_EXPORT void getOperands(std::vector<Operand>& operands) const;
     DYNINST_EXPORT Operand getOperand(int index) const;
 

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -32,6 +32,7 @@
 #define INSTRUCTION_H
 
 #include "ArchSpecificFormatters.h"
+#include "compiler_annotations.h"
 #include "Expression.h"
 #include "InstructionCategories.h"
 #include "Operand.h"
@@ -89,7 +90,9 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT std::vector<Operand> getAllOperands() const;
     DYNINST_EXPORT std::vector<Operand> getExplicitOperands() const;
     DYNINST_EXPORT std::vector<Operand> getImplicitOperands() const;
-    DYNINST_EXPORT void getOperands(std::vector<Operand>& operands) const;
+
+    DYNINST_EXPORT DYNINST_DEPRECATED("Use getallOperands()")
+    void getOperands(std::vector<Operand>& operands) const;
     DYNINST_EXPORT Operand getOperand(int index) const;
 
     DYNINST_EXPORT std::vector<Operand> getDisplayOrderedOperands() const;

--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -2798,8 +2798,7 @@ insn_in_progress->appendOperand(makeRnExpr(), true, true);
 
   void InstructionDecoder_aarch64::reorderOperands() {
     if(oprRotateAmt) {
-      std::vector<Operand> curOperands;
-      insn_in_progress->getOperands(curOperands);
+      std::vector<Operand> curOperands = insn_in_progress->getAllOperands();
 
       if(curOperands.empty())
         assert(!"empty operand list found while re-ordering operands");
@@ -2811,13 +2810,11 @@ insn_in_progress->appendOperand(makeRnExpr(), true, true);
 
       insn_in_progress->m_Operands.assign(curOperands.begin(), curOperands.end());
     } else if(IS_INSN_LDST_POST(insn) || IS_INSN_LDST_PAIR_POST(insn)) {
-      std::vector<Operand> curOperands;
-      insn_in_progress->getOperands(curOperands);
+      std::vector<Operand> curOperands = insn_in_progress->getAllOperands();
       std::iter_swap(curOperands.begin(), curOperands.end() - 1);
       insn_in_progress->m_Operands.assign(curOperands.begin(), curOperands.end());
     } else if(IS_INSN_LDST_PAIR(insn)) {
-      std::vector<Operand> curOperands;
-      insn_in_progress->getOperands(curOperands);
+      std::vector<Operand> curOperands = insn_in_progress->getAllOperands();
       assert(curOperands.size() == 4 || curOperands.size() == 3);
       if(curOperands.size() == 3) {
         curOperands.insert(curOperands.begin(), curOperands.back());
@@ -2827,8 +2824,7 @@ insn_in_progress->appendOperand(makeRnExpr(), true, true);
       }
       insn_in_progress->m_Operands.assign(curOperands.begin(), curOperands.end());
     } else if(IS_INSN_LDST_EX_PAIR(insn)) {
-      std::vector<Operand> curOperands;
-      insn_in_progress->getOperands(curOperands);
+      std::vector<Operand> curOperands = insn_in_progress->getAllOperands();
       if(curOperands.size() == 3) {
         curOperands.insert(curOperands.begin(), curOperands.back());
         curOperands.pop_back();
@@ -2838,8 +2834,7 @@ insn_in_progress->appendOperand(makeRnExpr(), true, true);
       }
       insn_in_progress->m_Operands.assign(curOperands.begin(), curOperands.end());
     } else if(IS_INSN_ST_EX(insn)) {
-      std::vector<Operand> curOperands;
-      insn_in_progress->getOperands(curOperands);
+      std::vector<Operand> curOperands = insn_in_progress->getAllOperands();
       if(curOperands.size() == 3) {
         curOperands.insert(curOperands.begin() + 1, curOperands.back());
         curOperands.pop_back();

--- a/instructionAPI/src/syscalls.C
+++ b/instructionAPI/src/syscalls.C
@@ -130,8 +130,7 @@ namespace x86 {
      *  so we'll consider it as our special case here.
      */
     if(id == e_call) {
-      std::vector<di::Operand> operands;
-      ins.getOperands(operands);
+      auto operands = ins.getExplicitOperands();
 
       if(operands.size() != 1) {
         di::decode_printf("[%s:%d] Incorrect number of arguments to 'call'. Found %lu, expected 1\n",

--- a/parseAPI/src/BoundFactCalculator.C
+++ b/parseAPI/src/BoundFactCalculator.C
@@ -376,8 +376,7 @@ void BoundFactsCalculator::CalcTransferFunction(Node::Ptr curNode, BoundFact *ne
     int derefSize = 0;
     if (node->assign() && node->assign()->insn().isValid() && node->assign()->insn().readsMemory()) {
         Instruction i = node->assign()->insn();
-	std::vector<Operand> ops;
-	i.getOperands(ops);
+	auto ops = i.getAllOperands();
 	for (auto oit = ops.begin(); oit != ops.end(); ++oit) {
 	    Operand o = *oit;
 	    if (o.readsMemory()) {

--- a/parseAPI/src/IA_x86.C
+++ b/parseAPI/src/IA_x86.C
@@ -186,8 +186,7 @@ bool isNopInsn(Instruction insn) {
     if (insn.getOperation().getID() == e_nop)  {
         return true;
     }  else if (insn.getOperation().getID() == e_lea)  {
-        std::vector<Operand> operands;
-        insn.getOperands(operands);
+        auto operands = insn.getAllOperands();
 
         if (operands.size() != 2)  {
             parsing_printf("%s[%d]: malformed lea instruction number of operands (%lu) not 2",
@@ -492,8 +491,7 @@ bool IA_x86::cleansStack() const
 {
     Instruction ci = curInsn();
 	if (!ci.isReturn()) return false;
-    std::vector<Operand> ops;
-	ci.getOperands(ops);
+    auto ops = ci.getAllOperands();
 	return (ops.size() > 1);
 }
 

--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -249,8 +249,7 @@ static Address ThunkAdjustment(Address afterThunk, MachRegister reg, ParseAPI::B
     Instruction nextInsn = dec.decode();
     // It has to be an add
     if (nextInsn.getOperation().getID() != e_add) return 0;
-    vector<Operand> operands;
-    nextInsn.getOperands(operands);
+    auto operands = nextInsn.getAllOperands();
     RegisterAST::Ptr regAST = boost::dynamic_pointer_cast<RegisterAST>(operands[0].getValue());
     // The first operand should be a register
     if (regAST == 0) return 0;
@@ -365,8 +364,7 @@ int IndirectControlFlowAnalyzer::GetMemoryReadSize(Assignment::Ptr memLoc) {
         return 0;
     }
     Instruction i = memLoc->insn();
-    std::vector<Operand> ops;
-    i.getOperands(ops);
+    auto ops = i.getAllOperands();
     parsing_printf("\t there are %lu operands\n", ops.size());
     for (auto oit = ops.begin(); oit != ops.end(); ++oit) {
         Operand o = *oit;

--- a/parseAPI/src/JumpTableFormatPred.C
+++ b/parseAPI/src/JumpTableFormatPred.C
@@ -421,8 +421,7 @@ static Assignment::Ptr SearchForWrite(SliceNode::Ptr n, AbsRegion &src, Slicer::
                     parsing_printf("\t\tFind matching at %lx\n", targetAddr);
 
                     // Now we try to identify the source register
-                    std::vector<Operand> ops;
-                    i.getOperands(ops);
+                    auto ops = i.getAllOperands();
                     for (auto oit = ops.begin(); oit != ops.end(); ++oit) {
                         if (!(*oit).writesMemory() && !(*oit).readsMemory()) {
                             std::set<RegisterAST::Ptr> regsRead;

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -2472,8 +2472,7 @@ bool Parser::getSyscallNumber(Function * /*func*/,
     InstructionAPI::RegisterAST* regAST = new InstructionAPI::RegisterAST(syscallNumberReg);
     InstructionAPI::RegisterAST::Ptr regASTPtr = InstructionAPI::RegisterAST::Ptr(regAST);
 
-    std::vector<InstructionAPI::Operand> operands;
-    prevInsn.getOperands(operands);
+    auto operands = prevInsn.getAllOperands();
     for (unsigned i = 0; i < operands.size(); i++) {
         if (!operands[i].isWritten(regASTPtr)) {
             InstructionAPI::Expression::Ptr value = operands[i].getValue();

--- a/parseAPI/src/ProbabilisticParser.C
+++ b/parseAPI/src/ProbabilisticParser.C
@@ -503,8 +503,7 @@ bool ProbabilityCalculator::decodeInstruction(DecodeData &data, Address addr) {
 	
 	data.entry_id = insn.getOperation().getID();
 
-	vector<Operand> ops;
-	insn.getOperands(ops);
+	auto ops = insn.getAllOperands();
 	int args[2] = {NOARG,NOARG};
 	for(unsigned int i=0;i<2 && i<ops.size();++i) {
 	    Operand & op = ops[i];


### PR DESCRIPTION
There are many places in Dyninst where only one type of operand is needed. This removes the need to do the filtering at those code points and allows for possibly expanding what an implicit register is (e.g., vector mask registers in some cases).

Deprecates Instruction::getOperands(std::vector<Operand>).