### PR TITLE
Remove unused parameter from dyninstAPI/convertRegID

### DIFF
--- a/dyninstAPI/src/BPatch_snippet.C
+++ b/dyninstAPI/src/BPatch_snippet.C
@@ -876,8 +876,7 @@ BPatch_registerExpr::BPatch_registerExpr(BPatch_register reg)
 }
 
 BPatch_registerExpr::BPatch_registerExpr(Dyninst::MachRegister mach) {
-   bool whocares;
-   Register reg = convertRegID(mach, whocares);
+   Register reg = convertRegID(mach);
    ast_wrapper = AstNodePtr(AstNode::operandNode(AstNode::operandType::origRegister,
                                                  (void *)(intptr_t)reg));
     assert(BPatch::bpatch != NULL);
@@ -1167,8 +1166,7 @@ BPatch_variableExpr::BPatch_variableExpr(BPatch_addressSpace *in_addSpace,
                 AstNodePtr variableAst;
                 BPatch_storageClass in_storage = lv->convertToBPatchStorage(& locs[i]);
                 void *in_address = (void *) locs[i].frameOffset;
-                bool ignored;
-                int in_register = convertRegID(locs[i].mr_reg, ignored);
+                int in_register = convertRegID(locs[i].mr_reg);
                 switch (in_storage) {
                         case BPatch_storageAddr:
                                 variableAst = AstNode::operandNode(AstNode::operandType::DataAddr, in_address);

--- a/dyninstAPI/src/BPatch_type.C
+++ b/dyninstAPI/src/BPatch_type.C
@@ -489,8 +489,7 @@ int BPatch_localVar::getRegister() {
     if (!locs.size())
         return -1;
 
-    bool ignored;
-    return convertRegID(locs[0].mr_reg, ignored);
+    return convertRegID(locs[0].mr_reg);
 }
 
 BPatch_storageClass BPatch_localVar::getStorageClass() {

--- a/dyninstAPI/src/IAPI_to_AST.C
+++ b/dyninstAPI/src/IAPI_to_AST.C
@@ -83,9 +83,8 @@ void ASTFactory::visit(Immediate* i)
 void ASTFactory::visit(RegisterAST* r)
 {
 #if defined(arch_x86) || defined(arch_x86_64)  
-    bool unused;
     m_stack.push_back(AstNode::operandNode(AstNode::operandType::origRegister,
-                      (void*)(intptr_t)(convertRegID(r, unused))));
+                      (void*)(intptr_t)(convertRegID(r))));
 #else
     MachRegister reg = r->getID();
     reg = reg.getBaseRegister();

--- a/dyninstAPI/src/RegisterConversion-aarch64.C
+++ b/dyninstAPI/src/RegisterConversion-aarch64.C
@@ -189,8 +189,7 @@ map<MachRegister, Register> reverseRegisterMap = map_list_of
   (aarch64::fpsr,   registerSpace::fpsr)
   ;
 
-Register convertRegID(MachRegister reg, bool &wasUpcast) {
-    wasUpcast = false;
+Register convertRegID(MachRegister reg) {
 
     MachRegister baseReg = MachRegister((reg.getBaseRegister().val() & ~reg.getArchitecture()) | Arch_aarch64);
 //    RegisterAST::Ptr debug(new RegisterAST(baseReg));
@@ -207,18 +206,18 @@ Register convertRegID(MachRegister reg, bool &wasUpcast) {
 }
 
 
-Register convertRegID(RegisterAST::Ptr toBeConverted, bool& wasUpcast)
+Register convertRegID(RegisterAST::Ptr toBeConverted)
 {
-    return convertRegID(toBeConverted.get(), wasUpcast);
+    return convertRegID(toBeConverted.get());
 }
 
-Register convertRegID(RegisterAST* toBeConverted, bool& wasUpcast)
+Register convertRegID(RegisterAST* toBeConverted)
 {
     if(!toBeConverted) {
         //assert(0);
       return registerSpace::ignored;
     }
-    return convertRegID(toBeConverted->getID(), wasUpcast);
+    return convertRegID(toBeConverted->getID());
 }
 
 MachRegister convertRegID(Register r, Dyninst::Architecture arch) {

--- a/dyninstAPI/src/RegisterConversion-ppc.C
+++ b/dyninstAPI/src/RegisterConversion-ppc.C
@@ -332,8 +332,7 @@ map<MachRegister, Register> reverseRegisterMap = map_list_of
   (ppc32::mq, registerSpace::mq)
   (ppc32::cr, registerSpace::cr);
 
-Register convertRegID(MachRegister reg, bool &wasUpcast) {
-    wasUpcast = false;
+Register convertRegID(MachRegister reg) {
 
     MachRegister baseReg = MachRegister((reg.getBaseRegister().val() & ~reg.getArchitecture()) | Arch_ppc32);
 //    RegisterAST::Ptr debug(new RegisterAST(baseReg));
@@ -350,18 +349,18 @@ Register convertRegID(MachRegister reg, bool &wasUpcast) {
 }
 
 
-Register convertRegID(RegisterAST::Ptr toBeConverted, bool& wasUpcast)
+Register convertRegID(RegisterAST::Ptr toBeConverted)
 {
-    return convertRegID(toBeConverted.get(), wasUpcast);
+    return convertRegID(toBeConverted.get());
 }
         
-Register convertRegID(RegisterAST* toBeConverted, bool& wasUpcast)
+Register convertRegID(RegisterAST* toBeConverted)
 {
     if(!toBeConverted) {
         //assert(0);
       return registerSpace::ignored;
     }
-    return convertRegID(toBeConverted->getID(), wasUpcast);
+    return convertRegID(toBeConverted->getID());
 }
 
 MachRegister convertRegID(Register r, Dyninst::Architecture arch) {

--- a/dyninstAPI/src/RegisterConversion-x86.C
+++ b/dyninstAPI/src/RegisterConversion-x86.C
@@ -462,9 +462,7 @@ map<MachRegister, Register> reverseRegisterMap = map_list_of
         (x86_64::st7, REGNUM_DUMMYFPR)
         ;
 
-Register convertRegID(MachRegister reg, bool &wasUpcast) {
-    wasUpcast = false;
-    if(reg.getBaseRegister().val() != reg.val()) wasUpcast = true;
+Register convertRegID(MachRegister reg) {
     MachRegister baseReg = MachRegister((reg.getBaseRegister().val() & ~reg.getArchitecture()) | Arch_x86_64);
 //    RegisterAST::Ptr debug(new RegisterAST(baseReg));
 //    fprintf(stderr, "DEBUG: converting %s", toBeConverted->format().c_str());
@@ -476,7 +474,6 @@ Register convertRegID(MachRegister reg, bool &wasUpcast) {
 		return REGNUM_IGNORED;
     }
     if(found->second == REGNUM_DUMMYFPR) {
-        wasUpcast = true;
         if(reg.getArchitecture() == Arch_x86)
         {
             return IA32_FPR_VIRTUAL_REGISTER;
@@ -486,18 +483,18 @@ Register convertRegID(MachRegister reg, bool &wasUpcast) {
 }
 
 
-Register convertRegID(RegisterAST::Ptr toBeConverted, bool& wasUpcast)
+Register convertRegID(RegisterAST::Ptr toBeConverted)
 {
-    return convertRegID(toBeConverted.get(), wasUpcast);
+    return convertRegID(toBeConverted.get());
 }
         
-Register convertRegID(RegisterAST* toBeConverted, bool& wasUpcast)
+Register convertRegID(RegisterAST* toBeConverted)
 {
     if(!toBeConverted) {
         //assert(0);
         return REGNUM_IGNORED;
     }
-    return convertRegID(toBeConverted->getID(), wasUpcast);
+    return convertRegID(toBeConverted->getID());
 }
 
 map<Register, MachRegister> machRegisterMapx86_64 = map_list_of

--- a/dyninstAPI/src/RegisterConversion.h
+++ b/dyninstAPI/src/RegisterConversion.h
@@ -42,9 +42,9 @@ using namespace Dyninst;
 extern std::multimap<Register, MachRegister> regToMachReg32;
 extern std::multimap<Register, MachRegister> regToMachReg64;
 
-Register convertRegID(Dyninst::InstructionAPI::RegisterAST::Ptr toBeConverted, bool& wasUpcast);
-Register convertRegID(Dyninst::InstructionAPI::RegisterAST* toBeConverted, bool& wasUpcast);
-Register convertRegID(Dyninst::MachRegister reg, bool &wasUpcast);
+Register convertRegID(Dyninst::InstructionAPI::RegisterAST::Ptr toBeConverted);
+Register convertRegID(Dyninst::InstructionAPI::RegisterAST* toBeConverted);
+Register convertRegID(Dyninst::MachRegister reg);
 Dyninst::MachRegister convertRegID(Register r, Dyninst::Architecture arch);
 
 #endif //!defined(REGISTER_CONVERSION_H)

--- a/dyninstAPI/src/Relocation/Widgets/PCWidget-aarch64.C
+++ b/dyninstAPI/src/Relocation/Widgets/PCWidget-aarch64.C
@@ -66,8 +66,7 @@ bool PCWidget::PCtoReturnAddr(const codeGen &templ, const RelocBlock *t, CodeBuf
 }
 
 bool PCWidget::PCtoReg(const codeGen &templ, const RelocBlock *t, CodeBuffer &buffer) {
-  bool ignored;
-  Register reg = convertRegID(a_.reg(), ignored);
+  Register reg = convertRegID(a_.reg());
 
   if(templ.addrSpace()->proc()) {
     // Move immediate to register?

--- a/dyninstAPI/src/Relocation/Widgets/PCWidget-ppc.C
+++ b/dyninstAPI/src/Relocation/Widgets/PCWidget-ppc.C
@@ -92,8 +92,7 @@ bool PCWidget::PCtoReturnAddr(const codeGen &templ, const RelocBlock *t, CodeBuf
 }
 
 bool PCWidget::PCtoReg(const codeGen &templ, const RelocBlock *t, CodeBuffer &buffer) {
-  bool ignored;
-  Register reg = convertRegID(a_.reg(), ignored);
+  Register reg = convertRegID(a_.reg());
 
   if(templ.addrSpace()->proc()) {
     // Move immediate to register?

--- a/dyninstAPI/src/Relocation/Widgets/PCWidget-x86.C
+++ b/dyninstAPI/src/Relocation/Widgets/PCWidget-x86.C
@@ -77,8 +77,7 @@ bool PCWidget::PCtoReturnAddr(const codeGen &templ, const RelocBlock *t, CodeBuf
 }
 
 bool PCWidget::PCtoReg(const codeGen &templ, const RelocBlock *t, CodeBuffer &buffer) {
-  bool ignored;
-  Register reg = convertRegID(a_.reg(), ignored);
+  Register reg = convertRegID(a_.reg());
 
   if(templ.addrSpace()->proc()) {
     std::vector<unsigned char> newInsn;

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -841,8 +841,7 @@ bool AstStackInsertNode::generateCode_phase2(codeGen &gen, bool noCost,
     gen.setInsertNaked(true);
     gen.setModifiedStackFrame(true);
 
-    bool ignored;
-    Dyninst::Register reg_sp = convertRegID(MachRegister::getStackPointer(gen.getArch()), ignored);
+    Dyninst::Register reg_sp = convertRegID(MachRegister::getStackPointer(gen.getArch()));
 
     Emitterx86* emitter = dynamic_cast<Emitterx86*>(gen.codeEmitter());
     assert(emitter);
@@ -947,8 +946,7 @@ bool AstStackRemoveNode::generateCode_phase2(codeGen &gen, bool noCost,
     gen.setInsertNaked(true);
     gen.setModifiedStackFrame(true);
 
-    bool ignored;
-    Dyninst::Register reg_sp = convertRegID(MachRegister::getStackPointer(gen.getArch()), ignored);
+    Dyninst::Register reg_sp = convertRegID(MachRegister::getStackPointer(gen.getArch()));
 
     Emitterx86* emitter = dynamic_cast<Emitterx86*>(gen.codeEmitter());
     assert(emitter);


### PR DESCRIPTION
Confirmed builds on x86, arm, and ppc.