### PR TITLE
Fix return semantics on aarch64 and ppc

### DIFF
--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -2993,29 +2993,6 @@ insn_in_progress->appendOperand(makeRnExpr(), true, true);
         insn_in_progress->appendOperand(makePstateExpr(), isPstateRead, isPstateWritten, true);
     }
 
-    if(insn_in_progress->getOperation().getID() == aarch64_op_ret) {
-      /*********************************************************************
-       *  Arm A64 Instruction Set Architecture Armv8. March 2021
-       *
-       *  The conventional return sequence is to use `ret {Xn}` where the
-       *  register is optional (in which case it is assumed to be X30).
-       *
-       *  There is no representation for `retaa` and `retab`, yet.
-       *
-       *********************************************************************/
-      auto res = [this]() -> std::pair<Expression::Ptr, bool> {
-        if(this->insn_in_progress->m_Operands.size()) {
-          // An explicit register was provided (e.g., `ret r0`)
-          return {insn_in_progress->getOperand(0).getValue(), false};
-        }
-        // For `ret`, `retaa`, and `retab`, implicitly use x30 (link register).
-        return {boost::make_shared<RegisterAST>(aarch64::x30), true};
-      }();
-      auto target = res.first;
-      auto is_implicit = res.second;
-      insn_in_progress->addSuccessor(target, false, true, false, false, is_implicit);
-    }
-
     return true;
   }
 

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -296,17 +296,17 @@ which are both 0).
 
     // bclr is either a conventional branch or used as a return from a procedure
     if(current->op == power_op_bclr) {
+      /*********************************************************************
+       *  Power ISA Version 3.1, Book I. May 2020. 2.4 Branch Instructions
+       *
+       *  The conventional return sequence is to use `bclr` (Branch
+       *  Conditional to Link Register) with BH=0b00.
+       *********************************************************************/
+      auto target = makeRegisterExpression(ppc32::lr);
+      insn_in_progress->addSuccessor(std::move(target), false, true, bcIsConditional, false);
+
       if(bcIsConditional) {
         insn_in_progress->addSuccessor(makeFallThroughExpr(), false, false, false, true);
-      } else {
-        /*********************************************************************
-         *  Power ISA Version 3.1, Book I. May 2020. 2.4 Branch Instructions
-         *
-         *  The conventional return sequence is to use `bclr` (Branch
-         *  Conditional to Link Register) with BH=0b00.
-         *********************************************************************/
-        insn_in_progress->addSuccessor(makeRegisterExpression(ppc32::lr), false, true, false, false,
-                                       true);
       }
     }
     if(current->op == power_op_bcctr) {


### PR DESCRIPTION
These were introduced by 902c6d3107. For aarch64, other parts of Dyninst assume that there is no AST for the implicit
case, causing test suite failures. On ppc, the bcIsConditional wasn't enough to determine if this is a return-from-
function instruction.

These tested fine on x86, aarch64, and ppc machines at UOregon's Frank enclave before I merged them. However, they are causing test failures on other machines on all platforms. I guess I'm going to have to start testing on a dozen machines before I can make any further changes to the decoders.