### PR TITLE
Fix crashes in Elf_X and DwarfHandle

### DIFF
--- a/dwarf/h/dwarfHandle.h
+++ b/dwarf/h/dwarfHandle.h
@@ -33,7 +33,6 @@
 
 #include "elfutils/libdw.h"
 #include "dyntypes.h"
-#include <map>
 #include <string>
 #include <boost/shared_ptr.hpp>
 
@@ -71,7 +70,7 @@ class DYNINST_EXPORT DwarfHandle {
    bool hasFrameData(Elf_X *elfx);
    std::string filename;
    std::string debug_filename;
-   static std::map<std::string, DwarfHandle::ptr> all_dwarf_handles;
+
    /*static Dwarf_Handler defaultErrFunc;
    static void defaultDwarfError(Dwarf_Error err, Dwarf_Ptr arg);*/
 

--- a/elf/h/Elf_X.h
+++ b/elf/h/Elf_X.h
@@ -33,9 +33,7 @@
 
 #include "libelf.h"
 #include <stddef.h>
-#include <utility>
 #include <string>
-#include <map>
 #include <vector>
 #include "util.h"
 #include "Architecture.h"
@@ -162,10 +160,6 @@ class DYNINST_EXPORT Elf_X {
     // Two maps:
     // One name/FD for Elf_Xs created that way
     // One name/baseaddr
-
-    static std::map<std::pair<std::string, int >, Elf_X *> elf_x_by_fd;
-    static std::map<std::pair<std::string, char *>, Elf_X *> elf_x_by_ptr;
-
 };
 
 // ------------------------------------------------------------------------


### PR DESCRIPTION
These caches are thread-unsafe, but instances of this class can be created by multiple threads simultaneously. Crashes were observed when running the test suite. The tests would pass, but then the processes would crash when being reaped.