### PR TITLE
Fix attribute ordering in deprecated Instruction::getOperands

### DIFF
--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -91,7 +91,7 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT std::vector<Operand> getExplicitOperands() const;
     DYNINST_EXPORT std::vector<Operand> getImplicitOperands() const;
 
-    DYNINST_EXPORT DYNINST_DEPRECATED("Use getallOperands()")
+    DYNINST_DEPRECATED("Use getallOperands()") DYNINST_EXPORT
     void getOperands(std::vector<Operand>& operands) const;
     DYNINST_EXPORT Operand getOperand(int index) const;
 


### PR DESCRIPTION
clang prefers this ordering of attributes. I'm not sure if this is mandated by the standard or just a clang QoI issue.

This wasn't caught by CI testing because I forgot to specify the compiler when building external-tests and unit-tests in the pr-tests workflow. I'll fix that separately.