### PR TITLE
Treat linker warnings as errors when DYNINST_WARNINGS_AS_ERRORS is on

### DIFF
--- a/cmake/DyninstOptimization.cmake
+++ b/cmake/DyninstOptimization.cmake
@@ -74,7 +74,7 @@ if(${CMAKE_CXX_COMPILER_ID} IN_LIST _linux_compilers)
   if(DYNINST_FORCE_RUNPATH)
     list(APPEND DYNINST_LINK_FLAGS "-Wl,--enable-new-dtags")
   endif()
-  
+
   if(DYNINST_WARNINGS_AS_ERRORS)
     list(APPEND DYNINST_LINK_FLAGS "-Wl,--fatal-warnings")
   endif()


### PR DESCRIPTION
I've confirmed this works with gcc-14 and clang-15. We should run this against the compiler multibuild workflow before merging.