### PR TITLE
GitHubCI: re-use source checkout in build action

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -29,13 +29,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
-      with:
-        path: "build-checkout"
-
     - name: Build
       if: ${{ startsWith(inputs.os, 'fedora') }}
-      uses: ./build-checkout/.github/actions/build-fedora 
+      uses: dyninst/dyninst/.github/actions/build-fedora@master
       with:
         extra-cmake-flags: "-DDYNINST_WARNINGS_AS_ERRORS=ON ${{ inputs.extra-cmake-flags }}"
         compiler: ${{ inputs.compiler }}
@@ -48,7 +44,7 @@ runs:
 
     - name: Build
       if: ${{ startsWith(inputs.os, 'ubuntu') }}
-      uses: ./build-checkout/.github/actions/build-ubuntu
+      uses: dyninst/dyninst/.github/actions/build-ubuntu@master
       with:
         extra-cmake-flags: "-DDYNINST_WARNINGS_AS_ERRORS=ON ${{ inputs.extra-cmake-flags }}"
         compiler: ${{ inputs.compiler }}


### PR DESCRIPTION
This will allow the build action to be used in other repos.