### PR TITLE
GitHubCI: expand events that trigger workflows

### DIFF
--- a/.github/workflows/cmake-formatting.yaml
+++ b/.github/workflows/cmake-formatting.yaml
@@ -2,6 +2,7 @@ name: CMake Formatting
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ master ]
     paths:
        - '**.cmake'

--- a/.github/workflows/dependency-version.yaml
+++ b/.github/workflows/dependency-version.yaml
@@ -2,6 +2,7 @@ name: Check dependency versions
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ master ]
     paths:
        - '**.cmake'

--- a/.github/workflows/libabigail.yaml
+++ b/.github/workflows/libabigail.yaml
@@ -2,6 +2,7 @@ name: Libabigail ABI Checks
 
 on: 
   pull_request:
+     types: [opened, synchronize, reopened, ready_for_review]
      branches:
         - master
      paths:

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -2,6 +2,7 @@ name: Pull Request Tests
 
 on:
   pull_request:
+     types: [opened, synchronize, reopened, ready_for_review]
      branches:
         - master
      paths:

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -9,6 +9,8 @@ on:
        - '**.h'
        - '**.C'
        - '**.c'
+       - '**.cmake'
+       - '**CMakeLists.txt'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This will make sure the workflows run after converting a draft to 'ready for review'.