### PR TITLE
Move MachRegister -> ROSE register conversion into dataflowAPI

### DIFF
--- a/common/h/registers/MachRegister.h
+++ b/common/h/registers/MachRegister.h
@@ -81,8 +81,6 @@ namespace Dyninst {
     bool isFlag() const;
     bool isZeroFlag() const;
 
-    void getROSERegister(int& c, int& n, int& p);
-
     static MachRegister DwarfEncToReg(int encoding, Dyninst::Architecture arch);
     static MachRegister getArchRegFromAbstractReg(MachRegister abstract,
                                                   Dyninst::Architecture arch);

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -604,157 +604,15 @@ namespace Dyninst {
    * see dataflowAPI/src/ExpressionConversionVisitor.C
    */
 
-  void MachRegister::getROSERegister(int& c, int& n, int& p) {
+  void MachRegister::getROSERegister(int& c, int& n, int&) {
     // Rose: class, number, position
     // Dyninst: category, base id, subrange
 
-    signed int category = (reg & 0x00ff0000);
-    signed int subrange = (reg & 0x0000ff00);
-    signed int baseID = (reg & 0x000000ff);
-
     switch(getArchitecture()) {
-      case Arch_x86_64:
-        switch(category) {
-          case x86_64::GPR:
-            c = x86_regclass_gpr;
-            switch(baseID) {
-              case x86_64::BASEA: n = x86_gpr_ax; break;
-              case x86_64::BASEC: n = x86_gpr_cx; break;
-              case x86_64::BASED: n = x86_gpr_dx; break;
-              case x86_64::BASEB: n = x86_gpr_bx; break;
-              case x86_64::BASESP: n = x86_gpr_sp; break;
-              case x86_64::BASEBP: n = x86_gpr_bp; break;
-              case x86_64::BASESI: n = x86_gpr_si; break;
-              case x86_64::BASEDI: n = x86_gpr_di; break;
-              case x86_64::BASE8: n = x86_gpr_r8; break;
-              case x86_64::BASE9: n = x86_gpr_r9; break;
-              case x86_64::BASE10: n = x86_gpr_r10; break;
-              case x86_64::BASE11: n = x86_gpr_r11; break;
-              case x86_64::BASE12: n = x86_gpr_r12; break;
-              case x86_64::BASE13: n = x86_gpr_r13; break;
-              case x86_64::BASE14: n = x86_gpr_r14; break;
-              case x86_64::BASE15: n = x86_gpr_r15; break;
-              default: n = 0; break;
-            }
-            break;
-          case x86_64::SEG:
-            c = x86_regclass_segment;
-            switch(baseID) {
-              case x86_64::BASEDS: n = x86_segreg_ds; break;
-              case x86_64::BASEES: n = x86_segreg_es; break;
-              case x86_64::BASEFS: n = x86_segreg_fs; break;
-              case x86_64::BASEGS: n = x86_segreg_gs; break;
-              case x86_64::BASECS: n = x86_segreg_cs; break;
-              case x86_64::BASESS: n = x86_segreg_ss; break;
-              default: n = 0; break;
-            }
-            break;
-          case x86_64::FLAG:
-            c = x86_regclass_flags;
-            switch(baseID) {
-              case x86_64::CF: n = x86_flag_cf; break;
-              case x86_64::FLAG1: n = x86_flag_1; break;
-              case x86_64::PF: n = x86_flag_pf; break;
-              case x86_64::FLAG3: n = x86_flag_3; break;
-              case x86_64::AF: n = x86_flag_af; break;
-              case x86_64::FLAG5: n = x86_flag_5; break;
-              case x86_64::ZF: n = x86_flag_zf; break;
-              case x86_64::SF: n = x86_flag_sf; break;
-              case x86_64::TF: n = x86_flag_tf; break;
-              case x86_64::IF: n = x86_flag_if; break;
-              case x86_64::DF: n = x86_flag_df; break;
-              case x86_64::OF: n = x86_flag_of; break;
-              case x86_64::FLAGC: n = x86_flag_iopl0; break;
-              case x86_64::FLAGD: n = x86_flag_iopl1; break;
-              case x86_64::NT: n = x86_flag_nt; break;
-              case x86_64::FLAGF: n = x86_flag_15; break;
-              case x86_64::VM: n = x86_flag_vm; break;
-              case x86_64::RF: n = x86_flag_rf; break;
-              case x86_64::AC: n = x86_flag_ac; break;
-              case x86_64::VIF: n = x86_flag_vif; break;
-              case x86_64::VIP: n = x86_flag_vip; break;
-              case x86_64::ID: n = x86_flag_id; break;
-              default:
-                c = -1;
-                return;
-                break;
-            }
-            break;
-          case x86_64::MISC: c = x86_regclass_unknown; break;
-          case x86_64::KMASK:
-            c = x86_regclass_kmask;
-            n = baseID;
-            break;
-          case x86_64::ZMM:
-            c = x86_regclass_zmm;
-            n = baseID;
-            break;
-          case x86_64::YMM:
-            c = x86_regclass_ymm;
-            n = baseID;
-            break;
-          case x86_64::XMM:
-            c = x86_regclass_xmm;
-            n = baseID;
-            break;
-          case x86_64::MMX:
-            c = x86_regclass_mm;
-            n = baseID;
-            break;
-          case x86_64::X87:
-            c = x86_regclass_st_top;
-            n = baseID;
-            break;
-          case x86_64::CTL:
-            c = x86_regclass_cr;
-            n = baseID;
-            break;
-          case x86_64::DBG:
-            c = x86_regclass_dr;
-            n = baseID;
-            break;
-          case x86_64::TST: c = x86_regclass_unknown; break;
-          case 0:
-            switch(baseID) {
-              case 0x10:
-                c = x86_regclass_ip;
-                n = 0;
-                break;
-              default: c = x86_regclass_unknown; break;
-            }
-            break;
-          default:
-	    common_parsing_printf("Unknown category '%d' for Arch_x86_64\n", category);
-	    break;
-      } break;
       default:
         c = x86_regclass_unknown;
         n = 0;
         break;
-    }
-
-    switch(getArchitecture()) {
-      case Arch_x86_64:
-        switch(subrange) {
-          case x86_64::FULL:
-          case x86_64::XMMS:
-          case x86_64::MMS:
-          case x86_64::KMSKS:
-          case x86_64::YMMS:
-          case x86_64::ZMMS:
-          case x86_64::FPDBL: p = x86_regpos_qword; break;
-          case x86_64::H_REG: p = x86_regpos_high_byte; break;
-          case x86_64::L_REG: p = x86_regpos_low_byte; break;
-          case x86_64::W_REG: p = x86_regpos_word; break;
-          case x86_64::D_REG: p = x86_regpos_dword; break;
-          case x86_64::BIT: p = x86_regpos_all; break;
-          default:
-              common_parsing_printf("Unknown subrange value '%d' for Arch_x86_64\n", subrange);
-              break;
-        }
-        break;
-
-      default: p = x86_regpos_unknown;
     }
   }
 

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -3,7 +3,6 @@
 #include "debug_common.h"
 #include "dyn_regs.h"
 
-#include "external/rose/armv8InstructionEnum.h"
 #include "external/rose/powerpcInstructionEnum.h"
 #include "external/rose/rose-compat.h"
 
@@ -848,67 +847,6 @@ namespace Dyninst {
         }
         return;
       } break;
-      case Arch_aarch64: {
-        p = 0;
-        switch(category) {
-          case aarch64::GPR: {
-            c = armv8_regclass_gpr;
-            int regnum = baseID - (aarch64::x0 & 0xFF);
-            n = armv8_gpr_r0 + regnum;
-          } break;
-          case aarch64::SPR: {
-            n = 0;
-            if(baseID == (aarch64::pstate & 0xFF)) {
-              c = armv8_regclass_pstate;
-            } else if(baseID == (aarch64::xzr & 0xFF) || baseID == (aarch64::wzr & 0xFF)) {
-              c = armv8_regclass_gpr;
-              n = armv8_gpr_zr;
-            } else if(baseID == (aarch64::pc & 0xFF)) {
-              c = armv8_regclass_pc;
-            } else if(baseID == (aarch64::sp & 0xFF) || baseID == (aarch64::wsp & 0xFF)) {
-              c = armv8_regclass_sp;
-            }
-          } break;
-          case aarch64::FPR: {
-            c = armv8_regclass_simd_fpr;
-
-            int firstRegId;
-            switch(reg & 0xFF00) {
-              case aarch64::Q_REG: firstRegId = (aarch64::q0 & 0xFF); break;
-              case aarch64::HQ_REG:
-                firstRegId = (aarch64::hq0 & 0xFF);
-                p = 64;
-                break;
-              case aarch64::FULL: firstRegId = (aarch64::d0 & 0xFF); break;
-              case aarch64::D_REG: firstRegId = (aarch64::s0 & 0xFF); break;
-              case aarch64::W_REG: firstRegId = (aarch64::h0 & 0xFF); break;
-              case aarch64::B_REG: firstRegId = (aarch64::b0 & 0xFF); break;
-              default: assert(!"invalid register subcategory for ARM64!"); break;
-            }
-            n = armv8_simdfpr_v0 + (baseID - firstRegId);
-          } break;
-          case aarch64::FLAG: {
-            c = armv8_regclass_pstate;
-            n = 0;
-            switch(baseID) {
-              case aarch64::N_FLAG: p = armv8_pstatefield_n; break;
-              case aarch64::Z_FLAG: p = armv8_pstatefield_z; break;
-              case aarch64::V_FLAG: p = armv8_pstatefield_v; break;
-              case aarch64::C_FLAG: p = armv8_pstatefield_c; break;
-              default: c = -1; return;
-            }
-          } break;
-          default:
-            // We do not want to assert here.
-            // Set these output variable to invalid values and let the
-            // semantics code to throw exceptions
-            p = -1;
-            c = -1;
-            n = -1;
-            break;
-        }
-        return;
-      } break;
       default:
         c = x86_regclass_unknown;
         n = 0;
@@ -954,10 +892,7 @@ namespace Dyninst {
               break;
         }
         break;
-      case Arch_aarch64: {
-        c = -1;
-        return;
-      }
+
       default: p = x86_regpos_unknown;
     }
   }

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -2,7 +2,7 @@
 #include "registers/MachRegisterCache.h"
 #include "debug_common.h"
 #include "dyn_regs.h"
-#include "external/rose/amdgpuInstructionEnum.h"
+
 #include "external/rose/armv8InstructionEnum.h"
 #include "external/rose/powerpcInstructionEnum.h"
 #include "external/rose/rose-compat.h"
@@ -593,128 +593,6 @@ namespace Dyninst {
     return false;
   }
 
-  // reg_idx needs to be set as the offset from base register
-  // offset needs to be set as the offset inside the register
-
-  static void getAmdgpuGfx908RoseRegister(int& reg_class, int& reg_idx, int& offset,
-                                          const int& reg) {
-    signed int category = (reg & 0x00ff0000);
-    signed int baseID = (reg & 0x000000ff);
-
-    offset = 0;
-    reg_idx = baseID;
-    switch(category) {
-      case amdgpu_gfx908::SGPR: {
-        reg_class = amdgpu_regclass_sgpr;
-        break;
-      }
-
-      case amdgpu_gfx908::VGPR: {
-        reg_class = amdgpu_regclass_vgpr;
-        break;
-      }
-
-      case amdgpu_gfx908::PC: {
-        reg_class = amdgpu_regclass_pc;
-        reg_idx = amdgpu_pc;
-        break;
-      }
-
-      case amdgpu_gfx908::HWR: {
-        reg_class = amdgpu_regclass_pc;
-        reg_idx = amdgpu_pc;
-        break;
-      }
-
-      default: {
-        assert(0 && "unsupported register type for amdgpu gfx908");
-      }
-    }
-    return;
-  }
-
-  static void getAmdgpuGfx90aRoseRegister(int& reg_class, int& reg_idx, int& offset,
-                                          const int& reg) {
-    signed int category = (reg & 0x00ff0000);
-    signed int baseID = (reg & 0x000000ff);
-
-    offset = 0;
-    reg_idx = baseID;
-    switch(category) {
-      case amdgpu_gfx90a::SGPR: {
-        reg_class = amdgpu_regclass_sgpr;
-        break;
-      }
-
-      case amdgpu_gfx90a::VGPR: {
-        reg_class = amdgpu_regclass_vgpr;
-        break;
-      }
-
-      case amdgpu_gfx90a::PC: {
-        reg_class = amdgpu_regclass_pc;
-        reg_idx = amdgpu_pc;
-        break;
-      }
-      case amdgpu_gfx90a::HWR: {
-        reg_class = amdgpu_regclass_hwr;
-        reg_idx = amdgpu_mode;
-        break;
-      }
-      case amdgpu_gfx90a::MISC: {
-        reg_class = amdgpu_regclass_misc;
-        break;
-      }
-
-      default: {
-        assert(0 && "unsupported register type for amdgpu gfx90a");
-      }
-    }
-    return;
-  }
-
-  static void getAmdgpuGfx940RoseRegister(int& reg_class, int& reg_idx, int& offset,
-                                          const int& reg) {
-    signed int category = (reg & 0x00ff0000);
-    signed int baseID = (reg & 0x000000ff);
-
-    offset = 0;
-    reg_idx = baseID;
-    switch(category) {
-      case amdgpu_gfx940::SGPR: {
-        reg_class = amdgpu_regclass_sgpr;
-        break;
-      }
-
-      case amdgpu_gfx940::VGPR: {
-        reg_class = amdgpu_regclass_vgpr;
-        break;
-      }
-
-      case amdgpu_gfx940::PC: {
-        reg_class = amdgpu_regclass_pc;
-        reg_idx = amdgpu_pc;
-        break;
-      }
-
-      case amdgpu_gfx940::HWR: {
-        reg_class = amdgpu_regclass_hwr;
-        reg_idx = amdgpu_mode;
-        break;
-      }
-
-      case amdgpu_gfx940::MISC: {
-        reg_class = amdgpu_regclass_misc;
-        break;
-      }
-
-      default: {
-        assert(0 && "unsupported register type for amdgpu gfx940");
-      }
-    }
-    return;
-  }
-
   /* This function should has a boolean return value
    * to indicate whether there is a corresponding
    * ROSE register.
@@ -737,18 +615,6 @@ namespace Dyninst {
     signed int baseID = (reg & 0x000000ff);
 
     switch(getArchitecture()) {
-      case Arch_amdgpu_gfx908: {
-        getAmdgpuGfx908RoseRegister(c, n, p, reg);
-        return;
-      }
-      case Arch_amdgpu_gfx90a: {
-        getAmdgpuGfx90aRoseRegister(c, n, p, reg);
-        return;
-      }
-      case Arch_amdgpu_gfx940: {
-        getAmdgpuGfx940RoseRegister(c, n, p, reg);
-        return;
-      }
       case Arch_x86:
         switch(category) {
           case x86::GPR:

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -3,8 +3,6 @@
 #include "debug_common.h"
 #include "dyn_regs.h"
 
-#include "external/rose/rose-compat.h"
-
 #include <cassert>
 #include <unordered_map>
 #include <map>
@@ -589,31 +587,6 @@ namespace Dyninst {
 	return *this == getZeroFlag(getArchitecture());
     }
     return false;
-  }
-
-  /* This function should has a boolean return value
-   * to indicate whether there is a corresponding
-   * ROSE register.
-   *
-   * Since historically, this function does not
-   * have a return value. We set c to -1 to represent
-   * error cases
-   * c is set to regClass
-   * n is set to regNum
-   * p is set to regPosition
-   * see dataflowAPI/src/ExpressionConversionVisitor.C
-   */
-
-  void MachRegister::getROSERegister(int& c, int& n, int&) {
-    // Rose: class, number, position
-    // Dyninst: category, base id, subrange
-
-    switch(getArchitecture()) {
-      default:
-        c = x86_regclass_unknown;
-        n = 0;
-        break;
-    }
   }
 
   /*

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -613,102 +613,6 @@ namespace Dyninst {
     signed int baseID = (reg & 0x000000ff);
 
     switch(getArchitecture()) {
-      case Arch_x86:
-        switch(category) {
-          case x86::GPR:
-            c = x86_regclass_gpr;
-            switch(baseID) {
-              case x86::BASEA: n = x86_gpr_ax; break;
-              case x86::BASEC: n = x86_gpr_cx; break;
-              case x86::BASED: n = x86_gpr_dx; break;
-              case x86::BASEB: n = x86_gpr_bx; break;
-              case x86::BASESP: n = x86_gpr_sp; break;
-              case x86::BASEBP: n = x86_gpr_bp; break;
-              case x86::BASESI: n = x86_gpr_si; break;
-              case x86::BASEDI: n = x86_gpr_di; break;
-              default: n = 0; break;
-            }
-            break;
-          case x86::SEG:
-            c = x86_regclass_segment;
-            switch(baseID) {
-              case x86::BASEDS: n = x86_segreg_ds; break;
-              case x86::BASEES: n = x86_segreg_es; break;
-              case x86::BASEFS: n = x86_segreg_fs; break;
-              case x86::BASEGS: n = x86_segreg_gs; break;
-              case x86::BASECS: n = x86_segreg_cs; break;
-              case x86::BASESS: n = x86_segreg_ss; break;
-              default: n = 0; break;
-            }
-            break;
-          case x86::FLAG:
-            c = x86_regclass_flags;
-            switch(baseID) {
-              case x86::CF: n = x86_flag_cf; break;
-              case x86::PF: n = x86_flag_pf; break;
-              case x86::AF: n = x86_flag_af; break;
-              case x86::ZF: n = x86_flag_zf; break;
-              case x86::SF: n = x86_flag_sf; break;
-              case x86::TF: n = x86_flag_tf; break;
-              case x86::IF: n = x86_flag_if; break;
-              case x86::DF: n = x86_flag_df; break;
-              case x86::OF: n = x86_flag_of; break;
-              case x86::FLAGC: n= x86_flag_iopl0; break;
-              case x86::FLAGD: n= x86_flag_iopl1; break;
-              case x86::NT: n = x86_flag_nt; break;
-              case x86::RF: n = x86_flag_rf; break;
-              case x86::VM: n= x86_flag_vm; break;
-              case x86::AC: n = x86_flag_ac; break;
-              case x86::VIF: n = x86_flag_vif; break;
-              case x86::VIP: n = x86_flag_vip; break;
-              case x86::ID: n = x86_flag_id; break;
-              default: assert(0); break;
-            }
-            break;
-          case x86::MISC: c = x86_regclass_unknown; break;
-          case x86::XMM:
-            c = x86_regclass_xmm;
-            n = baseID;
-            break;
-          case x86::MMX:
-            c = x86_regclass_mm;
-            n = baseID;
-            break;
-          case x86::X87:
-            c = x86_regclass_st_top;
-            n = baseID;
-            break;
-          case x86::YMM:
-            c = x86_regclass_ymm;
-            n = baseID;
-            break;
-          case x86::ZMM:
-            c = x86_regclass_zmm;
-            n = baseID;
-            break;
-          case x86::CTL:
-            c = x86_regclass_cr;
-            n = baseID;
-            break;
-          case x86::DBG:
-            c = x86_regclass_dr;
-            n = baseID;
-            break;
-          case x86::TST: c = x86_regclass_unknown; break;
-          case 0:
-            switch(baseID) {
-              case 0x10:
-                c = x86_regclass_ip;
-                n = 0;
-                break;
-              default: c = x86_regclass_unknown; break;
-            }
-            break;
-          default:
-              common_parsing_printf("Unknown category '%d' for Arch_x86\n", category);
-              break;
-        }
-        break;
       case Arch_x86_64:
         switch(category) {
           case x86_64::GPR:
@@ -830,25 +734,6 @@ namespace Dyninst {
     }
 
     switch(getArchitecture()) {
-      case Arch_x86:
-        switch(subrange) {
-          case x86::XMMS:
-          case x86::YMMS:
-          case x86::ZMMS:
-          case x86::KMSKS:
-          case x86::FPDBL: p = x86_regpos_qword; break;
-          case x86::MMS: p = x86_regpos_qword; break;
-          case x86::H_REG: p = x86_regpos_high_byte; break;
-          case x86::L_REG: p = x86_regpos_low_byte; break;
-          case x86::W_REG: p = x86_regpos_word; break;
-          case x86::FULL:
-          case x86::BIT: p = x86_regpos_all; break;
-          default:
-              common_parsing_printf("Unknown subrange value '%d' for Arch_x86\n", subrange);
-              break;
-        }
-        break;
-
       case Arch_x86_64:
         switch(subrange) {
           case x86_64::FULL:

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -3,7 +3,6 @@
 #include "debug_common.h"
 #include "dyn_regs.h"
 
-#include "external/rose/powerpcInstructionEnum.h"
 #include "external/rose/rose-compat.h"
 
 #include <cassert>
@@ -823,29 +822,6 @@ namespace Dyninst {
           default:
 	    common_parsing_printf("Unknown category '%d' for Arch_x86_64\n", category);
 	    break;
-        }
-        break;
-      case Arch_ppc64: {
-        baseID = reg & 0x0000FFFF;
-        n = baseID;
-        switch(category) {
-          case ppc64::GPR: c = powerpc_regclass_gpr; break;
-          case ppc64::FPR:
-          case ppc64::FSR: c = powerpc_regclass_fpr; break;
-          case ppc64::SPR: {
-            if(baseID < 613) {
-              c = powerpc_regclass_spr;
-            } else if(baseID < 621) {
-              c = powerpc_regclass_sr;
-            } else {
-              c = powerpc_regclass_cr;
-              n = 0;
-              p = baseID - 621;
-            }
-          } break;
-          default: c = -1; return;
-        }
-        return;
       } break;
       default:
         c = x86_regclass_unknown;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -826,28 +826,6 @@ namespace Dyninst {
 	    break;
         }
         break;
-      case Arch_ppc32: {
-        baseID = reg & 0x0000FFFF;
-        n = baseID;
-        switch(category) {
-          case ppc32::GPR: c = powerpc_regclass_gpr; break;
-          case ppc32::FPR:
-          case ppc32::FSR: c = powerpc_regclass_fpr; break;
-          case ppc32::SPR: {
-            if(baseID < 613) {
-              c = powerpc_regclass_spr;
-            } else if(baseID < 621) {
-              c = powerpc_regclass_sr;
-            } else {
-              c = powerpc_regclass_cr;
-              n = 0;
-              p = baseID - 621;
-            }
-          } break;
-          default: c = -1; return;
-        }
-        return;
-      } break;
       case Arch_ppc64: {
         baseID = reg & 0x0000FFFF;
         n = baseID;

--- a/dataflowAPI/CMakeLists.txt
+++ b/dataflowAPI/CMakeLists.txt
@@ -73,6 +73,7 @@ set(_dataflow_private_headers
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/typedefs.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/x86_64InstructionSemantics.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/x86InstructionSemantics.h
+    ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/amdgpu.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/convert.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/BaseSemantics2.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherAMDGPU.h

--- a/dataflowAPI/CMakeLists.txt
+++ b/dataflowAPI/CMakeLists.txt
@@ -77,6 +77,7 @@ set(_dataflow_private_headers
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/amdgpu.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/convert.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/ppc32.h
+    ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/ppc64.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/BaseSemantics2.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherAMDGPU.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherARM64.h

--- a/dataflowAPI/CMakeLists.txt
+++ b/dataflowAPI/CMakeLists.txt
@@ -78,6 +78,7 @@ set(_dataflow_private_headers
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/convert.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/ppc32.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/ppc64.h
+    ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/x86.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/BaseSemantics2.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherAMDGPU.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherARM64.h

--- a/dataflowAPI/CMakeLists.txt
+++ b/dataflowAPI/CMakeLists.txt
@@ -75,6 +75,7 @@ set(_dataflow_private_headers
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/x86InstructionSemantics.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/amdgpu.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/convert.h
+    ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/ppc32.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/BaseSemantics2.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherAMDGPU.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherARM64.h

--- a/dataflowAPI/CMakeLists.txt
+++ b/dataflowAPI/CMakeLists.txt
@@ -79,6 +79,7 @@ set(_dataflow_private_headers
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/ppc32.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/ppc64.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/x86.h
+    ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/x86_64.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/BaseSemantics2.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherAMDGPU.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherARM64.h

--- a/dataflowAPI/CMakeLists.txt
+++ b/dataflowAPI/CMakeLists.txt
@@ -73,6 +73,7 @@ set(_dataflow_private_headers
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/typedefs.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/x86_64InstructionSemantics.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/x86InstructionSemantics.h
+    ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/aarch64.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/amdgpu.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/convert.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/ppc32.h

--- a/dataflowAPI/CMakeLists.txt
+++ b/dataflowAPI/CMakeLists.txt
@@ -9,6 +9,7 @@ set(_rose_sources
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/Registers.C
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/RegisterStateGeneric.C
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/SymEvalSemantics.C
+    ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/convert.C
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/util/Assert.C
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/util/Attribute.C
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/util/Combinatorics.C
@@ -72,6 +73,7 @@ set(_dataflow_private_headers
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/typedefs.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/x86_64InstructionSemantics.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/x86InstructionSemantics.h
+    ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/registers/convert.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/BaseSemantics2.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherAMDGPU.h
     ${PROJECT_SOURCE_DIR}/dataflowAPI/rose/semantics/DispatcherARM64.h

--- a/dataflowAPI/rose/RegisterDescriptor.h
+++ b/dataflowAPI/rose/RegisterDescriptor.h
@@ -6,6 +6,7 @@
 #define DYNINST_REGISTERDESCRIPTOR_H
 
 #include <iostream>
+#include "dataflowAPI/rose/registers/convert.h"
 
 /** Describes (part of) a physical CPU register.
  *
@@ -27,6 +28,12 @@ public:
             : majr(0), minr(0), offset(0), nbits(0) {}
     RegisterDescriptor(unsigned majr_, unsigned minr_, unsigned offset_, unsigned nbits_)
             : majr(majr_), minr(minr_), offset(offset_), nbits(nbits_) {}
+
+    RegisterDescriptor(Dyninst::MachRegister reg) : reg_{reg} {
+      namespace dd = Dyninst::DataflowAPI;
+      std::tie(majr, minr, offset, nbits) = dd::convertToROSERegister(reg);
+    }
+
     unsigned get_major() const {
         return majr;
     }
@@ -58,6 +65,9 @@ public:
         this->nbits = nbits_;
         return *this;
     }
+    Dyninst::MachRegister get_machine_register() const {
+      return reg_;
+    }
     bool operator<(const RegisterDescriptor &other) const;
     bool operator==(const RegisterDescriptor &other) const;
     bool operator!=(const RegisterDescriptor &other) const;
@@ -71,6 +81,7 @@ private:
     unsigned minr;	/** Register number within major division. */
     unsigned offset;	/** Low-bit offset within the physical register. */
     unsigned nbits;	/** Number of bits referenced by this descriptor. */
+    Dyninst::MachRegister reg_;
 };
 
 #endif //DYNINST_REGISTERDESCRIPTOR_H

--- a/dataflowAPI/rose/registers/aarch64.h
+++ b/dataflowAPI/rose/registers/aarch64.h
@@ -1,0 +1,120 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_COMMON_REGISTERS_ROSE_AARCH64_H
+#define DYNINST_COMMON_REGISTERS_ROSE_AARCH64_H
+
+#include "external/rose/armv8InstructionEnum.h"
+#include "registers/aarch64_regs.h"
+#include "dataflowAPI/src/debug_dataflow.h"
+
+#include <tuple>
+
+namespace {
+
+  std::tuple<ARMv8RegisterClass, int, int, int>
+  aarch64Rose(int32_t category, int32_t baseID, int32_t subrange, int32_t num_bits) {
+    constexpr auto pos = 0;
+
+    switch(category) {
+      case Dyninst::aarch64::GPR: {
+        auto const c = armv8_regclass_gpr;
+        auto const regnum = baseID - (Dyninst::aarch64::x0 & 0xFF);
+        auto const n = armv8_gpr_r0 + regnum;
+        return std::make_tuple(c, n, pos, num_bits);
+      }
+
+      case Dyninst::aarch64::SPR: {
+        int n = 0;
+        ARMv8RegisterClass c;
+        if(baseID == (Dyninst::aarch64::pstate & 0xFF)) {
+          c = armv8_regclass_pstate;
+        } else if(baseID == (Dyninst::aarch64::xzr & 0xFF) || baseID == (Dyninst::aarch64::wzr & 0xFF)) {
+          c = armv8_regclass_gpr;
+          n = armv8_gpr_zr;
+        } else if(baseID == (Dyninst::aarch64::pc & 0xFF)) {
+          c = armv8_regclass_pc;
+        } else if(baseID == (Dyninst::aarch64::sp & 0xFF) || baseID == (Dyninst::aarch64::wsp & 0xFF)) {
+          c = armv8_regclass_sp;
+        }
+        return std::make_tuple(c, n, pos, num_bits);
+      }
+
+      case Dyninst::aarch64::FPR: {
+        auto c = armv8_regclass_simd_fpr;
+        auto p = 0;
+        int firstRegId;
+        switch(subrange) {
+          case Dyninst::aarch64::Q_REG:
+            firstRegId = (Dyninst::aarch64::q0 & 0xFF);
+            break;
+          case Dyninst::aarch64::HQ_REG:
+            firstRegId = (Dyninst::aarch64::hq0 & 0xFF);
+            p = 64;
+            break;
+          case Dyninst::aarch64::FULL:
+            firstRegId = (Dyninst::aarch64::d0 & 0xFF);
+            break;
+          case Dyninst::aarch64::D_REG:
+            firstRegId = (Dyninst::aarch64::s0 & 0xFF);
+            break;
+          case Dyninst::aarch64::W_REG:
+            firstRegId = (Dyninst::aarch64::h0 & 0xFF);
+            break;
+          case Dyninst::aarch64::B_REG:
+            firstRegId = (Dyninst::aarch64::b0 & 0xFF);
+            break;
+          default: assert(!"invalid register subcategory for ARM64!"); break;
+        }
+        auto n = armv8_simdfpr_v0 + (baseID - firstRegId);
+        return std::make_tuple(c, n, p, num_bits);
+      }
+
+      case Dyninst::aarch64::FLAG: {
+        auto c = armv8_regclass_pstate;
+        int n = 0;
+        int p = pos;
+        switch(baseID) {
+          case Dyninst::aarch64::N_FLAG: p = armv8_pstatefield_n; break;
+          case Dyninst::aarch64::Z_FLAG: p = armv8_pstatefield_z; break;
+          case Dyninst::aarch64::V_FLAG: p = armv8_pstatefield_v; break;
+          case Dyninst::aarch64::C_FLAG: p = armv8_pstatefield_c; break;
+          default:
+            c = static_cast<ARMv8RegisterClass>(-1);
+        }
+        return std::make_tuple(c, n, p, num_bits);
+      }
+    }
+    convert_printf("Unknown aarch64 category '%d'\n", category);
+    return std::make_tuple(armv8_regclass_unknown, -1, pos, 0);
+  }
+}
+
+#endif

--- a/dataflowAPI/rose/registers/amdgpu.h
+++ b/dataflowAPI/rose/registers/amdgpu.h
@@ -1,0 +1,133 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_COMMON_REGISTERS_ROSE_AMDGPU_H
+#define DYNINST_COMMON_REGISTERS_ROSE_AMDGPU_H
+
+#include "external/rose/amdgpuInstructionEnum.h"
+#include "registers/AMDGPU/amdgpu_gfx908_regs.h"
+#include "registers/AMDGPU/amdgpu_gfx90a_regs.h"
+#include "registers/AMDGPU/amdgpu_gfx940_regs.h"
+#include "dataflowAPI/src/debug_dataflow.h"
+
+#include <tuple>
+
+namespace {
+
+  std::tuple<AMDGPURegisterClass, AMDGPUHardwareRegister, int, int>
+  AmdgpuGfx908Rose(int32_t category, int32_t baseID, int32_t, int32_t size) {
+    auto const reg_idx = static_cast<AMDGPUHardwareRegister>(baseID);
+    constexpr auto pos = 0;
+
+    switch(category) {
+      case Dyninst::amdgpu_gfx908::SGPR: {
+        return std::make_tuple(amdgpu_regclass_sgpr, reg_idx, pos, size);
+      }
+
+      case Dyninst::amdgpu_gfx908::VGPR: {
+        return std::make_tuple(amdgpu_regclass_vgpr, reg_idx, pos, size);
+      }
+
+      case Dyninst::amdgpu_gfx908::PC: {
+        return std::make_tuple(amdgpu_regclass_pc, amdgpu_pc, pos, size);
+      }
+
+      case Dyninst::amdgpu_gfx908::HWR: {
+        return std::make_tuple(amdgpu_regclass_pc, amdgpu_pc, pos, size);
+      }
+    }
+    convert_printf("Unknown AmdgpuGfx908 category '%d'\n", category);
+    return std::make_tuple(amdgpu_regclass_unknown, reg_idx, pos, 0);
+  }
+
+  std::tuple<AMDGPURegisterClass, AMDGPUHardwareRegister, int, int>
+  AmdgpuGfx90aRose(int32_t category, int32_t baseID, int32_t, int32_t size) {
+    auto const reg_idx = static_cast<AMDGPUHardwareRegister>(baseID);
+    constexpr auto pos = 0;
+
+    switch(category) {
+      case Dyninst::amdgpu_gfx90a::SGPR: {
+        return std::make_tuple(amdgpu_regclass_sgpr, reg_idx, pos, size);
+      }
+
+      case Dyninst::amdgpu_gfx90a::VGPR: {
+        return std::make_tuple(amdgpu_regclass_vgpr, reg_idx, pos, size);
+      }
+
+      case Dyninst::amdgpu_gfx90a::PC: {
+        return std::make_tuple(amdgpu_regclass_pc, amdgpu_pc, pos, size);
+      }
+
+      case Dyninst::amdgpu_gfx90a::HWR: {
+        return std::make_tuple(amdgpu_regclass_hwr, amdgpu_mode, pos, size);
+      }
+
+      case Dyninst::amdgpu_gfx90a::MISC: {
+        return std::make_tuple(amdgpu_regclass_misc, reg_idx, pos, size);
+      }
+    }
+    convert_printf("Unknown AmdgpuGfx90a category '%d'\n", category);
+    return std::make_tuple(amdgpu_regclass_unknown, reg_idx, pos, 0);
+  }
+
+  std::tuple<AMDGPURegisterClass, AMDGPUHardwareRegister, int, int>
+  AmdgpuGfx940Rose(int32_t category, int32_t baseID, int32_t, int32_t size) {
+    auto const reg_idx = static_cast<AMDGPUHardwareRegister>(baseID);
+    constexpr auto pos = 0;
+
+    switch(category) {
+      case Dyninst::amdgpu_gfx940::SGPR: {
+        return std::make_tuple(amdgpu_regclass_sgpr, reg_idx, pos, size);
+        break;
+      }
+
+      case Dyninst::amdgpu_gfx940::VGPR: {
+        return std::make_tuple(amdgpu_regclass_vgpr, reg_idx, pos, size);
+      }
+
+      case Dyninst::amdgpu_gfx940::PC: {
+        return std::make_tuple(amdgpu_regclass_pc, amdgpu_pc, pos, size);
+      }
+
+      case Dyninst::amdgpu_gfx940::HWR: {
+        return std::make_tuple(amdgpu_regclass_hwr, amdgpu_mode, pos, size);
+      }
+
+      case Dyninst::amdgpu_gfx940::MISC: {
+        return std::make_tuple(amdgpu_regclass_misc, reg_idx, pos, size);
+      }
+    }
+    convert_printf("Unknown AmdgpuGfx940 category '%d'\n", category);
+    return std::make_tuple(amdgpu_regclass_unknown, reg_idx, pos, 0);
+  }
+
+}
+
+#endif

--- a/dataflowAPI/rose/registers/convert.C
+++ b/dataflowAPI/rose/registers/convert.C
@@ -1,9 +1,12 @@
 #include "rose/registers/convert.h"
 
+#include "dataflowAPI/rose/registers/aarch64.h"
 #include "dataflowAPI/rose/registers/amdgpu.h"
 #include "dataflowAPI/rose/registers/ppc32.h"
 
 #include "dataflowAPI/src/debug_dataflow.h"
+
+#include <tuple>
 
 namespace Dyninst { namespace DataflowAPI {
 
@@ -54,6 +57,9 @@ namespace Dyninst { namespace DataflowAPI {
       }
       case Arch_ppc32: {
         return ppc32Rose(category, reg, num_bits);
+      }
+      case Arch_aarch64: {
+        return aarch64Rose(category, baseID, subrange, num_bits);
       }
     }
     convert_printf("Unknown Architecture 0x%X\n", reg.getArchitecture());

--- a/dataflowAPI/rose/registers/convert.C
+++ b/dataflowAPI/rose/registers/convert.C
@@ -73,6 +73,14 @@ namespace Dyninst { namespace DataflowAPI {
       case Arch_aarch64: {
         return aarch64Rose(category, baseID, subrange, num_bits);
       }
+      case Arch_aarch32:
+      case Arch_cuda:
+      case Arch_intelGen9:
+      case Arch_none:
+        // Set these output variable to invalid values and let the
+        // semantics code to throw exceptions
+        convert_printf("No ROSE register for architecture 0x%X\n", reg.getArchitecture());
+        return INVALID_REG;
     }
     convert_printf("Unknown Architecture 0x%X\n", reg.getArchitecture());
     return INVALID_REG;

--- a/dataflowAPI/rose/registers/convert.C
+++ b/dataflowAPI/rose/registers/convert.C
@@ -3,6 +3,7 @@
 #include "dataflowAPI/rose/registers/aarch64.h"
 #include "dataflowAPI/rose/registers/amdgpu.h"
 #include "dataflowAPI/rose/registers/ppc32.h"
+#include "dataflowAPI/rose/registers/ppc64.h"
 
 #include "dataflowAPI/src/debug_dataflow.h"
 
@@ -57,6 +58,9 @@ namespace Dyninst { namespace DataflowAPI {
       }
       case Arch_ppc32: {
         return ppc32Rose(category, reg, num_bits);
+      }
+      case Arch_ppc64: {
+        return ppc64Rose(category, reg, num_bits);
       }
       case Arch_aarch64: {
         return aarch64Rose(category, baseID, subrange, num_bits);

--- a/dataflowAPI/rose/registers/convert.C
+++ b/dataflowAPI/rose/registers/convert.C
@@ -1,5 +1,7 @@
 #include "rose/registers/convert.h"
 
+#include "dataflowAPI/rose/registers/amdgpu.h"
+
 #include "dataflowAPI/src/debug_dataflow.h"
 
 namespace Dyninst { namespace DataflowAPI {
@@ -40,6 +42,15 @@ namespace Dyninst { namespace DataflowAPI {
     auto const INVALID_REG = std::make_tuple(0,0,0,0);
 
     switch(reg.getArchitecture()) {
+      case Arch_amdgpu_gfx908: {
+        return AmdgpuGfx908Rose(category, baseID, subrange, num_bits);
+      }
+      case Arch_amdgpu_gfx90a: {
+        return AmdgpuGfx90aRose(category, baseID, subrange, num_bits);
+      }
+      case Arch_amdgpu_gfx940: {
+        return AmdgpuGfx940Rose(category, baseID, subrange, num_bits);
+      }
     }
     convert_printf("Unknown Architecture 0x%X\n", reg.getArchitecture());
     return INVALID_REG;

--- a/dataflowAPI/rose/registers/convert.C
+++ b/dataflowAPI/rose/registers/convert.C
@@ -1,6 +1,7 @@
 #include "rose/registers/convert.h"
 
 #include "dataflowAPI/rose/registers/amdgpu.h"
+#include "dataflowAPI/rose/registers/ppc32.h"
 
 #include "dataflowAPI/src/debug_dataflow.h"
 
@@ -50,6 +51,9 @@ namespace Dyninst { namespace DataflowAPI {
       }
       case Arch_amdgpu_gfx940: {
         return AmdgpuGfx940Rose(category, baseID, subrange, num_bits);
+      }
+      case Arch_ppc32: {
+        return ppc32Rose(category, reg, num_bits);
       }
     }
     convert_printf("Unknown Architecture 0x%X\n", reg.getArchitecture());

--- a/dataflowAPI/rose/registers/convert.C
+++ b/dataflowAPI/rose/registers/convert.C
@@ -4,6 +4,7 @@
 #include "dataflowAPI/rose/registers/amdgpu.h"
 #include "dataflowAPI/rose/registers/ppc32.h"
 #include "dataflowAPI/rose/registers/ppc64.h"
+#include "dataflowAPI/rose/registers/x86.h"
 
 #include "dataflowAPI/src/debug_dataflow.h"
 
@@ -55,6 +56,9 @@ namespace Dyninst { namespace DataflowAPI {
       }
       case Arch_amdgpu_gfx940: {
         return AmdgpuGfx940Rose(category, baseID, subrange, num_bits);
+      }
+      case Arch_x86: {
+        return x86Rose(category, baseID, subrange, num_bits);
       }
       case Arch_ppc32: {
         return ppc32Rose(category, reg, num_bits);

--- a/dataflowAPI/rose/registers/convert.C
+++ b/dataflowAPI/rose/registers/convert.C
@@ -5,6 +5,7 @@
 #include "dataflowAPI/rose/registers/ppc32.h"
 #include "dataflowAPI/rose/registers/ppc64.h"
 #include "dataflowAPI/rose/registers/x86.h"
+#include "dataflowAPI/rose/registers/x86_64.h"
 
 #include "dataflowAPI/src/debug_dataflow.h"
 
@@ -59,6 +60,9 @@ namespace Dyninst { namespace DataflowAPI {
       }
       case Arch_x86: {
         return x86Rose(category, baseID, subrange, num_bits);
+      }
+      case Arch_x86_64: {
+        return x8664Rose(category, baseID, subrange, num_bits);
       }
       case Arch_ppc32: {
         return ppc32Rose(category, reg, num_bits);

--- a/dataflowAPI/rose/registers/convert.C
+++ b/dataflowAPI/rose/registers/convert.C
@@ -45,7 +45,7 @@ namespace Dyninst { namespace DataflowAPI {
     // MachRegister::size is in _bytes_
     auto const num_bits = 8*static_cast<int32_t>(reg.size());
 
-    // A RegisterDescriptor descriptor is invalid if it has no bits
+    // A RegisterDescriptor is invalid if it has no bits
     auto const INVALID_REG = std::make_tuple(0,0,0,0);
 
     switch(reg.getArchitecture()) {

--- a/dataflowAPI/rose/registers/convert.C
+++ b/dataflowAPI/rose/registers/convert.C
@@ -1,0 +1,48 @@
+#include "rose/registers/convert.h"
+
+#include "dataflowAPI/src/debug_dataflow.h"
+
+namespace Dyninst { namespace DataflowAPI {
+
+  rose_reg_raw_t convertToROSERegister(Dyninst::MachRegister reg) {
+
+    /*
+     * A ROSE register has a major version, minor version, position, and size.
+     *
+     * These map to a MachRegister as follows:
+     *
+     *  category -> major version
+     *  baseID   -> minor version
+     *  subrange -> position
+     *
+     * The major version, register position, and size (in bits) are based on the
+     * user-provided register.
+     *
+     * On most platforms, ROSE only has minor versions for the most-basal registers.
+     *
+     *  For example, the aarch64 8-bit FPR b0 is mapped to the 128-bit q0 represented
+     *  by armv8_simdfpr_v0.
+     *
+     *  For x86, ROSE sometimes uses the 16-bit names and sometimes the 64-bit names.
+     *
+     *  For example, the major version for 'rax' is x86_gpr_ax, and the major version
+     *  for 'r15' is x86_gpr_r15.
+     *
+     */
+    auto const category = reg.regClass();
+    auto const baseID = reg.getBaseRegister().val() & 0x000000ff;
+    auto const subrange = reg.val() & 0x0000ff00;
+
+    // MachRegister::size is in _bytes_
+    auto const num_bits = 8*static_cast<int32_t>(reg.size());
+
+    // A RegisterDescriptor descriptor is invalid if it has no bits
+    auto const INVALID_REG = std::make_tuple(0,0,0,0);
+
+    switch(reg.getArchitecture()) {
+    }
+    convert_printf("Unknown Architecture 0x%X\n", reg.getArchitecture());
+    return INVALID_REG;
+  }
+
+}}

--- a/dataflowAPI/rose/registers/convert.h
+++ b/dataflowAPI/rose/registers/convert.h
@@ -1,0 +1,52 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_DATAFLOW_ROSE_REGISTERS_CONVERT_H
+#define DYNINST_DATAFLOW_ROSE_REGISTERS_CONVERT_H
+
+#include "registers/MachRegister.h"
+
+#include <tuple>
+
+namespace Dyninst { namespace DataflowAPI {
+
+  /*
+   * Ultimately, a ROSE register is four C-style enums
+   * representing major version, minor version, and
+   * position. The fourth value is the size in bits.
+   */
+  using rose_reg_raw_t = std::tuple<int,int,int,int>;
+
+  // Returns the ROSE register equivalent to a MachRegister
+  rose_reg_raw_t convertToROSERegister(Dyninst::MachRegister);
+
+}}
+
+#endif

--- a/dataflowAPI/rose/registers/ppc32.h
+++ b/dataflowAPI/rose/registers/ppc32.h
@@ -1,0 +1,75 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_COMMON_REGISTERS_ROSE_PPC32_H
+#define DYNINST_COMMON_REGISTERS_ROSE_PPC32_H
+
+#include "external/rose/powerpcInstructionEnum.h"
+#include "registers/ppc32_regs.h"
+#include "dataflowAPI/src/debug_dataflow.h"
+
+#include <tuple>
+
+namespace {
+
+  std::tuple<PowerpcRegisterClass, int, int, int>
+  ppc32Rose(int32_t category, int32_t reg, int32_t num_bits) {
+    int const baseID = reg & 0x0000FFFF;
+    constexpr auto pos = 0;
+
+    switch(category) {
+      case Dyninst::ppc32::GPR:
+        return std::make_tuple(powerpc_regclass_gpr, baseID, pos, num_bits);
+
+      case Dyninst::ppc32::FPR:
+      case Dyninst::ppc32::FSR:
+        return std::make_tuple(powerpc_regclass_fpr, baseID, pos, num_bits);
+
+      case Dyninst::ppc32::SPR: {
+        if(baseID < 613) {
+          return std::make_tuple(powerpc_regclass_spr, baseID, pos, num_bits);
+        }
+        if(baseID < 621) {
+          return std::make_tuple(powerpc_regclass_sr, baseID, pos, num_bits);
+        }
+        // ROSE treats CR as one register, so `minor` is always 0.
+        constexpr auto minor = 0;
+        auto const offset = baseID - 621;
+        auto const pos = 4 * offset;
+        constexpr auto nbits = 4;
+        return std::make_tuple(powerpc_regclass_cr, minor, pos, nbits);
+      }
+    }
+    convert_printf("Unknown ppc32 category '%d'\n", category);
+    return std::make_tuple(powerpc_regclass_unknown, baseID, pos, num_bits);
+  }
+}
+
+#endif

--- a/dataflowAPI/rose/registers/ppc64.h
+++ b/dataflowAPI/rose/registers/ppc64.h
@@ -1,0 +1,75 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_COMMON_REGISTERS_ROSE_PPC64_H
+#define DYNINST_COMMON_REGISTERS_ROSE_PPC64_H
+
+#include "external/rose/powerpcInstructionEnum.h"
+#include "registers/ppc64_regs.h"
+#include "dataflowAPI/src/debug_dataflow.h"
+
+#include <tuple>
+
+namespace {
+
+  std::tuple<PowerpcRegisterClass, int, int, int>
+  ppc64Rose(int32_t category, int32_t reg, int32_t num_bits) {
+    auto const baseID = reg & 0x0000FFFF;
+    constexpr auto pos = 0;
+
+    switch(category) {
+      case Dyninst::ppc64::GPR:
+        return std::make_tuple(powerpc_regclass_gpr, baseID, pos, num_bits);
+
+      case Dyninst::ppc64::FPR:
+      case Dyninst::ppc64::FSR:
+        return std::make_tuple(powerpc_regclass_fpr, baseID, pos, num_bits);
+
+      case Dyninst::ppc64::SPR: {
+        if(baseID < 613) {
+          return std::make_tuple(powerpc_regclass_spr, baseID, pos, num_bits);
+        }
+        if(baseID < 621) {
+          return std::make_tuple(powerpc_regclass_sr, baseID, pos, num_bits);
+        }
+        // ROSE treats CR as one register, so `minor` is always 0.
+        constexpr auto minor = 0;
+        auto const offset = baseID - 621;
+        auto const pos = 4 * offset;
+        constexpr auto nbits = 4;
+        return std::make_tuple(powerpc_regclass_cr, minor, pos, nbits);
+      }
+    }
+    convert_printf("Unknown ppc64 category '%d'\n", category);
+    return std::make_tuple(powerpc_regclass_unknown, baseID, 0, 0);
+  }
+}
+
+#endif

--- a/dataflowAPI/rose/registers/x86.h
+++ b/dataflowAPI/rose/registers/x86.h
@@ -1,0 +1,178 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_COMMON_REGISTERS_ROSE_X86_H
+#define DYNINST_COMMON_REGISTERS_ROSE_X86_H
+
+#include "external/rose/rose-compat.h"
+#include "registers/x86_regs.h"
+#include "dataflowAPI/src/debug_dataflow.h"
+
+#include <tuple>
+
+namespace {
+  namespace x86_rose {
+
+    X86PositionInRegister pos(int32_t subrange) {
+      switch(subrange) {
+        case Dyninst::x86::XMMS:
+        case Dyninst::x86::YMMS:
+        case Dyninst::x86::ZMMS:
+        case Dyninst::x86::KMSKS:
+        case Dyninst::x86::FPDBL: return x86_regpos_qword;
+        case Dyninst::x86::MMS: return x86_regpos_qword;
+        case Dyninst::x86::H_REG: return x86_regpos_high_byte;
+        case Dyninst::x86::L_REG: return x86_regpos_low_byte;
+        case Dyninst::x86::W_REG: return x86_regpos_word;
+        case Dyninst::x86::FULL:
+        case Dyninst::x86::BIT: return x86_regpos_all;
+      }
+      convert_printf("Unknown x86 subrange value '%d'\n", subrange);
+      return x86_regpos_unknown;
+    }
+
+    X86GeneralPurposeRegister gpr(int32_t baseID) {
+      switch(baseID) {
+        case Dyninst::x86::BASEA: return x86_gpr_ax;
+        case Dyninst::x86::BASEC: return x86_gpr_cx;
+        case Dyninst::x86::BASED: return x86_gpr_dx;
+        case Dyninst::x86::BASEB: return x86_gpr_bx;
+        case Dyninst::x86::BASESP: return x86_gpr_sp;
+        case Dyninst::x86::BASEBP: return x86_gpr_bp;
+        case Dyninst::x86::BASESI: return x86_gpr_si;
+        case Dyninst::x86::BASEDI: return x86_gpr_di;
+      }
+      convert_printf("Unknown x86 GPR '%d'\n", baseID);
+      return static_cast<X86GeneralPurposeRegister>(-1);
+    }
+
+    X86SegmentRegister seg(int32_t baseID) {
+      switch(baseID) {
+        case Dyninst::x86::BASEDS: return x86_segreg_ds;
+        case Dyninst::x86::BASEES: return x86_segreg_es;
+        case Dyninst::x86::BASEFS: return x86_segreg_fs;
+        case Dyninst::x86::BASEGS: return x86_segreg_gs;
+        case Dyninst::x86::BASECS: return x86_segreg_cs;
+        case Dyninst::x86::BASESS: return x86_segreg_ss;
+      }
+      convert_printf("Unknown x86 segment register '%d'\n", baseID);
+      return x86_segreg_none;
+    }
+
+    X86Flag flag(int32_t baseID) {
+      switch(baseID) {
+        case Dyninst::x86::CF: return x86_flag_cf;
+        case Dyninst::x86::PF: return x86_flag_pf;
+        case Dyninst::x86::AF: return x86_flag_af;
+        case Dyninst::x86::ZF: return x86_flag_zf;
+        case Dyninst::x86::SF: return x86_flag_sf;
+        case Dyninst::x86::TF: return x86_flag_tf;
+        case Dyninst::x86::IF: return x86_flag_if;
+        case Dyninst::x86::DF: return x86_flag_df;
+        case Dyninst::x86::OF: return x86_flag_of;
+        case Dyninst::x86::FLAGC: return x86_flag_iopl0;
+        case Dyninst::x86::FLAGD: return x86_flag_iopl1;
+        case Dyninst::x86::NT: return x86_flag_nt;
+        case Dyninst::x86::RF: return x86_flag_rf;
+        case Dyninst::x86::VM: return x86_flag_vm;
+        case Dyninst::x86::AC: return x86_flag_ac;
+        case Dyninst::x86::VIF: return x86_flag_vif;
+        case Dyninst::x86::VIP: return x86_flag_vip;
+        case Dyninst::x86::ID: return x86_flag_id;
+      }
+      convert_printf("Unknown x86 flag register '%d'\n", baseID);
+      return static_cast<X86Flag>(-1);
+    }
+  }
+
+  std::tuple<X86RegisterClass, int, X86PositionInRegister, int>
+  x86Rose(int32_t category, int32_t baseID, int32_t subrange, int32_t num_bits) {
+    auto const p = x86_rose::pos(subrange);
+
+    switch(category) {
+      case Dyninst::x86::GPR: {
+        auto const c = x86_regclass_gpr;
+        auto const n = x86_rose::gpr(baseID);
+        return std::make_tuple(c, static_cast<int>(n), p, num_bits);
+      }
+
+      case Dyninst::x86::SEG: {
+        auto const c = x86_regclass_segment;
+        auto const n = x86_rose::seg(baseID);
+        return std::make_tuple(c, static_cast<int>(n), p, num_bits);
+      }
+
+      case Dyninst::x86::FLAG: {
+        auto const c = x86_regclass_flags;
+        auto const n = x86_rose::flag(baseID);
+        auto const pos = static_cast<X86PositionInRegister>(0);  // ROSE docs: only value allowed is 0
+        return std::make_tuple(c, static_cast<int>(n), pos, num_bits);
+      }
+
+      case Dyninst::x86::XMM:
+        return std::make_tuple(x86_regclass_xmm, baseID, p, num_bits);
+
+      case Dyninst::x86::MMX:
+        return std::make_tuple(x86_regclass_mm, baseID, p, num_bits);
+
+      case Dyninst::x86::X87: {
+        auto const pos = static_cast<X86PositionInRegister>(0);  // ROSE docs: only value allowed is 0
+        return std::make_tuple(x86_regclass_st_top, baseID, pos, num_bits);
+      }
+
+      case Dyninst::x86::YMM:
+        return std::make_tuple(x86_regclass_ymm, baseID, p, num_bits);
+
+      case Dyninst::x86::ZMM:
+        return std::make_tuple(x86_regclass_zmm, baseID, p, num_bits);
+
+      case Dyninst::x86::CTL:
+        return std::make_tuple(x86_regclass_cr, baseID, p, num_bits);
+
+      case Dyninst::x86::DBG:
+        return std::make_tuple(x86_regclass_dr, baseID, p, num_bits);
+
+      case Dyninst::x86::TST:
+      case Dyninst::x86::MISC:
+        return std::make_tuple(x86_regclass_unknown, -1, p, 0);
+
+      case 0: {
+        switch(baseID) {
+          case 0x10:
+            return std::make_tuple(x86_regclass_ip, 0, p, num_bits);
+        }
+      }
+    }
+    convert_printf("Unknown x86 category '%d'\n", category);
+    return std::make_tuple(x86_regclass_unknown, -1, p, 0);
+  }
+}
+
+#endif

--- a/dataflowAPI/rose/registers/x86_64.h
+++ b/dataflowAPI/rose/registers/x86_64.h
@@ -1,0 +1,195 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_COMMON_REGISTERS_ROSE_X86_64_H
+#define DYNINST_COMMON_REGISTERS_ROSE_X86_64_H
+
+#include "external/rose/rose-compat.h"
+#include "registers/x86_64_regs.h"
+#include "dataflowAPI/src/debug_dataflow.h"
+
+#include <tuple>
+
+namespace {
+  namespace x86_64_rose {
+
+    X86PositionInRegister pos(int32_t subrange) {
+      switch(subrange) {
+        case Dyninst::x86_64::FULL:
+        case Dyninst::x86_64::XMMS:
+        case Dyninst::x86_64::MMS:
+        case Dyninst::x86_64::KMSKS:
+        case Dyninst::x86_64::YMMS:
+        case Dyninst::x86_64::ZMMS:
+        case Dyninst::x86_64::FPDBL: return x86_regpos_qword; break;
+        case Dyninst::x86_64::H_REG: return x86_regpos_high_byte; break;
+        case Dyninst::x86_64::L_REG: return x86_regpos_low_byte; break;
+        case Dyninst::x86_64::W_REG: return x86_regpos_word; break;
+        case Dyninst::x86_64::D_REG: return x86_regpos_dword; break;
+        case Dyninst::x86_64::BIT: return x86_regpos_all; break;
+      }
+      convert_printf("Unknown x86_64 subrange value '%d'\n", subrange);
+      return x86_regpos_unknown;
+    }
+
+    X86GeneralPurposeRegister gpr(int32_t baseID) {
+      switch(baseID) {
+        case Dyninst::x86_64::BASEA: return x86_gpr_ax;
+        case Dyninst::x86_64::BASEC: return x86_gpr_cx;
+        case Dyninst::x86_64::BASED: return x86_gpr_dx;
+        case Dyninst::x86_64::BASEB: return x86_gpr_bx;
+        case Dyninst::x86_64::BASESP: return x86_gpr_sp;
+        case Dyninst::x86_64::BASEBP: return x86_gpr_bp;
+        case Dyninst::x86_64::BASESI: return x86_gpr_si;
+        case Dyninst::x86_64::BASEDI: return x86_gpr_di;
+        case Dyninst::x86_64::BASE8: return x86_gpr_r8;
+        case Dyninst::x86_64::BASE9: return x86_gpr_r9;
+        case Dyninst::x86_64::BASE10: return x86_gpr_r10;
+        case Dyninst::x86_64::BASE11: return x86_gpr_r11;
+        case Dyninst::x86_64::BASE12: return x86_gpr_r12;
+        case Dyninst::x86_64::BASE13: return x86_gpr_r13;
+        case Dyninst::x86_64::BASE14: return x86_gpr_r14;
+        case Dyninst::x86_64::BASE15: return x86_gpr_r15;
+      }
+      convert_printf("Unknown x86_64 GPR '%d'\n", baseID);
+      return static_cast<X86GeneralPurposeRegister>(-1);
+    }
+
+    X86SegmentRegister seg(int32_t baseID) {
+      switch(baseID) {
+        case Dyninst::x86_64::BASEDS: return x86_segreg_ds;
+        case Dyninst::x86_64::BASEES: return x86_segreg_es;
+        case Dyninst::x86_64::BASEFS: return x86_segreg_fs;
+        case Dyninst::x86_64::BASEGS: return x86_segreg_gs;
+        case Dyninst::x86_64::BASECS: return x86_segreg_cs;
+        case Dyninst::x86_64::BASESS: return x86_segreg_ss;
+      }
+      convert_printf("Unknown x86_64 segment register '%d'\n", baseID);
+      return x86_segreg_none;
+    }
+
+    X86Flag flag(int32_t baseID) {
+      switch(baseID) {
+        case Dyninst::x86_64::CF: return x86_flag_cf;
+        case Dyninst::x86_64::FLAG1: return x86_flag_1;
+        case Dyninst::x86_64::PF: return x86_flag_pf;
+        case Dyninst::x86_64::FLAG3: return x86_flag_3;
+        case Dyninst::x86_64::AF: return x86_flag_af;
+        case Dyninst::x86_64::FLAG5: return x86_flag_5;
+        case Dyninst::x86_64::ZF: return x86_flag_zf;
+        case Dyninst::x86_64::SF: return x86_flag_sf;
+        case Dyninst::x86_64::TF: return x86_flag_tf;
+        case Dyninst::x86_64::IF: return x86_flag_if;
+        case Dyninst::x86_64::DF: return x86_flag_df;
+        case Dyninst::x86_64::OF: return x86_flag_of;
+        case Dyninst::x86_64::FLAGC: return x86_flag_iopl0;
+        case Dyninst::x86_64::FLAGD: return x86_flag_iopl1;
+        case Dyninst::x86_64::NT: return x86_flag_nt;
+        case Dyninst::x86_64::FLAGF: return x86_flag_15;
+        case Dyninst::x86_64::VM: return x86_flag_vm;
+        case Dyninst::x86_64::RF: return x86_flag_rf;
+        case Dyninst::x86_64::AC: return x86_flag_ac;
+        case Dyninst::x86_64::VIF: return x86_flag_vif;
+        case Dyninst::x86_64::VIP: return x86_flag_vip;
+        case Dyninst::x86_64::ID: return x86_flag_id;
+      }
+      convert_printf("Unknown x86_64 flag register '%d'\n", baseID);
+      return static_cast<X86Flag>(-1);
+    }
+  }
+
+  std::tuple<X86RegisterClass, int, X86PositionInRegister, int>
+  x8664Rose(int32_t category, int32_t baseID, int32_t subrange, int32_t num_bits) {
+    auto const p = x86_64_rose::pos(subrange);
+
+    switch(category) {
+      case Dyninst::x86_64::GPR: {
+        auto const c = x86_regclass_gpr;
+        auto const n = x86_64_rose::gpr(baseID);
+        return std::make_tuple(c, static_cast<int>(n), p, num_bits);
+      }
+
+      case Dyninst::x86_64::SEG: {
+        auto const c = x86_regclass_segment;
+        auto const n = x86_64_rose::seg(baseID);
+        return std::make_tuple(c, static_cast<int>(n), p, num_bits);
+      }
+
+      case Dyninst::x86_64::FLAG: {
+        auto const c = x86_regclass_flags;
+        auto const n = x86_64_rose::flag(baseID);
+        auto const pos = static_cast<X86PositionInRegister>(0);  // ROSE docs: only value allowed is 0
+        return std::make_tuple(c, static_cast<int>(n), pos, num_bits);
+      }
+
+      case Dyninst::x86_64::KMASK:
+        return std::make_tuple(x86_regclass_kmask, baseID, p, num_bits);
+
+      case Dyninst::x86_64::ZMM:
+        return std::make_tuple(x86_regclass_zmm, baseID, p, num_bits);
+
+      case Dyninst::x86_64::YMM:
+        return std::make_tuple(x86_regclass_ymm, baseID, p, num_bits);
+
+      case Dyninst::x86_64::XMM:
+        return std::make_tuple(x86_regclass_xmm, baseID, p, num_bits);
+
+      case Dyninst::x86_64::MMX:
+        return std::make_tuple(x86_regclass_mm, baseID, p, num_bits);
+
+      case Dyninst::x86_64::X87: {
+        auto const pos = static_cast<X86PositionInRegister>(0);  // ROSE docs: only value allowed is 0
+        return std::make_tuple(x86_regclass_st_top, baseID, pos, num_bits);
+      }
+
+      case Dyninst::x86_64::CTL:
+        return std::make_tuple(x86_regclass_cr, baseID, p, num_bits);
+
+      case Dyninst::x86_64::DBG:
+        return std::make_tuple(x86_regclass_dr, baseID, p, num_bits);
+
+      case Dyninst::x86_64::MISC:
+      case Dyninst::x86_64::TST:
+        return std::make_tuple(x86_regclass_unknown, -1, p, 0);
+
+      case 0: {
+        switch(baseID) {
+          case 0x10:
+            return std::make_tuple(x86_regclass_ip, 0, p, num_bits);
+        }
+      }
+    }
+    convert_printf("Unknown x86_64 category '%d'\n", category);
+    return std::make_tuple(x86_regclass_unknown, -1, p, 0);
+  }
+
+}
+
+#endif

--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -266,7 +266,6 @@ SgAsmExpression* ExpressionConversionVisitor::archSpecificRegisterProc(Instructi
 
   MachRegister machReg = regast->getID();
 
-  //std::cout << " in " << __func__ << " idx = " << machReg << " arch = " << arch   << std::endl;
   switch (arch) {
     case Arch_x86:
     case Arch_x86_64: {

--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -337,9 +337,16 @@ SgAsmExpression* ExpressionConversionVisitor::archSpecificRegisterProc(Instructi
       return dre;
     }
 
-    default:
-      return NULL;
+    case Arch_aarch32:
+    case Arch_cuda:
+    case Arch_intelGen9:
+    case Arch_none: {
+      convert_printf("No ROSE register for architecture 0x%X\n", machReg.getArchitecture());
+      return nullptr;
+    }
   }
+  convert_printf("Could not get ROSE expression for '%s'\n", regast->format().c_str());
+  return nullptr;
 }
 
 SgAsmExpression *ExpressionConversionVisitor::makeSegRegExpr() {

--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -28,21 +28,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include "ExpressionConversionVisitor.h"
-#include "dataflowAPI/rose/registers/convert.h"
+#include "Register.h"
+#include "MultiRegister.h"
+#include "rose/RegisterDescriptor.h"
+#include "rose/SgAsmExpression.h"
+#include "rose/registers/convert.h"
+#include "debug_dataflow.h"
 
 #include "Immediate.h"
 #include "BinaryFunction.h"
 #include "Dereference.h"
 #include "compiler_annotations.h"
-
-#include <list>
-
-#include "Register.h"
-#include "MultiRegister.h"
-#include "rose/RegisterDescriptor.h"
-#include "../rose/SgAsmExpression.h"
-#include "rose/registers/convert.h"
-#include "debug_dataflow.h"
 
 using namespace Dyninst;
 using namespace Dyninst::InstructionAPI;

--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -28,13 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include "ExpressionConversionVisitor.h"
-#include "external/rose/amdgpuInstructionEnum.h"
-#include "external/rose/armv8InstructionEnum.h"
-#include "external/rose/powerpcInstructionEnum.h"
-#include "external/rose/rose-compat.h"
 #include "dataflowAPI/rose/registers/convert.h"
-
-#include "debug_dataflow.h"
 
 #include "Immediate.h"
 #include "BinaryFunction.h"

--- a/external/rose/amdgpuInstructionEnum.h
+++ b/external/rose/amdgpuInstructionEnum.h
@@ -1,6 +1,7 @@
 #ifndef ROSE_AMDGPUINSTRUCTIONENUM_H
 #define ROSE_AMDGPUINSTRUCTIONENUM_H
 enum AMDGPURegisterClass{
+  amdgpu_regclass_unknown,
 	amdgpu_regclass_hwr,
 	amdgpu_regclass_pc,
 	amdgpu_regclass_misc,

--- a/external/rose/armv8InstructionEnum.h
+++ b/external/rose/armv8InstructionEnum.h
@@ -11,7 +11,8 @@ enum ARMv8RegisterClass {
     armv8_regclass_simd_fpr,	    /** TODO: Minors yet to be defined */
     armv8_regclass_pstate,	    /** Minor is the only one pstate register with its flags (defined in ARMv8Flag) being the only relevant fields */
     armv8_regclass_pc,		    /** Program counter, only allowed minor is 0 */
-    armv8_regclass_sp           /** Stack pointer, only allowed minor is 0 */
+    armv8_regclass_sp,          /** Stack pointer, only allowed minor is 0 */
+    armv8_regclass_unknown
 };
 
 /** ARMv8-A general purpose registers */


### PR DESCRIPTION
The conversion is only ever used in dataflowAPI, so that's where it belongs. It also simplifies the conversion by directly creating a `RegisterDescriptor` which is the register vocabulary for interacting with ROSE.

There are several bugs that I will submit fixes for in separate PRs, notably in `SymEvalSemantics::RegisterStateAST::convert`.

@bbiiggppiigg Could you double-check the GPU changes?