### PR TITLE
Fix register calculation in parse_func::calcUsedRegs for aarch64

### DIFF
--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -553,11 +553,7 @@ bool EmitterAARCH64::clobberAllFuncCall(registerSpace *rs,
 
         std::set<Register> *fpRegs = callee->ifunc()->usedFPRs();
         for(std::set<Register>::iterator itr = fpRegs->begin(); itr != fpRegs->end(); itr++) {
-            if (*itr <= rs->FPRs().size())
-              rs->FPRs()[*itr]->beenUsed = true;
-            else
-              // parse_func::calcUsedRegs includes the subtype; we only want the regno
-              rs->FPRs()[*itr & 0xff]->beenUsed = true;
+          rs->FPRs()[registerSpace::FPR(*itr)]->beenUsed = true;
         }
     } else {
         for(int idx = 0; idx < rs->numGPRs(); idx++)


### PR DESCRIPTION
The MachRegister ids are no longer guaranteed to be sequential, so performing arithmetic on them may not be valid. Because 'registerSlot' uses aarch64Registers_t to represent registers, MachRegisters need to be transformed using the conversion maps in RegisterConversion-aarch64.C. Those maps use the the base registers `x<N>` for GPRs and `q<N>` for FPRs, so the registers are correspondingly transformed before being stored in parse_func::usedRegisters.

@kupsch This fixes almost all test failures on zeroah. I'm working on the rest.