### PR TITLE
Fix register calculation in parse_func::calcUsedRegs for ppc

### DIFF
--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1126,7 +1126,7 @@ bool EmitterPOWER::clobberAllFuncCall( registerSpace *rs,
       std::set<Register>::iterator It2 = fprs->begin();
       for(unsigned i = 0; i < fprs->size(); i++)
       {
-          rs->FPRs()[*(It2++)]->beenUsed = true;
+          rs->FPRs()[registerSpace::FPR(*(It2++))]->beenUsed = true;
       }
     }
   else {


### PR DESCRIPTION
The MachRegister ids are no longer guaranteed to be sequential, so performing arithmetic on them may not be valid. Because 'registerSlot' uses powerRegisters_t to represent registers, MachRegisters need to be transformed using the conversion maps in RegisterConversion-ppc.C.