### PR TITLE
Unify valid instruction detection

### DIFF
--- a/instructionAPI/doc/API/Instruction.tex
+++ b/instructionAPI/doc/API/Instruction.tex
@@ -320,9 +320,7 @@ bool isValid() const
 bool isLegalInsn() const
 \end{apient}
 \apidesc{
-    Returns \code{true} if this Instruction object represents a legal
-    instruction, as specified by the architecture used to decode this
-    instruction.
+    An alias for \code{isValid}.
 }
 
 \begin{apient}

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -65,9 +65,36 @@ using namespace NS_x86;
 
 namespace Dyninst { namespace InstructionAPI {
 
+  namespace {
+    bool is_valid_mnemonic(Dyninst::Architecture arch, entryID id) {
+      switch(arch) {
+        case Arch_x86:
+        case Arch_x86_64:
+          return id != e_No_Entry;
+
+        case Arch_aarch64:
+          return id != aarch64_op_INVALID;
+
+        case Arch_ppc32:
+        case Arch_ppc64:
+          return id != power_op_INVALID;
+
+        case Arch_none:
+        case Arch_aarch32:
+        case Arch_cuda:
+        case Arch_intelGen9:
+        case Arch_amdgpu_gfx908:
+        case Arch_amdgpu_gfx90a:
+        case Arch_amdgpu_gfx940:
+          return false;
+      }
+      return false;
+    }
+  }
+
   DYNINST_EXPORT Instruction::Instruction(Operation what, size_t size, const unsigned char* raw,
                                           Dyninst::Architecture arch)
-      : m_InsnOp(what), m_Valid(what.getID() != e_No_Entry), arch_decoded_from(arch),
+      : m_InsnOp(what), m_Valid(is_valid_mnemonic(arch, what.getID())), arch_decoded_from(arch),
         formatter(&ArchSpecificFormatter::getFormatter(arch)) {
     copyRaw(size, raw);
   }
@@ -433,7 +460,7 @@ namespace Dyninst { namespace InstructionAPI {
     return false;
   }
 
-  DYNINST_EXPORT bool Instruction::isLegalInsn() const { return (m_InsnOp.getID() != e_No_Entry); }
+  DYNINST_EXPORT bool Instruction::isLegalInsn() const { return m_Valid; }
 
   DYNINST_EXPORT Architecture Instruction::getArch() const { return arch_decoded_from; }
 

--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -327,8 +327,7 @@ bool IA_IAPI::isAbort() const
 
 bool IA_IAPI::isInvalidInsn() const
 {
-    entryID e = curInsn().getOperation().getID();
-    if(e == e_No_Entry)
+    if(!curInsn().isValid())
     {
         parsing_printf("...WARNING: un-decoded instruction at 0x%lx\n", current);
         return true;

--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -395,7 +395,7 @@ bool IndirectControlFlowAnalyzer::FindJunkInstruction(Address addr) {
 
     while (!ahPtr->hasCFT()) {
         Instruction i = ahPtr->current_instruction();
-        if (i.getOperation().getID() == e_No_Entry) {
+        if (!i.isValid()) {
             return true;
         }
         if (i.size() == 2 && i.rawByte(0) == 0x00 && i.rawByte(1) == 0x00) {


### PR DESCRIPTION
These only detect actual decode failures on x86.

'isValid' was added by 410f34166 in 2008 and 'isLegalInsn' by b490edd40 in 2009. It's unclear why the latter was needed.

@bbiiggppiigg Is there a reason the AMD GPU opcodes don't have an invalid entryID?