### PR TITLE
Use MachRegister::isFlag in RegisterAST::isFlag

### DIFF
--- a/instructionAPI/src/Register.C
+++ b/instructionAPI/src/Register.C
@@ -156,7 +156,7 @@ namespace Dyninst { namespace InstructionAPI {
                                            regPtr->getPromotedReg().size());
   }
 
-  bool RegisterAST::isFlag() const { return m_Reg.getBaseRegister() == x86::flags; }
+  bool RegisterAST::isFlag() const { return m_Reg.isFlag(); }
 
   bool RegisterAST::checkRegID(MachRegister r, unsigned int low, unsigned int high) const {
     return (r.getBaseRegister() == m_Reg.getBaseRegister()) && (low <= m_High) && (high >= m_Low);


### PR DESCRIPTION
This isn't currently used inside of Dyninst, but this class is intended to be overridden by users creating their own AST. In the base case, it should do the right thing here instead of only working on x86.