### PR TITLE
Add executor for aarch64 return instruction

### DIFF
--- a/dataflowAPI/rose/semantics/DispatcherARM64.C
+++ b/dataflowAPI/rose/semantics/DispatcherARM64.C
@@ -4901,6 +4901,19 @@ namespace rose {
                     }
                 };
 
+    struct IP_ret: P {
+      void p(D d, Ops ops, I insn, A args, B) {
+          BaseSemantics::SValue::Ptr targetVa;
+          if (args.empty()) {
+              targetVa = ops->readRegister(d->REG_LR);
+          } else {
+              assert_args(insn, args, 1);
+              targetVa = d->read(args[0]);
+          }
+          ops->writeRegister(d->REG_PC, targetVa);
+      }
+    };
+
             } // namespace
 
 /*******************************************************************************************************************************
@@ -5067,6 +5080,7 @@ namespace rose {
                 iproc_set(rose_aarch64_op_stlrh, new ARM64::IP_stlrh_execute);
                 iproc_set(rose_aarch64_op_udiv, new ARM64::IP_udiv_execute);
                 iproc_set(rose_aarch64_op_sdiv, new ARM64::IP_udiv_execute);
+                iproc_set(rose_aarch64_op_ret, new ARM64::IP_ret);
             }
 
             void
@@ -5078,6 +5092,7 @@ namespace rose {
                     REG_C = findRegister("c", 1);
                     REG_V = findRegister("v", 1);
                     REG_SP = findRegister("sp", 64);
+                    REG_LR = findRegister("lr", 64);
                 }
             }
 

--- a/dataflowAPI/rose/semantics/DispatcherARM64.h
+++ b/dataflowAPI/rose/semantics/DispatcherARM64.h
@@ -60,7 +60,7 @@ namespace rose {
                  *
                  * @{ */
 
-                RegisterDescriptor REG_PC, REG_N, REG_Z, REG_C, REG_V, REG_SP;
+                RegisterDescriptor REG_PC, REG_N, REG_Z, REG_C, REG_V, REG_SP, REG_LR;
 
                 /** @}*/
 

--- a/dataflowAPI/rose/semantics/Registers.C
+++ b/dataflowAPI/rose/semantics/Registers.C
@@ -306,6 +306,9 @@ RegisterDictionary::dictionary_armv8() {
         /* 64-bit program counter register */
         regs->insert("pc", armv8_regclass_pc, 0, 0, 64);
 
+        /* 64-bit link register */
+        regs->insert("lr", armv8_regclass_sp, 0, 0, 64);
+
         /* 32-bit pstate register and the four relevant flags.*/
         /* Each flag is added as a separate register for individual access. Only allowed minor is 0 (since there is only one pstate register);
          * the different offsets indicate the positions of the flags within the pstate register. */


### PR DESCRIPTION
This is based on the latest ROSE source. Fixes two aarch64 test suite failures.

Requires #1859