### PR TITLE
Fix base register calculation for ppc

### DIFF
--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -194,6 +194,46 @@ namespace Dyninst {
         return *this;
       }
 
+      case Arch_ppc64: {
+        auto ppc_id = [](MachRegister r) {
+          return r.val() & 0x0000FFFF;
+        };
+
+        /* Power ISA
+         *  Version 3.1C
+         *  May 26, 2024
+         *  7.2.1.2 Vector Registers
+         */
+        auto to_vsr = [ppc_id](int32_t offset) {
+          auto const new_id = ppc_id(ppc64::vsr32) + offset;
+          auto const r = new_id | ppc64::VSR | Arch_ppc64;
+          return MachRegister(r);
+        };
+
+        auto const id = ppc_id(*this);
+
+        if(category == ppc64::FPR) {
+          // fpr<N> -> vsr<32+N>[0:63]
+          return to_vsr(id - ppc_id(ppc64::fpr0));
+        }
+
+        if(category == ppc64::FSR) {
+          // fsr<N> -> vsr<32+N>[0:31]
+          return to_vsr(id - ppc_id(ppc64::fsr0));
+        }
+
+        // Condition register (cr<N>, cr<N><len>)
+        if((id >= 621 && id <= 628) || (id >= 700 && id <= 731)) {
+          return ppc64::cr;
+        }
+
+        // Floating-point Control/Status
+        if(id >= 602 && id <= 609) {
+          return ppc64::fpscw;
+        }
+        return *this;
+      }
+
       case Arch_aarch32:
       case Arch_intelGen9:
       case Arch_cuda:


### PR DESCRIPTION
OpenPOWER Foundation
Power Instruction Set Architecture
Version 3.1C
May 26, 2024
4.2 Floating-Point Facility Registers
3.2 Fixed-Point Facility Registers
6.3 Vector Facility Registers
7.2 VSX Registers

Unit tests are passing: https://github.com/dyninst/unit-tests/pull/12
