### PR TITLE
Fix AMDGPU rose to use explicit operands

### DIFF
--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -439,47 +439,39 @@ void RoseInsnAMDGPUFactory::massageOperands(const Instruction &insn,
     case amdgpu_gfx908_op_S_SWAPPC_B64:
     case amdgpu_gfx90a_op_S_SWAPPC_B64: 
     case amdgpu_gfx940_op_S_SWAPPC_B64: {
-        assert(operands.size() == 4);
-        operands.reserve(6);
-        operands.push_back(operands[2]);
-        operands.push_back(operands[3]);
-        MultiRegisterAST::Ptr src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[1].getValue());
-        const std::vector<RegisterAST::Ptr> & src_reg_asts = src_regs->getRegs();
-        operands[3] = Operand(src_reg_asts[1]);
-        operands[2] = Operand(src_reg_asts[0]);
+        assert(operands.size() == 2);
+        operands.reserve(4);
         MultiRegisterAST::Ptr dst_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
         const std::vector<RegisterAST::Ptr> & dst_reg_asts = dst_regs->getRegs();
-        operands[1] = Operand(dst_reg_asts[1]);
+        MultiRegisterAST::Ptr src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[1].getValue());
+        const std::vector<RegisterAST::Ptr> & src_reg_asts = src_regs->getRegs();
         operands[0] = Operand(dst_reg_asts[0]);
- 
-
+        operands[1] = Operand(dst_reg_asts[1]);
+        operands.push_back(Operand(src_reg_asts[0]));
+        operands.push_back(Operand(src_reg_asts[1]));
         break;
     }
     case amdgpu_gfx908_op_S_SETPC_B64:
     case amdgpu_gfx90a_op_S_SETPC_B64: 
     case amdgpu_gfx940_op_S_SETPC_B64: {
-        assert(operands.size() == 2);
-        operands.reserve(3);
-        operands.push_back(operands[1]);
+        assert(operands.size() == 1);
+        operands.reserve(2);
         MultiRegisterAST::Ptr src_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
         const std::vector<RegisterAST::Ptr> & src_reg_asts = src_regs->getRegs();
-        operands[1] = Operand(src_reg_asts[1]);
         operands[0] = Operand(src_reg_asts[0]);
-
+        operands.push_back(Operand(src_reg_asts[1]));
         break;
-
     }
     case amdgpu_gfx908_op_S_GETPC_B64:
     case amdgpu_gfx90a_op_S_GETPC_B64: 
     case amdgpu_gfx940_op_S_GETPC_B64: {
-        assert(operands.size() == 2);
+        assert(operands.size() == 1);
         operands.reserve(3);
-        operands.push_back(Operand(InstructionAPI::Immediate::makeImmediate(Result(u64,_addr+4)),false,false));
         MultiRegisterAST::Ptr dst_regs  = boost::dynamic_pointer_cast<MultiRegisterAST>(operands[0].getValue());
         const std::vector<RegisterAST::Ptr> & dst_reg_asts = dst_regs->getRegs();
-        operands[1] = Operand(dst_reg_asts[1]);
         operands[0] = Operand(dst_reg_asts[0]);
-
+        operands.push_back(Operand(dst_reg_asts[1]));
+        operands.push_back(Operand(InstructionAPI::Immediate::makeImmediate(Result(u64,_addr+4)),false,false));
         break;
     }
     default:

--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -432,9 +432,9 @@ void RoseInsnAMDGPUFactory::massageOperands(const Instruction &insn,
         std::vector<InstructionAPI::Operand> &operands) {
     switch (insn.getOperation().getID()) {
 
-    // SWAPPC has 4 operands, two multiregisters followed by two copies of PC
+    // SWAPPC has 2 operands, two multiregisters
     // Breaking up the multiregisters into individual registers 
-    // So we end up getting 6 operands
+    // So we end up getting 4 operands
     // Similar concept for SETPC and GETPC
     case amdgpu_gfx908_op_S_SWAPPC_B64:
     case amdgpu_gfx90a_op_S_SWAPPC_B64: 


### PR DESCRIPTION
Previous implementation assumed the existence of allOperands instead of just explicitOperands.
This change is required to reflect the changes made in #1859.
