### PR TITLE
Separate usage of aarch64 pstate and nzcv flag registers

### DIFF
--- a/common/src/arch-aarch64.h
+++ b/common/src/arch-aarch64.h
@@ -106,7 +106,7 @@ namespace NS_aarch64 {
 
 //Would probably want to use the register category as well (FPR/SPR/GPR), but for the uses of these macros, this should suffice
 #define SPR_LR      (((Dyninst::aarch64::x29).val()) & 0x1F)
-#define SPR_NZCV    (((Dyninst::aarch64::pstate).val()) & 0x1F)
+#define SPR_NZCV    (((Dyninst::aarch64::nzcv).val()) & 0x1F)
 #define SPR_FPCR    (((Dyninst::aarch64::fpcr).val()) & 0x1F)
 #define SPR_FPSR    (((Dyninst::aarch64::fpsr).val()) & 0x1F)
 

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -683,7 +683,10 @@ namespace Dyninst {
     switch(getArchitecture()) {
       case Arch_x86: return regC == x86::FLAG;
       case Arch_x86_64: return regC == x86_64::FLAG;
-      case Arch_aarch64: return regC == aarch64::FLAG;
+      case Arch_aarch64: {
+        return regC == aarch64::FLAG ||
+               regC == aarch64::PSTATE;
+      }
       case Arch_ppc32:
       case Arch_ppc64: {
         // For power, we have a different register representation.

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -781,7 +781,7 @@ namespace Dyninst {
 
           case 100: return Dyninst::aarch64::sp;
           case 101: return Dyninst::aarch64::pc;
-          case 102: return Dyninst::aarch64::pstate;
+          case 102: return Dyninst::aarch64::nzcv;
           case 103: return Dyninst::aarch64::xzr;
           default: return InvalidReg;
         }

--- a/dataflowAPI/rose/registers/aarch64.h
+++ b/dataflowAPI/rose/registers/aarch64.h
@@ -160,6 +160,7 @@ namespace {
       }
 
       case Dyninst::aarch64::FLAG: {
+        // ROSE supports NZCV, but not DAIF
         auto const c = armv8_regclass_pstate;
         auto const n = 0;  // ROSE docs: only minor value allowed is 0
         auto const p = aarch64_rose::pstate_field(baseID);

--- a/dataflowAPI/rose/registers/convert.C
+++ b/dataflowAPI/rose/registers/convert.C
@@ -88,8 +88,9 @@ namespace Dyninst { namespace DataflowAPI {
           // ROSE docs: only minor value allowed is 0
           return std::make_tuple(armv8_regclass_sp, 0, 0, num_bits);
         }
-        if(reg.getBaseRegister() == Dyninst::aarch64::nzcv) {
-          // Preserve the individual flags as separate registers
+        if(reg.isFlag()) {
+          // Use the given register rather than the bas to preserve the
+          // individual flags as separate registers
           auto const id = reg.val() & 0x000000ff;
           return aarch64Rose(category, id, subrange, num_bits);
         }

--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -98,7 +98,7 @@ void AbsRegionConverter::convertAll(const InstructionAPI::Instruction &insn,
             MachRegister machReg = (*i)->getID();
             std::vector<MachRegister> flagRegs = {aarch64::n, aarch64::z, aarch64::c, aarch64::v};
 
-            if(machReg == aarch64::pstate) {
+            if(machReg == aarch64::nzcv) {
                 for(std::vector<MachRegister>::iterator itr = flagRegs.begin(); itr != flagRegs.end(); itr++) {
                     used.push_back(AbsRegionConverter::convert(RegisterAST::Ptr(new RegisterAST(*itr))));
                 }
@@ -130,7 +130,7 @@ void AbsRegionConverter::convertAll(const InstructionAPI::Instruction &insn,
             MachRegister machReg = (*i)->getID();
             std::vector<MachRegister> flagRegs = {aarch64::n, aarch64::z, aarch64::c, aarch64::v};
 
-            if(machReg == aarch64::pstate) {
+            if(machReg == aarch64::nzcv) {
                 for(std::vector<MachRegister>::iterator itr = flagRegs.begin(); itr != flagRegs.end(); itr++) {
                     defined.push_back(AbsRegionConverter::convert(RegisterAST::Ptr(new RegisterAST(*itr))));
                 }

--- a/dataflowAPI/src/RegisterMap.C
+++ b/dataflowAPI/src/RegisterMap.C
@@ -781,7 +781,8 @@ RegisterMap &machRegIndex_aarch64() {
      {aarch64::pc,  65},
      {aarch64::sp,  66},
      {aarch64::pstate, 67},
-     {aarch64::xzr, 68}};
+     {aarch64::xzr, 68},
+     {aarch64::nzcv, 69}};
    }
    return *mrmap;
 }

--- a/dyninstAPI/src/RegisterConversion-aarch64.C
+++ b/dyninstAPI/src/RegisterConversion-aarch64.C
@@ -112,7 +112,7 @@ multimap<Register, MachRegister> regToMachReg64 = map_list_of
   (registerSpace::lr, 		aarch64::x30)
   (registerSpace::sp, 		aarch64::sp)
   (registerSpace::pc, 		aarch64::pc)
-  (registerSpace::pstate, 	aarch64::pstate)
+  (registerSpace::nzcv, 	aarch64::nzcv)
   (registerSpace::fpcr, 	aarch64::fpcr)
   (registerSpace::fpsr, 	aarch64::fpsr)
   ;
@@ -184,7 +184,7 @@ map<MachRegister, Register> reverseRegisterMap = map_list_of
   //(aarch64::x30,   registerSpace::lr)
   (aarch64::sp,   registerSpace::sp)
   (aarch64::pc,   registerSpace::pc)
-  (aarch64::pstate,   registerSpace::pstate)
+  (aarch64::nzcv,   registerSpace::nzcv)
   (aarch64::fpcr,   registerSpace::fpcr)
   (aarch64::fpsr,   registerSpace::fpsr)
   ;
@@ -289,7 +289,7 @@ MachRegister convertRegID(Register r, Dyninst::Architecture arch) {
             case registerSpace::lr: 	return aarch64::x30;
             case registerSpace::sp: 	return aarch64::sp;
             case registerSpace::pc: 	return aarch64::pc;
-            case registerSpace::pstate: 	return aarch64::pstate;
+            case registerSpace::nzcv: 	return aarch64::nzcv;
             default:
                 break;
         }

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -106,7 +106,7 @@ void registerSpace::initialize64() {
     //SPRs
     registers.push_back(new registerSlot(lr, "lr", true, registerSlot::liveAlways, registerSlot::SPR));
     registers.push_back(new registerSlot(sp, "sp", true, registerSlot::liveAlways, registerSlot::SPR));
-    registers.push_back(new registerSlot(pstate, "nzcv", true, registerSlot::liveAlways, registerSlot::SPR));
+    registers.push_back(new registerSlot(nzcv, "nzcv", true, registerSlot::liveAlways, registerSlot::SPR));
     registers.push_back(new registerSlot(fpcr, "fpcr", true, registerSlot::liveAlways, registerSlot::SPR));
     registers.push_back(new registerSlot(fpsr, "fpsr", true, registerSlot::liveAlways, registerSlot::SPR));
 
@@ -217,7 +217,7 @@ unsigned EmitterAARCH64SaveRegs::saveSPRegisters(
     std::vector<registerSlot *> spRegs;
     map<registerSlot *, int> regMap;
 
-    registerSlot *regNzcv = (*theRegSpace)[registerSpace::pstate];
+    registerSlot *regNzcv = (*theRegSpace)[registerSpace::nzcv];
     assert(regNzcv);
     regMap[regNzcv] = SPR_NZCV;
     if(force_save || regNzcv->liveState == registerSlot::live)
@@ -326,7 +326,7 @@ unsigned EmitterAARCH64RestoreRegs::restoreSPRegisters(
     if(force_save || regFpcr->liveState == registerSlot::spilled)
         spRegs.push_back(regFpcr);
 
-    registerSlot *regNzcv = (*theRegSpace)[registerSpace::pstate];
+    registerSlot *regNzcv = (*theRegSpace)[registerSpace::nzcv];
     assert(regNzcv);
     regMap[regNzcv] = SPR_NZCV;
     if(force_save || regNzcv->liveState == registerSlot::spilled)

--- a/dyninstAPI/src/registerSpace.h
+++ b/dyninstAPI/src/registerSpace.h
@@ -492,7 +492,7 @@ class registerSpace {
                    fpr14, fpr15, fpr16, fpr17, fpr18, fpr19, fpr20,
                    fpr21, fpr22, fpr23, fpr24, fpr25, fpr26, fpr27,
                    fpr28, fpr29, fpr30, fpr31,
-                   lr, sp, pc, pstate, fpcr, fpsr, ignored } aarch64Registers_t;
+                   lr, sp, pc, nzcv, fpcr, fpsr, ignored } aarch64Registers_t;
     static unsigned GPR(Dyninst::Register x) { return x; }
     static unsigned FPR(Dyninst::Register x) { return x - fpr0; }
     int framePointer() { return r29; }

--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -1107,7 +1107,7 @@ void InstructionDecoder_aarch64::set32Mode()
   }
 
   Expression::Ptr InstructionDecoder_aarch64::makePstateExpr() {
-    MachRegister baseReg = aarch64::pstate;
+    MachRegister baseReg = aarch64::nzcv;
 
     return makeRegisterExpression(makeAarch64RegID(baseReg, 0));
   }

--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -2223,7 +2223,7 @@ static void init_dynreg_to_user()
    dynreg_to_user[aarch64::x30]        = make_pair(cur+=step, 8);
    dynreg_to_user[aarch64::sp]         = make_pair(cur+=step, 8);
    dynreg_to_user[aarch64::pc]         = make_pair(cur+=step, 8);
-   dynreg_to_user[aarch64::pstate]     = make_pair(cur+=step, 8);
+   dynreg_to_user[aarch64::nzcv]     = make_pair(cur+=step, 8);
 
    initialized = true;
 


### PR DESCRIPTION
This should have been part of #1866