### PR TITLE
Update sha1.C: #include <cstdint>

### DIFF
--- a/common/src/sha1.C
+++ b/common/src/sha1.C
@@ -102,6 +102,7 @@ A million repetitions of "a"
 
 #include <stdio.h>
 #include <string.h>
+#include <cstdint>
 
 #include "dyntypes.h"
 #include "common/src/sha1.h"


### PR DESCRIPTION
Subject header is needed on gcc15 to compile sha1.C, supplying declaration of types like uint32_t.