### PR TITLE
refactor amdgpu register handling

### DIFF
--- a/common/h/registers/AMDGPU/amdgpu_gfx908_regs.h
+++ b/common/h/registers/AMDGPU/amdgpu_gfx908_regs.h
@@ -52,23 +52,27 @@ namespace Dyninst { namespace amdgpu_gfx908 {
 
   // 0xff000000  0x00ff0000      0x0000ff00      0x000000ff
   // arch        reg cat:GPR     alias&subrange  reg ID
-  const signed int SGPR     = 0x00010000;
-  const signed int VGPR     = 0x00060000;
-  const signed int ACC_VGPR = 0x000B0000;
+  const signed int SGPR      = 0x00010000;
+  const signed int VGPR      = 0x00060000;
+
+  const signed int MISC      = 0x000A0000;
+  const signed int ACC_VGPR  = 0x000B0000;
 
   const signed int HWR       = 0x000C0000;
   const signed int TTMP_SGPR = 0x000D0000;
-  const signed int FLAGS     = 0x000E0000;
+  const signed int WAITCNT   = 0x000E0000;
   const signed int PC        = 0x000F0000;
   const signed int SYSREG    = 0x00100000;
   const signed int TGT       = 0x00110000; // I have no idea what TGT is yet
   const signed int ATTR      = 0x00120000;
   const signed int PARAM     = 0x00130000; // LDS Parameter
-  const signed int INFO      = 0x00140000;  // Addition Info
+  const signed int INFO      = 0x00140000;  // Additional Info
 
   // aliasing for flags
   // if we found out that it is a flag, we no longer need to use the cat  0x00ff0000
   // so we use that part to encode the low offset in the base register
+  //
+
   const signed int BITS_1   = 0x00000100;
   const signed int BITS_2   = 0x00000200;
   const signed int BITS_3   = 0x00000300;
@@ -92,41 +96,61 @@ namespace Dyninst { namespace amdgpu_gfx908 {
   DEF_REGISTER(                 invalid,   1 | BITS_32 |    SYSREG |Arch_amdgpu_gfx908, "amdgpu_gfx908");
   DEF_REGISTER(                  pc_all,   0 | BITS_48 |        PC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
 
-  DEF_REGISTER(                 src_scc,   0 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(             hw_reg_mode,   1 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908"); // read only shader status bits
+  DEF_REGISTER(           hw_reg_status,   2 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908"); // writeable shader mode bits
+  DEF_REGISTER(          hw_reg_trapsts,   3 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908"); // trap status
+  DEF_REGISTER(            hw_reg_hw_id,   4 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908"); // hardware id
+  DEF_REGISTER(        hw_reg_gpr_alloc,   5 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(        hw_reg_lds_alloc,   6 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(           hw_reg_ib_sts,   7 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(            hw_reg_pc_lo,   8 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(            hw_reg_pc_hi,   9 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(         hw_reg_inst_dw0,  10 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(         hw_reg_inst_dw1,  11 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(          hw_reg_ib_dbg0,  12 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(          hw_reg_ib_dbg1,  13 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(         hw_reg_flush_ib,  14 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(     hw_reg_sh_mem_bases,  15 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER( hw_reg_sq_shader_tba_lo,  16 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908"); // trap base address points to trap handler
+  DEF_REGISTER( hw_reg_sq_shader_tba_hi,  17 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER( hw_reg_sq_shader_tma_lo,  18 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908"); // trap memory address holding data to be used
+  DEF_REGISTER( hw_reg_sq_shader_tma_hi,  19 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
 
-  DEF_REGISTER(                src_vccz,   1 |  BITS_1 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(                  vcc_lo,   2 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(                  vcc_hi,   3 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(                     vcc,   2 | BITS_64 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                 src_scc,   0 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                src_vccz,   1 |  BITS_1 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                  vcc_lo,   2 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                  vcc_hi,   3 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                     vcc,   2 | BITS_64 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
 
-  DEF_REGISTER(               src_execz,   4 |  BITS_1 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(                 exec_lo,   5 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(                 exec_hi,   6 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(                    exec,   5 | BITS_64 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(               src_execz,   4 |  BITS_1 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                 exec_lo,   5 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                 exec_hi,   6 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                    exec,   5 | BITS_64 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
 
-  DEF_REGISTER(         flat_scratch_lo,   7 | BITS_64 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(         flat_scratch_hi,   8 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(        flat_scratch_all,   7 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(         flat_scratch_lo,   7 | BITS_64 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(         flat_scratch_hi,   8 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(        flat_scratch_all,   7 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
 
-  DEF_REGISTER(                      m0,  10 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                      m0,   9 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
 
-  DEF_REGISTER(             src_literal,  11 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");//TODO
-  DEF_REGISTER(src_pops_exiting_wave_id,  12 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");//TODO
+  DEF_REGISTER(             src_literal,  10 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");//TODO
+  DEF_REGISTER(src_pops_exiting_wave_id,  11 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");//TODO
 
-  DEF_REGISTER(        src_private_base,  13 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(       src_private_limit,  14 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(         src_shared_base,  15 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(        src_shared_limit,  16 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(        src_private_base,  12 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(       src_private_limit,  13 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(         src_shared_base,  14 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(        src_shared_limit,  15 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
 
-  DEF_REGISTER(           xnack_mask_lo,  17 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(           xnack_mask_hi,  18 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(           xnack_mask_lo,  16 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(           xnack_mask_hi,  17 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
 
-  DEF_REGISTER(          src_lds_direct,  19 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(                   vmcnt,  20 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(                  expcnt,  21 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(                 lgkmcnt,  22 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
-  DEF_REGISTER(                   dsmem,  23 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(          src_lds_direct,  18 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                   dsmem,  19 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
 
+  DEF_REGISTER(                   vmcnt,   0 | BITS_32 |   WAITCNT |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                  expcnt,   1 | BITS_32 |   WAITCNT |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                 lgkmcnt,   2 | BITS_32 |   WAITCNT |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+ 
   DEF_REGISTER(                   ttmp0,   0 | BITS_32 | TTMP_SGPR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
   DEF_REGISTER(                   ttmp1,   1 | BITS_32 | TTMP_SGPR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
   DEF_REGISTER(                   ttmp2,   2 | BITS_32 | TTMP_SGPR |Arch_amdgpu_gfx908, "amdgpu_gfx908");

--- a/common/h/registers/AMDGPU/amdgpu_gfx908_regs.h
+++ b/common/h/registers/AMDGPU/amdgpu_gfx908_regs.h
@@ -116,7 +116,7 @@ namespace Dyninst { namespace amdgpu_gfx908 {
   DEF_REGISTER( hw_reg_sq_shader_tma_lo,  18 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908"); // trap memory address holding data to be used
   DEF_REGISTER( hw_reg_sq_shader_tma_hi,  19 | BITS_32 |       HWR |Arch_amdgpu_gfx908, "amdgpu_gfx908");
 
-  DEF_REGISTER(                 src_scc,   0 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
+  DEF_REGISTER(                 src_scc,   0 |  BITS_1 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
   DEF_REGISTER(                src_vccz,   1 |  BITS_1 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
   DEF_REGISTER(                  vcc_lo,   2 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");
   DEF_REGISTER(                  vcc_hi,   3 | BITS_32 |      MISC |Arch_amdgpu_gfx908, "amdgpu_gfx908");

--- a/common/h/registers/AMDGPU/amdgpu_gfx90a_regs.h
+++ b/common/h/registers/AMDGPU/amdgpu_gfx90a_regs.h
@@ -60,7 +60,7 @@ namespace Dyninst { namespace amdgpu_gfx90a {
 
   const signed int HWR       = 0x000C0000;
   const signed int TTMP_SGPR = 0x000D0000;
-  const signed int FLAGS     = 0x000E0000;
+  const signed int WAITCNT   = 0x000E0000;
   const signed int PC        = 0x000F0000;
   const signed int SYSREG    = 0x00100000;
   const signed int TGT       = 0x00110000; // I have no idea what TGT is yet
@@ -90,7 +90,7 @@ namespace Dyninst { namespace amdgpu_gfx90a {
   const signed int BITS_256 = 0x00000F00;
   const signed int BITS_512 = 0x00001000;
 
-  //          (                    name,  ID | alias   |      cat  |              arch,           arch )
+  //          (                    name,  ID | alias   |      cat  |              arch,            arch)
   DEF_REGISTER(                     tid,   0 | BITS_32 |    SYSREG |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
 
   DEF_REGISTER(                 invalid,   1 | BITS_32 |    SYSREG |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
@@ -102,7 +102,7 @@ namespace Dyninst { namespace amdgpu_gfx90a {
   DEF_REGISTER(            hw_reg_hw_id,   4 | BITS_32 |       HWR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a"); // hardware id
   DEF_REGISTER(        hw_reg_gpr_alloc,   5 | BITS_32 |       HWR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(        hw_reg_lds_alloc,   6 | BITS_32 |       HWR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
-  DEF_REGISTER(           hw_reg_ib_sts,   2 | BITS_32 |       HWR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(           hw_reg_ib_sts,   7 | BITS_32 |       HWR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(            hw_reg_pc_lo,   8 | BITS_32 |       HWR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(            hw_reg_pc_hi,   9 | BITS_32 |       HWR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(         hw_reg_inst_dw0,  10 | BITS_32 |       HWR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
@@ -127,29 +127,30 @@ namespace Dyninst { namespace amdgpu_gfx90a {
   DEF_REGISTER(                 exec_hi,   6 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(                    exec,   5 | BITS_64 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
 
-  DEF_REGISTER(         flat_scratch_lo,   7 | BITS_64 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(         flat_scratch_lo,   7 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(         flat_scratch_hi,   8 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
-  DEF_REGISTER(        flat_scratch_all,   7 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(        flat_scratch_all,   7 | BITS_64 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
 
-  DEF_REGISTER(                      m0,  10 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(                      m0,   9 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
 
-  DEF_REGISTER(             src_literal,  11 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");//TODO
-  DEF_REGISTER(src_pops_exiting_wave_id,  12 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");//TODO
+  DEF_REGISTER(             src_literal,  10 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");//TODO
+  DEF_REGISTER(src_pops_exiting_wave_id,  11 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");//TODO
 
-  DEF_REGISTER(        src_private_base,  13 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
-  DEF_REGISTER(       src_private_limit,  14 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
-  DEF_REGISTER(         src_shared_base,  15 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
-  DEF_REGISTER(        src_shared_limit,  16 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(        src_private_base,  12 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(       src_private_limit,  13 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(         src_shared_base,  14 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(        src_shared_limit,  15 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
 
-  DEF_REGISTER(           xnack_mask_lo,  17 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
-  DEF_REGISTER(           xnack_mask_hi,  18 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(           xnack_mask_lo,  16 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(           xnack_mask_hi,  17 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
 
-  DEF_REGISTER(          src_lds_direct,  19 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
-  DEF_REGISTER(                   vmcnt,  20 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
-  DEF_REGISTER(                  expcnt,  21 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
-  DEF_REGISTER(                 lgkmcnt,  22 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
-  DEF_REGISTER(                   dsmem,  23 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(          src_lds_direct,  18 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(                   dsmem,  19 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
 
+  DEF_REGISTER(                   vmcnt,   0 | BITS_32 |   WAITCNT |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(                  expcnt,   1 | BITS_32 |   WAITCNT |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(                 lgkmcnt,   2 | BITS_32 |   WAITCNT |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+ 
   DEF_REGISTER(                   ttmp0,   0 | BITS_32 | TTMP_SGPR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(                   ttmp1,   1 | BITS_32 | TTMP_SGPR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(                   ttmp2,   2 | BITS_32 | TTMP_SGPR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");

--- a/common/h/registers/AMDGPU/amdgpu_gfx90a_regs.h
+++ b/common/h/registers/AMDGPU/amdgpu_gfx90a_regs.h
@@ -116,7 +116,7 @@ namespace Dyninst { namespace amdgpu_gfx90a {
   DEF_REGISTER( hw_reg_sq_shader_tma_lo,  18 | BITS_32 |       HWR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a"); // trap memory address holding data to be used
   DEF_REGISTER( hw_reg_sq_shader_tma_hi,  19 | BITS_32 |       HWR |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
 
-  DEF_REGISTER(                 src_scc,   0 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
+  DEF_REGISTER(                 src_scc,   0 |  BITS_1 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(                src_vccz,   1 |  BITS_1 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(                  vcc_lo,   2 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");
   DEF_REGISTER(                  vcc_hi,   3 | BITS_32 |      MISC |Arch_amdgpu_gfx90a, "amdgpu_gfx90a");

--- a/common/h/registers/AMDGPU/amdgpu_gfx940_regs.h
+++ b/common/h/registers/AMDGPU/amdgpu_gfx940_regs.h
@@ -52,14 +52,14 @@ namespace Dyninst { namespace amdgpu_gfx940 {
 
   // 0xff000000  0x00ff0000      0x0000ff00      0x000000ff
   // arch        reg cat:GPR     alias&subrange  reg ID
-const signed int SGPR     = 0x00010000;
-const signed int VGPR     = 0x00060000;
+const signed int SGPR      = 0x00010000;
+const signed int VGPR      = 0x00060000;
 
-const signed int MISC     = 0x000A0000;
-const signed int ACC_VGPR = 0x000B0000;
+const signed int MISC      = 0x000A0000;
+const signed int ACC_VGPR  = 0x000B0000;
 const signed int HWR       = 0x000C0000;
 const signed int TTMP_SGPR = 0x000D0000;
-const signed int FLAGS     = 0x000E0000;
+const signed int WAITCNT   = 0x000E0000;
 const signed int PC        = 0x000F0000;
 const signed int SYSREG    = 0x00100000;
 const signed int TGT       = 0x00110000; // I have no idea what TGT is yet
@@ -89,19 +89,19 @@ const signed int BITS_128 = 0x00000E00;
 const signed int BITS_256 = 0x00000F00;
 const signed int BITS_512 = 0x00001000;
 
-  //          (                    name,  ID | alias   |      cat  |              arch,           arch )
+  //          (                    name,  ID | alias   |      cat  |              arch,            arch)
   DEF_REGISTER(                     tid,   0 | BITS_32 |    SYSREG |Arch_amdgpu_gfx940, "amdgpu_gfx940");
 
   DEF_REGISTER(                 invalid,   1 | BITS_32 |    SYSREG |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(                  pc_all,   0 | BITS_48 |        PC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-
+  // Index comes from OPR_HWREG in ISA XML
   DEF_REGISTER(             hw_reg_mode,   1 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // read only shader status bits
   DEF_REGISTER(           hw_reg_status,   2 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // writeable shader mode bits
   DEF_REGISTER(          hw_reg_trapsts,   3 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // trap status
   DEF_REGISTER(            hw_reg_hw_id,   4 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // hardware id
   DEF_REGISTER(        hw_reg_gpr_alloc,   5 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(        hw_reg_lds_alloc,   6 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER(           hw_reg_ib_sts,   2 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(           hw_reg_ib_sts,   7 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(            hw_reg_pc_lo,   8 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(            hw_reg_pc_hi,   9 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(         hw_reg_inst_dw0,  10 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
@@ -110,16 +110,15 @@ const signed int BITS_512 = 0x00001000;
   DEF_REGISTER(          hw_reg_ib_dbg1,  13 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(         hw_reg_flush_ib,  14 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(     hw_reg_sh_mem_bases,  15 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER( hw_reg_sq_shader_tba_lo,  16 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // trap base address points to trap handler
+  DEF_REGISTER( hw_reg_sq_shader_tba_lo,  16 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER( hw_reg_sq_shader_tba_hi,  17 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER( hw_reg_sq_shader_tma_lo,  18 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // trap memory address holding data to be used
+  DEF_REGISTER( hw_reg_sq_shader_tma_lo,  18 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");   
   DEF_REGISTER( hw_reg_sq_shader_tma_hi,  19 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-
-  DEF_REGISTER(                  hw_reg_xcc_id,  20 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // trap base address points to trap handler
-  DEF_REGISTER(   hw_reg_sq_perf_snapshot_data,  21 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // trap base address points to trap handler
-  DEF_REGISTER(  hw_reg_sq_perf_snapshot_data1,  22 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // trap base address points to trap handler
-  DEF_REGISTER(  hw_reg_sq_perf_snapshot_pc_lo,  23 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // trap base address points to trap handler
-  DEF_REGISTER(  hw_reg_sq_perf_snapshot_pc_hi,  24 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); // trap base address points to trap handler
+  DEF_REGISTER(                  hw_reg_xcc_id,  20 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");   
+  DEF_REGISTER(   hw_reg_sq_perf_snapshot_data,  21 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");   
+  DEF_REGISTER(  hw_reg_sq_perf_snapshot_data1,  22 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");   
+  DEF_REGISTER(  hw_reg_sq_perf_snapshot_pc_lo,  23 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");   
+  DEF_REGISTER(  hw_reg_sq_perf_snapshot_pc_hi,  24 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); 
 
   DEF_REGISTER(                 src_scc,   0 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(                src_vccz,   1 |  BITS_1 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
@@ -136,24 +135,25 @@ const signed int BITS_512 = 0x00001000;
   DEF_REGISTER(         flat_scratch_hi,   8 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(        flat_scratch_all,   7 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
 
-  DEF_REGISTER(                      m0,  10 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(                      m0,   9 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
 
-  DEF_REGISTER(             src_literal,  11 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");//TODO
-  DEF_REGISTER(src_pops_exiting_wave_id,  12 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");//TODO
+  DEF_REGISTER(             src_literal,  10 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");//TODO
+  DEF_REGISTER(src_pops_exiting_wave_id,  11 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");//TODO
 
-  DEF_REGISTER(        src_private_base,  13 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER(       src_private_limit,  14 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER(         src_shared_base,  15 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER(        src_shared_limit,  16 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(        src_private_base,  12 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(       src_private_limit,  13 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(         src_shared_base,  14 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(        src_shared_limit,  15 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
 
-  DEF_REGISTER(           xnack_mask_lo,  17 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER(           xnack_mask_hi,  18 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(           xnack_mask_lo,  16 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(           xnack_mask_hi,  17 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
 
-  DEF_REGISTER(          src_lds_direct,  19 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER(                   vmcnt,  20 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER(                  expcnt,  21 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER(                 lgkmcnt,  22 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
-  DEF_REGISTER(                   dsmem,  23 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(          src_lds_direct,  18 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(                   dsmem,  19 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+
+  DEF_REGISTER(                   vmcnt,   0 | BITS_32 |   WAITCNT |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(                  expcnt,   1 | BITS_32 |   WAITCNT |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(                 lgkmcnt,   2 | BITS_32 |   WAITCNT |Arch_amdgpu_gfx940, "amdgpu_gfx940");
 
 
   

--- a/common/h/registers/AMDGPU/amdgpu_gfx940_regs.h
+++ b/common/h/registers/AMDGPU/amdgpu_gfx940_regs.h
@@ -120,7 +120,7 @@ const signed int BITS_512 = 0x00001000;
   DEF_REGISTER(  hw_reg_sq_perf_snapshot_pc_lo,  23 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940");   
   DEF_REGISTER(  hw_reg_sq_perf_snapshot_pc_hi,  24 | BITS_32 |       HWR |Arch_amdgpu_gfx940, "amdgpu_gfx940"); 
 
-  DEF_REGISTER(                 src_scc,   0 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
+  DEF_REGISTER(                 src_scc,   0 |  BITS_1 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(                src_vccz,   1 |  BITS_1 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(                  vcc_lo,   2 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");
   DEF_REGISTER(                  vcc_hi,   3 | BITS_32 |      MISC |Arch_amdgpu_gfx940, "amdgpu_gfx940");

--- a/dataflowAPI/rose/registers/amdgpu.h
+++ b/dataflowAPI/rose/registers/amdgpu.h
@@ -41,17 +41,18 @@
 
 namespace {
 
-  std::tuple<AMDGPURegisterClass, AMDGPUHardwareRegister, int, int>
+  std::tuple<AMDGPURegisterClass, int, int, int>
   AmdgpuGfx908Rose(int32_t category, int32_t baseID, int32_t, int32_t size) {
-    auto const reg_idx = static_cast<AMDGPUHardwareRegister>(baseID);
     constexpr auto pos = 0;
 
     switch(category) {
       case Dyninst::amdgpu_gfx908::SGPR: {
+        auto const reg_idx = static_cast<AMDGPUScalarGeneralPurposeRegister>(baseID);
         return std::make_tuple(amdgpu_regclass_sgpr, reg_idx, pos, size);
       }
 
       case Dyninst::amdgpu_gfx908::VGPR: {
+        auto const reg_idx = static_cast<AMDGPUVectorGeneralPurposeRegister>(baseID);
         return std::make_tuple(amdgpu_regclass_vgpr, reg_idx, pos, size);
       }
 
@@ -59,25 +60,28 @@ namespace {
         return std::make_tuple(amdgpu_regclass_pc, amdgpu_pc, pos, size);
       }
 
-      case Dyninst::amdgpu_gfx908::HWR: {
-        return std::make_tuple(amdgpu_regclass_pc, amdgpu_pc, pos, size);
+      case Dyninst::amdgpu_gfx908::MISC: {
+        auto const reg_idx = static_cast<AMDGPUMiscRegister>(baseID);
+        return std::make_tuple(amdgpu_regclass_misc, reg_idx, pos, size);
       }
+
     }
     convert_printf("Unknown AmdgpuGfx908 category '%d'\n", category);
-    return std::make_tuple(amdgpu_regclass_unknown, reg_idx, pos, 0);
+    return std::make_tuple(amdgpu_regclass_unknown, baseID, pos, 0);
   }
 
-  std::tuple<AMDGPURegisterClass, AMDGPUHardwareRegister, int, int>
+  std::tuple<AMDGPURegisterClass, int, int, int>
   AmdgpuGfx90aRose(int32_t category, int32_t baseID, int32_t, int32_t size) {
-    auto const reg_idx = static_cast<AMDGPUHardwareRegister>(baseID);
     constexpr auto pos = 0;
 
     switch(category) {
       case Dyninst::amdgpu_gfx90a::SGPR: {
+        auto const reg_idx = static_cast<AMDGPUScalarGeneralPurposeRegister>(baseID);
         return std::make_tuple(amdgpu_regclass_sgpr, reg_idx, pos, size);
       }
 
       case Dyninst::amdgpu_gfx90a::VGPR: {
+        auto const reg_idx = static_cast<AMDGPUVectorGeneralPurposeRegister>(baseID);
         return std::make_tuple(amdgpu_regclass_vgpr, reg_idx, pos, size);
       }
 
@@ -85,30 +89,28 @@ namespace {
         return std::make_tuple(amdgpu_regclass_pc, amdgpu_pc, pos, size);
       }
 
-      case Dyninst::amdgpu_gfx90a::HWR: {
-        return std::make_tuple(amdgpu_regclass_hwr, amdgpu_mode, pos, size);
-      }
-
       case Dyninst::amdgpu_gfx90a::MISC: {
+        auto const reg_idx = static_cast<AMDGPUMiscRegister>(baseID);
         return std::make_tuple(amdgpu_regclass_misc, reg_idx, pos, size);
       }
     }
     convert_printf("Unknown AmdgpuGfx90a category '%d'\n", category);
-    return std::make_tuple(amdgpu_regclass_unknown, reg_idx, pos, 0);
+    return std::make_tuple(amdgpu_regclass_unknown, baseID, pos, 0);
   }
 
-  std::tuple<AMDGPURegisterClass, AMDGPUHardwareRegister, int, int>
+  std::tuple<AMDGPURegisterClass, int, int, int>
   AmdgpuGfx940Rose(int32_t category, int32_t baseID, int32_t, int32_t size) {
-    auto const reg_idx = static_cast<AMDGPUHardwareRegister>(baseID);
     constexpr auto pos = 0;
 
     switch(category) {
       case Dyninst::amdgpu_gfx940::SGPR: {
+        auto const reg_idx = static_cast<AMDGPUScalarGeneralPurposeRegister>(baseID);
         return std::make_tuple(amdgpu_regclass_sgpr, reg_idx, pos, size);
         break;
       }
 
       case Dyninst::amdgpu_gfx940::VGPR: {
+        auto const reg_idx = static_cast<AMDGPUVectorGeneralPurposeRegister>(baseID);
         return std::make_tuple(amdgpu_regclass_vgpr, reg_idx, pos, size);
       }
 
@@ -116,16 +118,13 @@ namespace {
         return std::make_tuple(amdgpu_regclass_pc, amdgpu_pc, pos, size);
       }
 
-      case Dyninst::amdgpu_gfx940::HWR: {
-        return std::make_tuple(amdgpu_regclass_hwr, amdgpu_mode, pos, size);
-      }
-
       case Dyninst::amdgpu_gfx940::MISC: {
+        auto const reg_idx = static_cast<AMDGPUMiscRegister>(baseID);
         return std::make_tuple(amdgpu_regclass_misc, reg_idx, pos, size);
       }
     }
     convert_printf("Unknown AmdgpuGfx940 category '%d'\n", category);
-    return std::make_tuple(amdgpu_regclass_unknown, reg_idx, pos, 0);
+    return std::make_tuple(amdgpu_regclass_unknown, baseID, pos, 0);
   }
 
 }

--- a/dataflowAPI/rose/semantics/Registers.C
+++ b/dataflowAPI/rose/semantics/Registers.C
@@ -250,8 +250,9 @@ RegisterDictionary::dictionary_amdgpu() {
         }
 
         regs->insert("pc_all", amdgpu_regclass_pc, 0, 0, 64);
-        regs->insert("src_scc", amdgpu_regclass_hwr, amdgpu_status, 0, 1);
-        regs->insert("vcc", amdgpu_regclass_misc, 2, 0, 64);
+        regs->insert("src_scc",amdgpu_regclass_misc,amdgpu_src_scc, 0, 1);
+        regs->insert("vcc_lo", amdgpu_regclass_misc, amdgpu_vcc_lo, 0, 32);
+        regs->insert("vcc_hi", amdgpu_regclass_misc, amdgpu_vcc_hi, 0, 32);
     });
     return regs;
 }

--- a/dataflowAPI/rose/semantics/Registers.C
+++ b/dataflowAPI/rose/semantics/Registers.C
@@ -251,6 +251,7 @@ RegisterDictionary::dictionary_amdgpu() {
 
         regs->insert("pc_all", amdgpu_regclass_pc, 0, 0, 64);
         regs->insert("src_scc", amdgpu_regclass_hwr, amdgpu_status, 0, 1);
+        regs->insert("vcc", amdgpu_regclass_misc, 2, 0, 64);
     });
     return regs;
 }

--- a/dataflowAPI/rose/semantics/Registers.C
+++ b/dataflowAPI/rose/semantics/Registers.C
@@ -250,9 +250,9 @@ RegisterDictionary::dictionary_amdgpu() {
         }
 
         regs->insert("pc_all", amdgpu_regclass_pc, 0, 0, 64);
-        regs->insert("src_scc",amdgpu_regclass_misc,amdgpu_src_scc, 0, 1);
-        regs->insert("vcc_lo", amdgpu_regclass_misc, amdgpu_vcc_lo, 0, 32);
-        regs->insert("vcc_hi", amdgpu_regclass_misc, amdgpu_vcc_hi, 0, 32);
+        regs->insert("src_scc",amdgpu_regclass_misc, amdgpu_src_scc, 0,  1);
+        regs->insert("vcc_lo", amdgpu_regclass_misc,  amdgpu_vcc_lo, 0, 32);
+        regs->insert("vcc_hi", amdgpu_regclass_misc,  amdgpu_vcc_hi, 0, 32);
     });
     return regs;
 }

--- a/dataflowAPI/rose/semantics/SymEvalSemantics.C
+++ b/dataflowAPI/rose/semantics/SymEvalSemantics.C
@@ -106,12 +106,12 @@ Dyninst::Absloc SymEvalSemantics::RegisterStateAST_amdgpu_gfx908::convert(const 
     unsigned int minor = reg.get_minor();
     unsigned int size = reg.get_nbits();
     unsigned int offset = reg.get_offset();
-    //std::cout << "in func " << __func__ << " major = " << major  << " minor = " << minor << std::endl;
+    //std::cout << "in func " << __func__ << " major = " << major  << " minor = " << minor << std::std::endl;
     bool found = false;
     switch (major) {
     case amdgpu_regclass_sgpr : {
         Dyninst::MachRegister base = Dyninst::amdgpu_gfx908::s0;
-        //std::cout << "dealing with sgpr pair in , offset = " << minor << std::endl;
+        //std::cout << "dealing with sgpr pair in , offset = " << minor << std::std::endl;
         mreg  = Dyninst::MachRegister(base.val() + minor) ;
 
         found = true;
@@ -123,26 +123,14 @@ Dyninst::Absloc SymEvalSemantics::RegisterStateAST_amdgpu_gfx908::convert(const 
         found = true;
         break;
     }
-    case amdgpu_regclass_hwr : {
-        switch(minor){
-        case amdgpu_status:{
-            switch (offset) {
-            case 0:
-                mreg = Dyninst::amdgpu_gfx908::src_scc;
-                found = true;
-                break;
-            default:
-                break;
-            }
-            break;
-        }
-        default:
-            break;
-
-        }
+    case amdgpu_regclass_misc : {
+        Dyninst::MachRegister base = Dyninst::amdgpu_gfx908::src_scc;
+        mreg  = Dyninst::MachRegister(base.val() + minor) ;
+        found = true;
         break;
     }
     default:
+        std::cerr << "Unhandled register major type" << major << " " << minor << " " << size << " " << offset << std::endl;
         ASSERT_always_forbid("Unexpected register major type.");
     }
     if(found)
@@ -158,12 +146,12 @@ Dyninst::Absloc SymEvalSemantics::RegisterStateAST_amdgpu_gfx90a::convert(const 
     unsigned int minor = reg.get_minor();
     unsigned int size = reg.get_nbits();
     unsigned int offset = reg.get_offset();
-    //std::cout << "in func " << __func__ << " major = " << major  << " minor = " << minor << std::endl;
+    //std::cout << "in func " << __func__ << " major = " << major  << " minor = " << minor << std::std::endl;
     bool found = false;
     switch (major) {
     case amdgpu_regclass_sgpr : {
         Dyninst::MachRegister base = Dyninst::amdgpu_gfx90a::s0;
-        //std::cout << "dealing with sgpr pair in , offset = " << minor << std::endl;
+        //std::cout << "dealing with sgpr pair in , offset = " << minor << std::std::endl;
         mreg  = Dyninst::MachRegister(base.val() + minor) ;
 
         found = true;
@@ -175,26 +163,14 @@ Dyninst::Absloc SymEvalSemantics::RegisterStateAST_amdgpu_gfx90a::convert(const 
         found = true;
         break;
     }
-    case amdgpu_regclass_hwr : {
-        switch(minor){
-        case amdgpu_status:{
-            switch (offset) {
-            case 0:
-                mreg = Dyninst::amdgpu_gfx90a::src_scc;
-                found = true;
-                break;
-            default:
-                break;
-            }
-            break;
-        }
-        default:
-            break;
-
-        }
+    case amdgpu_regclass_misc : {
+        Dyninst::MachRegister base = Dyninst::amdgpu_gfx90a::src_scc;
+        mreg  = Dyninst::MachRegister(base.val() + minor) ;
+        found = true;
         break;
     }
     default:
+        std::cerr << "Unhandled register major type" << major << " " << minor << " " << size << " " << offset << std::endl;
         ASSERT_always_forbid("Unexpected register major type.");
     }
     if(found)
@@ -210,66 +186,34 @@ Dyninst::Absloc SymEvalSemantics::RegisterStateAST_amdgpu_gfx940::convert(const 
     unsigned int minor = reg.get_minor();
     unsigned int size = reg.get_nbits();
     unsigned int offset = reg.get_offset();
-    //std::cout << "in func " << __func__ << " major = " << major  << " minor = " << minor << std::endl;
+    //std::cout << "in func " << __func__ << " major = " << major  << " minor = " << minor << std::std::endl;
     bool found = false;
     switch (major) {
     case amdgpu_regclass_sgpr : {
         Dyninst::MachRegister base = Dyninst::amdgpu_gfx940::s0;
-        //std::cout << "dealing with sgpr pair in , offset = " << minor << std::endl;
+        //std::cout << "dealing with sgpr pair in , offset = " << minor << std::std::endl;
         mreg  = Dyninst::MachRegister(base.val() + minor) ;
-
         found = true;
-        break;
-    }
-    case amdgpu_regclass_pc : {
-        mreg = Dyninst::amdgpu_gfx940::pc_all;
-
-        found = true;
-        break;
-    }
-    case amdgpu_regclass_hwr : {
-        switch(minor){
-        case amdgpu_status:{
-            switch (offset) {
-            case 0:
-                mreg = Dyninst::amdgpu_gfx940::src_scc;
-                found = true;
-                break;
-            default:
-                break;
-            }
-            break;
-        }
-        default:
-            break;
-
-        }
         break;
     }
     case amdgpu_regclass_misc : {
-        switch(minor){
-            case 2:
-                if (size == 32)
-                  mreg = Dyninst::amdgpu_gfx940::vcc_lo;
-                else
-                  mreg = Dyninst::amdgpu_gfx940::vcc;
-                found = true;
-                break;
-            case 3:
-                mreg = Dyninst::amdgpu_gfx940::vcc_hi;
-                found = true;
-                break;
-            default:
-                break;
-        }
+        Dyninst::MachRegister base = Dyninst::amdgpu_gfx90a::src_scc;
+        mreg  = Dyninst::MachRegister(base.val() + minor) ;
+        found = true;
+        break;
+    }
+
+    case amdgpu_regclass_pc : {
+        mreg = Dyninst::amdgpu_gfx940::pc_all;
+        found = true;
         break;
     }
     default:
+        std::cerr << "Unhandled register major type" << major << " " << minor << " " << size << " " << offset << std::endl;
         ASSERT_always_forbid("Unexpected register major type.");
     }
     if(found)
         return Dyninst::Absloc(mreg);
-
     ASSERT_always_forbid("Unexpected register major type.");
 }
 

--- a/dataflowAPI/rose/semantics/SymEvalSemantics.C
+++ b/dataflowAPI/rose/semantics/SymEvalSemantics.C
@@ -246,6 +246,24 @@ Dyninst::Absloc SymEvalSemantics::RegisterStateAST_amdgpu_gfx940::convert(const 
         }
         break;
     }
+    case amdgpu_regclass_misc : {
+        switch(minor){
+            case 2:
+                if (size == 32)
+                  mreg = Dyninst::amdgpu_gfx940::vcc_lo;
+                else
+                  mreg = Dyninst::amdgpu_gfx940::vcc;
+                found = true;
+                break;
+            case 3:
+                mreg = Dyninst::amdgpu_gfx940::vcc_hi;
+                found = true;
+                break;
+            default:
+                break;
+        }
+        break;
+    }
     default:
         ASSERT_always_forbid("Unexpected register major type.");
     }

--- a/external/rose/amdgpuInstructionEnum.h
+++ b/external/rose/amdgpuInstructionEnum.h
@@ -8,19 +8,46 @@ enum AMDGPURegisterClass{
 	amdgpu_regclass_ttmp_sgpr,
 	amdgpu_regclass_sgpr,
 	amdgpu_regclass_vgpr,
+    amdgpu_regclass_waitcnt,
+    amdgpu_regclass_dsmem,
+};
+enum AMDGPUPCRegister{
+  amdgpu_pc,
+};
+enum AMDGPUWaitcntRegister{
+  amdgpu_vmcnt,
+  amdgpu_expcnt,
+  amdgpu_lgkmcnt,
+};
+enum AMDGPUMiscRegister{
+    amdgpu_src_scc,
+    amdgpu_src_vccz,
+    amdgpu_vcc_lo,
+    amdgpu_vcc_hi,
+    amdgpu_src_execz,
+    amdgpu_exec_lo,
+    amdgpu_exec_hi,
+    amdgpu_flat_scratch_lo,
+    amdgpu_flat_scratch_hi,
+    amdgpu_m0,
+    amdgpu_src_literal,
+    amdgpu_src_pops_exiting_wave_id,
+    amdgpu_src_private_base,
+    amdgpu_src_private_limit,
+    amdgpu_src_shared_base,
+    amdgpu_src_shared_limit,
+    amdgpu_xnack_mask_lo,
+    amdgpu_xnack_mask_hi,
+    amdgpu_src_lds_direct,
+    amdgpu_dsmem,
 };
 enum AMDGPUHardwareRegister{
 	amdgpu_address_mode_32,
-	amdgpu_exec,
-	amdgpu_expcnt,
 	amdgpu_export_icount,
-	amdgpu_flat_scratch,
 	amdgpu_gpr_alloc,
 	amdgpu_ib_sts,
 	amdgpu_lds_alloc,
 	amdgpu_lds_gds_constant_message_count,
-	amdgpu_lgkmcnt,
-	amdgpu_m0,
 	amdgpu_mode,
 	amdgpu_pops_exiting_wave_id,
 	amdgpu_private_base,
@@ -33,11 +60,7 @@ enum AMDGPUHardwareRegister{
 	amdgpu_tma,
 	amdgpu_trap_base_address,
 	amdgpu_trap_memory_address,
-	amdgpu_vcc,
 	amdgpu_vectory_memory_icount,
-	amdgpu_vmcnt,
-	amdgpu_xnack_mask,
-	amdgpu_pc
 };
 enum AMDGPUScalarGeneralPurposeRegister{
 	amdgpu_sgpr0,


### PR DESCRIPTION
1. Unify register definitions for GFX908 with 90A and 940
  a. Separate WAITCNT into a separate register class
  b. Move SCC into MISC class
  c. Fix wrong index number for hw_reg_ib_sts
2. Update rose AMDGPU enum to reflect the relavnt changes
  a. Each MISC type register should have a minor enum value matching
  its index number
3. Update the register descriptor creation logic casting the index
4. Update the register conversion logic in rose
  a. Remove the case for hardware register as scc is moved to MISC
  b. Add the case for handling the MISC registers