### PR TITLE
GithubCI: use spack-provided dyninst when building hpctoolkit

### DIFF
--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -66,9 +66,6 @@ jobs:
         run: |
           set -ex
           spack/bin/spack external find --not-buildable cmake git m4 gmake meson ninja pkgconf curl python curl cmake
-          
-          add="${GITHUB_WORKSPACE}/src/.github/scripts/add_spack_package.py"
-          python3 ${add} $HOME/.spack --lib dyninst --version master --location /dyninst/install
 
       - name: Build
         shell: bash


### PR DESCRIPTION
The spack update https://github.com/spack/spack/pull/47637 somehow broke the hpctoolkit install when using the sources in /dyninst/install on Ubuntu-24.10 and Fedora-41. This change has the added benefit of making the usage of spack for building hpctoolkit more idiomatic.