### PR TITLE
Define ObjectPE

### DIFF
--- a/symtabAPI/CMakeLists.txt
+++ b/symtabAPI/CMakeLists.txt
@@ -32,6 +32,7 @@ set(_private_headers
     src/emitWin.h
     src/LinkMap.h
     src/Object-elf.h
+    src/Object-pe.h
     src/Object.h
     src/Object-nt.h
     src/Type-mem.h
@@ -72,7 +73,8 @@ if(DYNINST_OS_UNIX)
     src/LinkMap.C
     src/emitElf.C
     src/emitElfStatic.C
-    src/dwarfWalker.C)
+    src/dwarfWalker.C
+    src/Object-pe.C)
 
   if(DYNINST_HOST_ARCH_X86_64 OR DYNINST_HOST_ARCH_I386)
     list(APPEND _sources src/emitElfStatic-x86.C src/relocationEntry-elf-x86.C)

--- a/symtabAPI/h/Function.h
+++ b/symtabAPI/h/Function.h
@@ -193,6 +193,7 @@ class DYNINST_EXPORT InlinedFunction : public FunctionBase
    friend class DwarfWalker;
    friend class Object;
    friend class ObjectELF;
+   friend class ObjectPE;
   public:
    InlinedFunction(FunctionBase *parent);
    virtual ~InlinedFunction();

--- a/symtabAPI/h/Region.h
+++ b/symtabAPI/h/Region.h
@@ -47,6 +47,7 @@ class Symtab;
 class DYNINST_EXPORT Region : public AnnotatableSparse {
    friend class Object;
    friend class ObjectELF;
+   friend class ObjectPE;
    friend class Symtab;
    friend class SymtabTranslatorBase;
    friend class SymtabTranslatorBin;

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -91,6 +91,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    friend class relocationEntry;
    friend class Object;
    friend class ObjectELF;
+   friend class ObjectPE;
 
    // Hide implementation details that are complex or add large dependencies
    const std::unique_ptr<symtab_impl> impl;
@@ -236,6 +237,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    bool isCode(const Offset where) const;
    bool isData(const Offset where) const;
    bool isValidOffset(const Offset where) const;
+   FileFormat getFileFormat() const;
 
    bool getMappedRegions(std::vector<Region *> &mappedRegs) const;
 

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2298,7 +2298,7 @@ ObjectELF::ObjectELF(MappedFile *mf_, bool, void (*err_func)(const char *),
         containingFunc(nullptr)
 {
     li_for_object = NULL; 
-
+    file_format_ = FileFormat::ELF;
 #if defined(TIMED_PARSE)
     struct timeval starttime;
   gettimeofday(&starttime, NULL);

--- a/symtabAPI/src/Object-pe.C
+++ b/symtabAPI/src/Object-pe.C
@@ -1,0 +1,113 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ * 
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ * 
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include "symtabAPI/src/Object-pe.h"
+
+using namespace Dyninst;
+using namespace Dyninst::SymtabAPI;
+
+void ObjectPE::log_error(const std::string &msg)
+{
+	if (err_func_) {
+		std::string full_msg = msg + std::string("\n");
+		err_func_(full_msg.c_str());
+	}
+}
+
+ObjectPE::ObjectPE(MappedFile *mf_,
+                   bool defensive,
+                   void (*err_func)(const char *),
+                   bool alloc_syms,
+                   Symtab *st) :
+    Object(mf_, err_func, st)
+{
+    (void)defensive;
+    (void)alloc_syms;
+
+    file_format_ = FileFormat::PE;
+
+    has_error = true;
+    log_error("Parsing of PE files is not implemented yet");
+}
+
+Offset ObjectPE::getPreferedBase() const
+{
+    return preferedBase_;
+}
+
+void ObjectPE::getDependencies(std::vector<std::string> &deps)
+{
+    deps.clear();
+    /* TODO */
+}
+
+Offset ObjectPE::getBaseAddress() const
+{
+    return 0;
+}
+
+Offset ObjectPE::getEntryAddress() const
+{
+    return entryAddress_;
+}
+
+Offset ObjectPE::getLoadAddress() const
+{
+    return loadAddress_;
+}
+
+bool ObjectPE::isOnlyExecutable() const
+{
+    return is_aout_;
+}
+
+bool ObjectPE::isExecutable() const
+{
+    /**
+     * This method is used only to check whether we should consider an entry point
+     * as a function hint. A DLL may have a valid entry point that is not covered by
+     * a symbol, so we want to always consider it as a hint.
+     */
+    return true;
+}
+
+bool ObjectPE::isOnlySharedLibrary() const
+{
+    return !is_aout_;
+}
+
+bool ObjectPE::isSharedLibrary() const
+{
+    return !is_aout_;
+}
+
+Dyninst::Architecture ObjectPE::getArch() const
+{
+    return Arch_none;
+}

--- a/symtabAPI/src/Object-pe.h
+++ b/symtabAPI/src/Object-pe.h
@@ -28,83 +28,49 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-//Hashing function for std::unordered_mapes
+#if !defined(_Object_pe_h_)
+#define _Object_pe_h_
 
-#if !defined(_symtab_util_h_)
-#define _symtab_util_h_
+#include "symtabAPI/src/Object.h"
 
-#include "dyntypes.h"
-#include "dyninst_visibility.h"
-#include <string>
+namespace Dyninst {
+namespace SymtabAPI {
 
-#if defined(_MSC_VER)	
-#include <set>
-#else
-#include <regex.h>
-#include <string>
-#endif
+class ObjectPE : public Object {
+    friend class Symtab;
 
-namespace Dyninst{
-namespace SymtabAPI{
+public:
+    ObjectPE(MappedFile *, bool, void(*)(const char *) = log_msg, bool = true, Symtab * = NULL);
 
+    Offset getPreferedBase() const override;
+    void getDependencies(std::vector<std::string> &deps) override;
+    Offset getEntryAddress() const override;
+    Offset getBaseAddress() const override;
+    Offset getLoadAddress() const override;
 
-typedef enum {
-    mangledName = 1,
-    prettyName = 2,
-    typedName = 4,
-    anyName = 7 } NameType;
+    DYNINST_EXPORT bool isOnlyExecutable() const override;
+    DYNINST_EXPORT bool isExecutable() const override;
+    DYNINST_EXPORT bool isSharedLibrary() const override;
+    DYNINST_EXPORT bool isOnlySharedLibrary() const override;
+    DYNINST_EXPORT Dyninst::Architecture getArch() const override;
 
-typedef enum { 
-   lang_Unknown,
-   lang_Assembly,
-   lang_C,
-   lang_CPlusPlus,
-   lang_GnuCPlusPlus,
-   lang_Fortran,
-   lang_CMFortran
-} supportedLanguages;
+    void insertPrereqLibrary(std::string) override {} // TODO
+    bool emitDriver(std::string, std::set<Symbol *> &, unsigned ) override { return false; } // TODO
+    void getModuleLanguageInfo(dyn_hash_map<std::string, supportedLanguages> *) override {} // TODO
 
-DYNINST_EXPORT const char *supportedLanguages2Str(supportedLanguages s);
+private:
+    ObjectPE(const ObjectPE &);
+    const ObjectPE& operator=(const ObjectPE &);
 
-enum class FileFormat {
-	Unknown,
-	ELF,
-	PE,
+    void log_error(const std::string &);
+
+    Offset entryAddress_;
+
+    Offset preferedBase_;
+    Offset loadAddress_;
 };
 
-typedef enum { 
-   Obj_Parsing = 0,
-   Syms_To_Functions,
-   Build_Function_Lists,
-   No_Such_Function,
-   No_Such_Variable,
-   No_Such_Module,
-   No_Such_Region,
-   No_Such_Symbol,
-   No_Such_Member,
-   Not_A_File,
-   Not_An_Archive,
-   Duplicate_Symbol,
-   Export_Error,
-   Emit_Error,
-   Invalid_Flags,
-   Bad_Frame_Data,      /* 15 */
-   No_Frame_Entry,
-   Frame_Read_Error,
-   Multiple_Region_Matches,
-   No_Error
-} SymtabError;
+} // namespace SymtabAPI
+} // namespace Dyninst
 
-typedef struct{
-    void *data;
-    Offset loadaddr;
-    unsigned long size;
-    std::string name; 
-    unsigned segFlags;
-}Segment;
-
-}//namespace SymtabAPI
-}//namespace Dyninst
-
-
-#endif
+#endif /* !defined(_Object_pe_h_) */

--- a/symtabAPI/src/Object.C
+++ b/symtabAPI/src/Object.C
@@ -297,7 +297,7 @@ DYNINST_EXPORT Object::Object(MappedFile *mf_, void (*err_func)(const char *), S
    has_error(false), is_static_binary_(false),
    no_of_sections_(0), no_of_symbols_(0),
   deferredParse(false), parsedAllLineInfo(false), err_func_(err_func), addressWidth_nbytes(4),
-  associated_symtab(st)
+  associated_symtab(st), file_format_(FileFormat::Unknown)
 {
 }
 
@@ -310,6 +310,8 @@ Object *Dyninst::SymtabAPI::parseObjectFile(MappedFile *mf,
     const char *mfa = (const char *)mf->base_addr();
     if (mfa[1] == 'E' && mfa[2] == 'L' && mfa[3] == 'F') {
         return new ObjectELF(mf, is_defensive, err, alloc_syms, symtab);
+    } else if (mfa[0] == 'M' && mfa[1] == 'Z') {
+        return new ObjectPE(mf, is_defensive, err, alloc_syms, symtab);
     } else {
         return NULL;
     }

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -185,6 +185,8 @@ public:
     DYNINST_EXPORT virtual void getSegmentsSymReader(std::vector<SymSegment> &) {}
 	  DYNINST_EXPORT virtual void rebase(Offset) {}
     virtual void addModule(SymtabAPI::Module *) {}
+
+    FileFormat getFileFormat() const { return file_format_; }
 protected:
     DYNINST_EXPORT virtual ~Object();
     // explicitly protected
@@ -242,6 +244,7 @@ friend class Module;
     std::vector<ExceptionBlock> catch_addrs_; //Addresses of C++ try/catch blocks;
     Symtab* associated_symtab;
 
+    FileFormat file_format_;
 private:
     friend class SymbolIter;
     friend class Symtab;
@@ -260,6 +263,7 @@ private:
 
 #if defined(os_linux) || defined(os_freebsd)
 #include "Object-elf.h"
+#include "Object-pe.h"
 #elif defined(os_windows)
 #include "Object-nt.h"
 #else

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -332,6 +332,11 @@ DYNINST_EXPORT bool Symtab::isRelocatableFile() const
     return obj_private->isRelocatableFile();
 }
 
+DYNINST_EXPORT FileFormat Symtab::getFileFormat() const
+{
+    return obj_private->getFileFormat();
+}
+
 DYNINST_EXPORT bool Symtab::isStripped() 
 {
 #if defined(os_linux) || defined(os_freebsd)


### PR DESCRIPTION
This is a next step towards support of PE files parsing.

A dummy ObjectPE class is defined. Actual parsing is not implemented yet.