### PR TITLE
Add regression tests for image::findMain

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -38,7 +38,7 @@ build_dir=$(mktemp -d "/tmp/XXXXXX")
 mkdir -p ${dest_dir}
 
 if test "${run_tests}" = "Y"; then
-  cmake_args="-DDYNINST_ENABLE_TESTS=ON ${cake_args}"
+  cmake_args="-DDYNINST_ENABLE_TESTS=ALL ${cmake_args}"
 fi
 
 cmake -S ${src_dir} -B ${build_dir} -DCMAKE_INSTALL_PREFIX=${dest_dir} -DDYNINST_WARNINGS_AS_ERRORS=ON ${cmake_args}
@@ -46,7 +46,7 @@ cmake -S ${src_dir} -B ${build_dir} -DCMAKE_INSTALL_PREFIX=${dest_dir} -DDYNINST
 cmake --build ${build_dir} --parallel ${num_jobs} ${verbose}
 
 if test "${run_tests}" = "Y"; then
-  ctest --test-dir ${build_dir} --output-on-failure
+  ctest --test-dir ${build_dir} --parallel 2 --output-on-failure
 fi
 
 cmake --install ${build_dir}

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -475,6 +475,7 @@ int image::findMain()
         vector <SymtabAPI::Function *> funcs;
         if (linkedFile->findFunctionsByName(funcs, "main") ||
                 linkedFile->findFunctionsByName(funcs, "_main"))  {
+            this->address_of_main = funcs[0]->getFirstSymbol()->getOffset();
             foundMain = true;
         }
 
@@ -545,7 +546,8 @@ int image::findMain()
                     linkedFile->getDefaultModule(),
                     eReg, 
                     0 );
-            linkedFile->addSymbol(newSym);		
+            linkedFile->addSymbol(newSym);
+            this->address_of_main = mainAddress;
         }
     }
 
@@ -566,6 +568,7 @@ int image::findMain()
         vector <SymtabAPI::Function *> funcs;
         if (linkedFile->findFunctionsByName(funcs, "main") ||
                 linkedFile->findFunctionsByName(funcs, "_main")) {
+            this->address_of_main = funcs[0]->getFirstSymbol()->getOffset();
             foundMain = true;
         }
 
@@ -797,6 +800,7 @@ int image::findMain()
                         eReg, 
                         0 );
                 linkedFile->addSymbol(newSym);		
+                this->address_of_main = mainAddress;
             }
         }
         if( !foundStart )
@@ -863,6 +867,7 @@ int image::findMain()
         for (unsigned i=0; i<NUMBER_OF_MAIN_POSSIBILITIES; i++) {
             if(linkedFile->findFunctionsByName(funcs, main_function_names[i])) {
                 found_main = true;
+                this->address_of_main = funcs[0]->getFirstSymbol()->getOffset();
                 break;
             }
         }
@@ -878,6 +883,7 @@ int image::findMain()
                         eReg,
                         UINT_MAX );
                 linkedFile->addSymbol(startSym);
+                this->address_of_main = eAddr;
             }
             syms.clear();
         } 
@@ -893,6 +899,7 @@ int image::findMain()
                         eAddr,
                         linkedFile->getDefaultModule(),
                         eReg));
+            this->address_of_main = eAddr;
         }
     }
 #endif
@@ -1354,7 +1361,6 @@ image::image(fileDescriptor &desc,
    dataOffset_(0),
    dataLen_(0),
    is_libdyninstRT(false),
-   main_call_addr_(0),
    linkedFile(NULL),
 #if defined(os_linux) || defined(os_freebsd)
    archive(NULL),

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -383,7 +383,7 @@ class image : public codeRange {
 
     int getNextBlockID() { return nextBlockID_++; }
 
-   Address get_main_call_addr() const { return main_call_addr_; }
+   Address getAddressOfMain() const { return address_of_main; }
 
    std::unordered_map<Address, std::string> *getPltFuncs();
    void getPltFuncs(std::map<Address, std::string> &out);
@@ -449,6 +449,7 @@ class image : public codeRange {
    //Address dataValidEnd_;
 
    bool is_libdyninstRT;
+   Address address_of_main{Dyninst::ADDR_NULL};
 
    // data from the symbol table 
    SymtabAPI::Symtab *linkedFile;

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -449,7 +449,6 @@ class image : public codeRange {
    //Address dataValidEnd_;
 
    bool is_libdyninstRT;
-   Address main_call_addr_; // address of call to main()
 
    // data from the symbol table 
    SymtabAPI::Symtab *linkedFile;

--- a/symtabAPI/h/Aggregate.h
+++ b/symtabAPI/h/Aggregate.h
@@ -45,11 +45,12 @@
 #include "Annotatable.h"
 #include <boost/iterator/transform_iterator.hpp>
 #include <functional>
+#include "Symbol.h"
+#include "concurrent.h"
 
 namespace Dyninst{
 namespace SymtabAPI{
 
-class Symbol;
 class Module;
 class Symtab; 
 class Region; 

--- a/symtabAPI/h/Archive.h
+++ b/symtabAPI/h/Archive.h
@@ -37,13 +37,12 @@
 #include <vector>
 #include "symutil.h"
 #include "Annotatable.h"
+#include "Symtab.h"
  
 class MappedFile;
 
 namespace Dyninst{
 namespace SymtabAPI{
-
-class Symtab;
 
 /**
  * Helps facilitate lazy parsing and quick lookup once parsing is finished

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -2,4 +2,5 @@ include_guard(GLOBAL)
 
 message(STATUS "Enabling regression tests")
 
+add_subdirectory(dyninstAPI)
 add_subdirectory(symtabAPI)

--- a/tests/regression/dyninstAPI/CMakeLists.txt
+++ b/tests/regression/dyninstAPI/CMakeLists.txt
@@ -1,0 +1,3 @@
+include_guard(GLOBAL)
+
+add_subdirectory(image)

--- a/tests/regression/dyninstAPI/image/CMakeLists.txt
+++ b/tests/regression/dyninstAPI/image/CMakeLists.txt
@@ -1,0 +1,56 @@
+include_guard(GLOBAL)
+
+include(DyninstLinkProperties)
+
+# Use PIE when POSITION_INDEPENDENT_CODE is used for executables
+if(POLICY CMP0083)
+  cmake_policy(SET CMP0083 NEW)
+endif()
+
+add_executable(findMain findMain.cpp)
+target_compile_options(findMain PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(findMain PRIVATE symtabAPI dyninstAPI)
+
+foreach(lang_t "c" "cxx")
+  foreach(pie_t "pie" "nopie")
+    foreach(link_t "stat" "dyn")
+      foreach(strip_t "stripped" "nostripped")
+
+        set(_targ "${lang_t}_${link_t}_${pie_t}_${strip_t}")
+        add_executable(${_targ} findMain_test.c)
+
+        if(lang_t STREQUAL "cxx")
+          set_property(TARGET ${_targ} PROPERTY LANGUAGE "CXX")
+        endif()
+
+        if(pie_t STREQUAL "pie")
+          set_property(TARGET ${_targ} PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+        endif()
+
+        if(link_t STREQUAL "stat")
+          if(${lang_t} STREQUAL "c" AND DYNINST_C_STATIC_LINK)
+            target_link_libraries(${_targ} "-static")
+          endif()
+          if(${lang_t} STREQUAL "cxx" AND DYNINST_CXX_STATIC_LINK)
+            target_link_libraries(${_targ} "-static")
+          endif()
+        endif()
+
+        if(strip_t STREQUAL "stripped")
+          # '-s' works for gcc and clang
+          target_link_libraries(${_targ} "-s")
+        endif()
+
+      endforeach()
+
+      set(_input_name "${lang_t}_${link_t}_${pie_t}")
+      set(_input_stripped "$<TARGET_FILE_NAME:${_input_name}_stripped>")
+      set(_input_nostripped "$<TARGET_FILE_NAME:${_input_name}_nostripped>")
+      set(_test_name "dyninstAPI_image_findMain_${_input_name}")
+      add_test(NAME ${_test_name} COMMAND findMain ${_input_nostripped}
+                                          ${_input_stripped})
+      set_tests_properties(${_test_name} PROPERTIES LABELS "regression")
+
+    endforeach()
+  endforeach()
+endforeach()

--- a/tests/regression/dyninstAPI/image/findMain.cpp
+++ b/tests/regression/dyninstAPI/image/findMain.cpp
@@ -1,0 +1,81 @@
+#include "BPatch_enums.h"
+#include "dyninstAPI/src/debug.h"
+#include "image.h"
+#include "Symtab.h"
+
+#include <array>
+#include <iostream>
+#include <vector>
+
+bool test_findMain(const char* filename, Dyninst::Address symtab_main_addr) {
+  std::cout << "Parsing image for " << filename << "\n";
+  fileDescriptor desc{filename, 0, 0};
+  constexpr auto analysisMode = BPatch_normalMode;
+  constexpr bool parseGaps = false;
+  image* img = image::parseImage(desc, analysisMode, parseGaps);
+
+  if(!img) {
+    std::cerr << "failed to parse image for '" << filename << "\n";
+    return false;
+  }
+
+  const auto image_main_addr = img->getAddressOfMain();
+
+  std::cout << "findMain returned 0x" << std::hex << image_main_addr << "\n";
+
+  if(image_main_addr != symtab_main_addr) {
+    std::cerr << "Addresses don't match: Symtab=0x" << std::hex << symtab_main_addr << ", image=0x" << image_main_addr
+              << "\n";
+    return false;
+  }
+
+  return true;
+}
+
+int main(int argc, char** argv) {
+  if(argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " file_with_syms file_without_syms\n";
+    return EXIT_FAILURE;
+  }
+
+  namespace st = Dyninst::SymtabAPI;
+
+  st::Symtab* symtab{};
+  if(!st::Symtab::openFile(symtab, argv[1])) {
+    std::cerr << "Failed to open '" << argv[1] << "'\n";
+    return EXIT_FAILURE;
+  }
+
+  std::vector<st::Function*> funcs;
+  symtab->findFunctionsByName(funcs, "main");
+
+  if(funcs.empty()) {
+    std::cerr << "Didn't find 'main' in Symtab\n";
+    return EXIT_FAILURE;
+  }
+
+  if(funcs.size() > 1UL) {
+    std::cerr << "Found more than one 'main' in Symtab: ";
+    for(auto* f : funcs) {
+      std::cerr << f->getName() << ", ";
+    }
+    std::cerr << "\n";
+    return EXIT_FAILURE;
+  }
+
+  const auto symtab_main_addr = funcs[0]->getFirstSymbol()->getOffset();
+
+  std::cout << "Symtab returned 0x" << std::hex << symtab_main_addr << "\n";
+
+  std::cout << "Testing findMain with symbols...\n";
+  if(!test_findMain(argv[1], symtab_main_addr)) {
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "Testing findMain without symbols...\n";
+  if(!test_findMain(argv[2], symtab_main_addr)) {
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/regression/dyninstAPI/image/findMain_test.c
+++ b/tests/regression/dyninstAPI/image/findMain_test.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+  printf("Hello");
+  return 0;
+}


### PR DESCRIPTION
This is needed for upcoming changes to this function. In particular, there is no implementation for aarch64.

Requires #1897 