### PR TITLE
Remove regTracker_t::astHash

### DIFF
--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -3256,10 +3256,6 @@ void regTracker_t::decreaseAndClean(codeGen &) {
     condLevel--;
 }
 
-unsigned regTracker_t::astHash(AstNode* const &ast) {
-	return addrHash4((Address) ast);
-}
-
 void regTracker_t::debugPrint() {
     if (!dyn_debug_ast) return;
 

--- a/dyninstAPI/src/ast.h
+++ b/dyninstAPI/src/ast.h
@@ -112,8 +112,6 @@ public:
 	};
 
 	int condLevel;
-	
-	static unsigned astHash(AstNode * const &ast);
 
   regTracker_t() : condLevel(0) {}
 


### PR DESCRIPTION
It's usage was removed by 2e73fd3f in 2013.