### PR TITLE
Remove pointer/address hashers in common/util

### DIFF
--- a/common/h/util.h
+++ b/common/h/util.h
@@ -38,15 +38,6 @@
 
 namespace Dyninst {
 
-DYNINST_EXPORT unsigned addrHashCommon(const Address &addr);
-DYNINST_EXPORT unsigned ptrHash(const void * addr);
-DYNINST_EXPORT unsigned ptrHash(void * addr);
-
-DYNINST_EXPORT unsigned addrHash(const Address &addr);
-DYNINST_EXPORT unsigned addrHash4(const Address &addr);
-DYNINST_EXPORT unsigned addrHash16(const Address &addr);
-
-DYNINST_EXPORT unsigned stringhash(const std::string &s);
 DYNINST_EXPORT std::string itos(int);
 DYNINST_EXPORT std::string utos(unsigned);
 

--- a/common/src/util.C
+++ b/common/src/util.C
@@ -41,66 +41,6 @@ using namespace std;
 
 namespace Dyninst {
 
-DYNINST_EXPORT unsigned addrHashCommon(const Address &addr)
-{
-   // inspired by hashs of string class
-
-   unsigned result = 5381;
-
-   Address accumulator = addr;
-   while (accumulator > 0) {
-      // We use 3 bits at a time from the address
-      result = (result << 4) + result + (accumulator & 0x07);
-      accumulator >>= 3;
-   }
-
-   return result;
-}
-
-DYNINST_EXPORT unsigned addrHash(const Address & iaddr)
-{
-   return Dyninst::addrHashCommon(iaddr);
-}
-
-DYNINST_EXPORT unsigned ptrHash(const void * iaddr)
-{
-   return Dyninst::addrHashCommon((Address)iaddr);
-}
-
-DYNINST_EXPORT unsigned ptrHash(void * iaddr)
-{
-   return Dyninst::addrHashCommon((Address)iaddr);
-}
-
-DYNINST_EXPORT unsigned addrHash4(const Address &iaddr)
-{
-   // call when you know that the low 2 bits are 0 (meaning they contribute
-   // nothing to an even hash distribution)
-   return Dyninst::addrHashCommon(iaddr >> 2);
-}
-
-DYNINST_EXPORT unsigned addrHash16(const Address &iaddr)
-{
-   // call when you know that the low 4 bits are 0 (meaning they contribute
-   // nothing to an even hash distribution)
-   return Dyninst::addrHashCommon(iaddr >> 4);
-}
-
-// string hash grabbed from pdstring
-unsigned stringhash(const std::string &s)
-{
-   const char *str = s.c_str();
-   if (!str)
-      return 1; // 0 is reserved for unhashed key
-
-   unsigned h = 5381;
-   while (*str) {
-      h = (h << 5) + h + (unsigned) (*str);
-      str++;
-   }
-   return h==0 ? 1 : h; // 0 is reserved for unhashed key
-}
-
 std::string itos(int in)
 {
   char buf[16];


### PR DESCRIPTION
These aren't and shouldn't be used. Using these types as keys in hashed
associative containers is fraught with danger.

Requires #1901 