### PR TITLE
Remove string conversion functions in common/util

### DIFF
--- a/common/h/util.h
+++ b/common/h/util.h
@@ -38,9 +38,6 @@
 
 namespace Dyninst {
 
-DYNINST_EXPORT std::string itos(int);
-DYNINST_EXPORT std::string utos(unsigned);
-
 #define WILDCARD_CHAR '?'
 #define MULTIPLE_WILDCARD_CHAR '*'
 

--- a/common/src/util.C
+++ b/common/src/util.C
@@ -41,21 +41,6 @@ using namespace std;
 
 namespace Dyninst {
 
-std::string itos(int in)
-{
-  char buf[16];
-  snprintf(buf, 16, "%d", in);
-  return std::string(buf);
-}
-
-std::string utos(unsigned in)
-{
-  char buf[16];
-  snprintf(buf, 16, "%u", in);
-  return std::string(buf);
-}
-
-
 // This function will match string s against pattern p.
 // Asterisks match 0 or more wild characters, and a question
 // mark matches exactly one wild character.  In other words,


### PR DESCRIPTION
These are no longer needed since C++11's std::to_string.

Requires https://github.com/dyninst/testsuite/pull/254