### PR TITLE
Deprecate Object::getObjectType()

### DIFF
--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -1165,7 +1165,7 @@ image *image::parseImage(fileDescriptor &desc,
   image *ret = new image(desc, err, mode, parseGaps); 
   startup_printf("%s[%d]:  created image\n", FILE__, __LINE__);
 
-  if (ret->isSharedObject()) 
+  if (ret->isSharedLibrary()) 
       startup_printf("%s[%d]: processing shared object\n", FILE__, __LINE__);
   else  
       startup_printf("%s[%d]: processing executable object\n", FILE__, __LINE__);
@@ -1441,7 +1441,7 @@ image::image(fileDescriptor &desc,
    // if unable to parse object file (somehow??), try to
    //  notify user/calling process + return....    
    if (!imageLen_ && 
-       linkedFile->getObjectType() != SymtabAPI::obj_RelocatableFile)
+       !linkedFile->isRelocatableFile())
     {
       string msg = string("Parsing problem with executable file: ") + desc.file();
       statusLine(msg.c_str());

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -346,11 +346,8 @@ class image : public codeRange {
    bool isDyninstRTLib() const { return is_libdyninstRT; }
    bool isExecutable() const { return getObject()->isExec(); }
    bool isSharedLibrary() const { return getObject()->isSharedLibrary(); }
-   bool isSharedObject() const { 
-    return (getObject()->getObjectType() == SymtabAPI::obj_SharedLib); 
-   }
    bool isRelocatableObj() const { 
-    return (getObject()->getObjectType() == SymtabAPI::obj_RelocatableFile);
+    return (getObject()->isRelocatableFile());
    }
 
    bool getExecCodeRanges(std::vector<std::pair<Address, Address> > &ranges);

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -636,7 +636,7 @@ mapped_object *BinaryEdit::openResolvedLibraryName(std::string filename,
       if (Symtab::openFile(singleObject, path)) {
         std::unique_ptr<Symtab> obj{singleObject};
         if (auto temp = is_compatible(path, {})) {
-          if (obj->getObjectType() == obj_SharedLib || obj->getObjectType() == obj_Executable) {
+          if (obj->isSharedLibrary() || obj->isExecutable()) {
             startup_printf(
                 "%s[%d]: cannot load dynamic object(%s) when rewriting a static binary\n", FILE__,
                 __LINE__, path.c_str());
@@ -780,7 +780,7 @@ void BinaryEdit::makeInitAndFiniIfNeeded()
 
     // Disable this for .o's and static binaries
     if( linkedFile->isStaticBinary() || 
-        linkedFile->getObjectType() == obj_RelocatableFile ) 
+        linkedFile->isRelocatableFile() ) 
     {
         return;
     }

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -230,8 +230,8 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    bool isExec() const;
    bool isExecutable() const;
    bool isSharedLibrary() const;
+   bool isRelocatableFile() const;
    bool isStripped();
-   ObjectType getObjectType() const;
    Dyninst::Architecture getArchitecture() const;
    bool isCode(const Offset where) const;
    bool isData(const Offset where) const;
@@ -487,7 +487,6 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    Offset entry_address_{};
    Offset base_address_{};
    Offset load_address_{};
-   ObjectType object_type_{obj_Unknown};
    bool is_eel_{false};
    std::vector<Segment> segments_{};
 

--- a/symtabAPI/h/symutil.h
+++ b/symtabAPI/h/symutil.h
@@ -66,13 +66,6 @@ typedef enum {
 
 DYNINST_EXPORT const char *supportedLanguages2Str(supportedLanguages s);
 
-typedef enum {
-   obj_Unknown,
-   obj_SharedLib,
-   obj_Executable,
-   obj_RelocatableFile
-} ObjectType;
-
 typedef enum { 
    Obj_Parsing = 0,
    Syms_To_Functions,

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -334,7 +334,7 @@ Module::~Module()
 
 bool Module::isShared() const
 {
-   return exec_->getObjectType() == obj_SharedLib;
+   return exec_->getObject()->isSharedLibrary();
 }
 
 bool Module::getAllSymbolsByType(std::vector<Symbol *> &found, Symbol::SymbolType sType)

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -344,11 +344,11 @@ bool ObjectELF::loaded_elf(Offset &txtaddr, Offset &dataddr,
     int e_type = elfHdr->e_type();
 
     if (e_type == ET_DYN) {
-	obj_type_ = obj_SharedLib;
+	obj_type_ = ObjectType::SharedLib;
     } else if (e_type == ET_EXEC) {
-	obj_type_ = obj_Executable;
+	obj_type_ = ObjectType::Executable;
     } else if (e_type == ET_REL) {
-	obj_type_ = obj_RelocatableFile;
+	obj_type_ = ObjectType::RelocatableFile;
     }
 
     entryAddress_ = elfHdr->e_entry();
@@ -2292,7 +2292,7 @@ ObjectELF::ObjectELF(MappedFile *mf_, bool, void (*err_func)(const char *),
         isStripped(false),
         dwarf(NULL),
         EEL(false), did_open(false),
-        obj_type_(obj_Unknown),
+        obj_type_(ObjectType::Unknown),
         DbgSectionMapSorted(false),
         soname_(NULL),
         containingFunc(nullptr)
@@ -2994,7 +2994,7 @@ bool ObjectELF::find_catch_blocks(Elf_X_Shdr *eh_frame,
 
 #endif
 
-ObjectType ObjectELF::objType() const {
+ObjectELF::ObjectType ObjectELF::objType() const {
     return obj_type_;
 }
 
@@ -4005,7 +4005,7 @@ void ObjectELF::getSegmentsSymReader(vector<SymSegment> &segs) {
 //   elfclassify.c
 bool ObjectELF::isLoadable() const
 {
-    return (objType() == obj_Executable || objType() == obj_SharedLib)
+    return (objType() == ObjectType::Executable || objType() == ObjectType::SharedLib)
 		&& hasProgramLoad()
 		&& (no_of_sections() == 0 || hasBitsAlloc());
 }
@@ -4039,7 +4039,7 @@ bool ObjectELF::isExecutable() const
 {
     if (!isLoadable())  {
 	return false;
-    }  else if (objType() == obj_Executable)  {
+    }  else if (objType() == ObjectType::Executable)  {
 	return true;
     }  else if (hasPieFlag())  {
 	return true;
@@ -4083,7 +4083,7 @@ bool ObjectELF::isSharedLibrary() const
 {
     if (!isLoadable())  {
 	return false;
-    }  else if (objType() != obj_SharedLib)  {
+    }  else if (objType() != ObjectType::SharedLib)  {
 	return false;
     }  else if (!getDynamicAddr())  {
 	return false;
@@ -4105,7 +4105,7 @@ bool ObjectELF::isOnlySharedLibrary() const
 {
     if (!isLoadable())  {
 	return false;
-    }  else if (objType() == obj_Executable)  {
+    }  else if (objType() == ObjectType::Executable)  {
 	return false;
     }  else if (!getDynamicAddr())  {
 	return false;
@@ -4131,8 +4131,8 @@ bool ObjectELF::isDebugOnly() const
 {
     auto type = objType();
 
-    return (type == obj_RelocatableFile || type == obj_Executable
-                    || type == obj_SharedLib)
+    return (type == ObjectType::RelocatableFile || type == ObjectType::Executable
+                    || type == ObjectType::SharedLib)
 	    && (hasDebugSections() || getSymtabAddr())
 	    && !hasBitsAlloc();
 }
@@ -4144,7 +4144,14 @@ bool ObjectELF::isDebugOnly() const
 //   elfutils' elfclassify.c
 bool ObjectELF::isLinuxKernelModule() const
 {
-    return objType() == obj_RelocatableFile
+    return objType() == ObjectType::RelocatableFile
             && hasModinfo()
             && hasGnuLinkonceThisModule();
+}
+
+// ObjectELF::isRelocatableFile
+//   True if this object is a relocatable file.
+bool ObjectELF::isRelocatableFile() const
+{
+    return objType() == ObjectType::RelocatableFile;
 }

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -196,7 +196,6 @@ public:
      return (char *)mf->base_addr();
   }
 
-  DYNINST_EXPORT ObjectType objType() const override;
   const char *interpreter_name() const override;
 
 
@@ -286,6 +285,7 @@ public:
     DYNINST_EXPORT bool isOnlySharedLibrary() const override;
     DYNINST_EXPORT bool isDebugOnly() const override;
     DYNINST_EXPORT bool isLinuxKernelModule() const override;
+    DYNINST_EXPORT bool isRelocatableFile() const override;
 
     bool getSegments(std::vector<Segment> &segs) const override;
 
@@ -373,9 +373,18 @@ public:
   Dyninst::DwarfDyninst::DwarfHandle::ptr dwarf;
   private:
 
+  enum class ObjectType {
+    Unknown,
+    SharedLib,
+    Executable,
+    RelocatableFile,
+  };
+
   bool      EEL;                 // true if EEL rewritten
   bool 	    did_open;		// true if the file has been mmapped
   ObjectType obj_type_;
+
+  ObjectType objType() const;
 
   // for sparc-solaris this is a table of PLT entry addr, function_name
   // for x86-solaris this is a table of GOT entry addr, function_name

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -151,7 +151,6 @@ public:
     virtual Offset getBaseAddress() const = 0;
     virtual Offset getLoadAddress() const = 0;
     virtual bool isEEL() const { return false; }
-    virtual ObjectType objType() const = 0;
     virtual void getModuleLanguageInfo(dyn_hash_map<std::string, supportedLanguages> *mod_langs) = 0;
 
     virtual void insertPrereqLibrary(std::string libname) = 0;
@@ -171,6 +170,7 @@ public:
     DYNINST_EXPORT virtual bool isOnlySharedLibrary() const { return false; }
     DYNINST_EXPORT virtual bool isDebugOnly() const { return false; }
     DYNINST_EXPORT virtual bool isLinuxKernelModule() const { return false; }
+    DYNINST_EXPORT virtual bool isRelocatableFile() const { return false; }
 
     virtual bool convertDebugOffset(Offset, Offset &) { return false; }
 

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -327,6 +327,11 @@ DYNINST_EXPORT bool Symtab::isSharedLibrary() const
     return obj_private->isSharedLibrary();
 }
 
+DYNINST_EXPORT bool Symtab::isRelocatableFile() const
+{
+    return obj_private->isRelocatableFile();
+}
+
 DYNINST_EXPORT bool Symtab::isStripped() 
 {
 #if defined(os_linux) || defined(os_freebsd)
@@ -662,7 +667,7 @@ bool Symtab::addSymbolToAggregates(const Symbol *sym_tmp)
              * and their Region is undefined. In this case, always create a 
              * new variable.
              */
-            if( obj_RelocatableFile == getObjectType() &&
+            if( getObject()->isRelocatableFile() &&
                 ( var->getRegion() != sym->getRegion() ||
                   NULL == sym->getRegion() ) )
             {
@@ -913,7 +918,7 @@ bool Symtab::extractInfo(Object *linkedFile)
        }
        else 
        {
-           if( object_type_ != obj_RelocatableFile ||
+           if( !linkedFile->isRelocatableFile() ||
                linkedFile->code_ptr() == 0)
            {
                setSymtabError(Obj_Parsing);
@@ -985,7 +990,6 @@ bool Symtab::extractInfo(Object *linkedFile)
     entry_address_ = linkedFile->getEntryAddress();
     base_address_ = linkedFile->getBaseAddress();
     load_address_ = linkedFile->getLoadAddress();
-    object_type_  = linkedFile->objType();
     is_eel_ = linkedFile->isEEL();
     linkedFile->getSegments(segments_);
 
@@ -1151,7 +1155,7 @@ DYNINST_EXPORT bool Symtab::findPltEntryByTarget(const Address target_address, r
      * linker
      */
     if(relocation_table_.empty() && !isStaticBinary() &&
-       getObjectType() != obj_RelocatableFile)
+       !getObject()->isRelocatableFile())
     {
         fprintf(stderr, "%s[%d]:  WARN:  zero func bindings\n", FILE__, __LINE__);
     }
@@ -1958,11 +1962,6 @@ DYNINST_EXPORT Offset Symtab::getFreeOffset(unsigned size)
 		newaddr += pgSize;
    return newaddr;
 #endif	
-}
-
-DYNINST_EXPORT ObjectType Symtab::getObjectType() const 
-{
-   return object_type_;
 }
 
 DYNINST_EXPORT Dyninst::Architecture Symtab::getArchitecture() const


### PR DESCRIPTION
ObjectType is internal to Object class. It can be different for different object file formats. Other code should be using accessors isExecutable(), isSharedLibrary(), etc.