### PR TITLE
Reduce usage of 'util.h' in headers

### DIFF
--- a/common/h/Annotatable.h
+++ b/common/h/Annotatable.h
@@ -35,6 +35,7 @@
 #define DYN_DETAIL_BOOST_NO_INTRINSIC_WCHAR_T 1
 #endif
 #include "dyntypes.h"
+#include "dyninst_visibility.h"
 #include <stddef.h>
 #include <vector>
 #include <map>
@@ -44,7 +45,6 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "util.h"
 #include "compiler_annotations.h"
 
 namespace Dyninst

--- a/common/h/Buffer.h
+++ b/common/h/Buffer.h
@@ -32,9 +32,10 @@
 
 #include <assert.h>
 #include <string.h>
-#include "util.h"
 #include "dyntypes.h"
 #include "unaligned_memory_access.h"
+#include "dyninst_visibility.h"
+
 namespace Dyninst {
 
 // A class to support multiple forms of code generation. The design of this class is as 

--- a/common/h/DynAST.h
+++ b/common/h/DynAST.h
@@ -37,7 +37,7 @@
 #include <sstream>
 #include <iostream>
 #include <map>
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "boost/enable_shared_from_this.hpp"
 
 namespace Dyninst {

--- a/common/h/Graph.h
+++ b/common/h/Graph.h
@@ -45,6 +45,7 @@
 #include <unordered_map>
 
 #include "Annotatable.h"
+#include "dyninst_visibility.h"
 #include "Node.h"
 
 

--- a/common/h/SymReader.h
+++ b/common/h/SymReader.h
@@ -31,7 +31,7 @@
 #define SYM_READER_H_
 
 #include "dyntypes.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 #include <string>
 #include <stddef.h>
 #include "Architecture.h"

--- a/common/h/VariableLocation.h
+++ b/common/h/VariableLocation.h
@@ -33,7 +33,7 @@
 
 #include "registers/MachRegister.h"
 #include "dyntypes.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 namespace Dyninst {
 

--- a/common/h/concurrent.h
+++ b/common/h/concurrent.h
@@ -31,7 +31,7 @@
 #ifndef _CONCURRENT_H_
 #define _CONCURRENT_H_
 
-#include "util.h"
+#include "dyninst_visibility.h"
 #include <memory>
 #include <stddef.h>
 #include <vector>

--- a/common/h/dyn_regs.h
+++ b/common/h/dyn_regs.h
@@ -32,7 +32,6 @@
 #if !defined(DYN_REGS_H_)
 #define DYN_REGS_H_
 
-#include "util.h"
 #include "Architecture.h"
 #include "registers/MachRegister.h"
 

--- a/common/h/entryIDs.h
+++ b/common/h/entryIDs.h
@@ -33,7 +33,7 @@
 
 #include <string>
 #include "dyntypes.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 /* clang-format off */
 enum entryID : unsigned int {

--- a/common/src/AST.C
+++ b/common/src/AST.C
@@ -29,7 +29,6 @@
  */
 
 #include "DynAST.h"
-#include "../../dyninstAPI/src/debug.h"
 
 using namespace Dyninst; 
 const int NOT_VISITED = 0;

--- a/common/src/MappedFile.h
+++ b/common/src/MappedFile.h
@@ -33,7 +33,7 @@
 #include "headers.h"
 
 #include <string>
-#include "util.h"
+#include "dyninst_visibility.h"
 
 class MappedFile {
      static dyn_hash_map<std::string, MappedFile *> mapped_files;

--- a/common/src/Timer.C
+++ b/common/src/Timer.C
@@ -31,6 +31,10 @@
 // $Id: Timer.C,v 1.19 2007/05/30 19:20:16 legendre Exp $
 
 #include "common/src/Timer.h"
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+
 #if defined(_MSC_VER)
 #include <time.h>
 #endif

--- a/common/src/Timer.h
+++ b/common/src/Timer.h
@@ -41,10 +41,6 @@
  * header files.
 ************************************************************************/
 #include "dyninst_visibility.h"
-#include <unistd.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <errno.h>
 
 /************************************************************************
  * class timer

--- a/common/src/debug_common.h
+++ b/common/src/debug_common.h
@@ -32,7 +32,7 @@
 #define COMMON_DEBUG_H
 
 #include <string>
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "compiler_annotations.h"
 
 DYNINST_EXPORT extern int common_debug_dwarf;

--- a/common/src/dthread.h
+++ b/common/src/dthread.h
@@ -32,7 +32,7 @@
 #define DTHREAD_H_
 
 #include <stdlib.h>
-#include "util.h"
+#include "dyninst_visibility.h"
 #include <cassert>
 
 #include <boost/thread/condition_variable.hpp>

--- a/common/src/linuxHeaders.h
+++ b/common/src/linuxHeaders.h
@@ -63,7 +63,7 @@
 
 #include "compiler_annotations.h"
 #include "dyntypes.h"
-#include "common/h/util.h"
+#include "dyninst_visibility.h"
 
 #define PDSOCKET_ERROR (-1)
 typedef int PDSOCKET;

--- a/common/src/linuxKludges.h
+++ b/common/src/linuxKludges.h
@@ -35,7 +35,7 @@
 #include <vector>
 #include "dyntypes.h"
 #include "common/src/vm_maps.h"
-#include "common/h/util.h"
+#include "dyninst_visibility.h"
 
 DYNINST_EXPORT bool PtraceBulkRead(Dyninst::Address inTraced, unsigned size, void *inSelf, int pid);
 

--- a/common/src/parseauxv.h
+++ b/common/src/parseauxv.h
@@ -31,7 +31,7 @@
 #ifndef auxvparser_h
 #define auxvparser_h
 
-#include "util.h"
+#include "dyninst_visibility.h"
 #include <map>
 #include "dyntypes.h"
 

--- a/common/src/stats.C
+++ b/common/src/stats.C
@@ -35,7 +35,7 @@
 
 #include "common/src/headers.h"
 #include "common/src/stats.h"
-#include "common/h/util.h"
+#include "dyninst_visibility.h"
 #include <sstream>
 #include <string>
 

--- a/common/src/stats.h
+++ b/common/src/stats.h
@@ -36,7 +36,8 @@
 #include <string>
 //#include "Dictionary.h"
 #include "Timer.h"
-#include "common/h/util.h"
+#include "dyninst_visibility.h"
+#include "dyntypes.h"
 
 class StatContainer;  // All your class declarations are forward. 
 

--- a/dataflowAPI/h/AbslocInterface.h
+++ b/dataflowAPI/h/AbslocInterface.h
@@ -40,7 +40,7 @@
 #include "Expression.h"
 #include "Operand.h"
 #include "Absloc.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 class int_function;
 class BPatch_function;

--- a/dataflowAPI/h/SymEval.h
+++ b/dataflowAPI/h/SymEval.h
@@ -46,7 +46,7 @@
 #include "DynAST.h"
 
 #include "Graph.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "Node.h"
 #include "Edge.h"
 

--- a/dataflowAPI/h/slicing.h
+++ b/dataflowAPI/h/slicing.h
@@ -47,7 +47,7 @@
 #include <string>
 #include <utility>
 
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "Node.h"
 #include "Edge.h"
 

--- a/dataflowAPI/h/stackanalysis.h
+++ b/dataflowAPI/h/stackanalysis.h
@@ -49,7 +49,7 @@
 
 #include "Absloc.h"
 #include "dyntypes.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 // FreeBSD is missing a MINLONG and MAXLONG
 #if defined(os_freebsd) 

--- a/dataflowAPI/src/ExpressionConversionVisitor.h
+++ b/dataflowAPI/src/ExpressionConversionVisitor.h
@@ -32,7 +32,7 @@
 #define _EXPRESSION_CONVERSION_VISITOR_H_
 
 
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "Architecture.h"
 
 class SgAsmx86Instruction;

--- a/dataflowAPI/src/RegisterMap.C
+++ b/dataflowAPI/src/RegisterMap.C
@@ -30,6 +30,7 @@
 
 #include "dataflowAPI/src/RegisterMap.h"
 #include "dyn_regs.h"
+#include "dyntypes.h"
 
 // We use the singleton approach, rather than static construction, to ensure the
 // register maps are created correctly. In at least one case (Ubuntu 12.04) they

--- a/dataflowAPI/src/RoseInsnFactory.h
+++ b/dataflowAPI/src/RoseInsnFactory.h
@@ -38,7 +38,7 @@
 #include "external/rose/amdgpuInstructionEnum.h"
 #include "Visitor.h"
 #include "Instruction.h"
-#include "common/h/util.h"
+#include "dyninst_visibility.h"
 #include "boost/shared_ptr.hpp"
 #include <vector>
 #include <stddef.h>

--- a/dwarf/h/dwarfExprParser.h
+++ b/dwarf/h/dwarfExprParser.h
@@ -35,7 +35,7 @@
 #include "Architecture.h"
 #include "elfutils/libdw.h"
 #include "dwarf.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 namespace Dyninst {
 

--- a/dwarf/h/dwarfFrameParser.h
+++ b/dwarf/h/dwarfFrameParser.h
@@ -39,7 +39,7 @@
 #include "registers/MachRegister.h"
 #include "ProcReader.h"
 #include "elfutils/libdw.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 #include <boost/thread/once.hpp>
 #include "concurrent.h"
 

--- a/dwarf/h/dwarfResult.h
+++ b/dwarf/h/dwarfResult.h
@@ -35,7 +35,7 @@
 #include "registers/MachRegister.h"
 #include "dyntypes.h"
 #include "elfutils/libdw.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 namespace Dyninst {
 

--- a/dwarf/src/dwarf_subrange.h
+++ b/dwarf/src/dwarf_subrange.h
@@ -28,7 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "util.h"
+#include "dyninst_visibility.h"
 #include <boost/optional.hpp>
 #include <dwarf.h>
 #include <elfutils/libdw.h>

--- a/dyninstAPI/src/BPatch_basicBlock.C
+++ b/dyninstAPI/src/BPatch_basicBlock.C
@@ -34,7 +34,7 @@
 #include <iostream>
 #include <boost/bind/bind.hpp>
 
-#include "util.h"
+#include "dyninst_visibility.h"
 
 #include "BPatch_flowGraph.h"
 #include "BPatch_collections.h"

--- a/dyninstAPI/src/BPatch_collections.C
+++ b/dyninstAPI/src/BPatch_collections.C
@@ -32,7 +32,6 @@
 
 #define BPATCH_FILE
 
-#include "util.h"
 #include "BPatch_collections.h"
 #include "BPatch_Vector.h"
 #include "BPatch.h"

--- a/dyninstAPI/src/BPatch_collections.h
+++ b/dyninstAPI/src/BPatch_collections.h
@@ -34,7 +34,6 @@
 #include <string>
 #include "BPatch_type.h"     //type and localVar
 #include <unordered_map>
-#include "common/h/util.h"
 
 
 /*

--- a/dyninstAPI/src/BPatch_edge.C
+++ b/dyninstAPI/src/BPatch_edge.C
@@ -30,7 +30,7 @@
 
 #define BPATCH_FILE
 
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "function.h"
 #include "BPatch_edge.h"
 #include "BPatch_flowGraph.h"

--- a/dyninstAPI/src/BPatch_flowGraph.C
+++ b/dyninstAPI/src/BPatch_flowGraph.C
@@ -42,7 +42,7 @@
 #include "BPatch_edge.h"
 #include "BPatch_point.h"
 
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "image.h"
 #include "instPoint.h"
 #include "debug.h"

--- a/dyninstAPI/src/BPatch_instruction.C
+++ b/dyninstAPI/src/BPatch_instruction.C
@@ -36,7 +36,7 @@
 #include "BPatch_basicBlock.h"
 #include "BPatch_libInfo.h"
 #include "BPatch_process.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "function.h"
 #include "instPoint.h"
 #include "addressSpace.h"

--- a/dyninstAPI/src/BPatch_libInfo.h
+++ b/dyninstAPI/src/BPatch_libInfo.h
@@ -36,8 +36,6 @@
 #include "dyninstAPI/h/BPatch_point.h"
 #include <unordered_map>
 #include "dyntypes.h"
-#include "common/h/util.h"
-#include "util.h"
 
 class BPatch_libInfo {
 public:

--- a/dyninstAPI/src/BPatch_loopTreeNode.C
+++ b/dyninstAPI/src/BPatch_loopTreeNode.C
@@ -30,7 +30,6 @@
 
 #define BPATCH_FILE
 
-#include "dyninstAPI/src/util.h"
 #include "dyninstAPI/src/function.h"
 #include "dyninstAPI/src/BPatch_libInfo.h"
 #include "dyninstAPI/h/BPatch_loopTreeNode.h"

--- a/dyninstAPI/src/BPatch_type.C
+++ b/dyninstAPI/src/BPatch_type.C
@@ -33,7 +33,7 @@
 #define BPATCH_FILE
 
 
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "BPatch_Vector.h"
 #include "BPatch_collections.h"
 #include "debug.h"

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -65,6 +65,7 @@
 #include "dynThread.h"
 #include "pcEventHandler.h"
 #include "unaligned_memory_access.h"
+#include "common/h/util.h"
 
 // Implementations of non-virtual functions in the address space
 // class.

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -35,7 +35,7 @@
 #include "inst.h"
 #include "instPoint.h"
 #include "ast.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "debug.h"
 
 extern int dyn_debug_ast;

--- a/dyninstAPI/src/codegen-x86.C
+++ b/dyninstAPI/src/codegen-x86.C
@@ -37,7 +37,6 @@
 #include <string>
 #include "common/src/ia32_locations.h"
 #include "codegen.h"
-#include "util.h"
 #include "debug.h"
 #include "addressSpace.h"
 

--- a/dyninstAPI/src/codegen.C
+++ b/dyninstAPI/src/codegen.C
@@ -39,7 +39,6 @@
 #include "dynProcess.h"
 #include "compiler_annotations.h"
 #include "codegen.h"
-#include "util.h"
 #include "function.h"
 #include "instPoint.h"
 #include "registerSpace.h"

--- a/dyninstAPI/src/debug.C
+++ b/dyninstAPI/src/debug.C
@@ -34,7 +34,6 @@
 #include <stdarg.h>
 #include <assert.h>
 #include <string>
-#include "util.h"
 #include "BPatch.h"
 #include "dyninstAPI/src/debug.h"
 #include "common/src/dthread.h"

--- a/dyninstAPI/src/function.h
+++ b/dyninstAPI/src/function.h
@@ -41,7 +41,6 @@
 #include <vector>
 #include "codegen.h"
 #include "codeRange.h"
-#include "util.h"
 #include "parse-cfg.h"
 
 #include "bitArray.h"

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -37,7 +37,6 @@
 
 #include "image.h"
 #include "parRegion.h"
-#include "util.h"
 #include "inst.h"
 #include "debug.h"
 #include "function.h"
@@ -46,9 +45,8 @@
 #include "common/src/Timer.h"
 #include "common/src/pathName.h"
 #include "common/src/MappedFile.h"
-
-#include "dyninstAPI/h/BPatch_flowGraph.h"
 #include "common/h/util.h"
+#include "dyninstAPI/h/BPatch_flowGraph.h"
 
 #include "symtabAPI/h/Function.h"
 

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -48,6 +48,7 @@
 
 #include <set>
 
+#include "dyninst_visibility.h"
 #include "dyninstAPI/src/util.h"
 #include "dyninstAPI/src/codeRange.h"
 #include "dyninstAPI/src/infHeap.h"

--- a/dyninstAPI/src/infHeap.h
+++ b/dyninstAPI/src/infHeap.h
@@ -39,8 +39,6 @@
 #include <vector>
 #include <unordered_map>
 #include "dyntypes.h"
-#include "common/h/util.h"
-#include "util.h"
 
 typedef enum { HEAPfree, HEAPallocated } heapStatus;
 // Bit pattern...

--- a/dyninstAPI/src/inst-linux.C
+++ b/dyninstAPI/src/inst-linux.C
@@ -38,7 +38,6 @@
 #include "dyninstAPI/src/image.h"
 #include "dyninstAPI/src/inst.h"
 #include "dyninstAPI/src/ast.h"
-#include "dyninstAPI/src/util.h"
 #include "common/src/stats.h"
 #include "dyninstAPI/src/frame.h"
 

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -42,7 +42,6 @@
 #include "common/src/arch-power.h"
 #include "dyninstAPI/src/codegen.h"
 #include "dyninstAPI/src/ast.h"
-#include "dyninstAPI/src/util.h"
 #include "common/src/stats.h"
 #include "dyninstAPI/src/os.h"
 #include "dyninstAPI/src/instPoint.h" // class instPoint

--- a/dyninstAPI/src/inst-winnt.C
+++ b/dyninstAPI/src/inst-winnt.C
@@ -35,7 +35,6 @@
 #include "dyninstAPI/src/dynProcess.h"
 #include "dyninstAPI/src/inst.h"
 #include "dyninstAPI/src/ast.h"
-#include "dyninstAPI/src/util.h"
 #include "common/src/stats.h"
 #include "dyninstAPI/src/instPoint.h"
 

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -42,7 +42,6 @@
 #include "dyninstAPI/src/image.h"
 #include "dyninstAPI/src/inst.h"
 #include "dyninstAPI/src/ast.h"
-#include "dyninstAPI/src/util.h"
 #include "common/src/stats.h"
 #include "dyninstAPI/src/os.h"
 #include "dyninstAPI/src/debug.h"

--- a/dyninstAPI/src/inst.C
+++ b/dyninstAPI/src/inst.C
@@ -36,7 +36,6 @@
 #include "dyninstAPI/src/image.h"
 #include "dyninstAPI/src/inst.h"
 #include "dyninstAPI/src/ast.h"
-#include "dyninstAPI/src/util.h"
 #include "common/src/stats.h"
 #include "dyninstAPI/src/debug.h"
 #include "dyninstAPI/src/instPoint.h"

--- a/dyninstAPI/src/instPoint.C
+++ b/dyninstAPI/src/instPoint.C
@@ -36,7 +36,6 @@
 #include "dyninstAPI/src/image.h"
 #include "dyninstAPI/src/inst.h"
 #include "dyninstAPI/src/ast.h"
-#include "dyninstAPI/src/util.h"
 #include "common/src/stats.h"
 #include "dyninstAPI/src/debug.h"
 #include "dyninstAPI/src/instPoint.h"

--- a/dyninstAPI/src/linux-x86.C
+++ b/dyninstAPI/src/linux-x86.C
@@ -47,7 +47,6 @@
 #include "dyninstAPI/src/os.h"
 #include "common/src/stats.h"
 #include "dyninstAPI/src/debug.h"
-#include "dyninstAPI/src/util.h" // getCurrWallTime
 #include "common/src/pathName.h"
 #include "dyninstAPI/src/inst-x86.h"
 #include "dyninstAPI/src/emit-x86.h"

--- a/dyninstAPI/src/mapped_object.C
+++ b/dyninstAPI/src/mapped_object.C
@@ -51,6 +51,7 @@
 #include "PatchCFG.h"
 #include "PCProcess.h"
 #include "compiler_annotations.h"
+#include "common/h/util.h"
 
 using namespace Dyninst;
 using namespace Dyninst::ParseAPI;

--- a/dyninstAPI/src/registerSpace.C
+++ b/dyninstAPI/src/registerSpace.C
@@ -34,7 +34,6 @@
 #include "dyninstAPI/src/inst.h"
 #include "dyninstAPI/src/instPoint.h"
 #include "dyninstAPI/src/ast.h"
-#include "dyninstAPI/src/util.h"
 #include "dyninstAPI/src/debug.h"
 #include "dyninstAPI/src/addressSpace.h"
 

--- a/dyninstAPI/src/util.C
+++ b/dyninstAPI/src/util.C
@@ -33,7 +33,6 @@
  */
 
 #include "common/src/headers.h"
-#include "dyninstAPI/src/util.h"
 #include "debug.h"
 
 using namespace Dyninst;

--- a/dyninstAPI/src/util.h
+++ b/dyninstAPI/src/util.h
@@ -38,7 +38,6 @@
 #define FILE__ strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__
 #endif
 
-#include <string>
 #include "common/src/stats.h"
 
 extern void printDyninstStats();

--- a/elf/h/Elf_X.h
+++ b/elf/h/Elf_X.h
@@ -35,7 +35,7 @@
 #include <stddef.h>
 #include <string>
 #include <vector>
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "Architecture.h"
 
 #ifndef EM_CUDA

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -37,7 +37,7 @@
 #include "InstructionCategories.h"
 #include "Operand.h"
 #include "Operation_impl.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 #include <list>
 #include <set>

--- a/instructionAPI/h/InstructionAST.h
+++ b/instructionAPI/h/InstructionAST.h
@@ -34,7 +34,7 @@
 #include "ArchSpecificFormatters.h"
 #include "Result.h"
 #include "boost/enable_shared_from_this.hpp"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 #include <iostream>
 #include <set>

--- a/instructionAPI/h/Operand.h
+++ b/instructionAPI/h/Operand.h
@@ -35,7 +35,9 @@
 #include "Expression.h"
 #include "Immediate.h"
 #include "Register.h"
-#include "util.h"
+#include "dyninst_visibility.h"
+#include "dyntypes.h"
+#include "Architecture.h"
 
 #include <set>
 #include <string>

--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -35,7 +35,7 @@
 #include "Register.h"
 #include "Result.h"
 #include "entryIDs.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 #include <mutex>
 #include <set>

--- a/instructionAPI/h/Result.h
+++ b/instructionAPI/h/Result.h
@@ -35,7 +35,7 @@
 #include <cstdint>
 #include <cassert>
 #include <string>
-#include "util.h"
+#include "dyninst_visibility.h"
 
 
 namespace Dyninst

--- a/instructionAPI/h/interrupts.h
+++ b/instructionAPI/h/interrupts.h
@@ -32,7 +32,7 @@
 #define INSTRUCTIONAPI_INTERRUPTS_H
 
 #include "Instruction.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 namespace Dyninst { namespace InstructionAPI {
 

--- a/instructionAPI/h/syscalls.h
+++ b/instructionAPI/h/syscalls.h
@@ -32,7 +32,7 @@
 #define INSTRUCTIONAPI_SYSCALLS_H
 
 #include "Instruction.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 namespace Dyninst { namespace InstructionAPI {
 

--- a/parseAPI/src/CodeSource.C
+++ b/parseAPI/src/CodeSource.C
@@ -37,7 +37,6 @@
 
 #include "CodeSource.h"
 #include "debug_parse.h"
-#include "util.h"
 
 using namespace std;
 using namespace Dyninst;

--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -32,7 +32,6 @@
 #include "dyntypes.h"
 #include "registers/x86_regs.h"
 #include "IA_IAPI.h"
-#include "util.h"
 #include "Dereference.h"
 #include "Immediate.h"
 #include "BinaryFunction.h"

--- a/parseAPI/src/IdiomModelDesc.C
+++ b/parseAPI/src/IdiomModelDesc.C
@@ -2,7 +2,6 @@
 
 
 #include "ProbabilisticParser.h"
-#include "util.h"
 
 #include "registers/x86_regs.h"
 #include "registers/x86_64_regs.h"

--- a/parseAPI/src/ParseData.C
+++ b/parseAPI/src/ParseData.C
@@ -31,7 +31,6 @@
 #include "Parser.h"
 #include "CodeObject.h"
 #include "CFGFactory.h"
-#include "util.h"
 #include "debug_parse.h"
 
 using namespace std;

--- a/parseAPI/src/Parser-speculative.C
+++ b/parseAPI/src/Parser-speculative.C
@@ -42,7 +42,6 @@
 
 #include "Parser.h"
 #include "debug_parse.h"
-#include "util.h"
 
 using namespace std;
 using namespace Dyninst;

--- a/parseAPI/src/StackTamperVisitor.C
+++ b/parseAPI/src/StackTamperVisitor.C
@@ -27,7 +27,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include "common/h/util.h"
 #include "StackTamperVisitor.h"
 #include "dataflowAPI/h/slicing.h"
 #include "dataflowAPI/h/stackanalysis.h"

--- a/parseAPI/src/SymLiteCodeSource.C
+++ b/parseAPI/src/SymLiteCodeSource.C
@@ -40,7 +40,6 @@
 
 #include "SymLiteCodeSource.h"
 #include "debug_parse.h"
-#include "util.h"
 
 #include "symlite/h/SymLite-elf.h"
 

--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -42,7 +42,6 @@
 
 #include "CodeSource.h"
 #include "debug_parse.h"
-#include "util.h"
 #include "unaligned_memory_access.h"
 
 #include "InstructionDecoder.h"

--- a/parseAPI/src/debug_parse.h
+++ b/parseAPI/src/debug_parse.h
@@ -33,7 +33,7 @@
 #include <string>
 #include <stdlib.h>
 #include <stdio.h>
-#include <common/h/util.h>
+#include "dyninst_visibility.h"
 #include "compiler_annotations.h"
 
 namespace Dyninst {

--- a/patchAPI/h/PatchCallback.h
+++ b/patchAPI/h/PatchCallback.h
@@ -38,7 +38,7 @@
 
 #include <utility>
 #include <vector>
-#include "util.h"
+#include "dyninst_visibility.h"
 
 namespace Dyninst {
 namespace PatchAPI {

--- a/patchAPI/h/Point.h
+++ b/patchAPI/h/Point.h
@@ -37,7 +37,7 @@
 #include <stddef.h>
 #include "PatchCommon.h"
 #include "Snippet.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "dyntypes.h"
 
 namespace Dyninst {

--- a/proccontrol/h/Decoder.h
+++ b/proccontrol/h/Decoder.h
@@ -32,7 +32,7 @@
 
 #include <vector>
 #include "Event.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 namespace Dyninst {
 namespace ProcControlAPI {

--- a/proccontrol/h/Event.h
+++ b/proccontrol/h/Event.h
@@ -38,7 +38,7 @@
 #include "MachSyscall.h"
 #include "EventType.h"
 #include "PCProcess.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 class HandlerPool;
 class HandleCallbacks;

--- a/proccontrol/h/EventType.h
+++ b/proccontrol/h/EventType.h
@@ -31,7 +31,7 @@
 #define EVENTTYPE_H_
 
 #include <string>
-#include "util.h"
+#include "dyninst_visibility.h"
 
 namespace Dyninst {
 namespace ProcControlAPI {

--- a/proccontrol/h/Generator.h
+++ b/proccontrol/h/Generator.h
@@ -35,7 +35,7 @@
 #include "PCErrors.h"
 
 #include "common/src/dthread.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 #include <set>
 #include <map>

--- a/proccontrol/h/Handler.h
+++ b/proccontrol/h/Handler.h
@@ -31,7 +31,7 @@
 #define HANDLER_H_
 
 #include "Event.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 #include <string>
 #include <set>

--- a/proccontrol/h/Mailbox.h
+++ b/proccontrol/h/Mailbox.h
@@ -31,7 +31,7 @@
 #define MAILBOX_H_
 
 #include "Event.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 namespace Dyninst {
 namespace ProcControlAPI {

--- a/proccontrol/h/PCErrors.h
+++ b/proccontrol/h/PCErrors.h
@@ -39,7 +39,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "dyntypes.h"
 
 DYNINST_EXPORT extern void pc_print_lock();

--- a/proccontrol/h/PCProcess.h
+++ b/proccontrol/h/PCProcess.h
@@ -43,7 +43,7 @@
 #include "Architecture.h"
 #include "registers/MachRegister.h"
 #include "EventType.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "PCErrors.h"
 #include "boost/checked_delete.hpp"
 #include "boost/shared_ptr.hpp"

--- a/stackwalk/h/swk_errors.h
+++ b/stackwalk/h/swk_errors.h
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "compiler_annotations.h"
 
 namespace Dyninst {

--- a/stackwalk/src/addrRange.h
+++ b/stackwalk/src/addrRange.h
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
+#include "dyntypes.h"
 
 /** template class for addrRangeTree. The implementation is based on red black
  * tree implementation for efficiency concerns and for getting sorted

--- a/symtabAPI/h/ExceptionBlock.h
+++ b/symtabAPI/h/ExceptionBlock.h
@@ -33,7 +33,7 @@
 
 #include <iosfwd>
 
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "dyntypes.h"
 #include "Annotatable.h"
 

--- a/symtabAPI/h/RangeLookup.h
+++ b/symtabAPI/h/RangeLookup.h
@@ -38,7 +38,7 @@
 #include <list>
 #include <assert.h>
 #include "dyntypes.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "IBSTree.h"
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>

--- a/symtabAPI/h/Statement.h
+++ b/symtabAPI/h/Statement.h
@@ -34,7 +34,7 @@
 #include "Annotatable.h"
 #include "RangeLookup.h"
 #include "StringTable.h"
-#include "util.h"
+#include "dyninst_visibility.h"
 
 namespace Dyninst { namespace SymtabAPI {
 

--- a/symtabAPI/h/relocationEntry.h
+++ b/symtabAPI/h/relocationEntry.h
@@ -34,7 +34,7 @@
 #include <iosfwd>
 #include <string>
 
-#include "util.h"
+#include "dyninst_visibility.h"
 #include "dyntypes.h"
 #include "Annotatable.h"
 #include "Region.h"


### PR DESCRIPTION
This reduces transitive includes, making it easier to add tests.