### PR TITLE
Remove image::getErrFunc

### DIFF
--- a/dyninstAPI/src/debug.C
+++ b/dyninstAPI/src/debug.C
@@ -63,12 +63,6 @@ void BPatch_reportError(int errLevel, int num, const char *str) {
     BPatch::reportError((BPatchErrorLevel) errLevel, num, str);
 }
 
-void
-dyninst_log_perror(const char* msg) {
-    sprintf(errorLine, "%s: %s\n", msg, strerror(errno));
-    logLine(errorLine);
-    // fprintf(stderr, "%s", log_buffer);
-}
 void showInfoCallback(std::string msg)
 {
     BPatch::reportError(BPatchWarning, 0, msg.c_str());

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -385,8 +385,6 @@ class image : public codeRange {
 
    Address get_main_call_addr() const { return main_call_addr_; }
 
-   void * getErrFunc() const { return (void *) dyninst_log_perror; }
-
    std::unordered_map<Address, std::string> *getPltFuncs();
    void getPltFuncs(std::map<Address, std::string> &out);
 #if defined(DYNINST_HOST_ARCH_POWER)

--- a/dyninstAPI/src/util.h
+++ b/dyninstAPI/src/util.h
@@ -38,7 +38,4 @@
 #define FILE__ strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__
 #endif
 
-void
-dyninst_log_perror(const char* msg);
-
 #endif /* UTIL_H */


### PR DESCRIPTION
Its usage was removed by 54ca2da51e in 2012.