### PR TITLE
Remove Symtab::main_call_addr_

### DIFF
--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -483,7 +483,6 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    unsigned dataLen_{};
 
    bool is_a_out{false};
-   Offset main_call_addr_{}; // address of call to main()
 
    unsigned address_width_{sizeof(int)};
    std::string interpreter_name_{};


### PR DESCRIPTION
It was added by 6b8446ea6f in 1999, but never used.