### PR TITLE
Correctly test PIE binaries in regression tests

### DIFF
--- a/tests/regression/symtabAPI/Symtab/file_properties/CMakeLists.txt
+++ b/tests/regression/symtabAPI/Symtab/file_properties/CMakeLists.txt
@@ -7,6 +7,9 @@ if(POLICY CMP0083)
   cmake_policy(SET CMP0083 NEW)
 endif()
 
+include(CheckPIESupported)
+check_pie_supported()
+
 set(_all_tests "")
 
 macro(make_lib_test test_type test_name)


### PR DESCRIPTION
This only happened to work on ubuntu because the gcc there accepts `-f[no-]PIE` as an equivalent to `-[no-]pie`. Fedora's gcc does not use that.