### PR TITLE
Remove elfutils dependency from dyninstAPI

### DIFF
--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -296,7 +296,7 @@ dyninst_library(
   DYNINST_DEPS common instructionAPI stackwalk pcontrol patchAPI parseAPI symtabAPI
   DYNINST_INTERNAL_DEPS dynDwarf dynElf
   PUBLIC_DEPS Dyninst::Boost_headers
-  PRIVATE_DEPS Dyninst::ElfUtils Threads::Threads
+  PRIVATE_DEPS Threads::Threads
 )
 # cmake-format: on
 

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -61,11 +61,6 @@
 #include <sys/time.h>
 #endif
 
-#if defined( cap_dwarf )
-#include "dwarf.h"
-#include "elfutils/libdw.h"
-#endif
-
 #if defined(_MSC_VER)
 #include <dbghelp.h>
 #endif


### PR DESCRIPTION
It's not actually needed. Binary rewriting uses dynElf and dynDwarf, though.