### PR TITLE
Don't include platform-specific Object headers in Object.h

### DIFF
--- a/dwarf/h/dwarfHandle.h
+++ b/dwarf/h/dwarfHandle.h
@@ -35,6 +35,7 @@
 #include "dyntypes.h"
 #include <string>
 #include <boost/shared_ptr.hpp>
+#include "dyninst_visibility.h"
 
 namespace Dyninst {
 class Elf_X;

--- a/symtabAPI/src/Archive-elf.C
+++ b/symtabAPI/src/Archive-elf.C
@@ -32,7 +32,8 @@
 
 #include "symtabAPI/h/Symtab.h"
 #include "symtabAPI/h/Archive.h"
-#include "symtabAPI/src/Object-elf.h"
+#include "Elf_X.h"
+#include "MappedFile.h"
 
 using namespace std;
 using namespace Dyninst;

--- a/symtabAPI/src/Archive-elf.C
+++ b/symtabAPI/src/Archive-elf.C
@@ -32,7 +32,7 @@
 
 #include "symtabAPI/h/Symtab.h"
 #include "symtabAPI/h/Archive.h"
-#include "symtabAPI/src/Object.h"
+#include "symtabAPI/src/Object-elf.h"
 
 using namespace std;
 using namespace Dyninst;

--- a/symtabAPI/src/Function.C
+++ b/symtabAPI/src/Function.C
@@ -37,6 +37,7 @@
 #include "Function.h"
 #include "VariableLocation.h"
 #include "Object.h"
+#include "Object-elf.h"
 #include "registers/abstract_regs.h"
 
 #if !defined(os_windows)

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -57,8 +57,14 @@
 #include <elf.h>
 #include <libelf.h>
 #include <string>
-
+#include "relocationEntry.h"
 #include "Elf_X.h"
+#include "registers/MachRegister.h"
+#include "Region.h"
+#include "SymReader.h"
+#include "Object.h"
+#include "Symtab.h"
+#include "ExceptionBlock.h"
 
 #include <fcntl.h>
 #include <stdlib.h>

--- a/symtabAPI/src/Object.C
+++ b/symtabAPI/src/Object.C
@@ -46,6 +46,15 @@
 
 #include "symtabAPI/src/Object.h"
 
+#if defined(os_linux) || defined(os_freebsd)
+#include "Object-elf.h"
+#include "Object-pe.h"
+#elif defined(os_windows)
+#include "Object-nt.h"
+#else
+#error "unknown platform"
+#endif
+
 #include <iostream>
 
 using namespace std;

--- a/symtabAPI/src/Object.h
+++ b/symtabAPI/src/Object.h
@@ -259,19 +259,6 @@ private:
 }//namespace Dyninst
 
 /************************************************************************
- * include the architecture-operating system specific object files.
-************************************************************************/
-
-#if defined(os_linux) || defined(os_freebsd)
-#include "Object-elf.h"
-#include "Object-pe.h"
-#elif defined(os_windows)
-#include "Object-nt.h"
-#else
-#error "unknown platform"
-#endif
-
-/************************************************************************
  * class SymbolIter
 ************************************************************************/
 

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -31,7 +31,7 @@
 #if !defined(_emit_Elf_64_h_)
 #define _emit_Elf_64_h_
 
-#include "Object.h"
+#include "Object-elf.h"
 #include "debug.h"
 #include "Elf_X.h"
 #include <iostream>

--- a/symtabAPI/src/emitElfStatic-aarch64.C
+++ b/symtabAPI/src/emitElfStatic-aarch64.C
@@ -47,6 +47,7 @@
 #include "Object.h"
 #include "Region.h"
 #include "debug.h"
+#include "elf.h"
 
 using namespace Dyninst;
 using namespace Dyninst::SymtabAPI;

--- a/symtabAPI/src/emitElfStatic-ppc64.C
+++ b/symtabAPI/src/emitElfStatic-ppc64.C
@@ -49,6 +49,7 @@
 #include "Region.h"
 #include "debug.h"
 #include "common/src/arch-power.h"
+#include "elf.h"
 
 using namespace Dyninst;
 using namespace Dyninst::SymtabAPI;

--- a/symtabAPI/src/emitElfStatic-x86.C
+++ b/symtabAPI/src/emitElfStatic-x86.C
@@ -48,6 +48,7 @@
 #include "Object.h"
 #include "Region.h"
 #include "debug.h"
+#include "elf.h"
 
 using namespace Dyninst;
 using namespace Dyninst::SymtabAPI;

--- a/symtabAPI/src/parseDwarf.C
+++ b/symtabAPI/src/parseDwarf.C
@@ -40,7 +40,7 @@
 #include "Type.h"
 #include "Function.h"
 #include "Module.h"
-#include "Object.h"
+#include "Object-elf.h"
 #include "Collections.h"
 #include "pathName.h"
 #include "Variable.h"


### PR DESCRIPTION
This was causing unnecessary build failures.