### PR TITLE
Rename, namespace pathName functions

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -75,7 +75,7 @@ set(_private_headers
     src/NodeIterator.h
     src/ntHeaders.h
     src/parseauxv.h
-    src/pathName.h
+    src/dyninst_filesystem.h
     src/sha1.h
     src/stats.h
     src/symbolDemangle.h
@@ -89,7 +89,7 @@ set(_sources
     src/concurrent.C
     src/Timer.C
     src/lprintf.C
-    src/pathName.C
+    src/dyninst_filesystem.C
     src/stats.C
     src/Annotatable.C
     src/MappedFile.C

--- a/common/src/MappedFile.C
+++ b/common/src/MappedFile.C
@@ -28,7 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include "common/src/MappedFile.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 #include <iostream>
 using namespace std;
 

--- a/common/src/addrtranslate-linux.C
+++ b/common/src/addrtranslate-linux.C
@@ -32,7 +32,7 @@
 #include "common/src/addrtranslate-sysv.h"
 #include "common/src/linuxKludges.h"
 #include "common/src/parseauxv.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 
 #include <elf.h>
 #include <cstdio>
@@ -189,7 +189,7 @@ string AddressTranslateSysV::getExecName()
    if (exec_name.empty()) {
       char name[64];
       snprintf(name, 64, "/proc/%d/exe", pid);
-      exec_name = Dyninst::resolve_file_path(name);
+      exec_name = Dyninst::filesystem::canonicalize(name);
    }
    return exec_name;
 }

--- a/common/src/addrtranslate-sysv.C
+++ b/common/src/addrtranslate-sysv.C
@@ -49,7 +49,7 @@
 
 #include "common/src/parseauxv.h"
 #include "common/src/headers.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 #include "common/src/vm_maps.h"
 #include "common/src/addrtranslate.h"
 #include "common/src/addrtranslate-sysv.h"
@@ -866,7 +866,7 @@ FCNode::FCNode(string f, dev_t d, ino_t i, SymbolReaderFactory *factory_) :
    symreader(NULL),
    factory(factory_)
 {
-   filename = Dyninst::resolve_file_path(std::move(f));
+   filename = Dyninst::filesystem::canonicalize(std::move(f));
 }
 
 string FCNode::getFilename() {

--- a/common/src/dyninst_filesystem.C
+++ b/common/src/dyninst_filesystem.C
@@ -28,7 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "pathName.h"
+#include "dyninst_filesystem.h"
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -53,7 +53,7 @@ namespace Dyninst {
 #include <unistd.h>
 #include <vector>
 
-namespace Dyninst {
+namespace Dyninst { namespace filesystem {
 
   static std::string get_home_dir(const std::string& username = {}) {
 
@@ -132,12 +132,12 @@ namespace Dyninst {
 
 #endif
 
-std::string extract_pathname_tail(const std::string& path) {
+std::string extract_filename(const std::string& path) {
   boost::filesystem::path p(path);
   return p.filename().string();
 }
 
-std::string resolve_file_path(std::string path) {
+std::string canonicalize(std::string path) {
   namespace ba = boost::algorithm;
   namespace bf = boost::filesystem;
 
@@ -174,4 +174,5 @@ std::string resolve_file_path(std::string path) {
 
   return canonical_path.string();
 }
-}
+
+}}

--- a/common/src/dyninst_filesystem.h
+++ b/common/src/dyninst_filesystem.h
@@ -35,12 +35,12 @@
 
 #include <string>
 
-namespace Dyninst {
+namespace Dyninst { namespace filesystem {
 
-  DYNINST_EXPORT std::string extract_pathname_tail(const std::string& path);
+  DYNINST_EXPORT std::string extract_filename(const std::string& path);
 
-  DYNINST_EXPORT std::string resolve_file_path(std::string);
+  DYNINST_EXPORT std::string canonicalize(std::string);
 
-}
+}}
 
 #endif

--- a/dyninstAPI/src/dynProcess.C
+++ b/dyninstAPI/src/dynProcess.C
@@ -43,7 +43,7 @@
 #include "mapped_object.h"
 #include "image.h"
 #include "common/src/headers.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 
 #include "PCErrors.h"
 #include <boost/tuple/tuple.hpp>

--- a/dyninstAPI/src/freebsd.C
+++ b/dyninstAPI/src/freebsd.C
@@ -47,7 +47,7 @@
 #include "common/src/headers.h"
 #include "common/src/freebsdKludges.h"
 #include "common/src/freebsdHeaders.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 
 #include "symtabAPI/h/Symtab.h"
 using namespace Dyninst::SymtabAPI;
@@ -224,7 +224,7 @@ bool AddressSpace::getDyninstRTLibName() {
                      std::string(modifier) +
                      std::string(suffix);
 
-    dyninstRT_name = std::move(Dyninst::resolve_file_path(dyninstRT_name));
+    dyninstRT_name = std::move(Dyninst::filesystem::canonicalize(dyninstRT_name));
 
     startup_printf("Dyninst RT Library name set to '%s'\n",
             dyninstRT_name.c_str());

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -43,7 +43,7 @@
 #include "Parsing.h"
 
 #include "common/src/Timer.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 #include "common/src/MappedFile.h"
 #include "common/h/util.h"
 #include "dyninstAPI/h/BPatch_flowGraph.h"
@@ -111,7 +111,7 @@ bool fileDescriptor::IsEqual(const fileDescriptor &fd) const {
 #endif  
 
 #if defined(os_windows)
-    if(Dyninst::extract_pathname_tail(file_) == Dyninst::extract_pathname_tail(fd.file_)) file_match_ = true;
+    if(Dyninst::filesystem::extract_filename(file_) == Dyninst::filesystem::extract_filename(fd.file_)) file_match_ = true;
 #endif
 
     bool addr_match = (code_ == fd.code_ && data_ == fd.data_);
@@ -1402,7 +1402,7 @@ image::image(fileDescriptor &desc,
 
    err = false;
 
-   name_ = Dyninst::extract_pathname_tail(string(desc.file().c_str()));
+   name_ = Dyninst::filesystem::extract_filename(string(desc.file().c_str()));
 
    pathname_ = desc.file().c_str();
 

--- a/dyninstAPI/src/linux-x86.C
+++ b/dyninstAPI/src/linux-x86.C
@@ -47,7 +47,7 @@
 #include "dyninstAPI/src/os.h"
 #include "common/src/stats.h"
 #include "dyninstAPI/src/debug.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 #include "dyninstAPI/src/inst-x86.h"
 #include "dyninstAPI/src/emit-x86.h"
 #include "registers/x86_regs.h"

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -38,7 +38,7 @@
 #include "dynThread.h"
 #include "function.h"
 #include "binaryEdit.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 #include <sys/stat.h>
 
 #include <sstream>
@@ -468,7 +468,7 @@ bool PCProcess::hasPassedMain()
       return true;
    }
 
-   std::string derefPath = Dyninst::resolve_file_path(path);
+   std::string derefPath = Dyninst::filesystem::canonicalize(path);
 
    // Search for the dynamic linker in the loaded libraries
    const LibraryPool &libraries = pcProc_->libraries();

--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -51,7 +51,7 @@
 #include "common/src/vm_maps.h"
 #include "compiler_annotations.h"
 
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 #include "PCErrors.h"
 #include "Generator.h"
 #include "Event.h"
@@ -1103,7 +1103,7 @@ bool linux_process::plat_execed()
 
    char proc_exec_name[128];
    snprintf(proc_exec_name, 128, "/proc/%d/exe", getPid());
-   executable = Dyninst::resolve_file_path(proc_exec_name);
+   executable = Dyninst::filesystem::canonicalize(proc_exec_name);
    return true;
 }
 

--- a/proccontrol/src/loadLibrary/codegen-freebsd.C
+++ b/proccontrol/src/loadLibrary/codegen-freebsd.C
@@ -6,7 +6,7 @@
 #include <iostream>
 #include "PCProcess.h"
 #include "int_process.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 #include <sys/mman.h>
 
 using namespace Dyninst;
@@ -27,7 +27,7 @@ bool Codegen::generateInt() {
     if (!objSymReader) {
       return false;
     }
-    std::string interp = Dyninst::resolve_file_path(objSymReader->getInterpreterName());
+    std::string interp = Dyninst::filesystem::canonicalize(objSymReader->getInterpreterName());
 
     objSymReader = proc_->llproc()->getSymReader()->openSymbolReader(interp);
     if (!objSymReader) {
@@ -43,7 +43,7 @@ bool Codegen::generateInt() {
     // But we still need the load addr...
     bool found = false;
     for (auto li = proc_->libraries().begin(); li != proc_->libraries().end(); ++li) {
-      std::string canonical = Dyninst::resolve_file_path((*li)->getName());
+      std::string canonical = Dyninst::filesystem::canonicalize((*li)->getName());
       if (canonical == interp) {
 	found = true;
 	dlopenAddr += (*li)->getLoadAddress();

--- a/proccontrol/src/windows_handler.C
+++ b/proccontrol/src/windows_handler.C
@@ -35,7 +35,7 @@
 
 #include "common/h/dyntypes.h"
 #include "symtabAPI/h/Symtab.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 #include "PCErrors.h"
 #include "Generator.h"
 #include "Event.h"

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -43,7 +43,7 @@
 #include "symutil.h"
 #include "annotations.h"
 
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 #include "Object.h"
 #include <boost/foreach.hpp>
 #include <algorithm>

--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -35,7 +35,7 @@
 #include <algorithm>
 
 #include "common/src/Timer.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 
 #include "Symtab.h"
 #include "Symbol.h"

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -40,7 +40,7 @@
 #include <algorithm>
 
 #include "common/src/Timer.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 
 #include "debug.h"
 #include "Symtab.h"

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -39,14 +39,14 @@
 #include <sstream>
 
 #include "common/src/Timer.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 
 #include "Symtab.h"
 #include "Module.h"
 #include "Collections.h"
 #include "Function.h"
 #include "Variable.h"
-#include "pathName.h"
+#include "dyninst_filesystem.h"
 #include "annotations.h"
 
 #include "debug.h"
@@ -1992,7 +1992,7 @@ DYNINST_EXPORT std::string Symtab::file() const
 
 DYNINST_EXPORT std::string Symtab::name() const 
 {
-  return Dyninst::extract_pathname_tail(impl->mf->filename());
+  return Dyninst::filesystem::extract_filename(impl->mf->filename());
 }
 
 DYNINST_EXPORT std::string Symtab::memberName() const 

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -41,7 +41,7 @@
 #include "Function.h"
 #include "debug.h"
 #include "dwarfExprParser.h"
-#include "pathName.h"
+#include "dyninst_filesystem.h"
 #include "debug_common.h"
 #include "Type-mem.h"
 #include <elfutils/libdw.h>

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -33,7 +33,7 @@
 #include <algorithm>
 #include "emitElf.h"
 #include "emitElfStatic.h"
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 #include "dyninstAPI_RT/h/dyninstAPI_RT.h"
 #include "unaligned_memory_access.h"
 

--- a/symtabAPI/src/parseDwarf.C
+++ b/symtabAPI/src/parseDwarf.C
@@ -42,7 +42,7 @@
 #include "Module.h"
 #include "Object-elf.h"
 #include "Collections.h"
-#include "pathName.h"
+#include "dyninst_filesystem.h"
 #include "Variable.h"
 #include "Type-mem.h"
 #include <stdarg.h>

--- a/tests/unit/common/CMakeLists.txt
+++ b/tests/unit/common/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_guard(GLOBAL)
 
-add_executable(pathName pathName.cpp)
+add_executable(pathName filesystem.cpp)
 target_compile_options(pathName PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
 target_include_directories(pathName PRIVATE ${UNIT_TESTS_INCLUDES})
 target_link_libraries(pathName PRIVATE common)

--- a/tests/unit/common/filesystem.cpp
+++ b/tests/unit/common/filesystem.cpp
@@ -1,4 +1,4 @@
-#include "common/src/pathName.h"
+#include "common/src/dyninst_filesystem.h"
 
 #include <array>
 #include <boost/algorithm/string/replace.hpp>
@@ -89,7 +89,7 @@ int main() {
   auto test_id = 1;
 
   for(auto t : tests) {
-    auto fp = Dyninst::resolve_file_path(t.input);
+    auto fp = Dyninst::filesystem::canonicalize(t.input);
     if(simplify(fp) != simplify(t.expected)) {
       std::cerr << "Test " << test_id << " '" << t.input << "' failed: expected '"
                 << t.expected << "', got '" << fp << "'\n";


### PR DESCRIPTION
I prefer free functions to be verbs, so I chose `canonicalize` over `boost::filesystem::canonical` and `extract_filename` over the member function `boost::filesystem::path::filename`.