### PR TITLE
Fix ROSE register size for ppc64 CR registers

### DIFF
--- a/dataflowAPI/rose/registers/ppc64.h
+++ b/dataflowAPI/rose/registers/ppc64.h
@@ -93,7 +93,8 @@ namespace {
         }
         if(baseID >= 621 && baseID <= 628) {
           auto const pos = baseID - 621;
-          return std::make_tuple(powerpc_regclass_cr, 0, pos, num_bits);
+          auto const size = 4;  // cr<0:7> in ROSE are 4 bits
+          return std::make_tuple(powerpc_regclass_cr, 0, pos, size);
         }
         if(baseID == 629) {
           return std::make_tuple(powerpc_regclass_cr, 0, 0, num_bits);


### PR DESCRIPTION
Dyninst treats them as the whole register, but ROSE splits them up.

The values come from `RegisterDictionary::dictionary_powerpc`.