### PR TITLE
Clean up and refactor string handling in parts of SymtabAPI and DyninstAPI

### DIFF
--- a/common/src/MappedFile.C
+++ b/common/src/MappedFile.C
@@ -34,7 +34,7 @@ using namespace std;
 
 dyn_hash_map<std::string, MappedFile *> MappedFile::mapped_files;
 
-MappedFile *MappedFile::createMappedFile(std::string fullpath_)
+MappedFile *MappedFile::createMappedFile(std::string const& fullpath_)
 {
    //fprintf(stderr, "%s[%d]:  createMappedFile %s\n", FILE__, __LINE__, fullpath_.c_str());
    if (mapped_files.find(fullpath_) != mapped_files.end()) {
@@ -92,7 +92,7 @@ MappedFile *MappedFile::createMappedFile(std::string fullpath_)
 }
 
 MappedFile::MappedFile(std::string fullpath_, bool &ok) :
-   fullpath(fullpath_),
+   fullpath(std::move(fullpath_)),
 	   map_addr(NULL),
 #if defined(os_windows)
 	   hMap(NULL),
@@ -131,8 +131,8 @@ MappedFile *MappedFile::createMappedFile(void *loc, unsigned long size_, const s
   return mf;
 }
 
-MappedFile::MappedFile(void *loc, unsigned long size_, const std::string &name, bool &ok) :
-   fullpath(name),
+MappedFile::MappedFile(void *loc, unsigned long size_, std::string name, bool &ok) :
+   fullpath(std::move(name)),
 	map_addr(NULL),
 #if defined(os_windows)
 	hMap(NULL),
@@ -211,7 +211,7 @@ MappedFile::~MappedFile()
       close_file();
 }
 
-bool MappedFile::check_path(std::string &filename)
+bool MappedFile::check_path(std::string const& filename)
 {
    struct stat statbuf;
    if (0 != stat(filename.c_str(), &statbuf)) {
@@ -414,7 +414,7 @@ bool MappedFile::close_file()
    return true;
 }
 
-std::string MappedFile::filename()
+std::string const& MappedFile::filename() const
 {
 	return fullpath;
 }

--- a/common/src/MappedFile.h
+++ b/common/src/MappedFile.h
@@ -39,11 +39,11 @@ class MappedFile {
      static dyn_hash_map<std::string, MappedFile *> mapped_files;
 
    public:
-      DYNINST_EXPORT static MappedFile *createMappedFile(std::string fullpath_);
+      DYNINST_EXPORT static MappedFile *createMappedFile(std::string const& fullpath_);
       DYNINST_EXPORT static MappedFile *createMappedFile(void *map_loc, unsigned long size_, const std::string &name);
       DYNINST_EXPORT static void closeMappedFile(MappedFile *&mf);
 
-      DYNINST_EXPORT std::string filename();
+      DYNINST_EXPORT std::string const& filename() const;
       DYNINST_EXPORT void *base_addr() {return map_addr;}
 #if defined(os_windows)
       DYNINST_EXPORT HANDLE getFileHandle() {return hFile;}
@@ -59,11 +59,11 @@ class MappedFile {
    private:
 
       MappedFile(std::string fullpath_, bool &ok);
-      MappedFile(void *loc, unsigned long size_, const std::string & name, bool &ok);
+      MappedFile(void *loc, unsigned long size_, std::string name, bool &ok);
       ~MappedFile();
       bool clean_up();
 
-      bool check_path(std::string &);
+      bool check_path(std::string const& );
       bool open_file();
       bool open_file(void *, unsigned long size_ = 0);
       bool map_file();

--- a/dyninstAPI/src/BPatch.C
+++ b/dyninstAPI/src/BPatch.C
@@ -1837,7 +1837,10 @@ void BPatch::getBPatchVersion(int &major, int &minor, int &subminor)
 }
 
 BPatch_binaryEdit *BPatch::openBinary(const char *path, bool openDependencies /* = false */) {
-   BPatch_binaryEdit *editor = new BPatch_binaryEdit(path, openDependencies);
+  if(!path) {
+    return nullptr;
+  }
+  BPatch_binaryEdit *editor = new BPatch_binaryEdit(path, openDependencies);
    if (!editor)
       return NULL;
    if (editor->creation_error) {

--- a/dyninstAPI/src/BPatch_binaryEdit.C
+++ b/dyninstAPI/src/BPatch_binaryEdit.C
@@ -87,7 +87,7 @@ BPatch_binaryEdit::BPatch_binaryEdit(const char *path, bool openDependencies) :
 
   startup_printf("[%s:%d] - Opening original file %s\n",
                  FILE__, __LINE__, path);
-  origBinEdit = BinaryEdit::openFile(std::string(path));
+  origBinEdit = BinaryEdit::openFile(path ? path : "");
 
   if (!origBinEdit){
      startup_printf("[%s:%d] - Creation error opening %s\n",

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -1612,7 +1612,8 @@ void pdmodule::dumpMangled(std::string const& prefix) const
       parse_func * pdf = (parse_func*)*fit;
       if (pdf->pdmod() != this) continue;
 
-      if(pdf->symTabName() != prefix) {
+      if(pdf->symTabName().find(prefix) != 0UL) {
+          // the name starts with the prefix
           cerr << pdf->symTabName() << " ";
       }
   }

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -545,7 +545,7 @@ class pdmodule {
                                std::vector<parse_func *> &found);
    bool findFunctionByPretty (const std::string &name,
                               std::vector<parse_func *> &found);
-   void dumpMangled(std::string &prefix) const;
+   void dumpMangled(std::string const& prefix) const;
    const string &fileName() const;
    SymtabAPI::supportedLanguages language() const;
    Address addr() const;

--- a/symtabAPI/h/Archive.h
+++ b/symtabAPI/h/Archive.h
@@ -50,10 +50,10 @@ class Symtab;
  */
 class DYNINST_EXPORT ArchiveMember {
     public:
-        ArchiveMember() : name_(""), offset_(0), member_(NULL) {}
-        ArchiveMember(const std::string name, const Offset offset,
+        ArchiveMember() = default;
+        ArchiveMember(std::string name, const Offset offset,
                 Symtab * img = NULL) :
-            name_(name), 
+            name_(std::move(name)),
             offset_(offset), 
             member_(img) 
         {}
@@ -66,31 +66,31 @@ class DYNINST_EXPORT ArchiveMember {
         void setSymtab(Symtab *img) { member_ = img; }
 
     private:
-        const std::string name_;
-        Offset offset_;
-        Symtab *member_;
+        const std::string name_{};
+        Offset offset_{};
+        Symtab *member_{};
 };
 
 class DYNINST_EXPORT Archive : public AnnotatableSparse {
    public:
-      static bool openArchive(Archive *&img, std::string filename);
+      static bool openArchive(Archive *&img, std::string const& filename);
       static bool openArchive(Archive *&img, char *mem_image, size_t image_size);
       static SymtabError getLastError();
       static std::string printError(SymtabError err);
 
       ~Archive();
-      bool getMember(Symtab *&img, std::string& member_name);
+      bool getMember(Symtab *&img, std::string const& member_name);
       bool getMemberByOffset(Symtab *&img, Offset memberOffset);
-      bool getMemberByGlobalSymbol(Symtab *&img, std::string& symbol_name);
+      bool getMemberByGlobalSymbol(Symtab *&img, std::string const& symbol_name);
       bool getAllMembers(std::vector<Symtab *> &members);
-      bool isMemberInArchive(std::string& member_name);
-      bool findMemberWithDefinition(Symtab *&obj, std::string& name);
-      std::string name();
+      bool isMemberInArchive(std::string const& member_name);
+      bool findMemberWithDefinition(Symtab *&obj, std::string const& name);
+      std::string const& name();
 
-      bool getMembersBySymbol(std::string name, std::vector<Symtab *> &matches);
+      bool getMembersBySymbol(std::string const& name, std::vector<Symtab *> &matches);
 
    private:
-      Archive(std::string &filename, bool &err);
+      Archive(std::string const& filename, bool &err);
       Archive(char *mem_image, size_t image_size, bool &err);
 
       /**

--- a/symtabAPI/h/Collections.h
+++ b/symtabAPI/h/Collections.h
@@ -148,8 +148,8 @@ public:
       return &dynamic_cast<T&>(*addOrUpdateType(boost::dynamic_pointer_cast<T>(t->reshare())));
     }
 
-    boost::shared_ptr<Type> findVariableType(std::string &name, Type::do_share_t);
-    Type* findVariableType(std::string& n) { return findVariableType(n, Type::share).get(); }
+    boost::shared_ptr<Type> findVariableType(std::string const& name, Type::do_share_t);
+    Type* findVariableType(std::string const& n) { return findVariableType(n, Type::share).get(); }
 
     void getAllTypes(std::vector<boost::shared_ptr<Type>>&);
     std::vector<Type*>* getAllTypes() {

--- a/symtabAPI/h/Module.h
+++ b/symtabAPI/h/Module.h
@@ -90,18 +90,18 @@ namespace Dyninst { namespace SymtabAPI {
                              bool checkCase = true);
 
     // Type output methods
-    virtual bool findType(boost::shared_ptr<Type> &type, std::string name);
+    virtual bool findType(boost::shared_ptr<Type> &type, std::string const& name);
 
-    bool findType(Type *&t, std::string n) {
+    bool findType(Type *&t, std::string const& n) {
       boost::shared_ptr<Type> tp;
       auto r = findType(tp, n);
       t = tp.get();
       return r;
     }
 
-    virtual bool findVariableType(boost::shared_ptr<Type> &type, std::string name);
+    virtual bool findVariableType(boost::shared_ptr<Type> &type, std::string const& name);
 
-    bool findVariableType(Type *&t, std::string n) {
+    bool findVariableType(Type *&t, std::string const& n) {
       boost::shared_ptr<Type> tp;
       auto r = findVariableType(tp, n);
       t = tp.get();
@@ -133,10 +133,10 @@ namespace Dyninst { namespace SymtabAPI {
     typeCollection *getModuleTypes();
 
     /***** Local Variable Information *****/
-    bool findLocalVariable(std::vector<localVar *> &vars, std::string name);
+    bool findLocalVariable(std::vector<localVar *> &vars, std::string const& name);
 
     /***** Line Number Information *****/
-    bool getAddressRanges(std::vector<AddressRange> &ranges, std::string lineSource,
+    bool getAddressRanges(std::vector<AddressRange> &ranges, std::string const& lineSource,
                           unsigned int LineNo);
     bool getSourceLines(std::vector<Statement::Ptr> &lines, Offset addressInRange);
     bool getSourceLines(std::vector<LineNoTuple> &lines, Offset addressInRange);

--- a/symtabAPI/h/Symbol.h
+++ b/symtabAPI/h/Symbol.h
@@ -231,7 +231,7 @@ class DYNINST_EXPORT Symbol : public AnnotatableSparse
    bool  setDebug(bool dbg) { isDebug_ = dbg; return true; }
    bool  setCommonStorage(bool cs) { isCommonStorage_ = cs; return true; }
 
-   bool  setVersionFileName(std::string &fileName);
+   bool  setVersionFileName(std::string fileName);
    bool  setVersions(std::vector<std::string> &vers);
    bool  setVersionNum(unsigned verNum);
    void setVersionHidden() { versionHidden_ = true; }
@@ -293,15 +293,15 @@ class DYNINST_EXPORT LookupInterface
                                             bool isRegex = false,
                                             bool checkCase = false,
                                             bool includeUndefined = false) = 0;
-      virtual bool findType(boost::shared_ptr<Type>& type, std::string name) = 0;
-      bool findType(Type*& t, std::string n) {
+      virtual bool findType(boost::shared_ptr<Type>& type, std::string const& name) = 0;
+      bool findType(Type*& t, std::string const& n) {
         boost::shared_ptr<Type> tp;
         auto r = findType(tp, n);
         t = tp.get();
         return r;
       }
-      virtual bool findVariableType(boost::shared_ptr<Type>& type, std::string name)= 0;
-      bool findVariableType(Type*& t, std::string n) {
+      virtual bool findVariableType(boost::shared_ptr<Type>& type, std::string const& name)= 0;
+      bool findVariableType(Type*& t, std::string const& n) {
         boost::shared_ptr<Type> tp;
         auto r = findVariableType(tp, n);
         t = tp.get();

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -117,11 +117,11 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
       NotDefensive,
       Defensive} def_t; 
 
-   static bool openFile(Symtab *&obj, std::string filename, 
+   static bool openFile(Symtab *&obj, std::string const& filename,
                                       def_t defensive_binary = NotDefensive);
    static bool openFile(Symtab *&obj, void *mem_image, size_t size, 
-                                      std::string name, def_t defensive_binary = NotDefensive);
-   static Symtab *findOpenSymtab(std::string filename);
+                                      std::string const& name, def_t defensive_binary = NotDefensive);
+   static Symtab *findOpenSymtab(std::string const& filename);
    static bool closeSymtab(Symtab *);
 
    bool getRegValueAtFrame(Address pc, 
@@ -160,7 +160,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    // Function
 
    bool findFuncByEntryOffset(Function *&ret, const Offset offset);
-   bool findFunctionsByName(std::vector<Function *> &ret, const std::string name,
+   bool findFunctionsByName(std::vector<Function *> &ret, std::string const& name,
                                           NameType nameType = anyName, 
                                           bool isRegex = false,
                                           bool checkCase = true);
@@ -174,7 +174,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
 
    // Variable
    bool findVariablesByOffset(std::vector<Variable *> &ret, const Offset offset);
-   bool findVariablesByName(std::vector<Variable *> &ret, const std::string name,
+   bool findVariablesByName(std::vector<Variable *> &ret, std::string const& name,
                                           NameType nameType = anyName, 
                                           bool isRegex = false, 
                                           bool checkCase = true);
@@ -196,7 +196,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    bool getAllRegions(std::vector<Region *>&ret);
    bool getAllNewRegions(std::vector<Region *>&ret);
    //  change me to use a hash
-   bool findRegion(Region *&ret, std::string regname);
+   bool findRegion(Region *&ret, std::string const& regname);
    bool findRegion(Region *&ret, const Offset addr, const unsigned long size);
    bool findRegionByEntry(Region *&ret, const Offset offset);
    Region *findEnclosingRegion(const Offset offset);
@@ -218,8 +218,8 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
 
    bool addSymbol(Symbol *newsym);
    bool addSymbol(Symbol *newSym, Symbol *referringSymbol);
-   Function *createFunction(std::string name, Offset offset, size_t size, Module *mod = NULL);
-   Variable *createVariable(std::string name, Offset offset, size_t size, Module *mod = NULL);
+   Function *createFunction(std::string const& name, Offset offset, size_t size, Module *mod = NULL);
+   Variable *createVariable(std::string const& name, Offset offset, size_t size, Module *mod = NULL);
 
    bool deleteFunction(Function *func);
    bool deleteVariable(Variable *var);
@@ -242,7 +242,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
 
    /***** Line Number Information *****/
    bool getAddressRanges(std::vector<AddressRange> &ranges,
-                         std::string lineSource, unsigned int LineNo);
+                         std::string const& lineSource, unsigned int LineNo);
    bool getSourceLines(std::vector<Statement::Ptr> &lines,
                        Offset addressInRange);
    bool getSourceLines(std::vector<LineNoTuple> &lines,
@@ -251,8 +251,8 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    bool getTruncateLinePaths();
    
    /***** Type Information *****/
-   virtual bool findType(boost::shared_ptr<Type>& type, std::string name);
-   bool findType(Type*& t, std::string n) {
+   virtual bool findType(boost::shared_ptr<Type>& type, std::string const& name);
+   bool findType(Type*& t, std::string const& n) {
      boost::shared_ptr<Type> tp;
      auto r = findType(tp, n);
      t = tp.get();
@@ -260,8 +260,8 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    }
    virtual boost::shared_ptr<Type> findType(unsigned type_id, Type::do_share_t);
    Type* findType(unsigned i) { return findType(i, Type::share).get(); }
-   virtual bool findVariableType(boost::shared_ptr<Type>& type, std::string name);
-   bool findVariableType(Type*& t, std::string n) {
+   virtual bool findVariableType(boost::shared_ptr<Type>& type, std::string const& name);
+   bool findVariableType(Type*& t, std::string const& n) {
      boost::shared_ptr<Type> tp;
      auto r = findVariableType(tp, n);
      t = tp.get();
@@ -293,7 +293,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    void parseTypesNow();
 
    /***** Local Variable Information *****/
-   bool findLocalVariable(std::vector<localVar *>&vars, std::string name);
+   bool findLocalVariable(std::vector<localVar *>&vars, std::string const& name);
 
    /***** Relocation Sections *****/
    bool hasRel() const;
@@ -306,15 +306,15 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    bool isStaticBinary() const;
 
    /***** Write Back binary functions *****/
-   bool emitSymbols(Object *linkedFile, std::string filename, unsigned flag = 0);
+   bool emitSymbols(Object *linkedFile, std::string const& filename, unsigned flag = 0);
    bool addRegion(Offset vaddr, void *data, unsigned int dataSize, 
-         std::string name, Region::RegionType rType_, bool loadable = false,
+         std::string const& name, Region::RegionType rType_, bool loadable = false,
          unsigned long memAlign = sizeof(unsigned), bool tls = false);
    bool addRegion(Region *newreg);
-   bool emit(std::string filename, unsigned flag = 0);
+   bool emit(std::string const& filename, unsigned flag = 0);
 
-   void addDynLibSubstitution(std::string oldName, std::string newName);
-   std::string getDynLibSubstitution(std::string name);
+   void addDynLibSubstitution(std::string const& oldName, std::string const& newName);
+   std::string getDynLibSubstitution(std::string const& name);
 
    bool getSegments(std::vector<Segment> &segs) const;
    
@@ -328,7 +328,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    bool updateData(void *buffer, unsigned size);
    Offset getFreeOffset(unsigned size);
 
-   bool addLibraryPrereq(std::string libname);
+   bool addLibraryPrereq(std::string const& libname);
    bool addSysVDynamic(long name, long value);
 
    bool addLinkingResource(Archive *library);
@@ -340,9 +340,9 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    bool updateRelocations(Address start, Address end, Symbol *oldsym, Symbol *newsym);
 
    /***** Data Member Access *****/
-   std::string file() const;
+   std::string const& file() const;
    std::string name() const;
-   std::string memberName() const;
+   std::string const& memberName() const;
 
    char *mem_image() const;
 
@@ -373,13 +373,13 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    Offset fileToMemOffset(Dyninst::Offset) const;
 
 
-   std::string getDefaultNamespacePrefix() const;
+   std::string const& getDefaultNamespacePrefix() const;
 
    unsigned getNumberOfRegions() const;
    unsigned getNumberOfSymbols() const;
 
    std::vector<std::string> &getDependencies();
-   bool removeLibraryDependency(std::string lib);
+   bool removeLibraryDependency(std::string const& lib);
 
    Archive *getParentArchive() const;
 
@@ -394,7 +394,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    /***** Private Member Functions *****/
    private:
 
-   Symtab(std::string filename, bool defensive_bin, bool &err);
+   Symtab(std::string const& filename, bool defensive_bin, bool &err);
 
    bool extractInfo(Object *linkedFile);
 
@@ -455,7 +455,7 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
    void parseLineInformation();
    
    void parseTypes();
-   bool setDefaultNamespacePrefix(std::string &str);
+   bool setDefaultNamespacePrefix(std::string str);
 
    bool addUserRegion(Region *newreg);
    bool addUserType(Type *newtypeg);

--- a/symtabAPI/src/Archive-elf.C
+++ b/symtabAPI/src/Archive-elf.C
@@ -39,7 +39,7 @@ using namespace std;
 using namespace Dyninst;
 using namespace Dyninst::SymtabAPI;
 
-Archive::Archive(std::string& filename, bool& err)
+Archive::Archive(std::string const& filename, bool& err)
     : basePtr(NULL), symbolTableParsed(false)
 {
     mf = MappedFile::createMappedFile(filename);

--- a/symtabAPI/src/Archive.C
+++ b/symtabAPI/src/Archive.C
@@ -86,11 +86,11 @@ std::string Archive::printError(SymtabError err)
    }
 }
 
-std::string Archive::name() {
+std::string const& Archive::name() {
     return mf->filename();
 }
 
-bool Archive::openArchive(Archive * &img, std::string filename)
+bool Archive::openArchive(Archive * &img, std::string const& filename)
 {
     bool err = false;
 
@@ -145,7 +145,7 @@ bool Archive::openArchive(Archive * &img, char *mem_image, size_t size)
     return err;
 }
 
-bool Archive::getMember(Symtab *&img, string& member_name) 
+bool Archive::getMember(Symtab *&img, string const& member_name)
 {
     dyn_hash_map<string, ArchiveMember *>::iterator mem_it;
     mem_it = membersByName.find(member_name);
@@ -185,7 +185,7 @@ bool Archive::getMemberByOffset(Symtab *&img, Offset memberOffset)
     return true;
 }
 
-bool Archive::getMemberByGlobalSymbol(Symtab *&img, string& symbol_name) 
+bool Archive::getMemberByGlobalSymbol(Symtab *&img, string const& symbol_name)
 {
     if( !symbolTableParsed ) {
        if( !parseSymbolTable() ) {
@@ -223,7 +223,7 @@ bool Archive::getMemberByGlobalSymbol(Symtab *&img, string& symbol_name)
     return true;
 }
 
-bool Archive::getMembersBySymbol(std::string name,
+bool Archive::getMembersBySymbol(std::string const& name,
                                  std::vector<Symtab *> &matches) {
    if (!symbolTableParsed && !parseSymbolTable())
       return false;
@@ -260,7 +260,7 @@ bool Archive::getAllMembers(vector<Symtab *> &members)
     return true;
 }
 
-bool Archive::isMemberInArchive(std::string& member_name) 
+bool Archive::isMemberInArchive(std::string const& member_name)
 {
     if (membersByName.count(member_name)) return true;
     return false;
@@ -278,7 +278,7 @@ bool Archive::isMemberInArchive(std::string& member_name)
  * for every member in an Archive and then searching each of these Symtab objects
  * for the symbol.
  */
-bool Archive::findMemberWithDefinition(Symtab * &obj, std::string& name)
+bool Archive::findMemberWithDefinition(Symtab * &obj, std::string const& name)
 {
     std::vector<Symtab *> members;
     if( !getAllMembers(members) ) {

--- a/symtabAPI/src/Collections.C
+++ b/symtabAPI/src/Collections.C
@@ -339,7 +339,7 @@ boost::shared_ptr<Type> typeCollection::findType(const int ID, Type::do_share_t)
  *
  * name		The name of the type to look up.
  */
-boost::shared_ptr<Type> typeCollection::findVariableType(std::string &name, Type::do_share_t)
+boost::shared_ptr<Type> typeCollection::findVariableType(std::string const& name, Type::do_share_t)
 {
     dyn_c_hash_map<std::string, boost::shared_ptr<Type>>::const_accessor a;
     if (globalVarsByName.find(a, name))

--- a/symtabAPI/src/Module.C
+++ b/symtabAPI/src/Module.C
@@ -126,7 +126,7 @@ supportedLanguages Module::language() const
 }
 
 bool Module::getAddressRanges(std::vector<AddressRange >&ranges_,
-      std::string lineSource, unsigned int lineNo)
+      std::string const& lineSource, unsigned int lineNo)
 {
    unsigned int originalSize = ranges_.size();
 
@@ -223,7 +223,7 @@ typeCollection *Module::getModuleTypesPrivate()
   return typeInfo_;
 }
 
-bool Module::findType(boost::shared_ptr<Type> &type, std::string name)
+bool Module::findType(boost::shared_ptr<Type> &type, std::string const& name)
 {
 	typeCollection *tc = getModuleTypes();
 	if (!tc) return false;
@@ -236,7 +236,7 @@ bool Module::findType(boost::shared_ptr<Type> &type, std::string name)
    return true;
 }
 
-bool Module::findVariableType(boost::shared_ptr<Type> &type, std::string name)
+bool Module::findVariableType(boost::shared_ptr<Type> &type, std::string const& name)
 {
 	typeCollection *tc = getModuleTypes();
 	if (!tc) return false;
@@ -263,7 +263,7 @@ LineInformation *Module::getLineInformation()
   return lineInfo_;
 }
 
-bool Module::findLocalVariable(std::vector<localVar *>&vars, std::string name)
+bool Module::findLocalVariable(std::vector<localVar *>&vars, std::string const& name)
 {
 	std::vector<Function *>mod_funcs;
 
@@ -290,7 +290,7 @@ Module::Module(supportedLanguages lang, Offset adr,
    objectLevelLineInfo(false),
    lineInfo_(NULL),
    typeInfo_(NULL),
-   fileName_(fullNm),
+   fileName_(std::move(fullNm)),
    compDir_(""),
    language_(lang),
    addr_(adr),
@@ -402,7 +402,7 @@ Offset Module::addr() const
 
 bool Module::setDefaultNamespacePrefix(string str)
 {
-    return exec_->setDefaultNamespacePrefix(str);
+    return exec_->setDefaultNamespacePrefix(std::move(str));
 }
 
 bool Module::findVariablesByOffset(std::vector<Variable *> &ret, const Offset offset)

--- a/symtabAPI/src/Region.C
+++ b/symtabAPI/src/Region.C
@@ -43,7 +43,7 @@ Region *Region::createRegion( Offset diskOff, perm_t perms, RegionType regType,
                               char *rawDataPtr, bool isLoadable, bool isTLS,
                               unsigned long memAlign)
 {
-   Region *newreg = new Region(0, name, diskOff, 
+   Region *newreg = new Region(0, std::move(name), diskOff,
                                diskSize, memOff, memSize, 
                                rawDataPtr, perms, regType, isLoadable, isTLS,
                                memAlign);
@@ -61,7 +61,7 @@ Region::Region(unsigned regnum, std::string name, Offset diskOff,
                     unsigned long diskSize, Offset memOff, unsigned long memSize,
                     char *rawDataPtr, perm_t perms, RegionType regType, bool isLoadable,
                     bool isThreadLocal, unsigned long memAlignment) :
-    regNum_(regnum), name_(name), diskOff_(diskOff), diskSize_(diskSize), memOff_(memOff),
+    regNum_(regnum), name_(std::move(name)), diskOff_(diskOff), diskSize_(diskSize), memOff_(memOff),
     memSize_(memSize), fileOff_(0), rawDataPtr_(rawDataPtr), permissions_(perms), rType_(regType),
     isDirty_(false), buffer_(NULL), isLoadable_(isLoadable), isTLS_(isThreadLocal),
     memAlign_(memAlignment), symtab_(NULL)

--- a/symtabAPI/src/Symbol.C
+++ b/symtabAPI/src/Symbol.C
@@ -173,7 +173,7 @@ DYNINST_EXPORT bool Symbol::setSymbolType(SymbolType sType)
     return true;
 }
 
-DYNINST_EXPORT bool Symbol::setVersionFileName(std::string &fileName)
+DYNINST_EXPORT bool Symbol::setVersionFileName(std::string fileName)
 {
    std::string *fn_p = NULL;
    if (getAnnotation(fn_p, SymbolFileNameAnno)) 
@@ -183,7 +183,7 @@ DYNINST_EXPORT bool Symbol::setVersionFileName(std::string &fileName)
    else
    {
       //  not sure if we need to copy here or not, so let's do it...
-      std::string *fn = new std::string(fileName);
+      std::string *fn = new std::string(std::move(fileName));
       if (!addAnnotation(fn, SymbolFileNameAnno)) 
       {
          return false;
@@ -242,7 +242,7 @@ DYNINST_EXPORT bool Symbol::getVersions(std::vector<std::string> *&vers) const
 
 DYNINST_EXPORT bool Symbol::setMangledName(std::string name)
 {
-   mangledName_ = name;
+   mangledName_ = std::move(name);
    setStrIndex(-1);
    return true;
 }

--- a/symtabAPI/src/Symtab-edit.C
+++ b/symtabAPI/src/Symtab-edit.C
@@ -253,7 +253,7 @@ bool Symtab::addSymbol(Symbol *newSym)
 }
 
 
-Function *Symtab::createFunction(std::string name, 
+Function *Symtab::createFunction(std::string const& name,
                                  Offset offset, 
                                  size_t sz,
                                  Module *mod)
@@ -313,7 +313,7 @@ Function *Symtab::createFunction(std::string name,
 
 
 
-Variable *Symtab::createVariable(std::string name, 
+Variable *Symtab::createVariable(std::string const& name,
                                  Offset offset, 
                                  size_t sz,
                                  Module *mod)

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -256,7 +256,7 @@ bool sort_by_func_ptr(const Function *a, const Function *b) {
     return a < b;
 }
 
-bool Symtab::findFunctionsByName(std::vector<Function *> &ret, const std::string name,
+bool Symtab::findFunctionsByName(std::vector<Function *> &ret, std::string const& name,
                                  NameType nameType, bool isRegex, bool checkCase) {
     std::vector<Symbol *> funcSyms;
     if (!findSymbol(funcSyms, name, Symbol::ST_FUNCTION, nameType, isRegex, checkCase)) {
@@ -316,7 +316,7 @@ static bool sort_by_var_ptr(const Variable * a, const Variable *b) {
     return a < b;
 }
 
-bool Symtab::findVariablesByName(std::vector<Variable *> &ret, const std::string name,
+bool Symtab::findVariablesByName(std::vector<Variable *> &ret, std::string const& name,
                                  NameType nameType, bool isRegex, bool checkCase) {
     std::vector<Symbol *> varSyms;
     if (!findSymbol(varSyms, name, Symbol::ST_OBJECT, nameType, isRegex, checkCase))
@@ -527,7 +527,7 @@ Region *Symtab::findEnclosingRegion(const Offset where)
     return NULL;
 }
 
-bool Symtab::findRegion(Region *&ret, const std::string secName)
+bool Symtab::findRegion(Region *&ret, std::string const& secName)
 {
     for(unsigned index=0;index<regions_.size();index++)
     {

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -427,7 +427,7 @@ void Symtab::setTOCOffset(Offset off) {
   return;
 }
 
-DYNINST_EXPORT string Symtab::getDefaultNamespacePrefix() const
+DYNINST_EXPORT string const& Symtab::getDefaultNamespacePrefix() const
 {
     return defaultNamespacePrefix;
 }
@@ -746,7 +746,7 @@ void Symtab::setModuleLanguages(dyn_hash_map<std::string, supportedLanguages> *m
          continue;  // need to find some way to get shared object languages?
       }
 
-      const std::string fn = currmod->fileName();
+      std::string const& fn = currmod->fileName();
       if (mod_langs->find(currmod->fileName()) != mod_langs->end())
       {
          currLang = (*mod_langs)[fn];
@@ -807,7 +807,7 @@ Module *Symtab::getOrCreateModule(const std::string &modName,
     return mod;
 }
 
-Symtab::Symtab(std::string filename, bool defensive_bin, bool &err) : Symtab()
+Symtab::Symtab(std::string const& filename, bool defensive_bin, bool &err) : Symtab()
 {
    isDefensiveBinary_ = defensive_bin;
 
@@ -1285,7 +1285,7 @@ Symtab::~Symtab()
 }	
 
 bool Symtab::openFile(Symtab *&obj, void *mem_image, size_t size, 
-                      std::string name, def_t def_bin)
+                      std::string const& name, def_t def_bin)
 {
    bool err = false;
 #if defined(TIMED_PARSE)
@@ -1341,7 +1341,7 @@ bool Symtab::closeSymtab(Symtab *st)
 	return found;
 }
 
-Symtab *Symtab::findOpenSymtab(std::string filename)
+Symtab *Symtab::findOpenSymtab(std::string const& filename)
 {
    unsigned numSymtabs = allSymtabs.size();
 	for (unsigned u=0; u<numSymtabs; u++) 
@@ -1358,7 +1358,7 @@ Symtab *Symtab::findOpenSymtab(std::string filename)
 	return NULL;
 }
 
-bool Symtab::openFile(Symtab *&obj, std::string filename, def_t def_binary)
+bool Symtab::openFile(Symtab *&obj, std::string const& filename, def_t def_binary)
 {
    bool err = false;
 #if defined(TIMED_PARSE)
@@ -1404,7 +1404,7 @@ bool Symtab::openFile(Symtab *&obj, std::string filename, def_t def_binary)
    return !err;
 }
 
-bool Symtab::addRegion(Offset vaddr, void *data, unsigned int dataSize, std::string name, 
+bool Symtab::addRegion(Offset vaddr, void *data, unsigned int dataSize, std::string const& name,
         Region::RegionType rType_, bool loadable, unsigned long memAlign, bool tls)
 {
    Region *sec;
@@ -1518,7 +1518,7 @@ void Symtab::parseLineInformation()
 }
 
 DYNINST_EXPORT bool Symtab::getAddressRanges(std::vector<AddressRange > &ranges,
-                                            std::string lineSource, unsigned int lineNo)
+                                            std::string const& lineSource, unsigned int lineNo)
 {
    unsigned int originalSize = ranges.size();
    parseLineInformation();
@@ -1626,7 +1626,7 @@ DYNINST_EXPORT void Symtab::getAllbuiltInTypes(vector<boost::shared_ptr<Type>>& 
    return builtInTypes()->getAllBuiltInTypes(v);
 }
 
-DYNINST_EXPORT bool Symtab::findType(boost::shared_ptr<Type> &type, std::string name)
+DYNINST_EXPORT bool Symtab::findType(boost::shared_ptr<Type> &type, std::string const& name)
 {
    parseTypesNow();
 
@@ -1685,7 +1685,7 @@ DYNINST_EXPORT boost::shared_ptr<Type> Symtab::findType(unsigned type_id, Type::
    return t;	
 }
 
-DYNINST_EXPORT bool Symtab::findVariableType(boost::shared_ptr<Type>& type, std::string name)
+DYNINST_EXPORT bool Symtab::findVariableType(boost::shared_ptr<Type>& type, std::string const& name)
 {
    parseTypesNow();
     type = NULL;
@@ -1703,7 +1703,7 @@ DYNINST_EXPORT bool Symtab::findVariableType(boost::shared_ptr<Type>& type, std:
    return true;	
 }
 
-DYNINST_EXPORT bool Symtab::findLocalVariable(std::vector<localVar *>&vars, std::string name)
+DYNINST_EXPORT bool Symtab::findLocalVariable(std::vector<localVar *>&vars, std::string const& name)
 {
    parseTypesNow();
    unsigned origSize = vars.size();
@@ -1754,13 +1754,13 @@ DYNINST_EXPORT bool Symtab::isStaticBinary() const
    return isStaticBinary_;
 }
 
-bool Symtab::setDefaultNamespacePrefix(string &str)
+bool Symtab::setDefaultNamespacePrefix(string str)
 {
-   defaultNamespacePrefix = str;
+   defaultNamespacePrefix = std::move(str);
    return true;
 }
 
-DYNINST_EXPORT bool Symtab::emitSymbols(Object *linkedFile,std::string filename, unsigned flag)
+DYNINST_EXPORT bool Symtab::emitSymbols(Object *linkedFile,std::string const& filename, unsigned flag)
 {
     // Start with all the defined symbols
     std::set<Symbol* > allSyms;
@@ -1774,7 +1774,7 @@ DYNINST_EXPORT bool Symtab::emitSymbols(Object *linkedFile,std::string filename,
     return linkedFile->emitDriver(filename, allSyms, flag);
 }
 
-DYNINST_EXPORT bool Symtab::emit(std::string filename, unsigned flag)
+DYNINST_EXPORT bool Symtab::emit(std::string const& filename, unsigned flag)
 {
 	Object *obj = getObject();
 	if (!obj)
@@ -1785,12 +1785,12 @@ DYNINST_EXPORT bool Symtab::emit(std::string filename, unsigned flag)
    return emitSymbols(obj, filename, flag);
 }
 
-DYNINST_EXPORT void Symtab::addDynLibSubstitution(std::string oldName, std::string newName)
+DYNINST_EXPORT void Symtab::addDynLibSubstitution(std::string const& oldName, std::string const& newName)
 {
    dynLibSubs[oldName] = newName;
 }
 
-DYNINST_EXPORT std::string Symtab::getDynLibSubstitution(std::string name)
+DYNINST_EXPORT std::string Symtab::getDynLibSubstitution(std::string const& name)
 {
    map<std::string, std::string>::iterator loc = dynLibSubs.find(name);
 
@@ -1984,7 +1984,7 @@ DYNINST_EXPORT char *Symtab::mem_image() const
    return (char *)impl->mf->base_addr();
 }
 
-DYNINST_EXPORT std::string Symtab::file() const 
+DYNINST_EXPORT std::string const& Symtab::file() const
 {
    assert(impl->mf);
    return impl->mf->filename();
@@ -1995,7 +1995,7 @@ DYNINST_EXPORT std::string Symtab::name() const
   return Dyninst::filesystem::extract_filename(impl->mf->filename());
 }
 
-DYNINST_EXPORT std::string Symtab::memberName() const 
+DYNINST_EXPORT std::string const& Symtab::memberName() const
 {
     return member_name_;
 }
@@ -2072,7 +2072,7 @@ DYNINST_EXPORT Offset Symtab::getElfDynamicOffset()
 #endif
 }
 
-DYNINST_EXPORT bool Symtab::removeLibraryDependency(std::string lib)
+DYNINST_EXPORT bool Symtab::removeLibraryDependency(std::string const& lib)
 {
 #if defined(os_windows)
    return false;
@@ -2085,7 +2085,7 @@ DYNINST_EXPORT bool Symtab::removeLibraryDependency(std::string lib)
 #endif
 }
    
-DYNINST_EXPORT bool Symtab::addLibraryPrereq(std::string name)
+DYNINST_EXPORT bool Symtab::addLibraryPrereq(std::string const& name)
 {
    Object *obj = getObject();
 	if (!obj)


### PR DESCRIPTION
I was chasing down an unrelated bug and kept running into corrupted `std::string`s- probably from a life-extended temporary getting modified. This fixes that issue.