### PR TITLE
Remove binaryEdit::getStatFileDescriptor

### DIFF
--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -302,12 +302,7 @@ BinaryEdit *BinaryEdit::openFile(const std::string &file,
         return NULL;
     }
     
-    fileDescriptor desc;
-    if (!getStatFileDescriptor(file, desc)) {
-        startup_printf("%s[%d]: failed to create file descriptor for %s!\n",
-                       FILE__, __LINE__, file.c_str());
-        return NULL;
-    }
+    fileDescriptor desc(file, 0, 0);
     
     // Open the mapped object as an archive member
     if( !member.empty() ) {
@@ -379,13 +374,6 @@ bool BinaryEdit::archSpecificMultithreadCapable() {
     return false;
 }
 #endif
-
-bool BinaryEdit::getStatFileDescriptor(const std::string &name, fileDescriptor &desc) {
-   desc = fileDescriptor(name.c_str(),
-                         0, // code base address
-                         0); // data base address
-   return true;
-}
 
 #if !defined(os_linux) && !defined(os_freebsd)
 mapped_object *BinaryEdit::openResolvedLibraryName(std::string filename, std::map<std::string, BinaryEdit *> &allOpened) {

--- a/dyninstAPI/src/binaryEdit.h
+++ b/dyninstAPI/src/binaryEdit.h
@@ -195,10 +195,6 @@ class BinaryEdit : public AddressSpace {
     Address lowWaterMark_;
     bool isDirty_;
 
-    static bool getStatFileDescriptor(const std::string &file,
-                                      fileDescriptor &desc);
-
-
     bool inferiorMallocStatic(unsigned size);
 
     Address maxAllocedAddr();


### PR DESCRIPTION
It's only used in the one spot, so just make it a local variable declaration.