### PR TITLE
Mark CMake dummy targets as IMPORTED

### DIFF
--- a/cmake/tpls/DyninstElfUtils.cmake
+++ b/cmake/tpls/DyninstElfUtils.cmake
@@ -20,7 +20,7 @@ include_guard(GLOBAL)
 # elfutils is only available on Unixes; provide a dummy target on other platforms
 if(NOT UNIX)
   if(NOT TARGET Dyninst::ElfUtils)
-    add_library(Dyninst::ElfUtils INTERFACE)
+    add_library(Dyninst::ElfUtils INTERFACE IMPORTED)
   endif()
   return()
 endif()

--- a/cmake/tpls/DyninstLibIberty.cmake
+++ b/cmake/tpls/DyninstLibIberty.cmake
@@ -20,7 +20,7 @@ include_guard(GLOBAL)
 # libiberty is only available on Unixes; provide a dummy target on other platforms
 if(NOT UNIX)
   if(NOT TARGET Dyninst::LibIberty)
-    add_library(Dyninst::LibIberty INTERFACE)
+    add_library(Dyninst::LibIberty INTERFACE IMPORTED)
   endif()
   return()
 endif()

--- a/cmake/tpls/DyninstThread_DB.cmake
+++ b/cmake/tpls/DyninstThread_DB.cmake
@@ -13,7 +13,7 @@ include_guard(GLOBAL)
 # thread_db is only available on Unixes; provide a dummy target on other platforms
 if(NOT UNIX)
   if(NOT TARGET Dyninst::Thread_DB)
-    add_library(Dyninst::Thread_DB INTERFACE)
+    add_library(Dyninst::Thread_DB INTERFACE IMPORTED)
   endif()
   return()
 endif()

--- a/cmake/tpls/DyninstThreads.cmake
+++ b/cmake/tpls/DyninstThreads.cmake
@@ -8,5 +8,5 @@ find_package(Threads ${_required})
 
 if(NOT Threads_FOUND)
   # make a dummy
-  add_library(Threads::Threads INTERFACE)
+  add_library(Threads::Threads INTERFACE IMPORTED)
 endif()


### PR DESCRIPTION
Since they don't have actual source files, then CMake requires them to be imported.