### PR TITLE
Track unreliable jump table bounds

### DIFF
--- a/parseAPI/h/CFG.h
+++ b/parseAPI/h/CFG.h
@@ -402,6 +402,8 @@ class DYNINST_EXPORT Function : public AnnotatableSparse, public boost::lockable
         int indexStride;
         int memoryReadSize;
         bool isZeroExtend;
+        // If there's something wrong with targets
+        bool areBoundsUnreliable;
         std::map<Address, Address> tableEntryMap;
         Block* block;
     };

--- a/parseAPI/src/IndirectAnalyzer.h
+++ b/parseAPI/src/IndirectAnalyzer.h
@@ -21,7 +21,7 @@ class IndirectControlFlowAnalyzer {
 
     void GetAllReachableBlock();  
     void FindAllThunks();
-    void ReadTable(AST::Ptr,
+    bool ReadTable(AST::Ptr,
                    AbsRegion,
                    StridedInterval &,
                    int ,


### PR DESCRIPTION
When analyzing a jump table, the parser determines the bounds optimistically. When it can't determine bounds, it arbitrary declares there are 256 entires; the parser limits bounds when it found the bad entry. This means we can end up with jump tables which have potentially incorrect parameters.

Having any, even optimistically determined, boundaries is beneficial for analysis. But, when it comes to binary rewriting, having potentially incorrect parameters given to the user in the jump table info, may lead to hidden pitfalls.

Say, the user is transforming binary code via DynInst. They receive the info: there are only 256 entries. They transform those 256 entries but all entries beyond this remain unprocessed.
If a jump leads to one of these discarded entries, the target will be determined incorrectly and the binary won't work.

Let's extend the API for jump tables and track the cases when the bounds are unreliable. We introduce an additional flag for jump tables which tells the user whether they can rely upon the boundaries.