### PR TITLE
Fix copying missing constant instruction literal

### DIFF
--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -168,7 +168,7 @@ namespace Dyninst { namespace InstructionAPI {
     typedef boost::shared_ptr<Instruction> Ptr;
 
   private:
-    void updateSize(const unsigned int new_size) { m_size = new_size; }
+    void updateSize(const unsigned int new_size, const unsigned char * raw);
 
     void decodeOperands() const;
     void addSuccessor(Expression::Ptr e, bool isCall, bool isIndirect, bool isConditional, bool isFallthrough,

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -181,7 +181,7 @@ namespace Dyninst { namespace InstructionAPI {
     mutable Operation m_InsnOp;
     bool m_Valid;
     raw_insn_T m_RawInsn;
-    unsigned int m_size;
+    unsigned int m_size{};
     Architecture arch_decoded_from;
     mutable std::list<CFT> m_Successors;
     // formatter is a non-owning pointer to a singleton object

--- a/instructionAPI/src/AMDGPU/gfx908/amdgpu_gfx908_decoder_impl.C
+++ b/instructionAPI/src/AMDGPU/gfx908/amdgpu_gfx908_decoder_impl.C
@@ -651,7 +651,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_SOP1_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOP1Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -667,7 +667,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_SOPC_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOPCOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -682,7 +682,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_SOPP_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOPPOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -698,7 +698,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_SOPK_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOPKOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -715,7 +715,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_SOP2_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOP2Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -737,7 +737,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_SMEM_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SMEMOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -753,7 +753,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_VOP1_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP1Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -769,7 +769,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_VOPC_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOPCOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -786,7 +786,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_VOP2_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP2Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -804,7 +804,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_VINTRP_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VINTRPOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -828,7 +828,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_VOP3P_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3POperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -851,7 +851,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_VOP3_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -872,7 +872,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_DS_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_DSOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -897,7 +897,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_MUBUF_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_MUBUFOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -923,7 +923,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_MTBUF_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_MTBUFOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -951,7 +951,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_MIMG_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_MIMGOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -980,7 +980,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_FLAT_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_FLATOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -1004,7 +1004,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_FLAT_GLBL_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_FLAT_GLBLOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -1028,7 +1028,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_FLAT_SCRATCH_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_FLAT_SCRATCHOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -1045,7 +1045,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = SOPK_INST_LITERAL__insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeSOPK_INST_LITERAL_Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -1063,7 +1063,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_VOP2_LITERAL_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP2_LITERALOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -1085,7 +1085,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_VOP3B_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3BOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -1107,7 +1107,7 @@ namespace InstructionAPI {
         const amdgpu_gfx908_insn_entry &insn_entry = ENC_VOP3P_MFMA_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3P_MFMAOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 

--- a/instructionAPI/src/AMDGPU/gfx90a/amdgpu_gfx90a_decoder_impl.C
+++ b/instructionAPI/src/AMDGPU/gfx90a/amdgpu_gfx90a_decoder_impl.C
@@ -609,7 +609,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_SOP1_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOP1Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -625,7 +625,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_SOPC_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOPCOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -640,7 +640,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_SOPP_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOPPOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -656,7 +656,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_SOPK_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOPKOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -673,7 +673,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_SOP2_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOP2Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -695,7 +695,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_SMEM_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SMEMOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -711,7 +711,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_VOP1_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP1Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -727,7 +727,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_VOPC_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOPCOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -744,7 +744,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_VOP2_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP2Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -768,7 +768,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_VOP3P_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3POperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -791,7 +791,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_VOP3_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -813,7 +813,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_DS_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_DSOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -839,7 +839,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_MUBUF_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_MUBUFOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -866,7 +866,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_MTBUF_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_MTBUFOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -895,7 +895,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_MIMG_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_MIMGOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -920,7 +920,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_FLAT_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_FLATOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -945,7 +945,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_FLAT_GLBL_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_FLAT_GLBLOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -970,7 +970,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_FLAT_SCRATCH_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_FLAT_SCRATCHOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -987,7 +987,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = SOPK_INST_LITERAL__insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeSOPK_INST_LITERAL_Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -1005,7 +1005,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_VOP2_LITERAL_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP2_LITERALOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -1027,7 +1027,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_VOP3B_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3BOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -1050,7 +1050,7 @@ namespace InstructionAPI {
         const amdgpu_gfx90a_insn_entry &insn_entry = ENC_VOP3P_MFMA_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3P_MFMAOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 

--- a/instructionAPI/src/AMDGPU/gfx940/amdgpu_gfx940_decoder_impl.C
+++ b/instructionAPI/src/AMDGPU/gfx940/amdgpu_gfx940_decoder_impl.C
@@ -604,7 +604,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_SOP1_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOP1Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -620,7 +620,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_SOPC_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOPCOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -635,7 +635,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_SOPP_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOPPOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -651,7 +651,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_SOPK_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOPKOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -668,7 +668,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_SOP2_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SOP2Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -690,7 +690,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_SMEM_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_SMEMOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -706,7 +706,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_VOP1_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP1Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -722,7 +722,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_VOPC_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOPCOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -739,7 +739,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_VOP2_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP2Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -763,7 +763,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_VOP3P_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3POperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -786,7 +786,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_VOP3_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -808,7 +808,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_DS_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_DSOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -834,7 +834,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_MUBUF_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_MUBUFOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -861,7 +861,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_MTBUF_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_MTBUFOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -886,7 +886,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_FLAT_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_FLATOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -911,7 +911,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_FLAT_GLBL_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_FLAT_GLBLOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -936,7 +936,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_FLAT_SCRATCH_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_FLAT_SCRATCHOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -953,7 +953,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = SOPK_INST_LITERAL__insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeSOPK_INST_LITERAL_Operands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -971,7 +971,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_VOP2_LITERAL_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP2_LITERALOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -993,7 +993,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_VOP3B_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3BOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 
@@ -1016,7 +1016,7 @@ namespace InstructionAPI {
         const amdgpu_gfx940_insn_entry &insn_entry = ENC_VOP3P_MFMA_insn_table[layout.OP];
         this->insn_in_progress = makeInstruction(insn_entry.op,insn_entry.mnemonic,insn_size+immLen,reinterpret_cast<unsigned char *>(&insn));
         finalizeENC_VOP3P_MFMAOperands();
-        this->insn_in_progress->updateSize(insn_size + immLen);
+        this->insn_in_progress->updateSize(insn_size +immLen,reinterpret_cast<unsigned char*>(&insn));
         this->insn_in_progress->updateMnemonic(std::string(insn_entry.mnemonic) + extension);
     }
 

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -109,29 +109,26 @@ namespace Dyninst { namespace InstructionAPI {
   }
 
   void Instruction::copyRaw(size_t size, const unsigned char* raw) {
+    if(m_size > sizeof(m_RawInsn.small_insn)) {
+        delete[] m_RawInsn.large_insn; 
+    }
+    m_size = 0;
+    m_RawInsn.small_insn = 0;
     if(raw) {
       m_size = size;
-      m_RawInsn.small_insn = 0;
       if(size <= sizeof(m_RawInsn.small_insn)) {
         memcpy(&m_RawInsn.small_insn, raw, size);
       } else {
         m_RawInsn.large_insn = new unsigned char[size];
         memcpy(m_RawInsn.large_insn, raw, size);
       }
-    } else {
-      m_size = 0;
-      m_RawInsn.small_insn = 0;
     }
   }
+
   void Instruction::updateSize(const unsigned int new_size, const unsigned char * raw) {
-    if(m_size > 0){
-      if(m_size > sizeof(m_RawInsn.small_insn)) {
-        delete[] m_RawInsn.large_insn; 
-      }
-    }
-    m_size = 0;
     copyRaw(new_size, raw);
   }
+
   void Instruction::decodeOperands() const {
     if(!m_Valid)
       return;

--- a/instructionAPI/src/Instruction.C
+++ b/instructionAPI/src/Instruction.C
@@ -123,7 +123,15 @@ namespace Dyninst { namespace InstructionAPI {
       m_RawInsn.small_insn = 0;
     }
   }
-
+  void Instruction::updateSize(const unsigned int new_size, const unsigned char * raw) {
+    if(m_size > 0){
+      if(m_size > sizeof(m_RawInsn.small_insn)) {
+        delete[] m_RawInsn.large_insn; 
+      }
+    }
+    m_size = 0;
+    copyRaw(new_size, raw);
+  }
   void Instruction::decodeOperands() const {
     if(!m_Valid)
       return;


### PR DESCRIPTION
AMDGPU instructions could use a 32 bit instruction literall following the current instruction.
However, whether a instruction uses a literal can only be determined after parsing the operands.
Previous approach crafts a instruction first and then update the bytes if a literal is beng used, but the 
copy of raw bytes is copied only during the construction of the instruction.

This PR updated the implementation of updateSize to copy the literal bytes.