### PR TITLE
Fix possible use of uninitialized value in Result::operator<

### DIFF
--- a/instructionAPI/h/Result.h
+++ b/instructionAPI/h/Result.h
@@ -395,9 +395,10 @@ namespace Dyninst
 
                 bool operator<(const Result& o) const
                 {
-                    if(type < o.type) return true;
                     if(!defined) return false;
                     if(!o.defined) return true;
+                    if(type < o.type) return true;
+                    if(type > o.type) return false;
 
                     switch(type)
                     {


### PR DESCRIPTION
When Result object is not defined, its `type` field may be uninitialized or contain a meaningless value. Thus check the `defined` field first.
Also the case `type > o.type` was missing, which may lead to an incorrect comparison.

The issue was highlighted by Valgrind.