### PR TITLE
GitHubCI: add /usr/lib to LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -135,6 +135,7 @@ jobs:
         shell: bash
         run: |
           set -ex
+          export LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
           export DYNINSTAPI_RT_LIB=$(find ${{ matrix.install-dir }} -name libdyninstAPI_RT.so)
           cd ${GITHUB_WORKSPACE}/external-tests/build
           ctest -VV --output-on-failure .

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -49,6 +49,7 @@ cmake -S ${src_dir} -B ${build_dir} -DCMAKE_INSTALL_PREFIX=${dest_dir} ${cmake_a
 cmake --build ${build_dir} --parallel ${num_jobs} ${verbose}
 
 if test "${run_tests}" = "Y"; then
+  export LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
   ctest --test-dir ${build_dir} --parallel 2 --output-on-failure
 fi
 


### PR DESCRIPTION
This is needed on Fedora where, for a yet-unknown reason, the RUNPATH does not include /usr/lib even though

1) DYNINST_FORCE_RUNPATH=ON

2) `ldd libsymtabAPI.so` clearly shows that pe-parse.so resolves to /usr/lib/pe-parse.so.

Even more vexxing is that it works correctly when the idential container and commands are run locally (i.e., not in GitHub).