### PR TITLE
GitHubCI: don't build extrae on ubuntu-24.10

### DIFF
--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -356,7 +356,7 @@ jobs:
 
         # extrae does not build with gcc-14 (the default compiler on the latest fedora)
       - name: Build extrae
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.os != 'ubuntu-24.10'}}
         shell: bash
         run: |
           set -ex


### PR DESCRIPTION
There's a bug in their config I haven't been able to fix, so just exclude it for now.