### PR TITLE
Remove SymtabAPI convertCharToString

### DIFF
--- a/symtabAPI/src/parseDwarf.C
+++ b/symtabAPI/src/parseDwarf.C
@@ -54,15 +54,6 @@ using namespace Dyninst;
 using namespace Dyninst::SymtabAPI;
 
 
-std::string convertCharToString(char *ptr)
-{
-  std::string str;
-  if (ptr)
-    str = ptr;
-  else
-    str = "";
-  return str;	
-}
 
 bool ObjectELF::hasFrameDebugInfo()
 {


### PR DESCRIPTION
This one isn't used. There is another copy in Object-nt.C that is.