### PR TITLE
adjust handling for indirect jump analysis for AMD GPUs

### DIFF
--- a/dataflowAPI/src/ExpressionConversionVisitor.C
+++ b/dataflowAPI/src/ExpressionConversionVisitor.C
@@ -163,7 +163,6 @@ void ExpressionConversionVisitor::visit(RegisterAST *regast) {
 
 void ExpressionConversionVisitor::visit(MultiRegisterAST * ) {
     roseExpression = NULL;
-    assert(0);
 }
 
 void ExpressionConversionVisitor::visit(Dereference *deref) {

--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -112,6 +112,8 @@ bool IndirectControlFlowAnalyzer::NewJumpTableAnalysis(std::vector<std::pair< Ad
 
         auto old_ast = symRet[assignments[0]];
 
+	if (!old_ast) return false;
+
         auto new_ast = se.SimplifyAnAST(old_ast,0,false);
 
         /*do {


### PR DESCRIPTION
Don't assert or SEGV during indirect jump analysis if analysis can't proceed because an AST node is NULL.

If analysis yields a NULL AST node, analysis is simply over.