### PR TITLE
CMake: update detection of static libraries

### DIFF
--- a/cmake/Modules/DyninstLinkProperties.cmake
+++ b/cmake/Modules/DyninstLinkProperties.cmake
@@ -1,15 +1,29 @@
 include_guard(GLOBAL)
 
-include(CheckCSourceCompiles)
-include(CheckCXXSourceCompiles)
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 
 # Check if the CMAKE_<LANG>_COMPILER supports static linking
-set(_CMAKE_REQUIRED_LIBRARIES_BAK ${CMAKE_REQUIRED_LIBRARIES})
-set(CMAKE_REQUIRED_LIBRARIES "-static")
 
-set(_src_code "int main(){ return 0; }")
+# gcc and clang both use '-static', but allow for other compilers
+set(_possible_static_flags "-static")
 
-check_c_source_compiles("${_src_code}" DYNINST_C_STATIC_LINK)
-check_cxx_source_compiles("${_src_code}" DYNINST_CXX_STATIC_LINK)
+foreach(_flag ${_possible_static_flags})
+  set(_saved_link_opts ${CMAKE_REQUIRED_LINK_OPTIONS})
 
-set(CMAKE_REQUIRED_LIBRARIES ${_CMAKE_REQUIRED_LIBRARIES_BAK})
+  set(CMAKE_REQUIRED_LINK_OPTIONS "${_flag}")
+
+  check_c_compiler_flag("${_flag}" DYNINST_C_HAVE_STATIC_LINK_FLAG)
+
+  if(DYNINST_C_HAVE_STATIC_LINK_FLAG AND NOT DYNINST_C_STATIC_LINK_FLAG)
+    set(DYNINST_C_STATIC_LINK_FLAG "${_flag}" CACHE STRING "C static link flag" FORCE)
+  endif()
+
+  check_cxx_compiler_flag("${_flag}" DYNINST_CXX_HAVE_STATIC_LINK_FLAG)
+
+  if(DYNINST_CXX_HAVE_STATIC_LINK_FLAG AND NOT DYNINST_CXX_STATIC_LINK_FLAG)
+    set(DYNINST_CXX_STATIC_LINK_FLAG "${_flag}" CACHE STRING "C++ static link flag" FORCE)
+  endif()
+
+  set(CMAKE_REQUIRED_LINK_OPTIONS "${_saved_link_opts}")
+endforeach()

--- a/tests/regression/symtabAPI/Symtab/file_properties/CMakeLists.txt
+++ b/tests/regression/symtabAPI/Symtab/file_properties/CMakeLists.txt
@@ -53,7 +53,7 @@ foreach(main_t "hasmain" "none")
 endforeach()
 
 # Test static libraries
-if(DYNINST_CXX_STATIC_LINK)
+if(DYNINST_CXX_HAVE_STATIC_LINK_FLAG)
   make_lib_test(STATIC "staticlib")
 endif()
 
@@ -62,7 +62,7 @@ foreach(strip_t "stripped" "none")
   foreach(pic_t "pic" "none")
     foreach(link_t "staticlink" "dynlink")
 
-      if(link_t STREQUAL "staticlink" AND NOT DYNINST_CXX_STATIC_LINK)
+      if(link_t STREQUAL "staticlink" AND NOT DYNINST_CXX_HAVE_STATIC_LINK_FLAG)
         continue()
       endif()
 


### PR DESCRIPTION
Since we require CMake >= v3.14.0, then we can use CMAKE_REQUIRED_LINK_OPTIONS. Update names to follow standard conventions.