### PR TITLE
CMake: update detection of 32-bit runtime

### DIFF
--- a/cmake/Modules/DyninstCheck32bitRuntimeSupported.cmake
+++ b/cmake/Modules/DyninstCheck32bitRuntimeSupported.cmake
@@ -1,0 +1,107 @@
+#[=======================================================================[.rst:
+Dyninst32bitRuntimeSupported
+----------------------------
+
+This module provides the ``dyninst_check_32bit_runtime_supported()`` function
+to check whether the linker supports dynamically or statically linking to a
+32-bit runtime.
+
+.. command:: dyninst_check_32bit_runtime_supported
+
+  .. code-block:: cmake
+
+    dyninst_check_32bit_runtime_supported([LANGUAGES <lang>...])
+
+  Options are:
+
+  ``LANGUAGES <lang>...``
+    Check the linkers used for each of the specified languages.
+    If this option is not provided, the command checks all enabled languages.
+
+Variables
+^^^^^^^^^
+
+For each language checked, ``dyninst_check_32bit_runtime_supported()`` function
+defines the follow cache variables:
+
+ ``DYNINST_<lang>_32BIT_RUNTIME_SUPPORTED``
+   Set to true if a 32-bit runtime is supported by the linker and false otherwise.
+
+ ``DYNINST_<lang>_32BIT_RUNTIME_FLAG``
+   The flag needed to use a 32-bit runtime or blank otherwise.
+
+ ``DYNINST_<lang>_32BIT_STATIC_RUNTIME_SUPPORTED``
+   Set to true if a static 32-bit runtime is supported by the linker and false otherwise.
+
+ ``DYNINST_<lang>_32BIT_STATIC_RUNTIME_FLAG``
+   The flag needed to use a static 32-bit runtime or blank otherwise.
+
+#]=======================================================================]
+include_guard(GLOBAL)
+
+include(DyninstCheckCompilerFlag)
+
+function(dyninst_check_32bit_runtime_supported)
+
+  cmake_parse_arguments(_dyn32rt_args "" "" "LANGUAGES" "${ARGN}")
+  if(_dyn32rt_args_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "Unparsed arguments: ${_dyn32rt_args_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(_dyn32rt_args_LANGUAGES)
+    set(_languages "${_dyn32rt_args_LANGUAGES}")
+  else()
+    # User did not set any languages, use defaults
+    get_property(_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+  endif()
+
+  # gcc and clang both use 'm32', but allow for other compilers
+  set(_possible_32bit_flags "-m32")
+
+  foreach(_32bit_flag ${_possible_32bit_flags})
+    set(_saved_link_opts ${CMAKE_REQUIRED_LINK_OPTIONS})
+
+    set(CMAKE_REQUIRED_LINK_OPTIONS "${_32bit_flag}")
+
+    foreach(_lang ${_languages})
+      _dyn32bitrt_int(${_lang} ${_32bit_flag} "")
+
+      # gcc and clang both use '-static', but allow for other compilers
+      set(_possible_static_flags "-static")
+
+      foreach(_static_flag ${_possible_static_flags})
+        _dyn32bitrt_int(${_lang} ${_32bit_flag} ${_static_flag})
+      endforeach()
+    endforeach()
+
+    set(CMAKE_REQUIRED_LINK_OPTIONS "${_saved_link_opts}")
+  endforeach()
+
+endfunction()
+
+function(_dyn32bitrt_int _lang _32bit_flag _static_flag)
+  if(_static_flag)
+    set(_sname "STATIC_")
+    set(_smsg "static")
+  endif()
+
+  set(_32rf DYNINST_${_lang}_32BIT_${_sname}RUNTIME_FLAG)
+
+  # If a flag has already been found, don't re-check.
+  if(${_32rf})
+    return()
+  endif()
+
+  set(_32rs DYNINST_${_lang}_32BIT_${_sname}RUNTIME_SUPPORTED)
+
+  dyninst_check_compiler_flag(${_lang} "${_32bit_flag} ${_static_flag}" ${_32rs})
+
+  set(${_32rs}
+      ${${_32rs}}
+      CACHE BOOL "${_lang} ${_smsg} 32-bit runtime supported" FORCE)
+
+  set(${_32rf}
+      "${_32bit_flag}"
+      CACHE STRING "${_lang} ${_smsg} 32-bit runtime flag" FORCE)
+
+endfunction()

--- a/dyninstAPI_RT/CMakeLists.txt
+++ b/dyninstAPI_RT/CMakeLists.txt
@@ -83,18 +83,19 @@ foreach(t ${dyninstAPI_RT_TARGETS})
 endforeach()
 
 if(BUILD_RTLIB_32)
-  include(CheckCCompilerFlag)
+  include(DyninstCheck32bitRuntimeSupported)
+  dyninst_check_32bit_runtime_supported(LANGUAGES C)
 
-  # '-m32' is really a linker option, but CMAKE_REQUIRED_LINK_OPTIONS isn't available until
-  # cmake-3.14.0, so hijack the libraries argument instead.
-  set(_m ${CMAKE_REQUIRED_LIBRARIES})
-  list(APPEND CMAKE_REQUIRED_LIBRARIES "-m32")
-  check_c_compiler_flag("-m32" _has_mabi)
-  set(CMAKE_REQUIRED_LIBRARIES ${_m})
-  unset(_m)
+  if(NOT DYNINST_C_32BIT_RUNTIME_SUPPORTED)
+    message(
+      FATAL_ERROR "BUILD_RTLIB_32 enabled, but compiler doesn't support 32-bit runtime")
+  endif()
 
-  if(NOT _has_mabi)
-    message(FATAL_ERROR "BUILD_RTLIB_32 enabled, but compiler doesn't support '-m32'")
+  if(ENABLE_STATIC_LIBS)
+    if(NOT DYNINST_C_32BIT_STATIC_RUNTIME_SUPPORTED)
+      message(FATAL_ERROR "32-bit static runtime not supported")
+    endif()
+    set(_force_static FORCE_STATIC)
   endif()
 
   if(NOT DYNINST_OS_UNIX)
@@ -119,12 +120,13 @@ if(BUILD_RTLIB_32)
 	  SOURCE_FILES ${_sources} src/RTthread-x86.c src/RTtlsgetaddr-x86.S
 	  DEFINES "MUTATEE_32"
 	  PRIVATE_DEPS Threads::Threads
+	  ${_force_static}
 	)
 	# cmake-format: on
 
   foreach(t ${dyninstAPI_RT_m32_TARGETS})
-    target_compile_options(${t} PRIVATE "-m32")
-    target_link_options(${t} PRIVATE "-m32")
+    target_compile_options(${t} PRIVATE "${DYNINST_C_32BIT_RUNTIME_FLAG}")
+    target_link_options(${t} PRIVATE "${DYNINST_C_32BIT_RUNTIME_FLAG}")
 
     target_include_directories(
       ${t} BEFORE PRIVATE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/common/h>")
@@ -136,8 +138,13 @@ if(BUILD_RTLIB_32)
     endif()
 
     if(${t} MATCHES "static")
+      # Both shared and static should be named 'dyninstAPI_RT_m32'- only extension differs
+      set_property(TARGET ${t} PROPERTY OUTPUT_NAME dyninstAPI_RT_m32)
+
       target_sources(${t} PRIVATE ${static_sources} src/RTstatic_ctors_dtors-x86.c)
       target_compile_definitions(${t} PRIVATE DYNINST_RT_STATIC_LIB)
+      target_compile_options(${t} PRIVATE "${DYNINST_C_32BIT_STATIC_RUNTIME_FLAG}")
+      target_link_options(${t} PRIVATE "${DYNINST_C_32BIT_STATIC_RUNTIME_FLAG}")
     endif()
   endforeach()
 endif()


### PR DESCRIPTION
Requires #1965 

This also fixes a bug in the filename generated for the 32-bit static dyninstAPI_RT.