### PR TITLE
Refactor Codegen as a first step for removing ifdefs

### DIFF
--- a/common/src/arch-aarch64.h
+++ b/common/src/arch-aarch64.h
@@ -56,7 +56,7 @@ namespace NS_aarch64 {
 //#define UNCOND_BR_REG_MASK  (0xfe000000)
 //#define UNCOND_BR_REG       (0xd6000000)
 
-#define BREAK_POINT_INSN 0xd4200000
+const uint64_t BREAK_POINT_INSN=0xd4200000;
 
 #define BOp             0x05
 #define BCondOp         0x2A
@@ -95,17 +95,17 @@ namespace NS_aarch64 {
 
 #define MIN_IMM8    (-128)
 #define MAX_IMM8    (127)
-#define MIN_IMM16   (-32768)
-#define MAX_IMM16   (32767)
-#define MIN_IMM32   (-2147483647 - 1)
-#define MAX_IMM32   (2147483647)
+const uint64_t MIN_IMM16   =(-32768);
+const uint64_t MAX_IMM16   = (32767);
+const uint64_t MIN_IMM32   = (-2147483647 - 1);
+const uint64_t MAX_IMM32   (2147483647);
 #define MAX_IMM48   ((long)(-1 >> 17))
 #define MIN_IMM48   ((long)(~MAX_IMM48))
 #define MAX_IMM52   ((long)(1 << 52))
 #define MIN_IMM52   ((long)(~MAX_IMM52))
 
 //Would probably want to use the register category as well (FPR/SPR/GPR), but for the uses of these macros, this should suffice
-#define SPR_LR      (((Dyninst::aarch64::x29).val()) & 0x1F)
+const uint64_t SPR_LR   =   (((Dyninst::aarch64::x29).val()) & 0x1F);
 #define SPR_NZCV    (((Dyninst::aarch64::nzcv).val()) & 0x1F)
 #define SPR_FPCR    (((Dyninst::aarch64::fpcr).val()) & 0x1F)
 #define SPR_FPSR    (((Dyninst::aarch64::fpsr).val()) & 0x1F)
@@ -173,9 +173,6 @@ typedef union {
 
 typedef instructUnion codeBuf_t;
 typedef unsigned codeBufIndex_t;
-
-#define maxGPR 31           /* More space than is needed */
-#define maxFPR 32           /* Save FPRs 0-13 */
 
 // Helps to mitigate host/target endian mismatches
 unsigned int swapBytesIfNeeded(unsigned int i);

--- a/common/src/arch-power.h
+++ b/common/src/arch-power.h
@@ -370,7 +370,7 @@ typedef instructUnion codeBuf_t;
 typedef unsigned codeBufIndex_t;
 
 #define SPR_XER	1
-#define SPR_LR	8
+const unsigned SPR_LR=8;
 #define SPR_CTR	9
 #define SPR_TAR 815
 #define SPR_MQ 0
@@ -378,10 +378,7 @@ typedef unsigned codeBufIndex_t;
 /*
  * Register saving constants
  */
-#define maxFPR 32           /* Save FPRs 0-13 */
-#define maxGPR 32           /* More space than is needed */
 #define FPRspaceUsed (8*16) /* Aligned space for FPRs */
-#define GPRoffset(reg) (-1* (FPRspaceUsed + 4*(maxGPR-reg)))
 #define GPRspaceUsed (20*4) /* Aligned space for GPRs */
 
 #define stackFrameSize (FPRspaceUsed+GPRspaceUsed+128)
@@ -745,7 +742,7 @@ typedef unsigned codeBufIndex_t;
 
 
 
-#define BREAK_POINT_INSN 0x7d821008  /* trap */
+const uint64_t BREAK_POINT_INSN=0x7d821008;  /* trap */
 
 /* high and low half words.  Useful to load addresses as two parts */
 #define LOW(x)  ((x) & 0xffff)
@@ -763,10 +760,10 @@ typedef unsigned codeBufIndex_t;
 
 #define ABS(x)		((x) > 0 ? x : -x)
 //#define MAX_BRANCH	0x1<<23
-#define MAX_BRANCH      0x01fffffc
+const int64_t MAX_BRANCH    =  0x01fffffc;
 #define MAX_CBRANCH	0x1<<13
 
-#define MAX_IMM		0x1<<15		/* 15 plus sign == 16 bits */
+const int64_t MAX_IMM=		(0x1<<15);		/* 15 plus sign == 16 bits */
 
 // Delcared some other functions in inst-power.C
 // bool isCallInsn(const instruction);
@@ -774,11 +771,11 @@ typedef unsigned codeBufIndex_t;
 
 // Define bounds for immediate offsets.
 // Use strange definitions to avoid compiler warnings.
-#define MAX_IMM16      32767
-#define MIN_IMM16      -32768
+const int64_t MAX_IMM16=    32767;
+const int64_t MIN_IMM16=   -32768;
 
-#define MAX_IMM32      2147483647
-#define MIN_IMM32      (-2147483647 - 1)    // In C90, there are no negative
+const int64_t MAX_IMM32=     2147483647;
+const int64_t MIN_IMM32=      (-2147483647 - 1);    // In C90, there are no negative
                                             // constants. Only negated positive
                                             // constants. Hopefully, compiler
                                             // will optimize this away.

--- a/common/src/arch-x86.h
+++ b/common/src/arch-x86.h
@@ -219,12 +219,6 @@ enum AMD64_REG_NUMBERS {
 }
 ;
 
-#if defined(DYNINST_CODEGEN_ARCH_X86_64)
-#define maxGPR 16
-#else
-#define maxGPR 8
-#endif 
-
 #define READ_OP 0
 #define WRITE_OP 1
 
@@ -446,10 +440,10 @@ enum AMD64_REG_NUMBERS {
 const unsigned char SYSCALL[] = {0x0F, 0x05};
 
 /* limits */
-#define MIN_IMM8 (-128)
-#define MAX_IMM8 (127)
-#define MIN_IMM16 (-32768)
-#define MAX_IMM16 (32767)
+const uint64_t MIN_IMM8 = (-128);
+const uint64_t MAX_IMM8 = (127);
+const uint64_t MIN_IMM16 = (-32768);
+const uint64_t MAX_IMM16 = (32767);
 
 // Size of floating point information saved by FSAVE
 #define FSAVE_STATE_SIZE 108

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -71,6 +71,7 @@ set(_private_headers
     src/IAPI_to_AST.h
     src/image.h
     src/infHeap.h
+    src/insn-codegen.h
     src/inst-aarch64.h
     src/inst.h
     src/instPoint.h
@@ -120,6 +121,7 @@ set(_sources
     src/hybridCallbacks.C
     src/hybridInstrumentation.C
     src/hybridOverwrites.C
+    src/insn-codegen.C
     src/image.C
     src/infHeap.C
     src/inst.C

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget-aarch64.C
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget-aarch64.C
@@ -59,7 +59,7 @@ bool CFWidget::generateIndirect(CodeBuffer &buffer,
     mod_insn.setBits(21, 1, 0);
 
     codeGen gen(4);
-    insnCodeGen::generate(gen, mod_insn);
+    insnCodeGenAarch64::generate(gen, mod_insn);
     buffer.addPIC(gen, tracker(trace));
 
     return true;
@@ -76,7 +76,7 @@ bool CFWidget::generateIndirectCall(CodeBuffer &buffer,
     mod_insn.setBits(21, 1, 1);
 
     codeGen gen(4);
-    insnCodeGen::generate(gen, mod_insn);
+    insnCodeGenAarch64::generate(gen, mod_insn);
     buffer.addPIC(gen, tracker(trace));
     return true;
 }
@@ -103,7 +103,7 @@ bool CFPatch::apply(codeGen &gen, CodeBuffer *buf) {
             case CFPatch::Jump: {
                 relocation_cerr << "\t\t\t Generating CFPatch::Jump from "
                                 << hex << gen.currAddr() << " to " << buf->predictedAddr(targetLabel) << dec << endl;
-                if (!insnCodeGen::modifyJump(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
+                if (!insnCodeGenAarch64::modifyJump(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
                     relocation_cerr << "modifyJump failed, ret false" << endl;
                     return false;
                 }
@@ -112,14 +112,14 @@ bool CFPatch::apply(codeGen &gen, CodeBuffer *buf) {
             case CFPatch::JCC: {
                 relocation_cerr << "\t\t\t Generating CFPatch::JCC from "
                                 << hex << gen.currAddr() << " to " << buf->predictedAddr(targetLabel) << dec << endl;
-                if (!insnCodeGen::modifyJcc(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
+                if (!insnCodeGenAarch64::modifyJcc(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
                     relocation_cerr << "modifyJcc failed, ret false" << endl;
                     return false;
                 }
                 return true;
             }
             case CFPatch::Call: {
-                if (!insnCodeGen::modifyCall(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
+                if (!insnCodeGenAarch64::modifyCall(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
                     relocation_cerr << "modifyCall failed, ret false" << endl;
                     return false;
                 }
@@ -134,10 +134,10 @@ bool CFPatch::apply(codeGen &gen, CodeBuffer *buf) {
     } else {
         switch (type) {
             case CFPatch::Jump:
-                insnCodeGen::generateBranch(gen, gen.currAddr(), buf->predictedAddr(targetLabel));
+                insnCodeGenAarch64::generateBranch(gen, gen.currAddr(), buf->predictedAddr(targetLabel));
                 break;
             case CFPatch::Call:
-                insnCodeGen::generateCall(gen, gen.currAddr(), buf->predictedAddr(targetLabel));
+                insnCodeGenAarch64::generateCall(gen, gen.currAddr(), buf->predictedAddr(targetLabel));
                 break;
             default:
                 assert(0);

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget-x86.C
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget-x86.C
@@ -176,7 +176,7 @@ bool CFPatch::apply(codeGen &gen, CodeBuffer *buf) {
          case CFPatch::Jump: {
             relocation_cerr << "\t\t\t Generating CFPatch::Jump from "
                             << hex << gen.currAddr() << " to " << buf->predictedAddr(targetLabel) << dec << endl;
-            if (!insnCodeGen::modifyJump(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
+            if (!insnCodeGenX86::modifyJump(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
                cerr << "Failed to modify jump" << endl;
                return false;
             }
@@ -185,21 +185,21 @@ bool CFPatch::apply(codeGen &gen, CodeBuffer *buf) {
          case CFPatch::JCC: {
             relocation_cerr << "\t\t\t Generating CFPatch::JCC from "
                             << hex << gen.currAddr() << " to " << buf->predictedAddr(targetLabel) << dec << endl;            
-            if (!insnCodeGen::modifyJcc(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
+            if (!insnCodeGenX86::modifyJcc(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
                cerr << "Failed to modify conditional jump" << endl;
                return false;
             }
             return true;            
          }
          case CFPatch::Call: {
-            if (!insnCodeGen::modifyCall(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
+            if (!insnCodeGenX86::modifyCall(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
                cerr << "Failed to modify call" << endl;
                return false;
             }
             return true;
          }
          case CFPatch::Data: {
-            if (!insnCodeGen::modifyData(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
+            if (!insnCodeGenX86::modifyData(buf->predictedAddr(targetLabel), *ugly_insn, gen)) {
                cerr << "Failed to modify data" << endl;
                return false;
             }
@@ -210,10 +210,10 @@ bool CFPatch::apply(codeGen &gen, CodeBuffer *buf) {
    else {
       switch(type) {
          case CFPatch::Jump:
-            insnCodeGen::generateBranch(gen, gen.currAddr(), buf->predictedAddr(targetLabel));
+            insnCodeGenX86::generateBranch(gen, gen.currAddr(), buf->predictedAddr(targetLabel));
             break;
          case CFPatch::Call:
-            insnCodeGen::generateCall(gen, gen.currAddr(), buf->predictedAddr(targetLabel));
+            insnCodeGenX86::generateCall(gen, gen.currAddr(), buf->predictedAddr(targetLabel));
             break;
          default:
             assert(0);

--- a/dyninstAPI/src/Relocation/Widgets/PCWidget-aarch64.C
+++ b/dyninstAPI/src/Relocation/Widgets/PCWidget-aarch64.C
@@ -54,7 +54,7 @@ bool PCWidget::PCtoReturnAddr(const codeGen &templ, const RelocBlock *t, CodeBuf
     codeGen gen(16);
     gen.applyTemplate(templ);
     Address origRet = addr() + insn_.size();
-    insnCodeGen::loadImmIntoReg(gen, 30 /* LR */, origRet);
+    insnCodeGenAarch64::loadImmIntoReg(gen, 30 /* LR */, origRet);
     buffer.addPIC(gen, tracker(t));
   }
   else {
@@ -71,7 +71,7 @@ bool PCWidget::PCtoReg(const codeGen &templ, const RelocBlock *t, CodeBuffer &bu
   if(templ.addrSpace()->proc()) {
     // Move immediate to register?
     codeGen gen(16);
-    insnCodeGen::loadImmIntoReg(gen, reg, addr_);
+    insnCodeGenAarch64::loadImmIntoReg(gen, reg, addr_);
     buffer.addPIC(gen, tracker(t));
   }
   else {
@@ -106,11 +106,11 @@ bool IPPatch::apply(codeGen &gen, CodeBuffer *) {
   // Load the offset into a scratch register
   std::vector<Register> exclude;
   exclude.push_back(30 /* LR */);
-  Register scratchReg = insnCodeGen::moveValueToReg(gen, labs(RAOffset), &exclude);
+  Register scratchReg = insnCodeGenAarch64::moveValueToReg(gen, labs(RAOffset), &exclude);
   // Put the original RA into LR
-  insnCodeGen::generateAddSubShifted(gen, RAOffset>0?insnCodeGen::Add:insnCodeGen::Sub,
+  insnCodeGenAarch64::generateAddSubShifted(gen, RAOffset>0?insnCodeGenAarch64::Add:insnCodeGenAarch64::Sub,
           0, 0, scratchReg, 30, 30, true);
   // Do a jump to the actual target (so do not overwrite LR)
-  insnCodeGen::generateBranch(gen, gen.currAddr(), addr, false);
+  insnCodeGenAarch64::generateBranch(gen, gen.currAddr(), addr, false);
   return true;
 }

--- a/dyninstAPI/src/Relocation/Widgets/PCWidget-ppc.C
+++ b/dyninstAPI/src/Relocation/Widgets/PCWidget-ppc.C
@@ -72,15 +72,15 @@ bool PCWidget::PCtoReturnAddr(const codeGen &templ, const RelocBlock *t, CodeBuf
     Register scratch = gen.rs()->getScratchRegister(gen, true);
     bool createFrame = false;
     if (scratch == Null_Register) {
-      stackSize = insnCodeGen::createStackFrame(gen, 1, freeReg, excludeReg);
+      stackSize = insnCodeGenPower::createStackFrame(gen, 1, freeReg, excludeReg);
       assert(stackSize == 1);
       scratch = freeReg[0];
       createFrame = true;
     }
-    insnCodeGen::loadImmIntoReg(gen, scratch, origRet);
-    insnCodeGen::generateMoveToLR(gen, scratch);
+    insnCodeGenPower::loadImmIntoReg(gen, scratch, origRet);
+    insnCodeGenPower::generateMoveToLR(gen, scratch);
     if (createFrame) {
-      insnCodeGen::removeStackFrame(gen);
+      insnCodeGenPower::removeStackFrame(gen);
     }
     buffer.addPIC(gen, tracker(t));
   }
@@ -97,7 +97,7 @@ bool PCWidget::PCtoReg(const codeGen &templ, const RelocBlock *t, CodeBuffer &bu
   if(templ.addrSpace()->proc()) {
     // Move immediate to register?
     codeGen gen(16);
-    insnCodeGen::loadImmIntoReg(gen, reg, addr_);
+    insnCodeGenPower::loadImmIntoReg(gen, reg, addr_);
     buffer.addPIC(gen, tracker(t));
   }
   else {
@@ -139,13 +139,13 @@ bool IPPatch::apply(codeGen &gen, CodeBuffer *) {
     
   if ((scratchPCReg == Null_Register) && (scratchReg == Null_Register)) {
     excludeReg.clear();
-    stackSize = insnCodeGen::createStackFrame(gen, 2, freeReg, excludeReg);
+    stackSize = insnCodeGenPower::createStackFrame(gen, 2, freeReg, excludeReg);
     assert(stackSize == 2);
     scratchPCReg = freeReg[0];
     scratchReg = freeReg[1];
       
   } else if (scratchReg == Null_Register && scratchPCReg != Null_Register) {
-    stackSize = insnCodeGen::createStackFrame(gen, 1, freeReg, excludeReg);
+    stackSize = insnCodeGenPower::createStackFrame(gen, 1, freeReg, excludeReg);
     assert(stackSize == 1);
     scratchReg = freeReg[0];
   } 
@@ -156,15 +156,15 @@ bool IPPatch::apply(codeGen &gen, CodeBuffer *) {
   // relocaAddr may have moved if we added instructions to setup a new stack frame
   Address newRelocAddr = gen.currAddr();
     
-  insnCodeGen::generateBranch(gen, gen.currAddr(),  gen.currAddr()+4, true); // blrl
-  insnCodeGen::generateMoveFromLR(gen, scratchPCReg); // mflr
+  insnCodeGenPower::generateBranch(gen, gen.currAddr(),  gen.currAddr()+4, true); // blrl
+  insnCodeGenPower::generateMoveFromLR(gen, scratchPCReg); // mflr
     
   Address varOffset = addr - newRelocAddr;
   gen.emitter()->emitCallRelative(scratchReg, varOffset, scratchPCReg, gen);
-  insnCodeGen::generateMoveToLR(gen, scratchReg);
+  insnCodeGenPower::generateMoveToLR(gen, scratchReg);
 
   if( stackSize > 0) {
-    insnCodeGen::removeStackFrame(gen); 
+    insnCodeGenPower::removeStackFrame(gen); 
   }
   return true;
 }

--- a/dyninstAPI/src/Relocation/Widgets/PCWidget-x86.C
+++ b/dyninstAPI/src/Relocation/Widgets/PCWidget-x86.C
@@ -56,7 +56,7 @@ bool PCWidget::PCtoReturnAddr(const codeGen &templ, const RelocBlock *t, CodeBuf
     if (templ.getArch() == Arch_x86_64) {
         codeGen gen(16);
         Address RIP = addr_ + insn_.size();
-        insnCodeGen::generatePush64(gen, RIP);
+        insnCodeGenX86::generatePush64(gen, RIP);
         buffer.addPIC(gen, tracker(t));
     } else if (templ.getArch() == Arch_x86) {
         newInsn.push_back(0x68); // push

--- a/dyninstAPI/src/codegen-aarch64.C
+++ b/dyninstAPI/src/codegen-aarch64.C
@@ -38,27 +38,27 @@
 #include "dyninstAPI/src/emit-aarch64.h"
 #include "dyninstAPI/src/function.h"
 
-void insnCodeGen::generate(codeGen &gen, instruction &insn) {
+void insnCodeGenAarch64::generate(codeGen &gen, instruction &insn) {
   unsigned raw = insn.asInt();
   gen.copy(&raw, sizeof(unsigned));
 }
 
-void insnCodeGen::generate(codeGen &gen, instruction &insn, unsigned position) {
+void insnCodeGenAarch64::generate(codeGen &gen, instruction &insn, unsigned position) {
     unsigned raw = insn.asInt();
     gen.insert(&raw, sizeof(unsigned), position);
 }
 
-void insnCodeGen::generateIllegal(codeGen &gen) {
+void insnCodeGenAarch64::generateIllegal(codeGen &gen) {
     instruction insn;
     generate(gen,insn);
 }
 
-void insnCodeGen::generateTrap(codeGen &gen) {
+void insnCodeGenAarch64::generateTrap(codeGen &gen) {
     instruction insn(BREAK_POINT_INSN);
     generate(gen,insn);
 }
 
-void insnCodeGen::generateBranch(codeGen &gen, long disp, bool link) {
+void insnCodeGenAarch64::generateBranch(codeGen &gen, long disp, bool link) {
     if (labs(disp) > MAX_BRANCH_OFFSET) {
         fprintf(stderr, "ABS OFF: 0x%lx, MAX: 0x%lx\n",
                 (unsigned long)labs(disp), (unsigned long) MAX_BRANCH_OFFSET);
@@ -80,10 +80,10 @@ void insnCodeGen::generateBranch(codeGen &gen, long disp, bool link) {
     else
         INSN_SET(insn, 31, 31, 0);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 }
 
-void insnCodeGen::generateBranch(codeGen &gen, Dyninst::Address from, Dyninst::Address to, bool link) {
+void insnCodeGenAarch64::generateBranch(codeGen &gen, Dyninst::Address from, Dyninst::Address to, bool link) {
     long disp = (to - from);
 
     if (labs(disp) > MAX_BRANCH_OFFSET) {
@@ -92,11 +92,11 @@ void insnCodeGen::generateBranch(codeGen &gen, Dyninst::Address from, Dyninst::A
         generateBranch(gen, disp, link);
 }
 
-void insnCodeGen::generateCall(codeGen &gen, Dyninst::Address from, Dyninst::Address to) {
+void insnCodeGenAarch64::generateCall(codeGen &gen, Dyninst::Address from, Dyninst::Address to) {
     generateBranch(gen, from, to, true);
 }
 
-void insnCodeGen::generateLongBranch(codeGen &gen,
+void insnCodeGenAarch64::generateLongBranch(codeGen &gen,
                                      Dyninst::Address from,
                                      Dyninst::Address to,
                                      bool isCall) 
@@ -119,7 +119,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
         if(isCall)
             INSN_SET(branchInsn, 21, 21, 1);
 
-        insnCodeGen::generate(gen, branchInsn);
+        insnCodeGenAarch64::generate(gen, branchInsn);
     };
 
     Dyninst::Register scratch = Null_Register;
@@ -155,7 +155,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
     generateBReg(scratch);
 }
 
-void insnCodeGen::generateBranchViaTrap(codeGen &gen, Dyninst::Address from, Dyninst::Address to, bool isCall) {
+void insnCodeGenAarch64::generateBranchViaTrap(codeGen &gen, Dyninst::Address from, Dyninst::Address to, bool isCall) {
     long disp = to - from;
     if (labs(disp) <= MAX_BRANCH_OFFSET) {
         // We shouldn't be here, since this is an internal-called-only func.
@@ -167,7 +167,7 @@ void insnCodeGen::generateBranchViaTrap(codeGen &gen, Dyninst::Address from, Dyn
     if (gen.addrSpace()) {
         // Too far to branch.  Use trap-based instrumentation.
         gen.addrSpace()->trapMapping.addTrapMapping(from, to, true);
-        insnCodeGen::generateTrap(gen);
+        insnCodeGenAarch64::generateTrap(gen);
     } else {
         // Too far to branch and no proc to register trap.
         fprintf(stderr, "ABS OFF: 0x%lx, MAX: 0x%lx\n",
@@ -180,7 +180,7 @@ void insnCodeGen::generateBranchViaTrap(codeGen &gen, Dyninst::Address from, Dyn
     }
 }
 
-void insnCodeGen::generateConditionalBranch(codeGen& gen, Dyninst::Address to, unsigned opcode, bool s)
+void insnCodeGenAarch64::generateConditionalBranch(codeGen& gen, Dyninst::Address to, unsigned opcode, bool s)
 {
     instruction insn;
     insn.clear();
@@ -213,12 +213,12 @@ void insnCodeGen::generateConditionalBranch(codeGen& gen, Dyninst::Address to, u
     //Set condition 
     INSN_SET(insn, 0, 3, getConditionCode());
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 }
 
 
-void insnCodeGen::generateAddSubShifted(
-        codeGen &gen, insnCodeGen::ArithOp op, int shift, int imm6, Dyninst::Register rm,
+void insnCodeGenAarch64::generateAddSubShifted(
+        codeGen &gen, insnCodeGenAarch64::ArithOp op, int shift, int imm6, Dyninst::Register rm,
         Dyninst::Register rn, Dyninst::Register rd, bool is64bit)
 {
     instruction insn;
@@ -243,11 +243,11 @@ void insnCodeGen::generateAddSubShifted(
     INSN_SET(insn, 5, 9, rn);
     INSN_SET(insn, 16, 20, rm);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 }
 
-void insnCodeGen::generateAddSubImmediate(
-        codeGen &gen, insnCodeGen::ArithOp op, int shift, int imm12, Dyninst::Register rn, Dyninst::Register rd, bool is64bit)
+void insnCodeGenAarch64::generateAddSubImmediate(
+        codeGen &gen, insnCodeGenAarch64::ArithOp op, int shift, int imm12, Dyninst::Register rn, Dyninst::Register rd, bool is64bit)
 {
     instruction insn;
     insn.clear();
@@ -269,10 +269,10 @@ void insnCodeGen::generateAddSubImmediate(
     INSN_SET(insn, 5, 9, rn);
     INSN_SET(insn, 0, 4, rd);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 }
 
-void insnCodeGen::generateMul(codeGen &gen, Dyninst::Register rm, Dyninst::Register rn, Dyninst::Register rd, bool is64bit) {
+void insnCodeGenAarch64::generateMul(codeGen &gen, Dyninst::Register rm, Dyninst::Register rn, Dyninst::Register rd, bool is64bit) {
     instruction insn;
     insn.clear();
 
@@ -290,11 +290,11 @@ void insnCodeGen::generateMul(codeGen &gen, Dyninst::Register rm, Dyninst::Regis
     INSN_SET(insn, 5, 9, rn);
     INSN_SET(insn, 0, 4, rd);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 }
 
 //#sasha is rm or rn the denominator?
-void insnCodeGen::generateDiv(
+void insnCodeGenAarch64::generateDiv(
         codeGen &gen, Dyninst::Register rm, Dyninst::Register rn, Dyninst::Register rd, bool is64bit, bool s)
 {
     instruction insn;
@@ -319,12 +319,12 @@ void insnCodeGen::generateDiv(
     INSN_SET(insn, 5, 9, rn);
     INSN_SET(insn, 0, 4, rd);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 
 }
 
-void insnCodeGen::generateBitwiseOpShifted(
-        codeGen &gen, insnCodeGen::BitwiseOp op, int shift, Dyninst::Register rm, int imm6,
+void insnCodeGenAarch64::generateBitwiseOpShifted(
+        codeGen &gen, insnCodeGenAarch64::BitwiseOp op, int shift, Dyninst::Register rm, int imm6,
         Dyninst::Register rn, Dyninst::Register rd, bool is64bit)
 {
     instruction insn;
@@ -337,14 +337,14 @@ void insnCodeGen::generateBitwiseOpShifted(
     //Set opcode
     int opcode;
     switch(op) {
-        case insnCodeGen::And: opcode = ANDShiftOp;
+        case insnCodeGenAarch64::And: opcode = ANDShiftOp;
             break;
-        case insnCodeGen::Or: opcode = ORRShiftOp;
+        case insnCodeGenAarch64::Or: opcode = ORRShiftOp;
             break;
-        case insnCodeGen::Eor: opcode = EORShiftOp;
+        case insnCodeGenAarch64::Eor: opcode = EORShiftOp;
             break;
         default:
-            assert(!"insnCodeGen::generateBitwiseOpShifted op is not And, Or or Eor");
+            assert(!"insnCodeGenAarch64::generateBitwiseOpShifted op is not And, Or or Eor");
     }
     INSN_SET(insn, 24, 30, opcode);
 
@@ -361,38 +361,38 @@ void insnCodeGen::generateBitwiseOpShifted(
     INSN_SET(insn, 5, 9, rn);
     INSN_SET(insn, 0, 4, rd);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 }
 
-void insnCodeGen::generateLoadReg(codeGen &, Dyninst::Register,
+void insnCodeGenAarch64::generateLoadReg(codeGen &, Dyninst::Register,
                                   Dyninst::Register, Dyninst::Register)
 {
     assert(0);
 //#warning "This function is not implemented yet!"
 }
 
-void insnCodeGen::generateStoreReg(codeGen &, Dyninst::Register,
+void insnCodeGenAarch64::generateStoreReg(codeGen &, Dyninst::Register,
                                    Dyninst::Register, Dyninst::Register)
 {
     assert(0);
 //#warning "This function is not implemented yet!"
 }
 
-void insnCodeGen::generateLoadReg64(codeGen &, Dyninst::Register,
+void insnCodeGenAarch64::generateLoadReg64(codeGen &, Dyninst::Register,
                                     Dyninst::Register, Dyninst::Register)
 {
 assert(0);
 //#warning "This function is not implemented yet!"
 }
 
-void insnCodeGen::generateStoreReg64(codeGen &, Dyninst::Register,
+void insnCodeGenAarch64::generateStoreReg64(codeGen &, Dyninst::Register,
                                      Dyninst::Register, Dyninst::Register)
 {
 assert(0);
 //#warning "This function is not implemented yet!"
 }
 
-void insnCodeGen::generateMove(codeGen &gen, int imm16, int shift, Dyninst::Register rd, MoveOp movOp)
+void insnCodeGenAarch64::generateMove(codeGen &gen, int imm16, int shift, Dyninst::Register rd, MoveOp movOp)
 {
     instruction insn;
     insn.clear();
@@ -412,16 +412,16 @@ void insnCodeGen::generateMove(codeGen &gen, int imm16, int shift, Dyninst::Regi
     //Set shift amount for immediate
     INSN_SET(insn, 21, 22, (shift & 0x3));
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 }
 
-void insnCodeGen::generateMove(
+void insnCodeGenAarch64::generateMove(
         codeGen &gen, Dyninst::Register rd, Dyninst::Register rm, bool is64bit)
 {
-    insnCodeGen::generateBitwiseOpShifted(gen, insnCodeGen::Or, 0, rm, 0, 0x1f, rd, is64bit);  
+    insnCodeGenAarch64::generateBitwiseOpShifted(gen, insnCodeGenAarch64::Or, 0, rm, 0, 0x1f, rd, is64bit);  
 }
 
-void insnCodeGen::generateMoveSP(codeGen &gen, Dyninst::Register rn, Dyninst::Register rd, bool is64bit) {
+void insnCodeGenAarch64::generateMoveSP(codeGen &gen, Dyninst::Register rn, Dyninst::Register rd, bool is64bit) {
     instruction insn;
     insn.clear();
 
@@ -435,11 +435,11 @@ void insnCodeGen::generateMoveSP(codeGen &gen, Dyninst::Register rn, Dyninst::Re
     //Set if using 64-bit registers
     INSN_SET(insn, 31, 31, is64bit);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 }
 
 
-Dyninst::Register insnCodeGen::moveValueToReg(codeGen &gen, long int val, std::vector<Dyninst::Register> *exclude) {
+Dyninst::Register insnCodeGenAarch64::moveValueToReg(codeGen &gen, long int val, std::vector<Dyninst::Register> *exclude) {
     Dyninst::Register scratchReg;
     if(exclude)
 	    scratchReg = gen.rs()->getScratchRegister(gen, *exclude, true);
@@ -463,7 +463,7 @@ Dyninst::Register insnCodeGen::moveValueToReg(codeGen &gen, long int val, std::v
 //     LDRH/STRH  (immediate) for 16-bit
 //
 // Encoding classes allowed: Post-index, Pre-index and Unsigned Offset
-void insnCodeGen::generateMemAccess(codeGen &gen, LoadStore accType,
+void insnCodeGenAarch64::generateMemAccess(codeGen &gen, LoadStore accType,
         Dyninst::Register r1, Dyninst::Register r2, int immd, unsigned size, IndexMode im)
 {
     instruction insn;
@@ -493,11 +493,11 @@ void insnCodeGen::generateMemAccess(codeGen &gen, LoadStore accType,
     INSN_SET(insn, 0, 4, r1 & 0x1F);
     INSN_SET(insn, 5, 9, r2 & 0x1F);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 }
 
 // This is for generating STR/LDR (SIMD&FP) (immediate) for indexing modes of Post, Pre and Offset
-void insnCodeGen::generateMemAccessFP(codeGen &gen, LoadStore accType,
+void insnCodeGenAarch64::generateMemAccessFP(codeGen &gen, LoadStore accType,
         Dyninst::Register rt, Dyninst::Register rn, int immd, int size, bool is128bit, IndexMode im)
 {
     instruction insn;
@@ -535,32 +535,32 @@ void insnCodeGen::generateMemAccessFP(codeGen &gen, LoadStore accType,
     INSN_SET(insn, 0, 4, rt);
     INSN_SET(insn, 5, 9, rn);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenAarch64::generate(gen, insn);
 }
 
 // rlwinm ra,rs,n,0,31-n
-void insnCodeGen::generateLShift(codeGen &, Dyninst::Register, int, Dyninst::Register)
+void insnCodeGenAarch64::generateLShift(codeGen &, Dyninst::Register, int, Dyninst::Register)
 {
 assert(0);
 //#warning "This function is not implemented yet!"
 }
 
 // rlwinm ra,rs,32-n,n,31
-void insnCodeGen::generateRShift(codeGen &, Dyninst::Register, int, Dyninst::Register)
+void insnCodeGenAarch64::generateRShift(codeGen &, Dyninst::Register, int, Dyninst::Register)
 {
 assert(0);
 //#warning "This function is not implemented yet!"
 }
 
 // sld ra, rs, rb
-void insnCodeGen::generateLShift64(codeGen &, Dyninst::Register, int, Dyninst::Register)
+void insnCodeGenAarch64::generateLShift64(codeGen &, Dyninst::Register, int, Dyninst::Register)
 {
 assert(0);
 //#warning "This function is not implemented yet!"
 }
 
 // srd ra, rs, rb
-void insnCodeGen::generateRShift64(codeGen &, Dyninst::Register, int, Dyninst::Register)
+void insnCodeGenAarch64::generateRShift64(codeGen &, Dyninst::Register, int, Dyninst::Register)
 {
 assert(0);
 //not implemented
@@ -570,16 +570,16 @@ assert(0);
 // generate an instruction that does nothing and has to side affect except to
 //   advance the program counter.
 //
-void insnCodeGen::generateNOOP(codeGen &gen, unsigned size) {
+void insnCodeGenAarch64::generateNOOP(codeGen &gen, unsigned size) {
     assert((size % instruction::size()) == 0);
     while (size) {
         instruction insn(NOOP);
-        insnCodeGen::generate(gen, insn);
+        insnCodeGenAarch64::generate(gen, insn);
         size -= instruction::size();
     }
 }
 
-void insnCodeGen::generateRelOp(codeGen &, int, int, Dyninst::Register,
+void insnCodeGenAarch64::generateRelOp(codeGen &, int, int, Dyninst::Register,
                                 Dyninst::Register, Dyninst::Register)
 {
 assert(0);
@@ -587,13 +587,13 @@ assert(0);
 }
 
 
-void insnCodeGen::saveRegister(codeGen &gen, Dyninst::Register r, int sp_offset, IndexMode im)
+void insnCodeGenAarch64::saveRegister(codeGen &gen, Dyninst::Register r, int sp_offset, IndexMode im)
 {
     generateMemAccess(gen, Store, r, REG_SP, sp_offset, 8, im);
 }
 
 
-void insnCodeGen::restoreRegister(codeGen &gen, Dyninst::Register r, int sp_offset, IndexMode im)
+void insnCodeGenAarch64::restoreRegister(codeGen &gen, Dyninst::Register r, int sp_offset, IndexMode im)
 {
     generateMemAccess(gen, Load, r, REG_SP, sp_offset, 8, im);
 }
@@ -602,24 +602,24 @@ void insnCodeGen::restoreRegister(codeGen &gen, Dyninst::Register r, int sp_offs
 // Helper method.  Fills register with partial value to be completed
 // by an operation with a 16-bit signed immediate.  Such as loads and
 // stores.
-void insnCodeGen::loadPartialImmIntoReg(codeGen &, Dyninst::Register, long)
+void insnCodeGenAarch64::loadPartialImmIntoReg(codeGen &, Dyninst::Register, long)
 {
 assert(0);
 //#warning "This function is not implemented yet!"
 }
 
-int insnCodeGen::createStackFrame(codeGen &, int, std::vector<Dyninst::Register>& freeReg, std::vector<Dyninst::Register>&){
+int insnCodeGenAarch64::createStackFrame(codeGen &, int, std::vector<Dyninst::Register>& freeReg, std::vector<Dyninst::Register>&){
 assert(0);
 //#warning "This function is not implemented yet!"
 		return freeReg.size();
 }
 
-void insnCodeGen::removeStackFrame(codeGen &) {
+void insnCodeGenAarch64::removeStackFrame(codeGen &) {
 assert(0);
 //#warning "This function is not implemented yet!"
 }
 
-bool insnCodeGen::generateMem(codeGen &,
+bool insnCodeGenAarch64::generateMem(codeGen &,
                               instruction&,
                               Dyninst::Address,
                               Dyninst::Address,
@@ -629,21 +629,21 @@ assert(0);
 //#warning "This function is not implemented yet!"
 return false; }
 
-void insnCodeGen::generateMoveFromLR(codeGen &, Dyninst::Register) {
+void insnCodeGenAarch64::generateMoveFromLR(codeGen &, Dyninst::Register) {
 assert(0);
 //#warning "This function is not implemented yet!"
 }
 
-void insnCodeGen::generateMoveToLR(codeGen &, Dyninst::Register) {
+void insnCodeGenAarch64::generateMoveToLR(codeGen &, Dyninst::Register) {
 assert(0);
 //#warning "This function is not implemented yet!"
 }
-void insnCodeGen::generateMoveToCR(codeGen &, Dyninst::Register) {
+void insnCodeGenAarch64::generateMoveToCR(codeGen &, Dyninst::Register) {
 assert(0);
 //#warning "This function is not implemented yet!"
 }
 
-bool insnCodeGen::modifyJump(Dyninst::Address target,
+bool insnCodeGenAarch64::modifyJump(Dyninst::Address target,
                              NS_aarch64::instruction &insn,
                              codeGen &gen) {
     long disp = target - gen.currAddr();
@@ -674,7 +674,7 @@ bool insnCodeGen::modifyJump(Dyninst::Address target,
  * bit-twiddling functions can then be defined if necessary in the codegen-* files 
  * and called as necessary by the common, refactored logic.
 */
-bool insnCodeGen::modifyJcc(Dyninst::Address target,
+bool insnCodeGenAarch64::modifyJcc(Dyninst::Address target,
 			    NS_aarch64::instruction &insn,
 			    codeGen &gen) {
     long disp = target - gen.currAddr();
@@ -725,7 +725,7 @@ bool insnCodeGen::modifyJcc(Dyninst::Address target,
          * So adjust it accordingly.*/
         codeBufIndex_t curIdx = gen.getIndex();
         Dyninst::Address newFrom = origFrom + (unsigned)(curIdx - startIdx);
-        insnCodeGen::generateBranch(gen, newFrom, target);
+        insnCodeGenAarch64::generateBranch(gen, newFrom, target);
     } 
     else
     {
@@ -743,7 +743,7 @@ bool insnCodeGen::modifyJcc(Dyninst::Address target,
     return true;
 }
 
-bool insnCodeGen::modifyCall(Dyninst::Address target,
+bool insnCodeGenAarch64::modifyCall(Dyninst::Address target,
                              NS_aarch64::instruction &insn,
                              codeGen &gen) {
     if (insn.isUncondBranch())
@@ -752,7 +752,7 @@ bool insnCodeGen::modifyCall(Dyninst::Address target,
         return modifyJcc(target, insn, gen);
 }
 
-bool insnCodeGen::modifyData(Dyninst::Address target,
+bool insnCodeGenAarch64::modifyData(Dyninst::Address target,
         NS_aarch64::instruction &insn,
         codeGen &gen) 
 {

--- a/dyninstAPI/src/codegen-aarch64.h
+++ b/dyninstAPI/src/codegen-aarch64.h
@@ -40,7 +40,7 @@ class AddressSpace;
 
 class codeGen;
 
-class insnCodeGen {
+class insnCodeGenAarch64 {
 public:
 
     enum MoveOp {
@@ -113,13 +113,13 @@ public:
 
     static inline void loadImmIntoReg(codeGen &gen, Dyninst::Register rt, Dyninst::Address value)
     {
-        insnCodeGen::generateMove(gen, (value & 0xFFFF), 0, rt, MovOp_MOVZ);
+        insnCodeGenAarch64::generateMove(gen, (value & 0xFFFF), 0, rt, MovOp_MOVZ);
         if(value > 0xFFFF)
-            insnCodeGen::generateMove(gen, ((value >> 16) & 0xFFFF), 0x1, rt, MovOp_MOVK);
+            insnCodeGenAarch64::generateMove(gen, ((value >> 16) & 0xFFFF), 0x1, rt, MovOp_MOVK);
         if(value > 0xFFFFFFFF)
-            insnCodeGen::generateMove(gen, ((value >> 32) & 0xFFFF), 0x2, rt, MovOp_MOVK);
+            insnCodeGenAarch64::generateMove(gen, ((value >> 32) & 0xFFFF), 0x2, rt, MovOp_MOVK);
         if(value > 0xFFFFFFFFFFFF)
-            insnCodeGen::generateMove(gen, ((value >> 48) & 0xFFFF), 0x3, rt, MovOp_MOVK);
+            insnCodeGenAarch64::generateMove(gen, ((value >> 48) & 0xFFFF), 0x3, rt, MovOp_MOVK);
     }
 
     static void saveRegister(codeGen &gen, Dyninst::Register r, int sp_offset, IndexMode im=Offset);

--- a/dyninstAPI/src/codegen-power.C
+++ b/dyninstAPI/src/codegen-power.C
@@ -75,7 +75,7 @@ std::shared_ptr<TrackStacktraces> _global_stack_track;
 
 
 
-void insnCodeGen::generate(codeGen &gen, instruction&insn) {
+void insnCodeGenPower::generate(codeGen &gen, instruction&insn) {
   // void *buffer[50];
   // char **strings;
   // int nptrs;
@@ -127,17 +127,17 @@ void insnCodeGen::generate(codeGen &gen, instruction&insn) {
   gen.copy(&raw, sizeof(unsigned));
 }
 
-void insnCodeGen::generateIllegal(codeGen &gen) {
+void insnCodeGenPower::generateIllegal(codeGen &gen) {
     instruction insn;
     generate(gen,insn);
 }
 
-void insnCodeGen::generateTrap(codeGen &gen) {
-    instruction insn(BREAK_POINT_INSN);
+void insnCodeGenPower::generateTrap(codeGen &gen) {
+    instruction insn(NS_power::BREAK_POINT_INSN);
     generate(gen,insn);
 }
 
-void insnCodeGen::generateBranch(codeGen &gen, long disp, bool link)
+void insnCodeGenPower::generateBranch(codeGen &gen, long disp, bool link)
 {
   //fprintf(stderr, "info: %s:%d: \n", __FILE__, __LINE__); 
     if (ABS(disp) > MAX_BRANCH) {
@@ -161,13 +161,13 @@ void insnCodeGen::generateBranch(codeGen &gen, long disp, bool link)
     else
         IFORM_LK_SET(insn, 0);
 
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 }
 
-void insnCodeGen::generateBranch(codeGen &gen, Dyninst::Address from, Dyninst::Address to, bool link) {
+void insnCodeGenPower::generateBranch(codeGen &gen, Dyninst::Address from, Dyninst::Address to, bool link) {
 
     long disp = (to - from);
-//    fprintf(stderr, "[insnCodeGen::generateBranch] Generating branch from %p to %p\n", from, to);
+//    fprintf(stderr, "[insnCodeGenPower::generateBranch] Generating branch from %p to %p\n", from, to);
     // if (from == 0x10000750 || from == 0x10000758) {
     //   fprintf(stderr, "Stop here\n");
     // }
@@ -180,7 +180,7 @@ void insnCodeGen::generateBranch(codeGen &gen, Dyninst::Address from, Dyninst::A
    
 }
 
-void insnCodeGen::generateCall(codeGen &gen, Dyninst::Address from, Dyninst::Address to) {
+void insnCodeGenPower::generateCall(codeGen &gen, Dyninst::Address from, Dyninst::Address to) {
     //fprintf(stderr, "info: %s:%d: \n", __FILE__, __LINE__); 
     generateBranch(gen, from, to, true);
 }
@@ -237,10 +237,10 @@ void GenerateRestoresBaseTrampStyle(codeGen &gen) {
     popStack(gen);
 }
 
-void insnCodeGen::generateMoveToSPR(codeGen &gen, Dyninst::Register toSPR,
+void insnCodeGenPower::generateMoveToSPR(codeGen &gen, Dyninst::Register toSPR,
                                     unsigned sprReg) {
   // Check that this SPR exists
-  if (sprReg != SPR_TAR && sprReg != SPR_LR && sprReg != SPR_CTR)
+  if (sprReg != SPR_TAR && sprReg != NS_power::SPR_LR && sprReg != SPR_CTR)
     assert("SPR Dyninst::Register is not valid" == 0);
 
   // Move the register to the spr 
@@ -251,13 +251,13 @@ void insnCodeGen::generateMoveToSPR(codeGen &gen, Dyninst::Register toSPR,
   XFORM_RA_SET(moveToBr, sprReg & 0x1f);
   XFORM_RB_SET(moveToBr, (sprReg >> 5) & 0x1f);
   XFXFORM_XO_SET(moveToBr, MTSPRxop); // From assembly manual
-  insnCodeGen::generate(gen,moveToBr); 
+  insnCodeGenPower::generate(gen,moveToBr); 
 }
 
-void insnCodeGen::generateMoveFromSPR(codeGen &gen,  Dyninst::Register toSPR,
+void insnCodeGenPower::generateMoveFromSPR(codeGen &gen,  Dyninst::Register toSPR,
                                     unsigned sprReg) {
   // Check that this SPR exists
-  if (sprReg != SPR_TAR && sprReg != SPR_LR && sprReg != SPR_CTR)
+  if (sprReg != SPR_TAR && sprReg != NS_power::SPR_LR && sprReg != SPR_CTR)
     assert("SPR Dyninst::Register is not valid" == 0);
 
   // Move the register to the spr 
@@ -268,11 +268,11 @@ void insnCodeGen::generateMoveFromSPR(codeGen &gen,  Dyninst::Register toSPR,
   XFORM_RA_SET(moveToBr, sprReg & 0x1f);
   XFORM_RB_SET(moveToBr, (sprReg >> 5) & 0x1f);
   XFXFORM_XO_SET(moveToBr, MFSPRxop); // From assembly manual
-  insnCodeGen::generate(gen,moveToBr); 
+  insnCodeGenPower::generate(gen,moveToBr); 
 }
 
-void insnCodeGen::generateVectorLoad(codeGen &gen, unsigned vectorReg, Dyninst::Register RegAddress) {
-  //insnCodeGen::generateImm(gen, CALop,  rt, 0,  BOT_LO(value)); 
+void insnCodeGenPower::generateVectorLoad(codeGen &gen, unsigned vectorReg, Dyninst::Register RegAddress) {
+  //insnCodeGenPower::generateImm(gen, CALop,  rt, 0,  BOT_LO(value)); 
   instruction loadInstruction;
   XLFORM_OP_SET(loadInstruction, LXVD2Xop);
   XLFORM_BT_SET(loadInstruction, vectorReg); // From architecture manual
@@ -280,10 +280,10 @@ void insnCodeGen::generateVectorLoad(codeGen &gen, unsigned vectorReg, Dyninst::
   XLFORM_BB_SET(loadInstruction, RegAddress); // Unused
   XLFORM_XO_SET(loadInstruction, LXVD2Xxo);
   XLFORM_LK_SET(loadInstruction, 0); // Unused? 
-  insnCodeGen::generate(gen,loadInstruction);
+  insnCodeGenPower::generate(gen,loadInstruction);
 }
 
-void insnCodeGen::generateVectorStore(codeGen & gen, unsigned vectorReg, Dyninst::Register RegAddress) {
+void insnCodeGenPower::generateVectorStore(codeGen & gen, unsigned vectorReg, Dyninst::Register RegAddress) {
   instruction storeInstruction;
   XLFORM_OP_SET(storeInstruction, STXVD2Xop);
   XLFORM_BT_SET(storeInstruction, vectorReg); // From architecture manual
@@ -291,23 +291,23 @@ void insnCodeGen::generateVectorStore(codeGen & gen, unsigned vectorReg, Dyninst
   XLFORM_BB_SET(storeInstruction, RegAddress); // Unused
   XLFORM_XO_SET(storeInstruction, STXVD2Xxo);
   XLFORM_LK_SET(storeInstruction, 0); // Unused? 
-  insnCodeGen::generate(gen,storeInstruction);  
+  insnCodeGenPower::generate(gen,storeInstruction);  
 }
 
-void insnCodeGen::saveVectors(codeGen & gen, int startStackOffset) {
+void insnCodeGenPower::saveVectors(codeGen & gen, int startStackOffset) {
   for (int i = 0; i < 32; i++) {
-    insnCodeGen::generateImm(gen, CALop, registerSpace::r10 , registerSpace::r1,  BOT_LO(startStackOffset + (16*(i+1))));
-    insnCodeGen::generateVectorStore(gen, i, registerSpace::r10);
+    insnCodeGenPower::generateImm(gen, CALop, registerSpace::r10 , registerSpace::r1,  BOT_LO(startStackOffset + (16*(i+1))));
+    insnCodeGenPower::generateVectorStore(gen, i, registerSpace::r10);
   }
 }
-void insnCodeGen::restoreVectors(codeGen & gen, int startStackOffset) {
+void insnCodeGenPower::restoreVectors(codeGen & gen, int startStackOffset) {
   for (int i = 0; i < 32; i++) {
-    insnCodeGen::generateImm(gen, CALop, registerSpace::r10 , registerSpace::r1,  BOT_LO(startStackOffset + (16*(i+1))));
-    insnCodeGen::generateVectorLoad(gen, i, registerSpace::r10);
+    insnCodeGenPower::generateImm(gen, CALop, registerSpace::r10 , registerSpace::r1,  BOT_LO(startStackOffset + (16*(i+1))));
+    insnCodeGenPower::generateVectorLoad(gen, i, registerSpace::r10);
   }
 }
 
-bool insnCodeGen::generateBranchTar(codeGen &gen, Dyninst::Register scratch,
+bool insnCodeGenPower::generateBranchTar(codeGen &gen, Dyninst::Register scratch,
                                     Dyninst::Address dest,
                                     bool isCall) {
   // Generates a branch using TAR to the address specified in dest. 
@@ -317,10 +317,10 @@ bool insnCodeGen::generateBranchTar(codeGen &gen, Dyninst::Register scratch,
 
   // Move the address to the scratch register
   // Done because TAR can only be set called using a register value
-  insnCodeGen::loadImmIntoReg(gen, scratch, dest);
+  insnCodeGenPower::loadImmIntoReg(gen, scratch, dest);
 
   // Generate the instruction to move the reg -> tar
-  insnCodeGen::generateMoveToSPR(gen, scratch, SPR_TAR);
+  insnCodeGenPower::generateMoveToSPR(gen, scratch, SPR_TAR);
 
   // Aaaand now branch, linking if appropriate
   instruction branchToBr;
@@ -331,11 +331,11 @@ bool insnCodeGen::generateBranchTar(codeGen &gen, Dyninst::Register scratch,
   XLFORM_BB_SET(branchToBr, 0); // Unused
   XLFORM_XO_SET(branchToBr, BCTARxop);
   XLFORM_LK_SET(branchToBr, (isCall ? 1 : 0));
-  insnCodeGen::generate(gen,branchToBr);
+  insnCodeGenPower::generate(gen,branchToBr);
   return true;
 }
 
-bool insnCodeGen::generateBranchLR(codeGen &gen, Dyninst::Register scratch,
+bool insnCodeGenPower::generateBranchLR(codeGen &gen, Dyninst::Register scratch,
                                     Dyninst::Address dest,
                                     bool isCall) {
   // Generates a branch using LR to the address specified in dest. 
@@ -345,10 +345,10 @@ bool insnCodeGen::generateBranchLR(codeGen &gen, Dyninst::Register scratch,
 
   // Move the address to the scratch register
   // Done because TAR can only be set called using a register value
-  insnCodeGen::loadImmIntoReg(gen, scratch, dest);
+  insnCodeGenPower::loadImmIntoReg(gen, scratch, dest);
 
   // Generate the instruction to move the reg -> tar
-  insnCodeGen::generateMoveToSPR(gen, scratch, SPR_LR);
+  insnCodeGenPower::generateMoveToSPR(gen, scratch, NS_power::SPR_LR);
 
   // Aaaand now branch, linking if appropriate
   instruction branchToBr;
@@ -359,12 +359,12 @@ bool insnCodeGen::generateBranchLR(codeGen &gen, Dyninst::Register scratch,
   XLFORM_BB_SET(branchToBr, 0); // Unused
   XLFORM_XO_SET(branchToBr, BCLRxop);
   XLFORM_LK_SET(branchToBr, (isCall ? 1 : 0));
-  insnCodeGen::generate(gen,branchToBr);
+  insnCodeGenPower::generate(gen,branchToBr);
   return true;
 }
 
 
-bool insnCodeGen::generateBranchCTR(codeGen &gen, 
+bool insnCodeGenPower::generateBranchCTR(codeGen &gen, 
                                     Dyninst::Register scratch,
                                     Dyninst::Address dest,
                                     bool isCall) {
@@ -375,10 +375,10 @@ bool insnCodeGen::generateBranchCTR(codeGen &gen,
 
   // Move the address to the scratch register
   // Done because TAR can only be set called using a register value
-  insnCodeGen::loadImmIntoReg(gen, scratch, dest);
+  insnCodeGenPower::loadImmIntoReg(gen, scratch, dest);
 
   // Generate the instruction to move the reg -> tar
-  insnCodeGen::generateMoveToSPR(gen, scratch, SPR_LR);
+  insnCodeGenPower::generateMoveToSPR(gen, scratch, NS_power::SPR_LR);
 
   // Aaaand now branch, linking if appropriate
   instruction branchToBr;
@@ -389,7 +389,7 @@ bool insnCodeGen::generateBranchCTR(codeGen &gen,
   XLFORM_BB_SET(branchToBr, 0); // Unused
   XLFORM_XO_SET(branchToBr, BCCTRxop);
   XLFORM_LK_SET(branchToBr, (isCall ? 1 : 0));
-  insnCodeGen::generate(gen,branchToBr);
+  insnCodeGenPower::generate(gen,branchToBr);
   return true;
 }
 
@@ -424,7 +424,7 @@ instPoint * GetInstPointPower(codeGen & gen, Dyninst::Address from) {
     }
     return NULL;
 }
-void insnCodeGen::generateLongBranch(codeGen &gen, 
+void insnCodeGenPower::generateLongBranch(codeGen &gen, 
                                      Dyninst::Address from,
                                      Dyninst::Address to,
                                      bool isCall) {
@@ -437,14 +437,14 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
     //fprintf(stderr, "%s\n", "generating call long branch using LR");
       // This is making the assumption R2/R12 has already been setup correctly, 
       // First generate a scratch register by moving something, i choose R11 to send to TAR
-      insnCodeGen::generateMoveToSPR(gen,registerSpace::r10, SPR_TAR);
+      insnCodeGenPower::generateMoveToSPR(gen,registerSpace::r10, SPR_TAR);
       
       // r10 is now free to setup the branch instruction
-      insnCodeGen::loadImmIntoReg(gen, registerSpace::r10, to);
-      insnCodeGen::generateMoveToSPR(gen,registerSpace::r10, SPR_LR);
+      insnCodeGenPower::loadImmIntoReg(gen, registerSpace::r10, to);
+      insnCodeGenPower::generateMoveToSPR(gen,registerSpace::r10, NS_power::SPR_LR);
 
       // Return r10 to its original state
-      insnCodeGen::generateMoveFromSPR(gen, registerSpace::r10, SPR_TAR);
+      insnCodeGenPower::generateMoveFromSPR(gen, registerSpace::r10, SPR_TAR);
 
       // Emit the branch instruction
       instruction branchToBr;
@@ -455,7 +455,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
       XLFORM_BB_SET(branchToBr, 0); // Unused
       XLFORM_XO_SET(branchToBr, BCLRxop);
       XLFORM_LK_SET(branchToBr, (isCall ? 1 : 0));
-      insnCodeGen::generate(gen,branchToBr);
+      insnCodeGenPower::generate(gen,branchToBr);
   } else {
     //fprintf(stderr, "%s\n", "generating non-call long branch using TAR");
     // What this does is the following:
@@ -495,7 +495,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
           if (liveRegs[registerSpace::lr] == false && isCall) {
               usingLR = true;
               // Dyninst::Register 11 is the chosen one for using temporarily.
-              generateMoveToSPR(gen, registerSpace::r10, SPR_LR);
+              generateMoveToSPR(gen, registerSpace::r10, NS_power::SPR_LR);
           } else if (liveRegs[registerSpace::ctr] == false) {
               usingCTR = true;
               generateMoveToSPR(gen, registerSpace::r10, SPR_CTR);
@@ -507,24 +507,24 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
         }
     } else if (scratch != Null_Register) {
         //fprintf(stderr, "%s\n", "Generating branch with TAR.....");
-        insnCodeGen::generateBranchTar(gen, scratch, to, isCall);
+        insnCodeGenPower::generateBranchTar(gen, scratch, to, isCall);
         return;
     }
 
     if (scratch == Null_Register) {
       // Now the fun stuff....
       // Loed destination value into r11, copy it to SPR_TAR, restore the original R11 value.
-      insnCodeGen::loadImmIntoReg(gen, registerSpace::r10, to);
-      insnCodeGen::generateMoveToSPR(gen, registerSpace::r10, SPR_TAR);
+      insnCodeGenPower::loadImmIntoReg(gen, registerSpace::r10, to);
+      insnCodeGenPower::generateMoveToSPR(gen, registerSpace::r10, SPR_TAR);
       if (usingCTR)
-        insnCodeGen::generateMoveFromSPR(gen, registerSpace::r10, SPR_CTR);
+        insnCodeGenPower::generateMoveFromSPR(gen, registerSpace::r10, SPR_CTR);
       else if (usingLR)
-        insnCodeGen::generateMoveFromSPR(gen, registerSpace::r10, SPR_LR);
+        insnCodeGenPower::generateMoveFromSPR(gen, registerSpace::r10, NS_power::SPR_LR);
       else 
         assert("SHOULD NEVER BE HERE" == 0);
     } else {
-      insnCodeGen::loadImmIntoReg(gen, scratch, to);
-      insnCodeGen::generateMoveToSPR(gen, scratch, SPR_TAR);      
+      insnCodeGenPower::loadImmIntoReg(gen, scratch, to);
+      insnCodeGenPower::generateMoveToSPR(gen, scratch, SPR_TAR);      
     }
     // Emit the call instruction.
     instruction branchToBr;
@@ -535,12 +535,12 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
     XLFORM_BB_SET(branchToBr, 0); // Unused
     XLFORM_XO_SET(branchToBr, BCTARxop);
     XLFORM_LK_SET(branchToBr, (isCall ? 1 : 0));
-    insnCodeGen::generate(gen, branchToBr);    
+    insnCodeGenPower::generate(gen, branchToBr);    
   }
   return;
 
   // bool everythingSaved = false;
-  // //fprintf(stderr, "[insnCodeGen::generateLongBranch] Generating long branch from %p to %p\n", from, to);
+  // //fprintf(stderr, "[insnCodeGenPower::generateLongBranch] Generating long branch from %p to %p\n", from, to);
   //   // First, see if we can cheap out
   //   long disp = (to - from);
   //   if (ABS(disp) <= MAX_BRANCH) {
@@ -555,7 +555,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
   //   if (!point) {
   //       // fprintf(stderr, " %s[%d] No point generateBranchViaTrap \n", FILE__, __LINE__);
   //       fprintf(stderr, "This is an instruction which we would trap on\n");
-  //       fprintf(stderr, "[insnCodeGen::generateLongBranch] Building long branch from %llx to %llx at position %llx and this branch call status is %d\n", from, to, gen.currAddr(), isCall);
+  //       fprintf(stderr, "[insnCodeGenPower::generateLongBranch] Building long branch from %llx to %llx at position %llx and this branch call status is %d\n", from, to, gen.currAddr(), isCall);
   //       // Generate branch via traps is broken, never call it. 
   //       // assert(1 == 0);
   //       // return generateBranchViaTrap(gen, from, to, isCall);
@@ -587,7 +587,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
   //   }
     
   //   // Load the destination into our scratch register
-  //   insnCodeGen::loadImmIntoReg(gen, scratch, to);
+  //   insnCodeGenPower::loadImmIntoReg(gen, scratch, to);
   //   unsigned branchRegister = registerSpace::lr;
   //   // Find out whether the LR or CTR is "dead"...
   //   //bitArray liveRegs = point->liveRegisters();
@@ -615,8 +615,8 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
   //   XFXFORM_OP_SET(moveToBr, MTSPRop);
   //   XFXFORM_RT_SET(moveToBr, scratch);
   //   if (branchRegister == registerSpace::lr) {
-  //       XFORM_RA_SET(moveToBr, SPR_LR & 0x1f);
-  //       XFORM_RB_SET(moveToBr, (SPR_LR >> 5) & 0x1f);
+  //       XFORM_RA_SET(moveToBr, NS_power::SPR_LR & 0x1f);
+  //       XFORM_RB_SET(moveToBr, (NS_power::SPR_LR >> 5) & 0x1f);
   //       // The two halves (top 5 bits/bottom 5 bits) are _reversed_ in this encoding. 
   //   }
   //   else {
@@ -624,7 +624,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
   //       XFORM_RB_SET(moveToBr, (SPR_CTR >> 5) & 0x1f);
   //   }
   //   XFXFORM_XO_SET(moveToBr, MTSPRxop); // From assembly manual
-  //   insnCodeGen::generate(gen,moveToBr);
+  //   insnCodeGenPower::generate(gen,moveToBr);
   //   // Aaaand now branch, linking if appropriate
   //   instruction branchToBr;
   //   branchToBr.clear();
@@ -639,16 +639,16 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
   //       XLFORM_XO_SET(branchToBr, BCCTRxop);
   //   }
   //   XLFORM_LK_SET(branchToBr, (isCall ? 1 : 0));
-  //   insnCodeGen::generate(gen,branchToBr);
+  //   insnCodeGenPower::generate(gen,branchToBr);
 
   //   // restore the world
   //   if(everythingSaved)
   //     GenerateRestoresBaseTrampStyle(gen);
 }
 
-void insnCodeGen::generateBranchViaTrap(codeGen &gen, Dyninst::Address from, Dyninst::Address to, bool isCall) {
+void insnCodeGenPower::generateBranchViaTrap(codeGen &gen, Dyninst::Address from, Dyninst::Address to, bool isCall) {
 
-  //fprintf(stderr, "[insnCodeGen::generateBranchViaTrap] Generating branch via trap from %p to %p\n", from, to);
+  //fprintf(stderr, "[insnCodeGenPower::generateBranchViaTrap] Generating branch via trap from %p to %p\n", from, to);
     long disp = to - from;
     if (ABS(disp) <= MAX_BRANCH) {
         // We shouldn't be here, since this is an internal-called-only func.
@@ -678,17 +678,17 @@ void insnCodeGen::generateBranchViaTrap(codeGen &gen, Dyninst::Address from, Dyn
 
 
         //instruction insn(NOOPraw);
-        //insnCodeGen::generate(gen,insn);
-        //insnCodeGen::generate(gen,insn);
-        //insnCodeGen::generate(gen,insn);
-        //insnCodeGen::generate(gen,insn);
-        //insnCodeGen::generate(gen,insn);
-        //insnCodeGen::generate(gen,insn);
-        //insnCodeGen::generate(gen,insn);
-        //insnCodeGen::generate(gen,insn);
-        //insnCodeGen::generate(gen,insn);
+        //insnCodeGenPower::generate(gen,insn);
+        //insnCodeGenPower::generate(gen,insn);
+        //insnCodeGenPower::generate(gen,insn);
+        //insnCodeGenPower::generate(gen,insn);
+        //insnCodeGenPower::generate(gen,insn);
+        //insnCodeGenPower::generate(gen,insn);
+        //insnCodeGenPower::generate(gen,insn);
+        //insnCodeGenPower::generate(gen,insn);
+        //insnCodeGenPower::generate(gen,insn);
         gen.addrSpace()->trapMapping.addTrapMapping(from, to, true);
-        insnCodeGen::generateTrap(gen);        
+        insnCodeGenPower::generateTrap(gen);        
       } else {
           // Too far to branch and no proc to register trap.
           fprintf(stderr, "ABS OFF: 0x%lx, MAX: 0x%lx\n",
@@ -702,7 +702,7 @@ void insnCodeGen::generateBranchViaTrap(codeGen &gen, Dyninst::Address from, Dyn
     }
 }
 
-void insnCodeGen::generateAddReg (codeGen & gen, int op, Dyninst::Register rt,
+void insnCodeGenPower::generateAddReg (codeGen & gen, int op, Dyninst::Register rt,
 				   Dyninst::Register ra, Dyninst::Register rb)
 {
 
@@ -716,10 +716,10 @@ void insnCodeGen::generateAddReg (codeGen & gen, int op, Dyninst::Register rt,
   XOFORM_XO_SET(insn, 266);
   XOFORM_RC_SET(insn, 0);
 
-  insnCodeGen::generate (gen,insn);
+  insnCodeGenPower::generate (gen,insn);
 }
 
-void insnCodeGen::generateLoadReg(codeGen &gen, Dyninst::Register rt,
+void insnCodeGenPower::generateLoadReg(codeGen &gen, Dyninst::Register rt,
                                   Dyninst::Register ra, Dyninst::Register rb)
 {
     instruction insn;
@@ -731,10 +731,10 @@ void insnCodeGen::generateLoadReg(codeGen &gen, Dyninst::Register rt,
     XFORM_XO_SET(insn, LXxop);
     XFORM_RC_SET(insn, 0);
 
-    insnCodeGen::generate (gen,insn);
+    insnCodeGenPower::generate (gen,insn);
 }
 
-void insnCodeGen::generateStoreReg(codeGen &gen, Dyninst::Register rt,
+void insnCodeGenPower::generateStoreReg(codeGen &gen, Dyninst::Register rt,
                                    Dyninst::Register ra, Dyninst::Register rb)
 {
     instruction insn;
@@ -746,10 +746,10 @@ void insnCodeGen::generateStoreReg(codeGen &gen, Dyninst::Register rt,
     XFORM_XO_SET(insn, STXxop);
     XFORM_RC_SET(insn, 0);
 
-    insnCodeGen::generate (gen,insn);
+    insnCodeGenPower::generate (gen,insn);
 }
 
-void insnCodeGen::generateLoadReg64(codeGen &gen, Dyninst::Register rt,
+void insnCodeGenPower::generateLoadReg64(codeGen &gen, Dyninst::Register rt,
                                     Dyninst::Register ra, Dyninst::Register rb)
 {
     instruction insn;
@@ -761,10 +761,10 @@ void insnCodeGen::generateLoadReg64(codeGen &gen, Dyninst::Register rt,
     XFORM_XO_SET(insn, LDXxop);
     XFORM_RC_SET(insn, 0);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenPower::generate(gen, insn);
 }
 
-void insnCodeGen::generateStoreReg64(codeGen &gen, Dyninst::Register rs,
+void insnCodeGenPower::generateStoreReg64(codeGen &gen, Dyninst::Register rs,
                                      Dyninst::Register ra, Dyninst::Register rb)
 {
     instruction insn;
@@ -776,10 +776,10 @@ void insnCodeGen::generateStoreReg64(codeGen &gen, Dyninst::Register rs,
     XFORM_XO_SET(insn, STXxop);
     XFORM_RC_SET(insn, 0);
 
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenPower::generate(gen, insn);
 }
 
-void insnCodeGen::generateImm(codeGen &gen, int op, Dyninst::Register rt, Dyninst::Register ra, int immd)
+void insnCodeGenPower::generateImm(codeGen &gen, int op, Dyninst::Register rt, Dyninst::Register ra, int immd)
  {
   // something should be here to make sure immd is within bounds
   // bound check really depends on op since we have both signed and unsigned
@@ -802,10 +802,10 @@ void insnCodeGen::generateImm(codeGen &gen, int op, Dyninst::Register rt, Dynins
   if (op==SIop) immd = -immd;
   DFORM_SI_SET(insn, immd);
 
-  insnCodeGen::generate(gen,insn);
+  insnCodeGenPower::generate(gen,insn);
 }
 
-void insnCodeGen::generateMemAccess64(codeGen &gen, int op, int xop, Dyninst::Register r1, Dyninst::Register r2, int immd)
+void insnCodeGenPower::generateMemAccess64(codeGen &gen, int op, int xop, Dyninst::Register r1, Dyninst::Register r2, int immd)
 {
     assert(MIN_IMM16 <= immd && immd <= MAX_IMM16);
     assert((immd & 0x3) == 0);
@@ -819,11 +819,11 @@ void insnCodeGen::generateMemAccess64(codeGen &gen, int op, int xop, Dyninst::Re
     DSFORM_DS_SET(insn, immd >> 2);
     DSFORM_XO_SET(insn, xop);
 
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 }
 
 // rlwinm ra,rs,n,0,31-n
-void insnCodeGen::generateLShift(codeGen &gen, Dyninst::Register rs, int shift, Dyninst::Register ra)
+void insnCodeGenPower::generateLShift(codeGen &gen, Dyninst::Register rs, int shift, Dyninst::Register ra)
 {
     instruction insn;
 
@@ -837,15 +837,15 @@ void insnCodeGen::generateLShift(codeGen &gen, Dyninst::Register rs, int shift, 
 	MFORM_MB_SET(insn, 0);
 	MFORM_ME_SET(insn, 31-shift);
 	MFORM_RC_SET(insn, 0);
-	insnCodeGen::generate(gen,insn);
+	insnCodeGenPower::generate(gen,insn);
 
     } else /* gen.addrSpace()->getAddressWidth() == 8 */ {
-	insnCodeGen::generateLShift64(gen, rs, shift, ra);
+	insnCodeGenPower::generateLShift64(gen, rs, shift, ra);
     }
 }
 
 // rlwinm ra,rs,32-n,n,31
-void insnCodeGen::generateRShift(codeGen &gen, Dyninst::Register rs, int shift, Dyninst::Register ra, bool s)
+void insnCodeGenPower::generateRShift(codeGen &gen, Dyninst::Register rs, int shift, Dyninst::Register ra, bool s)
 {
     instruction insn;
 
@@ -859,15 +859,15 @@ void insnCodeGen::generateRShift(codeGen &gen, Dyninst::Register rs, int shift, 
 	MFORM_MB_SET(insn, shift);
 	MFORM_ME_SET(insn, 31);
 	MFORM_RC_SET(insn, 0);
-	insnCodeGen::generate(gen,insn);
+	insnCodeGenPower::generate(gen,insn);
 
     } else /* gen.addrSpace()->getAddressWidth() == 8 */ {
-	insnCodeGen::generateRShift64(gen, rs, shift, ra, s);
+	insnCodeGenPower::generateRShift64(gen, rs, shift, ra, s);
     }
 }
 
 // sld ra, rs, rb
-void insnCodeGen::generateLShift64(codeGen &gen, Dyninst::Register rs, int shift, Dyninst::Register ra)
+void insnCodeGenPower::generateLShift64(codeGen &gen, Dyninst::Register rs, int shift, Dyninst::Register ra)
 {
     instruction insn;
 
@@ -883,11 +883,11 @@ void insnCodeGen::generateLShift64(codeGen &gen, Dyninst::Register rs, int shift
     MDFORM_SH2_SET(insn, shift / 32);
     MDFORM_RC_SET( insn, 0);
 
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 }
 
 // srd ra, rs, rb
-void insnCodeGen::generateRShift64(codeGen &gen, Dyninst::Register rs, int shift, Dyninst::Register ra, bool)
+void insnCodeGenPower::generateRShift64(codeGen &gen, Dyninst::Register rs, int shift, Dyninst::Register ra, bool)
 {
     // This function uses rotate-left to implement right shift.
     // Rotate left 64-n bits is rotating right n bits.
@@ -907,24 +907,24 @@ void insnCodeGen::generateRShift64(codeGen &gen, Dyninst::Register rs, int shift
     MDFORM_SH2_SET(insn, (64 - shift) / 32);
     MDFORM_RC_SET( insn, 0);
 
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 }
 
 //
 // generate an instruction that does nothing and has to side affect except to
 //   advance the program counter.
 //
-void insnCodeGen::generateNOOP(codeGen &gen, unsigned size)
+void insnCodeGenPower::generateNOOP(codeGen &gen, unsigned size)
 {
     assert ((size % instruction::size()) == 0);
     while (size) {
         instruction insn(NOOPraw);
-        insnCodeGen::generate(gen,insn);
+        insnCodeGenPower::generate(gen,insn);
         size -= instruction::size();
     }
 }
 
-void insnCodeGen::generateRelOp(codeGen &gen, int cond, int mode, Dyninst::Register rs1,
+void insnCodeGenPower::generateRelOp(codeGen &gen, int cond, int mode, Dyninst::Register rs1,
                                 Dyninst::Register rs2, Dyninst::Register rd, bool s)
 {
     instruction insn;
@@ -939,10 +939,10 @@ void insnCodeGen::generateRelOp(codeGen &gen, int cond, int mode, Dyninst::Regis
         XFORM_XO_SET(insn, CMPxop);
     else
         XFORM_XO_SET(insn, CMPLxop);
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 
     // li rd, 1
-    insnCodeGen::generateImm(gen, CALop, rd, 0, 1);
+    insnCodeGenPower::generateImm(gen, CALop, rd, 0, 1);
 
     // b??,a +2
     insn.clear();
@@ -952,42 +952,42 @@ void insnCodeGen::generateRelOp(codeGen &gen, int cond, int mode, Dyninst::Regis
     BFORM_BD_SET(insn, 2);		// + two instructions */
     BFORM_AA_SET(insn, 0);
     BFORM_LK_SET(insn, 0);
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 
     // clr rd
-    insnCodeGen::generateImm(gen, CALop, rd, 0, 0);
+    insnCodeGenPower::generateImm(gen, CALop, rd, 0, 0);
 }
 
 // Given a value, load it into a register.
-void insnCodeGen::loadImmIntoReg(codeGen &gen, Dyninst::Register rt, long value)
+void insnCodeGenPower::loadImmIntoReg(codeGen &gen, Dyninst::Register rt, long value)
 {
    // Writing a full 64 bits takes 5 instructions in the worst case.
    // Let's see if we use sign-extention to cheat.
    if (MIN_IMM16 <= value && value <= MAX_IMM16) {
-      insnCodeGen::generateImm(gen, CALop,  rt, 0,  BOT_LO(value));      
+      insnCodeGenPower::generateImm(gen, CALop,  rt, 0,  BOT_LO(value));      
    } else if (MIN_IMM32 <= value && value <= MAX_IMM32) {
-      insnCodeGen::generateImm(gen, CAUop,  rt, 0,  BOT_HI(value));
-      insnCodeGen::generateImm(gen, ORILop, rt, rt, BOT_LO(value));
+      insnCodeGenPower::generateImm(gen, CAUop,  rt, 0,  BOT_HI(value));
+      insnCodeGenPower::generateImm(gen, ORILop, rt, rt, BOT_LO(value));
    } 
 #if defined(DYNINST_CODEGEN_ARCH_64BIT)
    else if (MIN_IMM48 <= value && value <= MAX_IMM48) {
-      insnCodeGen::generateImm(gen, CALop,  rt, 0,  TOP_LO(value));
-      insnCodeGen::generateLShift64(gen, rt, 32, rt);
+      insnCodeGenPower::generateImm(gen, CALop,  rt, 0,  TOP_LO(value));
+      insnCodeGenPower::generateLShift64(gen, rt, 32, rt);
       if (BOT_HI(value))
-         insnCodeGen::generateImm(gen, ORIUop, rt, rt, BOT_HI(value));
+         insnCodeGenPower::generateImm(gen, ORIUop, rt, rt, BOT_HI(value));
       if (BOT_LO(value))
-         insnCodeGen::generateImm(gen, ORILop, rt, rt, BOT_LO(value));
+         insnCodeGenPower::generateImm(gen, ORILop, rt, rt, BOT_LO(value));
       
    } else {
 
-      insnCodeGen::generateImm(gen, CAUop,  rt,  0, TOP_HI(value));
+      insnCodeGenPower::generateImm(gen, CAUop,  rt,  0, TOP_HI(value));
       if (TOP_LO(value))
-         insnCodeGen::generateImm(gen, ORILop, rt, rt, TOP_LO(value));
-      insnCodeGen::generateLShift64(gen, rt, 32, rt);
+         insnCodeGenPower::generateImm(gen, ORILop, rt, rt, TOP_LO(value));
+      insnCodeGenPower::generateLShift64(gen, rt, 32, rt);
       if (BOT_HI(value))
-         insnCodeGen::generateImm(gen, ORIUop, rt, rt, BOT_HI(value));
+         insnCodeGenPower::generateImm(gen, ORIUop, rt, rt, BOT_HI(value));
       if (BOT_LO(value))
-         insnCodeGen::generateImm(gen, ORILop, rt, rt, BOT_LO(value));
+         insnCodeGenPower::generateImm(gen, ORILop, rt, rt, BOT_LO(value));
    }
 #endif
 }
@@ -995,7 +995,7 @@ void insnCodeGen::loadImmIntoReg(codeGen &gen, Dyninst::Register rt, long value)
 // Helper method.  Fills register with partial value to be completed
 // by an operation with a 16-bit signed immediate.  Such as loads and
 // stores.
-void insnCodeGen::loadPartialImmIntoReg(codeGen &gen, Dyninst::Register rt, long value)
+void insnCodeGenPower::loadPartialImmIntoReg(codeGen &gen, Dyninst::Register rt, long value)
 {
    if (MIN_IMM16 <= value && value <= MAX_IMM16) return;
    
@@ -1008,27 +1008,27 @@ void insnCodeGen::loadPartialImmIntoReg(codeGen &gen, Dyninst::Register rt, long
    }
    
    if (MIN_IMM32 <= value && value <= MAX_IMM32) {
-      insnCodeGen::generateImm(gen, CAUop,  rt, 0,  BOT_HI(value));       
+      insnCodeGenPower::generateImm(gen, CAUop,  rt, 0,  BOT_HI(value));       
    } 
 #if defined(DYNINST_CODEGEN_ARCH_64BIT)
    else if (MIN_IMM48 <= value && value <= MAX_IMM48) {
-      insnCodeGen::generateImm(gen, CALop,  rt, 0,  TOP_LO(value));
-      insnCodeGen::generateLShift64(gen, rt, 32, rt);
+      insnCodeGenPower::generateImm(gen, CALop,  rt, 0,  TOP_LO(value));
+      insnCodeGenPower::generateLShift64(gen, rt, 32, rt);
       if (BOT_HI(value))
-         insnCodeGen::generateImm(gen, ORIUop, rt, rt, BOT_HI(value));
+         insnCodeGenPower::generateImm(gen, ORIUop, rt, rt, BOT_HI(value));
       
    } else {
-      insnCodeGen::generateImm(gen, CAUop,  rt,  0, TOP_HI(value));
+      insnCodeGenPower::generateImm(gen, CAUop,  rt,  0, TOP_HI(value));
       if (TOP_LO(value))
-         insnCodeGen::generateImm(gen, ORILop, rt, rt, TOP_LO(value));
-      insnCodeGen::generateLShift64(gen, rt, 32, rt);
+         insnCodeGenPower::generateImm(gen, ORILop, rt, rt, TOP_LO(value));
+      insnCodeGenPower::generateLShift64(gen, rt, 32, rt);
       if (BOT_HI(value))
-         insnCodeGen::generateImm(gen, ORIUop, rt, rt, BOT_HI(value));
+         insnCodeGenPower::generateImm(gen, ORIUop, rt, rt, BOT_HI(value));
    }
 #endif
 }
 
-int insnCodeGen::createStackFrame(codeGen &gen, int numRegs, std::vector<Dyninst::Register>& freeReg, std::vector<Dyninst::Register>& excludeReg){
+int insnCodeGenPower::createStackFrame(codeGen &gen, int numRegs, std::vector<Dyninst::Register>& freeReg, std::vector<Dyninst::Register>& excludeReg){
               int gpr_off, stack_size;
                 //create new stack frame
                 gpr_off = TRAMP_GPR_OFFSET_32;
@@ -1045,7 +1045,7 @@ int insnCodeGen::createStackFrame(codeGen &gen, int numRegs, std::vector<Dyninst
 		return freeReg.size();
 }
 
-void insnCodeGen::removeStackFrame(codeGen &gen) {
+void insnCodeGenPower::removeStackFrame(codeGen &gen) {
                 int gpr_off = TRAMP_GPR_OFFSET_32;
                 restoreGPRegisters(gen, gen.rs(), gpr_off);
                 popStack(gen);
@@ -1053,35 +1053,35 @@ void insnCodeGen::removeStackFrame(codeGen &gen) {
 
                 // {insn_ = {byte = {0xa6, 0x3, 0x8, 0x7c}, raw = 0x7c0803a6}}    
                 // {insn_ = {byte = {0xa6, 0x3, 0x8, 0x7c}, raw = 0x7c0803a6}}       
-bool insnCodeGen::generateMem(codeGen &,
+bool insnCodeGenPower::generateMem(codeGen &,
                               instruction&,
                               Dyninst::Address,
                               Dyninst::Address,
                               Dyninst::Register,
                   Dyninst::Register) {return false; }
 
-void insnCodeGen::generateMoveFromLR(codeGen &gen, Dyninst::Register rt) {
+void insnCodeGenPower::generateMoveFromLR(codeGen &gen, Dyninst::Register rt) {
     instruction insn;
     insn.clear();
     XFORM_OP_SET(insn, MFSPRop);
     XFORM_RT_SET(insn, rt);
-    XFORM_RA_SET(insn, SPR_LR & 0x1f);
-    XFORM_RB_SET(insn, (SPR_LR >> 5) & 0x1f);
+    XFORM_RA_SET(insn, NS_power::SPR_LR & 0x1f);
+    XFORM_RB_SET(insn, (NS_power::SPR_LR >> 5) & 0x1f);
     XFORM_XO_SET(insn, MFSPRxop);
     generate(gen,insn);
 }
 
-void insnCodeGen::generateMoveToLR(codeGen &gen, Dyninst::Register rs) {
+void insnCodeGenPower::generateMoveToLR(codeGen &gen, Dyninst::Register rs) {
     instruction insn;
     insn.clear();
     XFORM_OP_SET(insn, MTSPRop);
     XFORM_RT_SET(insn, rs);
-    XFORM_RA_SET(insn, SPR_LR & 0x1f);
-    XFORM_RB_SET(insn, (SPR_LR >> 5) & 0x1f);
+    XFORM_RA_SET(insn, NS_power::SPR_LR & 0x1f);
+    XFORM_RB_SET(insn, (NS_power::SPR_LR >> 5) & 0x1f);
     XFORM_XO_SET(insn, MTSPRxop);
     generate(gen,insn);
 }
-void insnCodeGen::generateMoveToCR(codeGen &gen, Dyninst::Register rs) {
+void insnCodeGenPower::generateMoveToCR(codeGen &gen, Dyninst::Register rs) {
     instruction insn;
     insn.clear();
     XFORM_OP_SET(insn, MTSPRop);
@@ -1092,7 +1092,7 @@ void insnCodeGen::generateMoveToCR(codeGen &gen, Dyninst::Register rs) {
     generate(gen,insn);
 }    
 
-bool insnCodeGen::modifyJump(Dyninst::Address target,
+bool insnCodeGenPower::modifyJump(Dyninst::Address target,
 			     NS_power::instruction &,
 			     codeGen &gen) {
   failedLongBranchLocal = false;
@@ -1111,7 +1111,7 @@ bool insnCodeGen::modifyJump(Dyninst::Address target,
   return true;
 }
 
-bool insnCodeGen::modifyJumpCall(Dyninst::Address target,
+bool insnCodeGenPower::modifyJumpCall(Dyninst::Address target,
            NS_power::instruction &,
            codeGen &gen) {
   failedLongBranchLocal = false;
@@ -1131,7 +1131,7 @@ bool insnCodeGen::modifyJumpCall(Dyninst::Address target,
 }
 
 
-bool insnCodeGen::modifyJcc(Dyninst::Address target,
+bool insnCodeGenPower::modifyJcc(Dyninst::Address target,
 			    NS_power::instruction &insn,
 			    codeGen &gen) {
   // We can be handed a conditional call or return instruction here. In these cases,
@@ -1145,7 +1145,7 @@ bool insnCodeGen::modifyJcc(Dyninst::Address target,
       // Make sure to use the (to, from) version of generateBranch()
       // in case the branch is too far, and trap-based instrumentation
       // is needed.
-	    insnCodeGen::generateBranch(gen, gen.currAddr(), target, BFORM_LK(insn));
+	    insnCodeGenPower::generateBranch(gen, gen.currAddr(), target, BFORM_LK(insn));
         return true;
     } else {
       // Figure out if the original branch was predicted as taken or not
@@ -1197,14 +1197,14 @@ bool insnCodeGen::modifyJcc(Dyninst::Address target,
       // but I don't have the POWER manual with me.
       // -- bernat, 15JUN05
       
-      insnCodeGen::generateBranch(gen,
+      insnCodeGenPower::generateBranch(gen,
 				  2*instruction::size());
       
       bool link = (BFORM_LK(insn) == 1);
       // Make sure to use the (to, from) version of generateBranch()
       // in case the branch is too far, and trap-based instrumentation
       // is needed.
-      insnCodeGen::generateBranch(gen,
+      insnCodeGenPower::generateBranch(gen,
 				  gen.currAddr(),
 				  target,
 				  link);
@@ -1225,7 +1225,7 @@ bool insnCodeGen::modifyJcc(Dyninst::Address target,
   return false;
 }
 
-bool insnCodeGen::modifyCall(Dyninst::Address target,
+bool insnCodeGenPower::modifyCall(Dyninst::Address target,
 			     NS_power::instruction &insn,
 			     codeGen &gen) {
   // This is actually a mashup of conditional/unconditional handling
@@ -1237,7 +1237,7 @@ bool insnCodeGen::modifyCall(Dyninst::Address target,
 
 //FIXME
 //This function is used for PC-relative and hence may not be required for PPC. Consider for update/removal.
-bool insnCodeGen::modifyData(Dyninst::Address /*target*/,
+bool insnCodeGenPower::modifyData(Dyninst::Address /*target*/,
 			     NS_power::instruction &insn,
 			     codeGen &gen) {
   // Only know how to "modify" syscall...

--- a/dyninstAPI/src/codegen-power.h
+++ b/dyninstAPI/src/codegen-power.h
@@ -40,7 +40,7 @@
 class AddressSpace;
 class codeGen;
 
-class insnCodeGen {
+class insnCodeGenPower {
  public:
     // All of these write into a buffer
     static void generateTrap(codeGen &gen);

--- a/dyninstAPI/src/codegen.h
+++ b/dyninstAPI/src/codegen.h
@@ -38,6 +38,7 @@
 #include "dyn_register.h"
 #include "dyninstAPI/src/patch.h"
 
+#include "insn-codegen.h"
 #if defined(DYNINST_CODEGEN_ARCH_POWER)
 #include "codegen-power.h"
 using namespace NS_power;

--- a/dyninstAPI/src/emit-aarch64.C
+++ b/dyninstAPI/src/emit-aarch64.C
@@ -71,7 +71,7 @@ codeBufIndex_t EmitterAARCH64::emitIf(
     INSN_SET(insn, 25, 30, 0x1a); // CBZ
     INSN_SET(insn, 31, 31, 1);
 
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenAarch64::generate(gen,insn);
 
     // Retval: where the jump is in this sequence
     codeBufIndex_t retval = gen.getIndex();
@@ -80,7 +80,7 @@ codeBufIndex_t EmitterAARCH64::emitIf(
 
 void EmitterAARCH64::emitLoadConst(Register dest, Address imm, codeGen &gen)
 {
-    insnCodeGen::loadImmIntoReg(gen, dest, imm);
+    insnCodeGenAarch64::loadImmIntoReg(gen, dest, imm);
 }
 
 
@@ -88,9 +88,9 @@ void EmitterAARCH64::emitLoad(Register dest, Address addr, int size, codeGen &ge
 {
     Register scratch = gen.rs()->getScratchRegister(gen);
 
-    insnCodeGen::loadImmIntoReg(gen, scratch, addr);
-    insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, dest,
-            scratch, 0, size, insnCodeGen::Post);
+    insnCodeGenAarch64::loadImmIntoReg(gen, scratch, addr);
+    insnCodeGenAarch64::generateMemAccess(gen, insnCodeGenAarch64::Load, dest,
+            scratch, 0, size, insnCodeGenAarch64::Post);
 
     gen.rs()->freeRegister(scratch);
     gen.markRegDefined(dest);
@@ -101,9 +101,9 @@ void EmitterAARCH64::emitStore(Address addr, Register src, int size, codeGen &ge
 {
     Register scratch = gen.rs()->getScratchRegister(gen);
 
-    insnCodeGen::loadImmIntoReg(gen, scratch, addr);
-    insnCodeGen::generateMemAccess(gen, insnCodeGen::Store, src,
-            scratch, 0, size, insnCodeGen::Pre);
+    insnCodeGenAarch64::loadImmIntoReg(gen, scratch, addr);
+    insnCodeGenAarch64::generateMemAccess(gen, insnCodeGenAarch64::Store, src,
+            scratch, 0, size, insnCodeGenAarch64::Pre);
 
     gen.rs()->freeRegister(scratch);
     gen.markRegDefined(src);
@@ -115,27 +115,27 @@ void EmitterAARCH64::emitOp(
 {
     // dest = src1 + src2
     if( opcode == plusOp )
-        insnCodeGen::generateAddSubShifted(gen, insnCodeGen::Add, 0, 0, src1, src2, dest, true);
+        insnCodeGenAarch64::generateAddSubShifted(gen, insnCodeGenAarch64::Add, 0, 0, src1, src2, dest, true);
 
     // dest = src1 - src2
     else if( opcode == minusOp )
-        insnCodeGen::generateAddSubShifted(gen, insnCodeGen::Sub, 0, 0, src2, src1, dest, true);
+        insnCodeGenAarch64::generateAddSubShifted(gen, insnCodeGenAarch64::Sub, 0, 0, src2, src1, dest, true);
     
     // dest = src1 * src2
     else if( opcode == timesOp )
-        insnCodeGen::generateMul(gen, src1, src2, dest, true);
+        insnCodeGenAarch64::generateMul(gen, src1, src2, dest, true);
 
     // dest = src1 & src2
     else if( opcode == andOp )
-        insnCodeGen::generateBitwiseOpShifted(gen, insnCodeGen::And, 0, src1, 0, src2, dest, true);  
+        insnCodeGenAarch64::generateBitwiseOpShifted(gen, insnCodeGenAarch64::And, 0, src1, 0, src2, dest, true);  
 
     // dest = src1 | src2
     else if( opcode == orOp )
-        insnCodeGen::generateBitwiseOpShifted(gen, insnCodeGen::Or, 0, src1, 0, src2, dest, true);  
+        insnCodeGenAarch64::generateBitwiseOpShifted(gen, insnCodeGenAarch64::Or, 0, src1, 0, src2, dest, true);  
 
     // dest = src1 ^ src2
     else if( opcode == xorOp )
-        insnCodeGen::generateBitwiseOpShifted(gen, insnCodeGen::Eor, 0, src1, 0, src2, dest, true);
+        insnCodeGenAarch64::generateBitwiseOpShifted(gen, insnCodeGenAarch64::Eor, 0, src1, 0, src2, dest, true);
 
     else assert(0);
 }
@@ -149,17 +149,17 @@ void EmitterAARCH64::emitRelOp(
     // used for the comparison, not the subtration value.
     // Besides that dest must contain 1 for true or 0 for false, and the content
     // of dest is gonna be changed as follow.
-    insnCodeGen::generateAddSubShifted(gen, insnCodeGen::Sub, 0, 0, src2, src1, dest, true);
+    insnCodeGenAarch64::generateAddSubShifted(gen, insnCodeGenAarch64::Sub, 0, 0, src2, src1, dest, true);
 
     // make dest = 1, meaning true
-    insnCodeGen::loadImmIntoReg(gen, dest, 0x1);
+    insnCodeGenAarch64::loadImmIntoReg(gen, dest, 0x1);
 
     // insert conditional jump to skip dest=0 in case the comparison resulted true
     // therefore keeping dest=1
-    insnCodeGen::generateConditionalBranch(gen, 8, opcode, s);
+    insnCodeGenAarch64::generateConditionalBranch(gen, 8, opcode, s);
 
     // make dest = 0, in case it fails the branch
-    insnCodeGen::loadImmIntoReg(gen, dest, 0x0);
+    insnCodeGenAarch64::loadImmIntoReg(gen, dest, 0x0);
 }
 
 
@@ -205,17 +205,17 @@ void EmitterAARCH64::emitRelOpImm(
     // used for the comparison, not the subtration value.
     // Besides that dest must contain 1 for true or 0 for false, and the content
     // of dest is gonna be changed as follow.
-    insnCodeGen::generateAddSubShifted(gen, insnCodeGen::Sub, 0, 0, src2, src1, dest, true);
+    insnCodeGenAarch64::generateAddSubShifted(gen, insnCodeGenAarch64::Sub, 0, 0, src2, src1, dest, true);
 
     // make dest = 1, meaning true
-    insnCodeGen::loadImmIntoReg(gen, dest, 0x1);
+    insnCodeGenAarch64::loadImmIntoReg(gen, dest, 0x1);
 
     // insert conditional jump to skip dest=0 in case the comparison resulted true
     // therefore keeping dest=1
-    insnCodeGen::generateConditionalBranch(gen, 8, opcode, s);
+    insnCodeGenAarch64::generateConditionalBranch(gen, 8, opcode, s);
 
     // make dest = 0, in case it fails the branch
-    insnCodeGen::loadImmIntoReg(gen, dest, 0x0);
+    insnCodeGenAarch64::loadImmIntoReg(gen, dest, 0x0);
 
     gen.rs()->freeRegister(src2);
     gen.markRegDefined(dest);
@@ -224,15 +224,15 @@ void EmitterAARCH64::emitRelOpImm(
 
 void EmitterAARCH64::emitLoadIndir(Register dest, Register addr_src, int size, codeGen &gen)
 {
-    insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, dest,
-            addr_src, 0, size, insnCodeGen::Post);
+    insnCodeGenAarch64::generateMemAccess(gen, insnCodeGenAarch64::Load, dest,
+            addr_src, 0, size, insnCodeGenAarch64::Post);
 
     gen.markRegDefined(dest);
 }
 void EmitterAARCH64::emitStoreIndir(Register addr_reg, Register src, int size, codeGen &gen)
 {
-    insnCodeGen::generateMemAccess(gen, insnCodeGen::Store, src,
-            addr_reg, 0, size, insnCodeGen::Pre);
+    insnCodeGenAarch64::generateMemAccess(gen, insnCodeGenAarch64::Store, src,
+            addr_reg, 0, size, insnCodeGenAarch64::Pre);
 
     gen.markRegDefined(addr_reg);
 }
@@ -252,15 +252,15 @@ void EmitterAARCH64::emitLoadOrigRegRelative(
         // load the stored register 'base' into scratch
         emitLoadOrigRegister(base, scratch, gen);
         // move offset(%scratch), %dest
-        insnCodeGen::generateMemAccess(gen, insnCodeGen::Load, dest,
-            scratch, offset, /*size==8?true:false*/4, insnCodeGen::Offset);
+        insnCodeGenAarch64::generateMemAccess(gen, insnCodeGenAarch64::Load, dest,
+            scratch, offset, /*size==8?true:false*/4, insnCodeGenAarch64::Offset);
     }
     else
     {
         // load the stored register 'base' into dest
 	emitLoadOrigRegister(base, scratch, gen);
-	insnCodeGen::loadImmIntoReg(gen, dest, offset);
-	insnCodeGen::generateAddSubShifted(gen, insnCodeGen::Add, 0, 0, dest, scratch, dest, true);
+	insnCodeGenAarch64::loadImmIntoReg(gen, dest, offset);
+	insnCodeGenAarch64::generateAddSubShifted(gen, insnCodeGenAarch64::Add, 0, 0, dest, scratch, dest, true);
     }
 }
 
@@ -274,7 +274,7 @@ void EmitterAARCH64::emitLoadOrigRegister(Address register_num, Register destina
    assert(dest);
 
    if (src->name == "sp") {
-      insnCodeGen::generateAddSubImmediate(gen, insnCodeGen::Add, 0,
+      insnCodeGenAarch64::generateAddSubImmediate(gen, insnCodeGenAarch64::Add, 0,
              TRAMP_FRAME_SIZE_64, REG_SP, destination, true);
 
       return;
@@ -283,15 +283,15 @@ void EmitterAARCH64::emitLoadOrigRegister(Address register_num, Register destina
    if (src->spilledState == registerSlot::unspilled)
    {
       // not on the stack. Directly move the value
-      insnCodeGen::generateMove(gen, destination, (Register) register_num, true);
+      insnCodeGenAarch64::generateMove(gen, destination, (Register) register_num, true);
       return;
    }
 
 
     int offset = TRAMP_GPR_OFFSET(gen.width());
     // its on the stack so load it.
-    insnCodeGen::restoreRegister(gen, destination, offset + (register_num * gen.width()),
-            insnCodeGen::Offset);
+    insnCodeGenAarch64::restoreRegister(gen, destination, offset + (register_num * gen.width()),
+            insnCodeGenAarch64::Offset);
 }
 
 

--- a/dyninstAPI/src/insn-codegen.C
+++ b/dyninstAPI/src/insn-codegen.C
@@ -1,0 +1,211 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ * 
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ * 
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include "boost/assign/list_of.hpp"
+#include "boost/assign/std/vector.hpp"
+#include "boost/assign/std/set.hpp"
+#include <map>
+#include <string>
+#include "common/src/ia32_locations.h"
+#include "codegen.h"
+#include "debug.h"
+#include "addressSpace.h"
+
+#include "InstructionDecoder.h"
+#include "Instruction.h"
+
+#include "codegen-x86.h"
+#include "codegen-power.h"
+#include "codegen-aarch64.h"
+#include "emit-x86.h"
+#include "inst-x86.h"
+#include "pcrel.h"
+
+#include "StackMod/StackAccess.h"
+
+#include "unaligned_memory_access.h"
+
+using namespace std;
+using namespace boost::assign;
+using namespace Dyninst::InstructionAPI;
+
+
+void insnCodeGen::generateIllegal(codeGen &gen) {
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  insnCodeGenX86::generateIllegal(gen);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  insnCodeGenAarch64::generateIllegal(gen);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  insnCodeGenPower::generateIllegal(gen);
+#endif
+}
+
+void insnCodeGen::generateTrap(codeGen &gen) {
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  insnCodeGenX86::generateTrap(gen);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  insnCodeGenAarch64::generateTrap(gen);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  insnCodeGenPower::generateTrap(gen);
+#endif
+}
+
+/*
+ * change the insn at addr to be a branch to newAddr.
+ *   Used to add multiple tramps to a point.
+ */
+
+void insnCodeGen::generateBranch(codeGen &gen,
+                                 Dyninst::Address fromAddr, Dyninst::Address toAddr, bool link)
+{
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  insnCodeGenX86::generateBranch(gen,fromAddr,toAddr); (void) link;
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  insnCodeGenAarch64::generateBranch(gen,fromAddr,toAddr,link);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  insnCodeGenPower::generateBranch(gen,fromAddr,toAddr,link);
+#endif
+}
+
+void insnCodeGen::generateBranch(codeGen &gen,
+                                 int disp32)
+{
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  insnCodeGenX86::generateBranch(gen,disp32);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  insnCodeGenAarch64::generateBranch(gen,disp32);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  insnCodeGenPower::generateBranch(gen,disp32);
+#endif
+}
+
+void insnCodeGen::generateCall(codeGen &gen,
+                               Dyninst::Address from,
+                               Dyninst::Address target)
+{
+
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  insnCodeGenX86::generateCall(gen,from,target);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  insnCodeGenAarch64::generateCall(gen,from,target);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  insnCodeGenPower::generateCall(gen,from,target);
+#endif
+}
+
+void insnCodeGen::generateNOOP(codeGen &gen, unsigned size) {
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  insnCodeGenX86::generateNOOP(gen,size);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  insnCodeGenAarch64::generateNOOP(gen,size);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  insnCodeGenPower::generateNOOP(gen,size);
+#endif
+}
+
+void insnCodeGen::generate(codeGen &gen,instruction & insn) {
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  insnCodeGenX86::generate(gen,insn);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  insnCodeGenAarch64::generate(gen,insn);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  insnCodeGenPower::generate(gen,insn);
+#endif
+}
+
+
+bool insnCodeGen::generateMem(codeGen &gen,
+                              instruction & insn,
+                              Dyninst::Address origAddr,
+                              Dyninst::Address newAddr,
+                              Dyninst::Register loadExpr,
+                              Dyninst::Register storeExpr)
+{
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  return insnCodeGenX86::generateMem(gen,insn,origAddr,newAddr,loadExpr,storeExpr);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  return insnCodeGenAarch64::generateMem(gen,insn,origAddr,newAddr,loadExpr,storeExpr);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  return insnCodeGenPower::generateMem(gen,insn,origAddr,newAddr,loadExpr,storeExpr);
+#endif
+}
+
+
+bool insnCodeGen::modifyJump(Dyninst::Address targetAddr, instruction &insn, codeGen &gen) {
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  return insnCodeGenX86::modifyJump(targetAddr, insn, gen);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  return insnCodeGenAarch64::modifyJump(targetAddr, insn, gen);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  return insnCodeGenPower::modifyJump(targetAddr, insn, gen);
+#endif
+}
+
+bool insnCodeGen::modifyJcc(Dyninst::Address targetAddr, instruction &insn, codeGen &gen) {
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  return insnCodeGenX86::modifyJcc(targetAddr, insn, gen);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  return insnCodeGenAarch64::modifyJcc(targetAddr, insn, gen);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  return insnCodeGenPower::modifyJcc(targetAddr, insn, gen);
+#endif
+}
+
+bool insnCodeGen::modifyCall(Dyninst::Address targetAddr,instruction &insn, codeGen &gen) {
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  return insnCodeGenX86::modifyCall(targetAddr, insn, gen);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  return insnCodeGenAarch64::modifyCall(targetAddr, insn, gen);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  return insnCodeGenPower::modifyCall(targetAddr, insn, gen);
+#endif
+}
+
+bool insnCodeGen::modifyData(Dyninst::Address targetAddr, instruction &insn, codeGen &gen)
+{
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  return insnCodeGenX86::modifyData(targetAddr, insn, gen);
+#elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
+  return insnCodeGenAarch64::modifyData(targetAddr, insn, gen);
+#elif defined(DYNINST_CODEGEN_ARCH_POWER)
+  return insnCodeGenPower::modifyData(targetAddr, insn, gen);
+#endif
+}
+
+bool insnCodeGen::modifyDisp(signed long newDisp, NS_x86::instruction &insn, codeGen &gen, Dyninst::Architecture arch, Dyninst::Address addr) {
+#if defined(DYNINST_CODEGEN_ARCH_X86_64)
+  return insnCodeGenX86::modifyDisp(newDisp, insn, gen, arch, addr);
+#else
+  (void) newDisp; (void) insn; (void) gen; (void) arch; (void) addr;
+  return true;
+#endif
+}

--- a/dyninstAPI/src/insn-codegen.h
+++ b/dyninstAPI/src/insn-codegen.h
@@ -37,38 +37,59 @@
 #include "dyntypes.h"
 #include "dyn_register.h"
 #include "arch-x86.h"
+#include "arch-aarch64.h"
+#include "arch-power.h"
 #include "patch.h"
 
 #include "common/src/ia32_locations.h"
 
-#ifndef _CODEGEN_X86_H
-#define _CODEGEN_X86_H
+#ifndef _INSN_CODEGEN_H
+#define _INSN_CODEGEN_H
 
 // Code generation
 
 class codeGen;
 class AddressSpace;
 
-class insnCodeGenX86 : insnCodeGen {
+class insnCodeGen {
  public:
 
-  // More code generation
-  static void generatePush64(codeGen &gen, Dyninst::Address val);
-
-  // Code generation
-  static void generateBranch(codeGen &gen, Dyninst::Address from, Dyninst::Address to);
   static void generateBranch(codeGen &gen, int disp);
+  //static void generateBranch(codeGen &gen, Dyninst::Address from, Dyninst::Address to);
+  static void generateBranch(codeGen &gen,
+                               long jump_off,
+                               bool link = false);
+
+  static void generateBranch(codeGen &gen,
+                               Dyninst::Address from,
+                               Dyninst::Address to,
+                               bool link = false);
+
   static void generateBranch64(codeGen &gen, Dyninst::Address to);
   static void generateBranch32(codeGen &gen, Dyninst::Address to);
   static void generateCall(codeGen &gen, Dyninst::Address from, Dyninst::Address to);
 
-  // We may want to generate an efficient set 'o nops
-  static void generateNOOP(codeGen &gen, unsigned size = 1);
-  
+  #if defined(DYNINST_CODEGEN_ARCH_AARCH64)
+    static void generateNOOP(codeGen &gen, unsigned size = 4);
+  #else //if defined(DYNINST_CODEGEN_ARCH_X86_64)
+    static void generateNOOP(codeGen &gen, unsigned size = 1);
+  #endif
+
   static void generateIllegal(codeGen &gen);
   static void generateTrap(codeGen &gen);
 
   static void generate(codeGen &gen, NS_x86::instruction & insn);
+  static void generate(codeGen &gen, NS_power::instruction & insn);
+  static void generate(codeGen &gen, NS_aarch64::instruction & insn);
+  // Copy instruction at position in codeGen buffer
+  static void generate(codeGen &gen, NS_aarch64::instruction &insn, unsigned position);
+  static bool generate(codeGen &gen,
+                       NS_aarch64::instruction &insn,
+                       AddressSpace *proc,
+                       Dyninst::Address origAddr,
+                       Dyninst::Address newAddr,
+                       patchTarget *fallthroughOverride = NULL,
+                       patchTarget *targetOverride = NULL);
 
   // And generate an equivalent stream somewhere else...
   // fallthroughOverride and targetOverride are used for
@@ -101,9 +122,67 @@ class insnCodeGenX86 : insnCodeGen {
   static bool modifyData(Dyninst::Address target,
                          NS_x86::instruction &insn, 
                          codeGen &gen);
+
+  static bool modifyData(Dyninst::Address target,
+                           NS_aarch64::instruction &insn,
+                           codeGen &gen);
+
+  static bool modifyData(Dyninst::Address target,
+                           NS_power::instruction &insn,
+                           codeGen &gen);
+
+ 
   static bool modifyDisp(signed long newDisp,
                          NS_x86::instruction &insn,
                          codeGen &gen, Dyninst::Architecture arch, Dyninst::Address addr);
+
+  static bool modifyJump(Dyninst::Address target,
+                         NS_aarch64::instruction &insn,
+                         codeGen &gen);
+
+  static bool modifyJump(Dyninst::Address target,
+                         NS_power::instruction &insn,
+                         codeGen &gen);
+
+
+  static bool modifyJcc(Dyninst::Address target,
+                        NS_aarch64::instruction &insn,
+                        codeGen &gen);
+
+  static bool modifyJcc(Dyninst::Address target,
+                        NS_power::instruction &insn,
+                        codeGen &gen);
+
+
+  static bool modifyCall(Dyninst::Address target,
+                         NS_aarch64::instruction &insn,
+                         codeGen &gen);
+
+  static bool modifyCall(Dyninst::Address target,
+                         NS_power::instruction &insn,
+                         codeGen &gen);
+  // Generate conditional branch
+
+  // Generate conditional branch
+  static void generateConditionalBranch(codeGen& gen, Dyninst::Address to, unsigned opcode, bool s);
+
+  static bool generateMem(codeGen &gen,
+                          NS_aarch64::instruction &insn,
+                          Dyninst::Address origAddr,
+                          Dyninst::Address newAddr,
+                          Dyninst::Register newLoadReg,
+                          Dyninst::Register newStoreReg);
+
+   static bool generateMem(codeGen &gen,
+                          NS_power::instruction &insn,
+                          Dyninst::Address origAddr,
+                          Dyninst::Address newAddr,
+                          Dyninst::Register newLoadReg,
+                          Dyninst::Register newStoreReg);
+
+  
+ 
+
 };
 
 

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -433,13 +433,13 @@ void saveSPR(codeGen &gen,     //Instruction storage pointer
     XFORM_RA_SET(insn, sprnum & 0x1f);
     XFORM_RB_SET(insn, (sprnum >> 5) & 0x1f);
     XFORM_XO_SET(insn, MFSPRxop);
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 
     if (gen.width() == 4) {
-	insnCodeGen::generateImm(gen, STop,
+	insnCodeGenPower::generateImm(gen, STop,
                                  scratchReg, REG_SP, stkOffset);
     } else /* gen.width() == 8 */ {
-	insnCodeGen::generateMemAccess64(gen, STDop, STDxop,
+	insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop,
                                          scratchReg, REG_SP, stkOffset);
     }
 }
@@ -458,10 +458,10 @@ void restoreSPR(codeGen &gen,       //Instruction storage pointer
                 int           stkOffset)  //Offset from stack pointer
 {
     if (gen.width() == 4) {
-        insnCodeGen::generateImm(gen, Lop,
+        insnCodeGenPower::generateImm(gen, Lop,
                                  scratchReg, REG_SP, stkOffset);
     } else /* gen.width() == 8 */ {
-        insnCodeGen::generateMemAccess64(gen, LDop, LDxop,
+        insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop,
                                          scratchReg, REG_SP, stkOffset);
     }
 
@@ -474,7 +474,7 @@ void restoreSPR(codeGen &gen,       //Instruction storage pointer
     XFORM_RA_SET(insn, sprnum & 0x1f);
     XFORM_RB_SET(insn, (sprnum >> 5) & 0x1f);
     XFORM_XO_SET(insn, MTSPRxop);
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 }
 
            ////////////////////////////////////////////////////////////////////
@@ -519,7 +519,7 @@ void setBRL(codeGen &gen,        //Instruction storage pointer
             long          val,         //Value to set link register to
             instruction   ti)          //Tail instruction
 {
-    insnCodeGen::loadImmIntoReg(gen, scratchReg, val);
+    insnCodeGenPower::loadImmIntoReg(gen, scratchReg, val);
 
     instruction insn;
 
@@ -529,10 +529,10 @@ void setBRL(codeGen &gen,        //Instruction storage pointer
     XFORM_RT_SET(insn, scratchReg);
     XFORM_RA_SET(insn, SPR_LR);
     XFORM_XO_SET(insn, MTSPRxop);
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 
     insn = ti;
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 }
 
      //////////////////////////////////////////////////////////////////////////
@@ -573,13 +573,13 @@ void saveCR(codeGen &gen,       //Instruction storage pointer
     XFXFORM_OP_SET(insn, EXTop);
     XFXFORM_RT_SET(insn, scratchReg);
     XFXFORM_XO_SET(insn, MFCRxop);
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 
     if (gen.width() == 4) {
-        insnCodeGen::generateImm(gen, STop,
+        insnCodeGenPower::generateImm(gen, STop,
                                  scratchReg, REG_SP, stkOffset);
     } else /* gen.width() == 8 */ {
-        insnCodeGen::generateMemAccess64(gen, STDop, STDxop,
+        insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop,
                                          scratchReg, REG_SP, stkOffset);
     }
 }
@@ -598,10 +598,10 @@ void restoreCR(codeGen &gen,       //Instruction storage pointer
     instruction insn;
 
     if (gen.width() == 4) {
-        insnCodeGen::generateImm(gen, Lop,
+        insnCodeGenPower::generateImm(gen, Lop,
                                  scratchReg, REG_SP, stkOffset);
     } else /* gen.width() == 8 */ {
-        insnCodeGen::generateMemAccess64(gen, LDop, LDxop,
+        insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop,
                                          scratchReg, REG_SP, stkOffset);
     }
 
@@ -611,7 +611,7 @@ void restoreCR(codeGen &gen,       //Instruction storage pointer
     XFXFORM_RT_SET(insn, scratchReg);
     XFXFORM_SPR_SET(insn, 0xff << 1);
     XFXFORM_XO_SET(insn, MTCRFxop);
-    insnCodeGen::generate(gen,insn);
+    insnCodeGenPower::generate(gen,insn);
 }
 
     /////////////////////////////////////////////////////////////////////////
@@ -633,10 +633,10 @@ void saveFPSCR(codeGen &gen,       //Instruction storage pointer
     XFORM_OP_SET(mffs, X_FP_EXTENDEDop);
     XFORM_RT_SET(mffs, scratchReg);
     XFORM_XO_SET(mffs, MFFSxop);
-    insnCodeGen::generate(gen,mffs);
+    insnCodeGenPower::generate(gen,mffs);
 
     //st:     st scratchReg, stkOffset(r1)
-    insnCodeGen::generateImm(gen, STFDop, scratchReg, REG_SP, stkOffset);
+    insnCodeGenPower::generateImm(gen, STFDop, scratchReg, REG_SP, stkOffset);
 }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -651,7 +651,7 @@ void restoreFPSCR(codeGen &gen,       //Instruction storage pointer
                   Register      scratchReg, //Scratch fp register
                   int           stkOffset)  //Offset from stack pointer
 {
-    insnCodeGen::generateImm(gen, LFDop, scratchReg, REG_SP, stkOffset);
+    insnCodeGenPower::generateImm(gen, LFDop, scratchReg, REG_SP, stkOffset);
 
     instruction mtfsf;
 
@@ -661,7 +661,7 @@ void restoreFPSCR(codeGen &gen,       //Instruction storage pointer
     XFLFORM_FLM_SET(mtfsf, 0xff);
     XFLFORM_FRB_SET(mtfsf, scratchReg);
     XFLFORM_XO_SET(mtfsf, MTFSFxop);
-    insnCodeGen::generate(gen,mtfsf);
+    insnCodeGenPower::generate(gen,mtfsf);
 }
 
      //////////////////////////////////////////////////////////////////////////
@@ -679,10 +679,10 @@ void saveRegisterAtOffset(codeGen &gen,
                           Register reg,
                           int save_off) {
     if (gen.width() == 4) {
-        insnCodeGen::generateImm(gen, STop,
+        insnCodeGenPower::generateImm(gen, STop,
                                  reg, REG_SP, save_off);
     } else /* gen.width() == 8 */ {
-        insnCodeGen::generateMemAccess64(gen, STDop, STDxop,
+        insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop,
                                          reg, REG_SP, save_off);
     }
 }
@@ -707,10 +707,10 @@ void restoreRegisterAtOffset(codeGen &gen,
                              Register dest,
                              int saved_off) {
     if (gen.width() == 4) {
-        insnCodeGen::generateImm(gen, Lop, 
+        insnCodeGenPower::generateImm(gen, Lop, 
                                  dest, REG_SP, saved_off);
     } else /* gen.width() == 8 */ {
-        insnCodeGen::generateMemAccess64(gen, LDop, LDxop,
+        insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop,
                                          dest, REG_SP, saved_off);
     }
 }
@@ -737,7 +737,7 @@ void saveFPRegister(codeGen &gen,
 {
     assert("WE SHOULD NOT BE HERE" == 0);
 
-    insnCodeGen::generateImm(gen, STFDop, 
+    insnCodeGenPower::generateImm(gen, STFDop, 
                              reg, REG_SP, save_off + reg*FPRSIZE);
 }
 
@@ -748,7 +748,7 @@ void restoreFPRegister(codeGen &gen,
 {
     assert("WE SHOULD NOT BE HERE" == 0);
     
-    insnCodeGen::generateImm(gen, LFDop, 
+    insnCodeGenPower::generateImm(gen, LFDop, 
                              dest, REG_SP, save_off + source*FPRSIZE);
 }
 
@@ -765,10 +765,10 @@ void restoreFPRegister(codeGen &gen,
 void pushStack(codeGen &gen)
 {
     if (gen.width() == 4) {
-	insnCodeGen::generateImm(gen, STUop,
+	insnCodeGenPower::generateImm(gen, STUop,
 				 REG_SP, REG_SP, -TRAMP_FRAME_SIZE_32);
     } else /* gen.width() == 8 */ {
-	insnCodeGen::generateMemAccess64(gen, STDop, STDUxop,
+	insnCodeGenPower::generateMemAccess64(gen, STDop, STDUxop,
                                   REG_SP, REG_SP, -TRAMP_FRAME_SIZE_64);
     }
 }
@@ -776,11 +776,11 @@ void pushStack(codeGen &gen)
 void popStack(codeGen &gen)
 {
     if (gen.width() == 4) {
-	insnCodeGen::generateImm(gen, CALop, 
+	insnCodeGenPower::generateImm(gen, CALop, 
 				 REG_SP, REG_SP, TRAMP_FRAME_SIZE_32);
 
     } else /* gen.width() == 8 */ {
-	insnCodeGen::generateImm(gen, CALop,
+	insnCodeGenPower::generateImm(gen, CALop,
                                  REG_SP, REG_SP, TRAMP_FRAME_SIZE_64);
     }
 }
@@ -851,7 +851,7 @@ unsigned saveFPRegisters(codeGen &gen,
                          registerSpace *,
                          int save_off)
 {
-  insnCodeGen::saveVectors(gen, save_off);
+  insnCodeGenPower::saveVectors(gen, save_off);
   return 32;
 }
 
@@ -866,7 +866,7 @@ unsigned restoreFPRegisters(codeGen &gen,
                             int save_off)
 {
   
-  insnCodeGen::restoreVectors(gen, save_off);
+  insnCodeGenPower::restoreVectors(gen, save_off);
   return 32;
 }
 
@@ -1038,19 +1038,19 @@ void emitImm(opCode op, Register src1, RegValue src2imm, Register dest,
         // integer ops
     case plusOp:
         iop = CALop;
-        insnCodeGen::generateImm(gen, iop, dest, src1, src2imm);
+        insnCodeGenPower::generateImm(gen, iop, dest, src1, src2imm);
         return;
         break;
         
     case minusOp:
         iop = SIop;
-        insnCodeGen::generateImm(gen, iop, dest, src1, src2imm);
+        insnCodeGenPower::generateImm(gen, iop, dest, src1, src2imm);
         return;
         break;
         
     case timesOp:
        if (isPowerOf2(src2imm,result) && (result < (int) (gen.width() * 8))) {
-            insnCodeGen::generateLShift(gen, src1, result, dest);
+            insnCodeGenPower::generateLShift(gen, src1, result, dest);
             return;
         }
         else {
@@ -1073,14 +1073,14 @@ void emitImm(opCode op, Register src1, RegValue src2imm, Register dest,
     case orOp:
         iop = ORILop;
         // For some reason, the destField is 2nd for ORILop and ANDILop
-        insnCodeGen::generateImm(gen, iop, src1, dest, src2imm);
+        insnCodeGenPower::generateImm(gen, iop, src1, dest, src2imm);
         return;
         break;
         
     case andOp:
         iop = ANDILop;
         // For some reason, the destField is 2nd for ORILop and ANDILop
-        insnCodeGen::generateImm(gen, iop, src1, dest, src2imm);
+        insnCodeGenPower::generateImm(gen, iop, src1, dest, src2imm);
         return;
         break;
     default:
@@ -1180,10 +1180,10 @@ void EmitterPOWER::emitCallWithSaves(codeGen &gen, Address dest, bool saveToc, b
     if (saveR12) {}
 
     emitVload(loadConstOp, dest, 0, 0, gen, false);
-    insnCodeGen::generateMoveToLR(gen, 0);
+    insnCodeGenPower::generateMoveToLR(gen, 0);
     emitVload(loadConstOp, dest, 12, 12, gen, false);
     instruction brl(BRLraw);
-    insnCodeGen::generate(gen,brl);
+    insnCodeGenPower::generate(gen,brl);
     inst_printf("Generated BRL\n");
     // Retore the original
     if (saveToc) {}
@@ -1222,7 +1222,7 @@ Register EmitterPOWER::emitCallReplacement(opCode ocode,
     emitVload(loadConstOp, callee->addr(), freeReg, freeReg, gen, false);
 
     // Move to link register.
-    insnCodeGen::generate(gen,mtlr);
+    insnCodeGenPower::generate(gen,mtlr);
 
     Address toc_new = gen.addrSpace()->proc()->getTOCoffsetInfo(callee);
     if (toc_new) {
@@ -1232,7 +1232,7 @@ Register EmitterPOWER::emitCallReplacement(opCode ocode,
 
     // blr - branch through the link reg.
     instruction blr(BRraw);
-    insnCodeGen::generate(gen,blr);
+    insnCodeGenPower::generate(gen,blr);
 
     func_instance *caller = gen.point()->func();
     Address toc_orig = gen.addrSpace()->proc()->getTOCoffsetInfo(caller);
@@ -1319,7 +1319,7 @@ Register EmitterPOWER::emitCall(opCode ocode,
     // Linux, 32/64, stat/dynamic, instrumentation
     if (needToSaveLR) {
         assert(inInstrumentation);
-        insnCodeGen::generateMoveFromLR(gen, 0);
+        insnCodeGenPower::generateMoveFromLR(gen, 0);
         saveRegister(gen, 0, FUNC_CALL_SAVE(gen.width()));
         savedRegs.push_back(0);
         inst_printf("saved LR in 0\n");
@@ -1400,7 +1400,7 @@ Register EmitterPOWER::emitCall(opCode ocode,
 
         // If the parameter we want exists in a scratch register...
 	if (scratchRegs[u] != -1) {
-	    insnCodeGen::generateImm(gen, ORILop, scratchRegs[u], u+3, 0);
+	    insnCodeGenPower::generateImm(gen, ORILop, scratchRegs[u], u+3, 0);
 	    gen.rs()->freeRegister(scratchRegs[u]);
             // We should check to make sure the one we want isn't occupied?
 	} else {
@@ -1416,16 +1416,16 @@ Register EmitterPOWER::emitCall(opCode ocode,
             // into scratch.
 	    if (!hasSourceBeenCopied) {
                 Register scratch = gen.rs()->getScratchRegister(gen);
-		insnCodeGen::generateImm(gen, ORILop, u+3, scratch, 0);
+		insnCodeGenPower::generateImm(gen, ORILop, u+3, scratch, 0);
 		gen.rs()->freeRegister(u+3);
 		scratchRegs[whichSource] = scratch;
 		hasSourceBeenCopied = true;
 
-		insnCodeGen::generateImm(gen, ORILop, srcs[u], u+3, 0);
+		insnCodeGenPower::generateImm(gen, ORILop, srcs[u], u+3, 0);
 		gen.rs()->freeRegister(srcs[u]);
 
 	    } else {
-		insnCodeGen::generateImm(gen, ORILop, srcs[u], u+3, 0);
+		insnCodeGenPower::generateImm(gen, ORILop, srcs[u], u+3, 0);
 		gen.rs()->freeRegister(srcs[u]);
 	    }
 	} 
@@ -1447,7 +1447,7 @@ Register EmitterPOWER::emitCall(opCode ocode,
         // get a register to keep the return value in.
         retReg = gen.rs()->allocateRegister(gen, noCost);        
         // put the return value from register 3 to the newly allocated register.
-        insnCodeGen::generateImm(gen, ORILop, 3, retReg, 0);
+        insnCodeGenPower::generateImm(gen, ORILop, 3, retReg, 0);
     }
 
         
@@ -1468,7 +1468,7 @@ Register EmitterPOWER::emitCall(opCode ocode,
     // Reused from above. instruction mtlr0(MTLR0raw);
     if (needToSaveLR) {
         // We only use register 0 to save LR. 
-        insnCodeGen::generateMoveToLR(gen, 0);
+        insnCodeGenPower::generateMoveToLR(gen, 0);
     }
     
     if (!inInstrumentation && setTOC) {
@@ -1497,7 +1497,7 @@ codeBufIndex_t emitA(opCode op, Register src1, Register /*src2*/, long dest,
           DFORM_OP_SET(insn, CMPIop);
           DFORM_RA_SET(insn, src1);
           DFORM_SI_SET(insn, 0);
-          insnCodeGen::generate(gen,insn);
+          insnCodeGenPower::generate(gen,insn);
           retval = gen.getIndex();
           
           // be 0, dest
@@ -1509,12 +1509,12 @@ codeBufIndex_t emitA(opCode op, Register src1, Register /*src2*/, long dest,
           BFORM_AA_SET(insn, 0);
           BFORM_LK_SET(insn, 0);
           
-          insnCodeGen::generate(gen,insn);
+          insnCodeGenPower::generate(gen,insn);
           break;
       }
     case branchOp: {
         retval = gen.getIndex();
-        insnCodeGen::generateBranch(gen, dest);
+        insnCodeGenPower::generateBranch(gen, dest);
         break;
     }
     case trampPreamble: {
@@ -1651,12 +1651,12 @@ static inline void restoreGPRtoGPR(codeGen &gen,
 
     if (reg == 1) // SP is in a different place, but we don't need to
                   // restore it, just subtract the stack frame size
-        insnCodeGen::generateImm(gen, CALop, dest, REG_SP, frame_size);
+        insnCodeGenPower::generateImm(gen, CALop, dest, REG_SP, frame_size);
 
     else if((reg == 0) || ((reg >= 3) && (reg <=12)))
-	 insnCodeGen::generateMemAccess64(gen, LDop, LDxop, dest, REG_SP, gpr_off + reg*gpr_size);
+	 insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop, dest, REG_SP, gpr_off + reg*gpr_size);
 // Past code restoring 32bit's of register instead of entire register
-//        insnCodeGen::generateImm(gen, Lop, dest, REG_SP,
+//        insnCodeGenPower::generateImm(gen, Lop, dest, REG_SP,
 //                                 gpr_off + reg*gpr_size);
     else {
         bperr( "GPR %u should not be restored...", reg);
@@ -1668,10 +1668,10 @@ static inline void restoreGPRtoGPR(codeGen &gen,
 static inline void restoreXERtoGPR(codeGen &gen, Register dest)
 {
     if (gen.width() == 4) {
-        insnCodeGen::generateImm(gen, Lop, dest, REG_SP,
+        insnCodeGenPower::generateImm(gen, Lop, dest, REG_SP,
                                  TRAMP_SPR_OFFSET(4) + STK_XER_32);
     } else /* gen.width() == 8 */ {
-        insnCodeGen::generateMemAccess64(gen, LDop, LDxop, dest, REG_SP,
+        insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop, dest, REG_SP,
                                          TRAMP_SPR_OFFSET(8) + STK_XER_64);
     }
 }
@@ -1694,7 +1694,7 @@ static inline void moveGPR2531toGPR(codeGen &gen,
     MDFORM_XO_SET( rld, ICLxop);
     MDFORM_SH2_SET(rld, 0); //(32+25+7) / 32;
     MDFORM_RC_SET( rld, 0);
-    insnCodeGen::generate(gen,rld);
+    insnCodeGenPower::generate(gen,rld);
 }
 
 // VG(11/16/01): Emit code to add the original value of a register to
@@ -1776,23 +1776,23 @@ void emitVload(opCode op, Address src1, Register src2, Register dest,
 {
   switch(op) {
   case loadConstOp:
-    insnCodeGen::loadImmIntoReg(gen, dest, (long)src1);
+    insnCodeGenPower::loadImmIntoReg(gen, dest, (long)src1);
     break;
   case loadOp:
-    insnCodeGen::loadPartialImmIntoReg(gen, dest, (long)src1);
+    insnCodeGenPower::loadPartialImmIntoReg(gen, dest, (long)src1);
     
     // really load dest, (dest)imm
     if (size == 1) {
-      insnCodeGen::generateImm(gen, LBZop, dest, dest, LOW(src1));
+      insnCodeGenPower::generateImm(gen, LBZop, dest, dest, LOW(src1));
     }
     else if (size == 2) {
-      insnCodeGen::generateImm(gen, LHZop, dest, dest, LOW(src1));
+      insnCodeGenPower::generateImm(gen, LHZop, dest, dest, LOW(src1));
     }
     else if ((size == 4) ||
 	     (size == 8 && proc->getAddressWidth() == 4)) // Override bogus size
-      insnCodeGen::generateImm(gen, Lop,   dest, dest, LOW(src1));
+      insnCodeGenPower::generateImm(gen, Lop,   dest, dest, LOW(src1));
     else if (size == 8)
-      insnCodeGen::generateMemAccess64(gen, LDop, LDxop,
+      insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop,
 				       dest, dest, (int16_t)LOW(src1));
     else assert(0 && "Incompatible loadOp size");
     break;
@@ -1805,14 +1805,14 @@ void emitVload(opCode op, Address src1, Register src2, Register dest,
 
 	// return the value that is FP offset from the original fp
 	if (size == 1)
-	    insnCodeGen::generateImm(gen, LBZop, dest, REG_SP, offset);
+	    insnCodeGenPower::generateImm(gen, LBZop, dest, REG_SP, offset);
 	else if (size == 2)
-	    insnCodeGen::generateImm(gen, LHZop, dest, REG_SP, offset);
+	    insnCodeGenPower::generateImm(gen, LHZop, dest, REG_SP, offset);
 	else if ((size == 4) ||
 		 (size == 8 && proc->getAddressWidth() == 4)) // Override bogus size
-	    insnCodeGen::generateImm(gen, Lop,   dest, REG_SP, offset);
+	    insnCodeGenPower::generateImm(gen, Lop,   dest, REG_SP, offset);
 	else if (size == 8)
-	    insnCodeGen::generateMemAccess64(gen, LDop, LDxop,
+	    insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop,
 					     dest, REG_SP, offset);
 	else assert(0 && "Incompatible loadFrameRelativeOp size");
   }
@@ -1824,7 +1824,7 @@ void emitVload(opCode op, Address src1, Register src2, Register dest,
 	       : TRAMP_FRAME_SIZE_64);
     
     if (offset < MIN_IMM16 || MAX_IMM16 < offset) assert(0);
-    insnCodeGen::generateImm(gen, CALop, dest, REG_SP, offset);
+    insnCodeGenPower::generateImm(gen, CALop, dest, REG_SP, offset);
   }
     break;
   case loadRegRelativeAddr:
@@ -1835,14 +1835,14 @@ void emitVload(opCode op, Address src1, Register src2, Register dest,
     gen.rs()->readProgramRegister(gen, src2, dest, size);
 
     if (size == 1)
-      insnCodeGen::generateImm(gen, LBZop, dest, dest, src1);
+      insnCodeGenPower::generateImm(gen, LBZop, dest, dest, src1);
     else if (size == 2)
-      insnCodeGen::generateImm(gen, LHZop, dest, dest, src1);
+      insnCodeGenPower::generateImm(gen, LHZop, dest, dest, src1);
     else if ((size == 4) ||
 	     (size == 8 && proc->getAddressWidth() == 4)) // Override bogus size
-      insnCodeGen::generateImm(gen, Lop,   dest, dest, src1);
+      insnCodeGenPower::generateImm(gen, Lop,   dest, dest, src1);
     else if (size == 8)
-      insnCodeGen::generateMemAccess64(gen, LDop, LDxop,
+      insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop,
 				       dest, dest, src1);
     break;
   default:
@@ -1862,16 +1862,16 @@ void emitVstore(opCode op, Register src1, Register /*src2*/, Address dest,
 	// temp register to hold base address for store (added 6/26/96 jkh)
 	Register temp = gen.rs()->getScratchRegister(gen, noCost);
 
-        insnCodeGen::loadPartialImmIntoReg(gen, temp, (long)dest);
+        insnCodeGenPower::loadPartialImmIntoReg(gen, temp, (long)dest);
         if (size == 1)
-            insnCodeGen::generateImm(gen, STBop, src1, temp, LOW(dest));
+            insnCodeGenPower::generateImm(gen, STBop, src1, temp, LOW(dest));
         else if (size == 2)
-            insnCodeGen::generateImm(gen, STHop, src1, temp, LOW(dest));
+            insnCodeGenPower::generateImm(gen, STHop, src1, temp, LOW(dest));
         else if ((size == 4) ||
 		 (size == 8 && proc->getAddressWidth() == 4)) // Override bogus size
-            insnCodeGen::generateImm(gen, STop,  src1, temp, LOW(dest));
+            insnCodeGenPower::generateImm(gen, STop,  src1, temp, LOW(dest));
         else if (size == 8)
-            insnCodeGen::generateMemAccess64(gen, STDop, STDxop,
+            insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop,
                                              src1, temp, (int16_t)BOT_LO(dest));
         else assert(0 && "Incompatible storeOp size");
 
@@ -1882,14 +1882,14 @@ void emitVstore(opCode op, Register src1, Register /*src2*/, Address dest,
 		   : TRAMP_FRAME_SIZE_64);
 
         if (size == 1)
-            insnCodeGen::generateImm(gen, STBop, src1, REG_SP, offset);
+            insnCodeGenPower::generateImm(gen, STBop, src1, REG_SP, offset);
         else if (size == 2)
-            insnCodeGen::generateImm(gen, STHop, src1, REG_SP, offset);
+            insnCodeGenPower::generateImm(gen, STHop, src1, REG_SP, offset);
         else if ((size == 4) ||
 		 (size == 8 || proc->getAddressWidth() == 4)) // Override bogus size
-            insnCodeGen::generateImm(gen, STop,  src1, REG_SP, offset);
+            insnCodeGenPower::generateImm(gen, STop,  src1, REG_SP, offset);
         else if (size == 8)
-            insnCodeGen::generateMemAccess64(gen, STDop, STDxop, src1,
+            insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop, src1,
                                              REG_SP, offset);
         else assert(0 && "Incompatible storeFrameRelativeOp size");
 
@@ -1917,14 +1917,14 @@ void emitV(opCode op, Register src1, Register src2, Register dest,
        if (!size)
           size = proc->getAddressWidth();
        if (size == 1)
-          insnCodeGen::generateImm(gen, LBZop, dest, src1, 0);
+          insnCodeGenPower::generateImm(gen, LBZop, dest, src1, 0);
        else if (size == 2)
-          insnCodeGen::generateImm(gen, LHZop, dest, src1, 0);
+          insnCodeGenPower::generateImm(gen, LHZop, dest, src1, 0);
        else if ((size == 4) ||
                 (size == 8 && proc->getAddressWidth() == 4)) // Override bogus size
-          insnCodeGen::generateImm(gen, Lop,   dest, src1, 0);
+          insnCodeGenPower::generateImm(gen, Lop,   dest, src1, 0);
        else if (size == 8) {
-          insnCodeGen::generateMemAccess64(gen, LDop, LDxop,
+          insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop,
                                            dest, src1, 0);
        } 
        else 
@@ -1932,19 +1932,19 @@ void emitV(opCode op, Register src1, Register src2, Register dest,
     } else if (op == storeIndirOp) {
         // generate -- st src1, dest
         if (size == 1)
-            insnCodeGen::generateImm(gen, STBop, src1, dest, 0);
+            insnCodeGenPower::generateImm(gen, STBop, src1, dest, 0);
         else if (size == 2)
-            insnCodeGen::generateImm(gen, STHop, src1, dest, 0);
+            insnCodeGenPower::generateImm(gen, STHop, src1, dest, 0);
         else if ((size == 4) ||
 		 (size == 8 && proc->getAddressWidth() == 4)) // Override bogus size
-            insnCodeGen::generateImm(gen, STop,  src1, dest, 0);
+            insnCodeGenPower::generateImm(gen, STop,  src1, dest, 0);
         else if (size == 8)
-            insnCodeGen::generateMemAccess64(gen, STDop, STDxop,
+            insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop,
                                              src1, dest, 0);
         else assert(0 && "Incompatible storeOp size");
 
     } else if (op == noOp) {
-        insnCodeGen::generateNOOP(gen);
+        insnCodeGenPower::generateNOOP(gen);
 
     } else if (op == saveRegOp) {
         saveRegister(gen,src1,8);
@@ -1997,7 +1997,7 @@ void emitV(opCode op, Register src1, Register src2, Register dest,
                 XOFORM_RT_SET(insn, src1);
                 XOFORM_RB_SET(insn, src2);
                 XOFORM_XO_SET(insn, ORxop);
-                insnCodeGen::generate(gen,insn);
+                insnCodeGenPower::generate(gen,insn);
                 return;
                 break;
 
@@ -2010,7 +2010,7 @@ void emitV(opCode op, Register src1, Register src2, Register dest,
                 XOFORM_RT_SET(insn, src1);
                 XOFORM_RB_SET(insn, src2);
                 XOFORM_XO_SET(insn, ANDxop);
-                insnCodeGen::generate(gen,insn);
+                insnCodeGenPower::generate(gen,insn);
                 return;
 		break;
 
@@ -2022,38 +2022,38 @@ void emitV(opCode op, Register src1, Register src2, Register dest,
 		XOFORM_RT_SET(insn, src1);
 		XOFORM_RB_SET(insn, src2);
 		XOFORM_XO_SET(insn, XORxop);
-		insnCodeGen::generate(gen, insn);
+		insnCodeGenPower::generate(gen, insn);
 		return;
 		break;
 
             // rel ops
             case eqOp:
-                insnCodeGen::generateRelOp(gen, EQcond, BTRUEcond, src1, src2, dest, s);
+                insnCodeGenPower::generateRelOp(gen, EQcond, BTRUEcond, src1, src2, dest, s);
                 return;
                 break;
 
             case neOp:
-                insnCodeGen::generateRelOp(gen, EQcond, BFALSEcond, src1, src2, dest, s);
+                insnCodeGenPower::generateRelOp(gen, EQcond, BFALSEcond, src1, src2, dest, s);
                 return;
                 break;
 
             case lessOp:
-                insnCodeGen::generateRelOp(gen, LTcond, BTRUEcond, src1, src2, dest, s);
+                insnCodeGenPower::generateRelOp(gen, LTcond, BTRUEcond, src1, src2, dest, s);
                 return;
                 break;
 
             case greaterOp:
-                insnCodeGen::generateRelOp(gen, GTcond, BTRUEcond, src1, src2, dest, s);
+                insnCodeGenPower::generateRelOp(gen, GTcond, BTRUEcond, src1, src2, dest, s);
                 return;
                 break;
 
             case leOp:
-                insnCodeGen::generateRelOp(gen, GTcond, BFALSEcond, src1, src2, dest, s);
+                insnCodeGenPower::generateRelOp(gen, GTcond, BFALSEcond, src1, src2, dest, s);
                 return;
                 break;
 
             case geOp:
-                insnCodeGen::generateRelOp(gen, LTcond, BFALSEcond, src1, src2, dest, s);
+                insnCodeGenPower::generateRelOp(gen, LTcond, BFALSEcond, src1, src2, dest, s);
                 return;
                 break;
 
@@ -2072,7 +2072,7 @@ void emitV(opCode op, Register src1, Register src2, Register dest,
         XOFORM_RA_SET(insn, src1);
         XOFORM_RB_SET(insn, src2);
         XOFORM_XO_SET(insn, instXop);
-        insnCodeGen::generate(gen,insn);
+        insnCodeGenPower::generate(gen,insn);
     }
   return;
 }
@@ -2476,14 +2476,14 @@ bool EmitterPOWER::emitCallRelative(Register dest, Address offset, Register base
     if (gen.width() == 4) {
       if (((signed)MIN_IMM16 <= (signed)imm) && ((signed)imm <= (signed)MAX_IMM16))
         {
-          insnCodeGen::generateImm (gen, CALop, dest, base, imm);
+          insnCodeGenPower::generateImm (gen, CALop, dest, base, imm);
 
         }
       else if (((signed)MIN_IMM32 <= (signed)imm) && ((signed)imm <= (signed)MAX_IMM32))
         {
-          insnCodeGen::generateImm (gen, CAUop, dest, 0, BOT_HI (offset));
-          insnCodeGen::generateImm (gen, ORILop, dest, dest, BOT_LO (offset));
-          insnCodeGen::generateAddReg (gen, CAXop, dest, dest, base);
+          insnCodeGenPower::generateImm (gen, CAUop, dest, 0, BOT_HI (offset));
+          insnCodeGenPower::generateImm (gen, ORILop, dest, dest, BOT_LO (offset));
+          insnCodeGenPower::generateAddReg (gen, CAXop, dest, dest, base);
         }
 	else {
 		assert(0);
@@ -2513,13 +2513,13 @@ bool EmitterPOWER::emitLoadRelative(Register dest, Address offset, Register base
       return false;
       break;
     }
-    insnCodeGen::generateImm (gen, ocode, dest, base, offset);    
+    insnCodeGenPower::generateImm (gen, ocode, dest, base, offset);    
   }
   else {
     // Add the offset to the base register, which holds 
     // the current PC
-    insnCodeGen::generateImm (gen, CAUop, base, base, HA (offset));
-    insnCodeGen::generateImm (gen, CALop, base, base, LOW (offset));
+    insnCodeGenPower::generateImm (gen, CAUop, base, base, HA (offset));
+    insnCodeGenPower::generateImm (gen, CALop, base, base, LOW (offset));
 
     int ocode = LXop;
     int xcode = 0;
@@ -2549,7 +2549,7 @@ bool EmitterPOWER::emitLoadRelative(Register dest, Address offset, Register base
     XFORM_RB_SET(insn, base);
     XFORM_XO_SET(insn, xcode);
     XFORM_RC_SET(insn, 0);
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenPower::generate(gen, insn);
   }
   return true;
 }
@@ -2575,14 +2575,14 @@ void EmitterPOWER::emitStoreRelative(Register source, Address offset, Register b
       assert(0);
       break;
     }
-    insnCodeGen::generateImm (gen, ocode, source, base, offset);    
+    insnCodeGenPower::generateImm (gen, ocode, source, base, offset);    
   }
   else {
 
     // Add the offset to the base register, which holds 
     // the current PC
-    insnCodeGen::generateImm (gen, CAUop, base, base, HA (offset));
-    insnCodeGen::generateImm (gen, CALop, base, base, LOW (offset));
+    insnCodeGenPower::generateImm (gen, CAUop, base, base, HA (offset));
+    insnCodeGenPower::generateImm (gen, CALop, base, base, LOW (offset));
 
     int ocode = STXop;
     int xcode = 0;
@@ -2612,7 +2612,7 @@ void EmitterPOWER::emitStoreRelative(Register source, Address offset, Register b
     XFORM_RB_SET(insn, base);
     XFORM_XO_SET(insn, xcode);
     XFORM_RC_SET(insn, 0);
-    insnCodeGen::generate(gen, insn);
+    insnCodeGenPower::generate(gen, insn);
   }
 }
 
@@ -2623,7 +2623,7 @@ bool EmitterPOWER::emitMoveRegToReg(registerSlot *src,
 
     switch (src->type) {
     case registerSlot::GPR:
-        insnCodeGen::generateImm(gen, ORILop, src->encoding(), dest->encoding(), 0);
+        insnCodeGenPower::generateImm(gen, ORILop, src->encoding(), dest->encoding(), 0);
         break;
     case registerSlot::SPR: {
         instruction insn;
@@ -2639,14 +2639,14 @@ bool EmitterPOWER::emitMoveRegToReg(registerSlot *src,
             XFORM_RA_SET(insn, src->encoding() & 0x1f);
             XFORM_RB_SET(insn, (src->encoding() >> 5) & 0x1f);
             XFORM_XO_SET(insn, MFSPRxop);
-            insnCodeGen::generate(gen,insn);
+            insnCodeGenPower::generate(gen,insn);
             break;
         case registerSpace::cr:
             insn.clear();                    //mtcrf:  scratchReg
             XFXFORM_OP_SET(insn, EXTop);
             XFXFORM_RT_SET(insn, dest->encoding());
             XFXFORM_XO_SET(insn, MFCRxop);
-            insnCodeGen::generate(gen,insn);
+            insnCodeGenPower::generate(gen,insn);
             break;
         default:
             assert(0);
@@ -2670,7 +2670,7 @@ bool EmitterPOWER32Stat::emitCallInstruction(codeGen& gen, func_instance* callee
   if (gen.func()->obj() != callee->obj()) {
     return emitPLTCall(callee, gen);
   }
-  insnCodeGen::generateCall(gen, gen.currAddr(), callee->addr());
+  insnCodeGenPower::generateCall(gen, gen.currAddr(), callee->addr());
   return true;
 }
 
@@ -2689,7 +2689,7 @@ bool EmitterPOWER32Stat::emitPLTCommon(func_instance *callee, bool call, codeGen
 
   if (!call) {
     // Save the LR in scratchLR
-    insnCodeGen::generateMoveFromLR(gen, scratchLR);
+    insnCodeGenPower::generateMoveFromLR(gen, scratchLR);
   }
 
   // Generate the PLT call
@@ -2698,7 +2698,7 @@ bool EmitterPOWER32Stat::emitPLTCommon(func_instance *callee, bool call, codeGen
   Address pcVal = emitMovePCToReg(scratchReg, gen);
 
   if (!call) {
-    insnCodeGen::generateMoveToLR(gen, scratchLR);
+    insnCodeGenPower::generateMoveToLR(gen, scratchLR);
   }
 
   // We can now use scratchLR
@@ -2706,15 +2706,15 @@ bool EmitterPOWER32Stat::emitPLTCommon(func_instance *callee, bool call, codeGen
   Address varOffset = dest - pcVal;
   emitLoadRelative(scratchLR, varOffset, scratchReg, gen.width(), gen);
   
-  insnCodeGen::generateMoveToCR(gen, scratchLR);
+  insnCodeGenPower::generateMoveToCR(gen, scratchLR);
 
   if (!call) {
     instruction br(BCTRraw);
-    insnCodeGen::generate(gen, br);
+    insnCodeGenPower::generate(gen, br);
   }
   else {
     instruction brl(BCTRLraw);
-    insnCodeGen::generate(gen, brl);
+    insnCodeGenPower::generate(gen, brl);
   }
 
   return true;
@@ -2754,7 +2754,7 @@ bool EmitterPOWER32Stat::emitTOCCommon(block_instance *block, bool call, codeGen
 
   if (!call) {
     // Save the LR in scratchLR
-    insnCodeGen::generateMoveFromLR(gen, scratchLR);
+    insnCodeGenPower::generateMoveFromLR(gen, scratchLR);
   }
 
   // Generate the PLT call
@@ -2763,7 +2763,7 @@ bool EmitterPOWER32Stat::emitTOCCommon(block_instance *block, bool call, codeGen
   Address pcVal = emitMovePCToReg(scratchReg, gen);
 
   if (!call) {
-    insnCodeGen::generateMoveToLR(gen, scratchLR);
+    insnCodeGenPower::generateMoveToLR(gen, scratchLR);
   }
 
   // We can now use scratchLR
@@ -2771,15 +2771,15 @@ bool EmitterPOWER32Stat::emitTOCCommon(block_instance *block, bool call, codeGen
   Address varOffset = dest - pcVal;
   emitLoadRelative(scratchLR, varOffset, scratchReg, gen.width(), gen);
   
-  insnCodeGen::generateMoveToCR(gen, scratchLR);
+  insnCodeGenPower::generateMoveToCR(gen, scratchLR);
 
   if (!call) {
     instruction br(BCTRraw);
-    insnCodeGen::generate(gen, br);
+    insnCodeGenPower::generate(gen, br);
   }
   else {
     instruction brl(BCTRLraw);
-    insnCodeGen::generate(gen, brl);
+    insnCodeGenPower::generate(gen, brl);
   }
 
   return true;
@@ -2813,14 +2813,14 @@ bool EmitterPOWER64Stat::emitPLTCommon(func_instance *callee, bool call, codeGen
   unsigned r_tmp = 12; // R12 ; We need to put callee address into R12 
 
   // Save R12
-  insnCodeGen::generateMemAccess64(gen, STDop, STDxop, r_tmp, REG_SP, 3*wordsize);
+  insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop, r_tmp, REG_SP, 3*wordsize);
   
   // Save LR
-  insnCodeGen::generateMoveFromLR(gen, r_tmp);
-  insnCodeGen::generateMemAccess64(gen, STDop, STDxop, r_tmp, REG_SP, 4*wordsize);
+  insnCodeGenPower::generateMoveFromLR(gen, r_tmp);
+  insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop, r_tmp, REG_SP, 4*wordsize);
 
   // Save R2
-  insnCodeGen::generateMemAccess64(gen, STDop, STDxop, TOCreg, REG_SP, 5*wordsize);
+  insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop, TOCreg, REG_SP, 5*wordsize);
 
   // r_tmp := func_desc
   // We first load PC into R12
@@ -2830,26 +2830,26 @@ bool EmitterPOWER64Stat::emitPLTCommon(func_instance *callee, bool call, codeGen
 
   // Here we use R2 as a temp register:
   // We load the offset into R2
-  insnCodeGen::loadImmIntoReg(gen, TOCreg, func_desc_from_cur);
+  insnCodeGenPower::loadImmIntoReg(gen, TOCreg, func_desc_from_cur);
   
   // Add the offset to R12, which contains the PC
-  insnCodeGen::generateAddReg(gen, CAXop, r_tmp, r_tmp, TOCreg);
+  insnCodeGenPower::generateAddReg(gen, CAXop, r_tmp, r_tmp, TOCreg);
 
   // r_tmp := *(r_tmp)
-  insnCodeGen::generateMemAccess64(gen, LDop, LDxop, r_tmp, r_tmp, 0);
+  insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop, r_tmp, r_tmp, 0);
   
   // lr := r_tmp; Loading the call target
-  insnCodeGen::generateMoveToLR(gen, r_tmp);
+  insnCodeGenPower::generateMoveToLR(gen, r_tmp);
 
   // blrl
   instruction branch_insn(BRLraw);
-  insnCodeGen::generate(gen, branch_insn);
+  insnCodeGenPower::generate(gen, branch_insn);
 
   // Restore LR, R2, and R12
-  insnCodeGen::generateMemAccess64(gen, LDop, LDxop, r_tmp, REG_SP, 4*wordsize);
-  insnCodeGen::generateMoveToLR(gen, r_tmp);
-  insnCodeGen::generateMemAccess64(gen, LDop, LDxop, r_tmp, REG_SP, 3*wordsize);
-  insnCodeGen::generateMemAccess64(gen, LDop, LDxop, TOCreg, REG_SP, 5*wordsize);
+  insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop, r_tmp, REG_SP, 4*wordsize);
+  insnCodeGenPower::generateMoveToLR(gen, r_tmp);
+  insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop, r_tmp, REG_SP, 3*wordsize);
+  insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop, TOCreg, REG_SP, 5*wordsize);
 
   // Move back the stack
   popStack(gen);
@@ -2860,7 +2860,7 @@ bool EmitterPOWER64Stat::emitPLTCommon(func_instance *callee, bool call, codeGen
     // We do not want to execute the original code
     // in cases like function replacement and function wrapping.
     instruction ret(BRraw);
-    insnCodeGen::generate(gen, ret);
+    insnCodeGenPower::generate(gen, ret);
   }
 
   return true;
@@ -2909,34 +2909,34 @@ bool EmitterPOWER64Dyn::emitTOCCommon(block_instance *block, bool call, codeGen 
   pushStack(gen);
 
   // Save R12 and LR
-  insnCodeGen::generateMoveFromLR(gen, TOCreg);
-  insnCodeGen::generateMemAccess64(gen, STDop, STDxop, TOCreg, REG_SP, 3*wordsize);
-  insnCodeGen::generateMemAccess64(gen, STDop, STDxop, r12, REG_SP, 4*wordsize);
+  insnCodeGenPower::generateMoveFromLR(gen, TOCreg);
+  insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop, TOCreg, REG_SP, 3*wordsize);
+  insnCodeGenPower::generateMemAccess64(gen, STDop, STDxop, r12, REG_SP, 4*wordsize);
 				     
   // Use the R12 to generate the destination address
-  insnCodeGen::loadImmIntoReg(gen, r12, dest);
-  insnCodeGen::generateMoveToLR(gen, r12);
+  insnCodeGenPower::loadImmIntoReg(gen, r12, dest);
+  insnCodeGenPower::generateMoveToLR(gen, r12);
   
   // Load the callee TOC
-  insnCodeGen::loadImmIntoReg(gen, TOCreg, callee_toc);
+  insnCodeGenPower::loadImmIntoReg(gen, TOCreg, callee_toc);
   
   instruction branch_insn(BRLraw);
-  insnCodeGen::generate(gen, branch_insn);
+  insnCodeGenPower::generate(gen, branch_insn);
 
   // Restore R12 and LR
-  insnCodeGen::generateMemAccess64(gen, LDop, LDxop, TOCreg, REG_SP, 3*wordsize);
-  insnCodeGen::generateMoveToLR(gen, TOCreg);
-  insnCodeGen::generateMemAccess64(gen, LDop, LDxop, r12, REG_SP, 4*wordsize);
+  insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop, TOCreg, REG_SP, 3*wordsize);
+  insnCodeGenPower::generateMoveToLR(gen, TOCreg);
+  insnCodeGenPower::generateMemAccess64(gen, LDop, LDxop, r12, REG_SP, 4*wordsize);
 
   // Load caller TOC
-  insnCodeGen::loadImmIntoReg(gen, TOCreg, caller_toc);
+  insnCodeGenPower::loadImmIntoReg(gen, TOCreg, caller_toc);
 
   // Move up the stack
   popStack(gen);
 
   if (!call) {
     instruction ret(BRraw);
-    insnCodeGen::generate(gen, ret);
+    insnCodeGenPower::generate(gen, ret);
   }
   
   return true;
@@ -2996,11 +2996,11 @@ bool EmitterPOWER64Stat::emitCallInstruction(codeGen &gen,
     // TODO: if the premable changes, the amount of bytes to skip should change as well.
     //
     if (callee->ifunc()->containsPowerPreamble())
-        insnCodeGen::generateCall(gen, gen.currAddr(), dest + 8);
+        insnCodeGenPower::generateCall(gen, gen.currAddr(), dest + 8);
     else
     // For functions that do not have the R2 preabmle,
     // it means it will not change R2, we just call it.
-        insnCodeGen::generateCall(gen, gen.currAddr(), dest);
+        insnCodeGenPower::generateCall(gen, gen.currAddr(), dest);
     return true;
 }
 
@@ -3034,7 +3034,7 @@ bool EmitterPOWER::emitCallInstruction(codeGen &gen, func_instance *callee, bool
         inst_printf("[EmitterPOWER::EmitCallInstruction] needLongBranch, Emitting VLOAD  Callee: 0x%lx, ScratchReg: %u\n",
                     callee->addr(), (unsigned) scratchReg);
         emitVload(loadConstOp, callee->addr(), scratchReg, scratchReg, gen, false);
-        insnCodeGen::generateMoveToLR(gen, scratchReg);
+        insnCodeGenPower::generateMoveToLR(gen, scratchReg);
 
         inst_printf("Generated LR value in %d\n", scratchReg);
     }
@@ -3053,14 +3053,14 @@ bool EmitterPOWER::emitCallInstruction(codeGen &gen, func_instance *callee, bool
     if (needLongBranch) {
         emitVload(loadConstOp, callee->addr(), 12, 12, gen, false);
         instruction brl(BRLraw);
-        insnCodeGen::generate(gen,brl);
+        insnCodeGenPower::generate(gen,brl);
         inst_printf("Generated BRL\n");
     }
     else {
         inst_printf("[EmitterPOWER::EmitCallInstruction] Generating Call, curAddress: %lx, calleeAddr: %lx\n",
                      gen.currAddr(), callee->addr());
         emitVload(loadConstOp, callee->addr(), 12, 12, gen, false);
-        insnCodeGen::generateCall(gen, gen.currAddr(), callee->addr());
+        insnCodeGenPower::generateCall(gen, gen.currAddr(), callee->addr());
 
         inst_printf("Generated short call from 0x%lx to 0x%lx\n",
                 gen.currAddr(), callee->addr());
@@ -3094,7 +3094,7 @@ void EmitterPOWER::emitLoadShared(opCode op, Register dest, const image_variable
    if (scratchReg == Null_Register) {
    	std::vector<Register> freeReg;
         std::vector<Register> excludeReg;
-   	stackSize = insnCodeGen::createStackFrame(gen, 1, freeReg, excludeReg);
+   	stackSize = insnCodeGenPower::createStackFrame(gen, 1, freeReg, excludeReg);
    	assert (stackSize == 1);
    	scratchReg = freeReg[0];
    	inst_printf("emitLoadrelative - after new stack frame - addr 0x%lx curr adress 0x%lx offset %lu 0x%lx size %d\n", 
@@ -3122,14 +3122,14 @@ void EmitterPOWER::emitLoadShared(opCode op, Register dest, const image_variable
 
        // Move address of the variable into the register - load effective address
        //dest = effective address of pc+offset ;
-       insnCodeGen::generateImm (gen, CAUop, dest, 0, BOT_HI (varOffset));
-       insnCodeGen::generateImm (gen, ORILop, dest, dest, BOT_LO (varOffset));
-       insnCodeGen::generateAddReg (gen, CAXop, dest, dest, scratchReg);
+       insnCodeGenPower::generateImm (gen, CAUop, dest, 0, BOT_HI (varOffset));
+       insnCodeGenPower::generateImm (gen, ORILop, dest, dest, BOT_LO (varOffset));
+       insnCodeGenPower::generateAddReg (gen, CAXop, dest, dest, scratchReg);
      }
    }
    
    if (stackSize > 0)
-   	insnCodeGen::removeStackFrame(gen);
+   	insnCodeGenPower::removeStackFrame(gen);
 
   return;
 }
@@ -3154,7 +3154,7 @@ void EmitterPOWER::emitStoreShared(Register source, const image_variable * var, 
    if (scratchReg == Null_Register) {
    	std::vector<Register> freeReg;
         std::vector<Register> excludeReg;
-   	stackSize = insnCodeGen::createStackFrame(gen, 1, freeReg, excludeReg);
+   	stackSize = insnCodeGenPower::createStackFrame(gen, 1, freeReg, excludeReg);
 	assert (stackSize == 1);
 	scratchReg = freeReg[0];
 	
@@ -3172,7 +3172,7 @@ void EmitterPOWER::emitStoreShared(Register source, const image_variable * var, 
    	if (scratchReg1 == Null_Register) {
    		std::vector<Register> freeReg;
         	std::vector<Register> excludeReg;
-   		stackSize = insnCodeGen::createStackFrame(gen, 1, freeReg, excludeReg);
+   		stackSize = insnCodeGenPower::createStackFrame(gen, 1, freeReg, excludeReg);
 		assert (stackSize == 1);
 		scratchReg1 = freeReg[0];
 	
@@ -3186,7 +3186,7 @@ void EmitterPOWER::emitStoreShared(Register source, const image_variable * var, 
    }
    
    if (stackSize > 0)
-   	insnCodeGen::removeStackFrame(gen);
+   	insnCodeGenPower::removeStackFrame(gen);
   
   return;
 }
@@ -3251,9 +3251,9 @@ Address Emitter::getInterModuleVarAddr(const image_variable *var, codeGen& gen)
 
 Address EmitterPOWER::emitMovePCToReg(Register dest, codeGen &gen)
 {
-         insnCodeGen::generateBranch(gen, gen.currAddr(),  gen.currAddr()+4, true); // blrl
+         insnCodeGenPower::generateBranch(gen, gen.currAddr(),  gen.currAddr()+4, true); // blrl
 	 Address ret = gen.currAddr();
-         insnCodeGen::generateMoveFromLR(gen, dest); // mflr
+         insnCodeGenPower::generateMoveFromLR(gen, dest); // mflr
 	 return ret;
 }
 

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -47,6 +47,7 @@
 #include "dyninstAPI/src/debug.h"
 #include "dyninstAPI/src/function.h"
 #include "dyninstAPI/src/codegen.h"
+#include "dyninstAPI/src/codegen-x86.h"
 #include "dyninstAPI/src/inst-x86.h"
 #include "dyninstAPI/src/baseTramp.h"
 #include "dyninstAPI/src/emit-x86.h"
@@ -1384,7 +1385,7 @@ codeBufIndex_t emitA(opCode op, Dyninst::Register src1, Dyninst::Register /*src2
          // this will need to work for both 32-bits and 64-bits
          // (since there is no JMP rel64)
          retval = gen.getIndex();
-         insnCodeGen::generateBranch(gen, dest);
+         insnCodeGenX86::generateBranch(gen, dest);
          break;
       }
       case trampPreamble: {


### PR DESCRIPTION
- [ ] Make NS_instruction virtual
- [ ] Resolve conflicts betweeen NS_* name spaces

- [ ] Make insnCodeGen virtual
- [ ] Make all per architecture insnCodeGen classes a subclass of insnCodeGen.
- [ ] Change how code gen's are created


Cross Compilation Testng
Mahir
- [x] x86_64
- [x] x86
- [x] aarch64
- [x] ppc64le

Zeroah
- [ ] x86_64
- [ ] x86
- [ ] aarch64
- [ ] ppc64le

LLNL
- [ ] x86_64
- [ ] x86
- [ ] aarch64
- [ ] ppc64le




