### PR TITLE
Remove InstructionDecoderImpl::decodeOpcode

### DIFF
--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.C
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.C
@@ -213,11 +213,6 @@ namespace Dyninst {
 
 
 		}
-		void InstructionDecoder_amdgpu_gfx908::decodeOpcode(InstructionDecoder::buffer &b) {
-			setupInsnWord(b);
-			mainDecode();
-			b.start += insn_in_progress->size();
-		}
 		
 		void InstructionDecoder_amdgpu_gfx908::debug_instr(){
 			cout << "decoded instruction " <<  insn_in_progress->getOperation().mnemonic << " " << std::hex << insn_long << " insn_family = " << instr_family 

--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
@@ -58,8 +58,6 @@ namespace Dyninst {
 
             virtual ~InstructionDecoder_amdgpu_gfx908() = default;
 
-            virtual void decodeOpcode(InstructionDecoder::buffer &b);
-
             // decode one instruction starting from b.start
             // will advance b.start whenver a instruction is successfully decoded
             virtual Instruction decode(InstructionDecoder::buffer &b);

--- a/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.C
+++ b/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.C
@@ -211,11 +211,6 @@ namespace Dyninst {
 
             insn_long = ( ((uint64_t) insn_high) << 32) | insn;
         }
-        void InstructionDecoder_amdgpu_gfx90a::decodeOpcode(InstructionDecoder::buffer &b) {
-            setupInsnWord(b);
-            mainDecode();
-            b.start += insn_in_progress->size();
-        }
 
         void InstructionDecoder_amdgpu_gfx90a::debug_instr(){
             //	cout << "decoded instruction " <<  insn_in_progress->getOperation().mnemonic << " " << std::hex << insn_long << " insn_family = " << instr_family << "  length = " <<  insn_in_progress->size()<< endl << endl;

--- a/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.h
+++ b/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.h
@@ -58,8 +58,6 @@ namespace Dyninst {
 
             virtual ~InstructionDecoder_amdgpu_gfx90a() = default;
 
-            virtual void decodeOpcode(InstructionDecoder::buffer &b);
-
             // decode one instruction starting from b.start
             // will advance b.start whenver a instruction is successfully decoded
             virtual Instruction decode(InstructionDecoder::buffer &b);

--- a/instructionAPI/src/AMDGPU/gfx940/InstructionDecoder-amdgpu-gfx940.C
+++ b/instructionAPI/src/AMDGPU/gfx940/InstructionDecoder-amdgpu-gfx940.C
@@ -209,11 +209,6 @@ namespace Dyninst {
 
             insn_long = ( ((uint64_t) insn_high) << 32) | insn;
         }
-        void InstructionDecoder_amdgpu_gfx940::decodeOpcode(InstructionDecoder::buffer &b) {
-            setupInsnWord(b);
-            mainDecode();
-            b.start += insn_in_progress->size();
-        }
 
         void InstructionDecoder_amdgpu_gfx940::debug_instr(){
             //	cout << "decoded instruction " <<  insn_in_progress->getOperation().mnemonic << " " << std::hex << insn_long << " insn_family = " << instr_family << "  length = " <<  insn_in_progress->size()<< endl << endl;

--- a/instructionAPI/src/AMDGPU/gfx940/InstructionDecoder-amdgpu-gfx940.h
+++ b/instructionAPI/src/AMDGPU/gfx940/InstructionDecoder-amdgpu-gfx940.h
@@ -58,8 +58,6 @@ namespace Dyninst {
 
             virtual ~InstructionDecoder_amdgpu_gfx940() = default;
 
-            virtual void decodeOpcode(InstructionDecoder::buffer &b);
-
             // decode one instruction starting from b.start
             // will advance b.start whenver a instruction is successfully decoded
             virtual Instruction decode(InstructionDecoder::buffer &b);

--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -247,8 +247,6 @@ namespace Dyninst { namespace InstructionAPI {
 
   InstructionDecoder_aarch64::~InstructionDecoder_aarch64() {}
 
-  void InstructionDecoder_aarch64::decodeOpcode(InstructionDecoder::buffer& b) { b.start += 4; }
-
   using namespace std;
 
   Instruction InstructionDecoder_aarch64::decode(InstructionDecoder::buffer& b) {

--- a/instructionAPI/src/InstructionDecoder-aarch64.h
+++ b/instructionAPI/src/InstructionDecoder-aarch64.h
@@ -51,7 +51,6 @@ namespace Dyninst { namespace InstructionAPI {
 
     virtual ~InstructionDecoder_aarch64();
 
-    virtual void decodeOpcode(InstructionDecoder::buffer& b);
     virtual Instruction decode(InstructionDecoder::buffer& b);
 
     virtual void setMode(bool) {}

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -100,8 +100,6 @@ namespace Dyninst { namespace InstructionAPI {
 
   InstructionDecoder_power::~InstructionDecoder_power() {}
 
-  void InstructionDecoder_power::decodeOpcode(InstructionDecoder::buffer& b) { b.start += 4; }
-
   void InstructionDecoder_power::FRTP() {
     FRT();
     FRTS();

--- a/instructionAPI/src/InstructionDecoder-power.h
+++ b/instructionAPI/src/InstructionDecoder-power.h
@@ -45,7 +45,6 @@ namespace Dyninst { namespace InstructionAPI {
   public:
     InstructionDecoder_power(Architecture a);
     virtual ~InstructionDecoder_power();
-    virtual void decodeOpcode(InstructionDecoder::buffer& b);
     virtual Instruction decode(InstructionDecoder::buffer& b);
 
     virtual void setMode(bool) {}

--- a/instructionAPI/src/InstructionDecoder-x86.h
+++ b/instructionAPI/src/InstructionDecoder-x86.h
@@ -64,7 +64,6 @@ namespace Dyninst { namespace InstructionAPI {
     bool decodeOneOperand(const InstructionDecoder::buffer& b, const NS_x86::ia32_operand& operand,
                           int& imm_index, const Instruction* insn_to_complete, bool isRead,
                           bool isWritten, bool isImplicit);
-    virtual void decodeOpcode(InstructionDecoder::buffer& b);
 
     Expression::Ptr makeSIBExpression(const InstructionDecoder::buffer& b);
     Expression::Ptr makeModRMExpression(const InstructionDecoder::buffer& b, unsigned int opType);
@@ -78,6 +77,7 @@ namespace Dyninst { namespace InstructionAPI {
   private:
     void doIA32Decode(InstructionDecoder::buffer& b);
     bool isDefault64Insn();
+    void decodeOpcode(InstructionDecoder::buffer&);
 
     ia32_locations* locs;
     NS_x86::ia32_instruction* decodedInstruction;

--- a/instructionAPI/src/InstructionDecoderImpl.h
+++ b/instructionAPI/src/InstructionDecoderImpl.h
@@ -59,8 +59,6 @@ class InstructionDecoderImpl
     protected:
       
         virtual bool decodeOperands(const Instruction* insn_to_complete) = 0;
-
-        virtual void decodeOpcode(InstructionDecoder::buffer&) = 0;
       
         virtual Expression::Ptr makeAddExpression(Expression::Ptr lhs, Expression::Ptr rhs, Result_Type resultType);
         virtual Expression::Ptr makeMultiplyExpression(Expression::Ptr lhs, Expression::Ptr rhs, Result_Type resultType);


### PR DESCRIPTION
It is only used for x86, so move it there.

@wxrdnx I'm assuming RISCV doesn't really use this?