### PR TITLE
[BPatch] Add API function std::string BPatch_image::getProgramFileName()

### DIFF
--- a/dyninstAPI/h/BPatch_image.h
+++ b/dyninstAPI/h/BPatch_image.h
@@ -258,6 +258,9 @@ class DYNINST_EXPORT BPatch_image: public BPatch_sourceObj {
 
   char * getProgramFileName(char *name, unsigned int len);
 
+  // Same as above, but doesn't require knowing the length.
+  std::string getProgramFileName() const;
+
   /* BPatch_image::parseNewFunctions
    *
    * This function uses function entry addresses to find and parse

--- a/dyninstAPI/src/BPatch_image.C
+++ b/dyninstAPI/src/BPatch_image.C
@@ -919,20 +919,33 @@ char *BPatch_image::getProgramName(char *name, unsigned int len)
 
 char *BPatch_image::getProgramFileName(char *name, unsigned int len)
 {
-   std::vector<AddressSpace*> as;
-   addSpace->getAS(as);
-   AddressSpace *aout = as[0];
+  std::string fileName = this->getProgramFileName();
 
-   if (!aout->mappedObjects().size()) {
+  if (len > fileName.size())  {
+    std::strcpy(name, fileName.c_str());
+  } else if (len > 0u) {
+    name[0] = '\0';
+  }
+
+  return name;
+}
+
+std::string BPatch_image::getProgramFileName() const {
+   std::vector<AddressSpace*> addrSpaces;
+   addSpace->getAS(addrSpaces);
+
+   assert(!addrSpaces.empty());
+   AddressSpace *addrSpace = addrSpaces[0];
+
+   assert(addrSpace);
+   if (addrSpace->mappedObjects().empty()) {
       // No program defined yet
-      strncpy(name, "<no program defined>", len);
+      return "<no program defined>";
    }
 
-   string imname =  aout->getAOut()->fileName();
-   if (imname.empty()) imname = "<unnamed image file>";
-
-   strncpy(name, imname.c_str(), len);
-   return name;
+   string fileName =  addrSpace->getAOut()->fileName();
+   if (fileName.empty()) fileName = "<unnamed file>";
+   return fileName;
 }
 
 BPatch_module *BPatch_image::findModule(mapped_module *base) 


### PR DESCRIPTION
This method enables getting the filename without knowing the length.

It is used in #1802 for spitting out a file with instrumented kernel names from the GPU code object.