### PR TITLE
Add new interfaces to the emitter

### DIFF
--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -122,13 +122,16 @@ class Emitter {
     virtual bool emitTOCJump(block_instance *, codeGen &) { assert(0); return false; }
     virtual bool emitTOCCall(block_instance *, codeGen &) { assert(0); return false; }
 
-    virtual void emitNops(unsigned numNops, codeGen &gen) {}
-    virtual void emitEndProgram(codeGen &gen) {}
-    virtual void emitMovLiteral(Register reg, uint32_t value, codeGen &gen) {}
-    virtual void emitConditionalBranch(bool onConditionTrue, int16_t wordOffset,
-                                     codeGen &gen) {}
-    virtual void emitShortJump(int16_t wordOffset, codeGen &gen) {}
-    virtual void emitLongJump(Register reg, uint64_t toAddress, codeGen &gen) {}
+    virtual void emitNops(unsigned /* numNops */, codeGen & /* gen */) {}
+    virtual void emitEndProgram(codeGen & /* gen */) {}
+    virtual void emitMovLiteral(Register /* reg */, uint32_t /* value */, codeGen & /* gen */) {}
+    virtual void emitConditionalBranch(bool /* onConditionTrue */, int16_t /* wordOffset */,
+                                     codeGen & /* gen */) {}
+    virtual void emitShortJump(int16_t /* wordOffset */, codeGen & /* gen */) {}
+    virtual void emitLongJump(Register /* reg */, uint64_t /* fromAddress */, uint64_t /* toAddress */, codeGen & /* gen */) {}
+
+    // TODO : Make all targets use this instead of having this functionality floating around in the codebase.
+    virtual void emitMovePCtoReg(Register /* reg */, codeGen & /* gen */) {}
 };
 
 #endif


### PR DESCRIPTION
Most of these are used in #1802.

Also, the functionality of `emitMovePCtoReg` is used by other architectures as well, but it is implemented in various places in the codebase. It would be good to have this behavior implemented in respective emitter implementations. AMDGPU doesn't use it yet, but will switch to using it soon.