### PR TITLE
Handle s_endpgm as an aborting instruction

### DIFF
--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -321,7 +321,7 @@ bool IA_IAPI::isAbort() const
     entryID e = curInsn().getOperation().getID();
     return e == e_int3 ||
         e == e_hlt ||
-        e == e_ud2 || curInsn().isGPUKernelExit();
+        e == e_ud2;
 }
 
 bool IA_IAPI::isInvalidInsn() const

--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -321,7 +321,7 @@ bool IA_IAPI::isAbort() const
     entryID e = curInsn().getOperation().getID();
     return e == e_int3 ||
         e == e_hlt ||
-        e == e_ud2;
+        e == e_ud2 || curInsn().isGPUKernelExit();
 }
 
 bool IA_IAPI::isInvalidInsn() const

--- a/parseAPI/src/IA_amdgpu.C
+++ b/parseAPI/src/IA_amdgpu.C
@@ -62,6 +62,11 @@ IA_amdgpu* IA_amdgpu::clone() const {
     return new IA_amdgpu(*this);
 }
 
+bool IA_amdgpu::isAbort() const
+{
+    return curInsn().isGPUKernelExit();
+}
+
 bool IA_amdgpu::isFrameSetupInsn(Instruction ) const
 {
     return false;

--- a/parseAPI/src/IA_amdgpu.h
+++ b/parseAPI/src/IA_amdgpu.h
@@ -56,6 +56,7 @@ class IA_amdgpu : public IA_IAPI {
 	virtual bool isTailCall(const ParseAPI::Function* context, ParseAPI::EdgeTypeEnum type,
 							unsigned int, const set<Address>& knownTargets) const;
 	virtual bool savesFP() const;
+    bool isAbort() const override;
 	virtual bool isStackFramePreamble() const;
 	virtual bool cleansStack() const;
 	virtual bool sliceReturn(ParseAPI::Block* bit, Address ret_addr, ParseAPI::Function * func) const;

--- a/parseAPI/src/IA_amdgpu.h
+++ b/parseAPI/src/IA_amdgpu.h
@@ -49,23 +49,23 @@ class IA_amdgpu : public IA_IAPI {
                Dyninst::InstructionSource *isrc,
 	       Dyninst::ParseAPI::Block * curBlk_);
 	IA_amdgpu(const IA_amdgpu &);
-	IA_amdgpu* clone() const override;
-    bool isFrameSetupInsn(Dyninst::InstructionAPI::Instruction) const override;
-	bool isNop() const override;
-	bool isThunk() const override;
-	bool isTailCall(const ParseAPI::Function* context, ParseAPI::EdgeTypeEnum type,
-							unsigned int, const set<Address>& knownTargets) const override;
-	bool savesFP() const override;
-    bool isAbort() const override;
-	bool isStackFramePreamble() const override;
-	bool cleansStack() const override;
-	bool sliceReturn(ParseAPI::Block* bit, Address ret_addr, ParseAPI::Function * func) const override;
-	bool isReturnAddrSave(Address& retAddr) const override;
-	bool isReturn(Dyninst::ParseAPI::Function * context, Dyninst::ParseAPI::Block* currBlk) const override;
-	bool isFakeCall() const override;
-	bool isIATcall(std::string &) const override;
-	bool isLinkerStub() const override;
-	bool isNopJump() const override;
+	virtual IA_amdgpu* clone() const;
+    virtual bool isFrameSetupInsn(Dyninst::InstructionAPI::Instruction) const;
+	virtual bool isNop() const;
+	virtual bool isThunk() const;
+	virtual bool isTailCall(const ParseAPI::Function* context, ParseAPI::EdgeTypeEnum type,
+							unsigned int, const set<Address>& knownTargets) const;
+	virtual bool savesFP() const;
+    virtual bool isAbort() const;
+	virtual bool isStackFramePreamble() const;
+	virtual bool cleansStack() const;
+	virtual bool sliceReturn(ParseAPI::Block* bit, Address ret_addr, ParseAPI::Function * func) const;
+	virtual bool isReturnAddrSave(Address& retAddr) const;
+	virtual bool isReturn(Dyninst::ParseAPI::Function * context, Dyninst::ParseAPI::Block* currBlk) const;
+	virtual bool isFakeCall() const;
+	virtual bool isIATcall(std::string &) const;
+	virtual bool isLinkerStub() const;
+	virtual bool isNopJump() const;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_amdgpu.h
+++ b/parseAPI/src/IA_amdgpu.h
@@ -49,23 +49,23 @@ class IA_amdgpu : public IA_IAPI {
                Dyninst::InstructionSource *isrc,
 	       Dyninst::ParseAPI::Block * curBlk_);
 	IA_amdgpu(const IA_amdgpu &);
-	virtual IA_amdgpu* clone() const;
-    virtual bool isFrameSetupInsn(Dyninst::InstructionAPI::Instruction) const;
-	virtual bool isNop() const;
-	virtual bool isThunk() const;
-	virtual bool isTailCall(const ParseAPI::Function* context, ParseAPI::EdgeTypeEnum type,
-							unsigned int, const set<Address>& knownTargets) const;
-	virtual bool savesFP() const;
+	IA_amdgpu* clone() const override;
+    bool isFrameSetupInsn(Dyninst::InstructionAPI::Instruction) const override;
+	bool isNop() const override;
+	bool isThunk() const override;
+	bool isTailCall(const ParseAPI::Function* context, ParseAPI::EdgeTypeEnum type,
+							unsigned int, const set<Address>& knownTargets) const override;
+	bool savesFP() const override;
     bool isAbort() const override;
-	virtual bool isStackFramePreamble() const;
-	virtual bool cleansStack() const;
-	virtual bool sliceReturn(ParseAPI::Block* bit, Address ret_addr, ParseAPI::Function * func) const;
-	virtual bool isReturnAddrSave(Address& retAddr) const;
-	virtual bool isReturn(Dyninst::ParseAPI::Function * context, Dyninst::ParseAPI::Block* currBlk) const;
-	virtual bool isFakeCall() const;
-	virtual bool isIATcall(std::string &) const;
-	virtual bool isLinkerStub() const;
-	virtual bool isNopJump() const;
+	bool isStackFramePreamble() const override;
+	bool cleansStack() const override;
+	bool sliceReturn(ParseAPI::Block* bit, Address ret_addr, ParseAPI::Function * func) const override;
+	bool isReturnAddrSave(Address& retAddr) const override;
+	bool isReturn(Dyninst::ParseAPI::Function * context, Dyninst::ParseAPI::Block* currBlk) const override;
+	bool isFakeCall() const override;
+	bool isIATcall(std::string &) const override;
+	bool isLinkerStub() const override;
+	bool isNopJump() const override;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -1796,19 +1796,6 @@ Parser::parse_frame_one_iteration(ParseFrame &frame, bool recursive) {
                             false)
                         );
                 break;
-            } else if(ah->getInstruction().isGPUKernelExit()) {
-                // this is special treatment for non-returning instruction
-                // examples are amdgpu_op_s_endpgm and amddgpu_op_s_endpgm_saved
-                //cout << "calling endblock for non-returning instruction " << std::hex <<ah->getAddr() << endl; 
-                //
-
-
-                parsing_printf("[%s:%d] gpu exit insn 0x%lx: %s \n",
-                        FILE__,__LINE__,curAddr, ah->getInstruction().format().c_str() );
-
-
-                end_block(cur,ahPtr);
-                break;
             }
             // per-instruction callback notification
             ParseCallback::insn_details insn_det;


### PR DESCRIPTION
This is the correct fix for the problem of duplicated s_endpgm, which happens if a basic block starts with s_endpgm.