### PR TITLE
Add SoftwareException instruction category

### DIFF
--- a/dyninstAPI/src/Relocation/CFG/RelocBlock.C
+++ b/dyninstAPI/src/Relocation/CFG/RelocBlock.C
@@ -329,6 +329,14 @@ void RelocBlock::createCFWidget() {
    else {
       cfWidget_ = CFWidget::create(origAddr_);
    }
+   // FuncExit instrumentation will insert instrumentation before
+   // the last instruction of the block, thus we need to prevent a
+   // dummy CFWidget from being added as the last instruction of 
+   // the block. 
+   // TODO: Maybe this should be done for all endblocks that 
+   // doesn't end with CF instruction.
+   if(insn.isAbort())
+      return;
    elements_.push_back(cfWidget_);
 }
 

--- a/dyninstAPI/src/Relocation/CFG/RelocBlock.C
+++ b/dyninstAPI/src/Relocation/CFG/RelocBlock.C
@@ -335,7 +335,7 @@ void RelocBlock::createCFWidget() {
    // the block. 
    // TODO: Maybe this should be done for all endblocks that 
    // doesn't end with CF instruction.
-   if(insn.isAbort())
+   if(insn.isSoftwareException())
       return;
    elements_.push_back(cfWidget_);
 }

--- a/dyninstAPI/src/Relocation/CFG/RelocBlock.C
+++ b/dyninstAPI/src/Relocation/CFG/RelocBlock.C
@@ -329,14 +329,6 @@ void RelocBlock::createCFWidget() {
    else {
       cfWidget_ = CFWidget::create(origAddr_);
    }
-   // FuncExit instrumentation will insert instrumentation before
-   // the last instruction of the block, thus we need to prevent a
-   // dummy CFWidget from being added as the last instruction of 
-   // the block. 
-   // TODO: Maybe this should be done for all endblocks that 
-   // doesn't end with CF instruction.
-   if(insn.isSoftwareException())
-      return;
    elements_.push_back(cfWidget_);
 }
 

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -140,6 +140,7 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT bool isInterrupt() const { return getCategory() == c_InterruptInsn; }
     DYNINST_EXPORT bool isVector() const { return getCategory() == c_VectorInsn; }
     DYNINST_EXPORT bool isGPUKernelExit() const { return getCategory() == c_GPUKernelExitInsn; }
+    DYNINST_EXPORT bool isAbort() const { return isGPUKernelExit() || getCategory() == c_AbortInsn; }
 
     typedef std::list<CFT>::const_iterator cftConstIter;
     DYNINST_EXPORT cftConstIter cft_begin() const { return m_Successors.begin(); }

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -140,7 +140,7 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT bool isInterrupt() const { return getCategory() == c_InterruptInsn; }
     DYNINST_EXPORT bool isVector() const { return getCategory() == c_VectorInsn; }
     DYNINST_EXPORT bool isGPUKernelExit() const { return getCategory() == c_GPUKernelExitInsn; }
-    DYNINST_EXPORT bool isAbort() const { return isGPUKernelExit() || getCategory() == c_AbortInsn; }
+    DYNINST_EXPORT bool isSoftwareException() const { return isGPUKernelExit() || getCategory() == c_SoftwareExceptionInsn; }
 
     typedef std::list<CFT>::const_iterator cftConstIter;
     DYNINST_EXPORT cftConstIter cft_begin() const { return m_Successors.begin(); }

--- a/instructionAPI/h/InstructionCategories.h
+++ b/instructionAPI/h/InstructionCategories.h
@@ -49,6 +49,7 @@ namespace Dyninst { namespace InstructionAPI {
     c_VectorInsn,        // operates on more than one value simultaneously
     c_GPUKernelExitInsn, // AMD GPU kernel exit
     c_TransactionalInsn, // memory transaction (fences, hardware locks, etc.)
+    c_AbortInsn,         // Abort Insn exit
     c_NoCategory
   };
 

--- a/instructionAPI/h/InstructionCategories.h
+++ b/instructionAPI/h/InstructionCategories.h
@@ -49,7 +49,7 @@ namespace Dyninst { namespace InstructionAPI {
     c_VectorInsn,        // operates on more than one value simultaneously
     c_GPUKernelExitInsn, // AMD GPU kernel exit
     c_TransactionalInsn, // memory transaction (fences, hardware locks, etc.)
-    c_AbortInsn,         // Abort Insn exit
+    c_SoftwareExceptionInsn,         // Software Exception Insn exit
     c_NoCategory
   };
 

--- a/instructionAPI/src/InstructionCategories.C
+++ b/instructionAPI/src/InstructionCategories.C
@@ -122,7 +122,9 @@ namespace Dyninst { namespace InstructionAPI {
       case e_ud2:
       case aarch64_op_brk:
       case aarch64_op_hlt:
-        return c_AbortInsn;
+      case aarch64_op_wfe_hint:
+      case aarch64_op_wfi_hint:
+        return c_SoftwareExceptionInsn;
       default:
       	return c_NoCategory;
     }

--- a/instructionAPI/src/InstructionCategories.C
+++ b/instructionAPI/src/InstructionCategories.C
@@ -117,7 +117,8 @@ namespace Dyninst { namespace InstructionAPI {
       case e_syscall:
       case e_int:
         return c_SyscallInsn;
-
+      case e_hlt:
+        return c_AbortInsn;
       default:
       	return c_NoCategory;
     }

--- a/instructionAPI/src/InstructionCategories.C
+++ b/instructionAPI/src/InstructionCategories.C
@@ -118,6 +118,10 @@ namespace Dyninst { namespace InstructionAPI {
       case e_int:
         return c_SyscallInsn;
       case e_hlt:
+      case e_int3:
+      case e_ud2:
+      case aarch64_op_brk:
+      case aarch64_op_hlt:
         return c_AbortInsn;
       default:
       	return c_NoCategory;

--- a/parseAPI/h/InstructionAdapter.h
+++ b/parseAPI/h/InstructionAdapter.h
@@ -80,7 +80,6 @@ class InstructionAdapter
     virtual size_t getSize() const = 0;
     virtual bool isFrameSetupInsn() const = 0;
     virtual bool isInvalidInsn() const = 0;
-    virtual bool isAbort() const = 0;
     virtual bool isGarbageInsn() const = 0; //true for insns indicative of bad parse, for defensive mode
     virtual void
             getNewEdges(std::vector<std::pair<Address,ParseAPI::EdgeTypeEnum> >&
@@ -119,6 +118,8 @@ const;
     virtual bool isReturnAddrSave(Address &ret_addr) const = 0; // ret_addr holds the return address pushed in the stack using mflr at function entry 
     virtual bool isTailCall(const ParseAPI::Function *, ParseAPI::EdgeTypeEnum type, unsigned int num_insns,
                             const std::set<Address> &) const = 0;
+
+    virtual bool isSoftwareException() const = 0;
     protected:
     	// Uses pattern heuristics or backward slicing to determine if a blr instruction is a return or jump table
         virtual bool isReturn(Dyninst::ParseAPI::Function * context, Dyninst::ParseAPI::Block* currBlk) const = 0;

--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -318,10 +318,7 @@ bool IA_IAPI::hasCFT() const
 
 bool IA_IAPI::isAbort() const
 {
-    entryID e = curInsn().getOperation().getID();
-    return e == e_int3 ||
-        e == e_hlt ||
-        e == e_ud2;
+    return curInsn().isAbort();
 }
 
 bool IA_IAPI::isInvalidInsn() const

--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -316,9 +316,9 @@ bool IA_IAPI::hasCFT() const
     return hascftstatus.second;
 }
 
-bool IA_IAPI::isAbort() const
+bool IA_IAPI::isSoftwareException() const
 {
-    return curInsn().isAbort();
+    return curInsn().isSoftwareException();
 }
 
 bool IA_IAPI::isInvalidInsn() const

--- a/parseAPI/src/IA_IAPI.h
+++ b/parseAPI/src/IA_IAPI.h
@@ -84,7 +84,7 @@ class IA_IAPI : public InstructionAdapter {
         virtual bool hasCFT() const;
         virtual size_t getSize() const;
         virtual bool isFrameSetupInsn() const;
-        virtual bool isAbort() const;
+        virtual bool isSoftwareException() const;
         virtual bool isInvalidInsn() const;
         virtual bool isGarbageInsn() const; //true for insns indicative of bad parse, for defensive mode
         virtual void

--- a/parseAPI/src/IA_amdgpu.C
+++ b/parseAPI/src/IA_amdgpu.C
@@ -62,11 +62,6 @@ IA_amdgpu* IA_amdgpu::clone() const {
     return new IA_amdgpu(*this);
 }
 
-bool IA_amdgpu::isAbort() const
-{
-    return curInsn().isGPUKernelExit();
-}
-
 bool IA_amdgpu::isFrameSetupInsn(Instruction ) const
 {
     return false;

--- a/parseAPI/src/IA_amdgpu.h
+++ b/parseAPI/src/IA_amdgpu.h
@@ -56,7 +56,6 @@ class IA_amdgpu : public IA_IAPI {
 	virtual bool isTailCall(const ParseAPI::Function* context, ParseAPI::EdgeTypeEnum type,
 							unsigned int, const set<Address>& knownTargets) const;
 	virtual bool savesFP() const;
-    virtual bool isAbort() const;
 	virtual bool isStackFramePreamble() const;
 	virtual bool cleansStack() const;
 	virtual bool sliceReturn(ParseAPI::Block* bit, Address ret_addr, ParseAPI::Function * func) const;

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -1864,7 +1864,7 @@ Parser::parse_frame_one_iteration(ParseFrame &frame, bool recursive) {
                 func->_no_stack_frame = false;
             } else if (ah->isLeave()) {
                 func->_no_stack_frame = false;
-            } else if ( ah->isAbort() ) {
+            } else if ( ah->isSoftwareException() ) {
                 // 4. `abort-causing' instructions
                 end_block(cur,ahPtr);
                 set_edge_parsing_status(frame, cur->last(), cur);


### PR DESCRIPTION
Rename isAbort to SoftwareExcpetion, and add the corresponding instructions that fits this category.
Also remove isAbort/isSoftwareException implementation for AMDGPU in IA_IAPI.