### PR TITLE
Fix FuncExit instrumentation for software exceptions

### DIFF
--- a/dyninstAPI/src/Relocation/CFG/RelocBlock.C
+++ b/dyninstAPI/src/Relocation/CFG/RelocBlock.C
@@ -329,6 +329,14 @@ void RelocBlock::createCFWidget() {
    else {
       cfWidget_ = CFWidget::create(origAddr_);
    }
+   // FuncExit instrumentation will insert instrumentation before
+   // the last instruction of the block, thus we need to prevent a
+   // dummy CFWidget from being added as the last instruction of
+   // the block.
+   // TODO: Maybe this should be done for all endblocks that
+   // doesn't end with CF instruction.
+   if(insn.isSoftwareException())
+      return;
    elements_.push_back(cfWidget_);
 }
 


### PR DESCRIPTION
Change the logic for handling ending instruction of RelocBlock.

For FuncExit instrumentaiton, Dyninst will automatically insert instruction before the last instruction of the exit Block.  
The problem is that, for instructions that is not known to have cotnrol flow, (software exception instructions, for example), Dyninst will insert a dummy CFWidget, thus the instrumentation was inserted between the abort instruction and the dummy CFWidget.

This PR prevent the dummy CFWidget from being inserted if we know the last instruction is a software exception.

This is the old #1991
