### PR TITLE
Docker: remove Ubuntu 24. Add Ubuntu 25, Fedora 42, 43

### DIFF
--- a/.github/actions/os-versions/action.yaml
+++ b/.github/actions/os-versions/action.yaml
@@ -15,8 +15,7 @@ runs:
       run: |
         set -ex
         declare -a names=(
-                          ubuntu-20.04 ubuntu-22.04 ubuntu-24.04
-                          ubuntu-24.10
+                          ubuntu-20.04 ubuntu-22.04 ubuntu-25.04
                           
                           fedora-37 fedora-38 fedora-39 fedora-40
                           fedora-41
@@ -32,4 +31,4 @@ runs:
       shell: bash
       run: |
         set -ex
-        echo 'names=["ubuntu-24.10", "fedora-41"]' >> $GITHUB_OUTPUT
+        echo 'names=["ubuntu-25.04", "fedora-41"]' >> $GITHUB_OUTPUT

--- a/.github/actions/os-versions/action.yaml
+++ b/.github/actions/os-versions/action.yaml
@@ -18,7 +18,7 @@ runs:
                           ubuntu-20.04 ubuntu-22.04 ubuntu-25.04
                           
                           fedora-37 fedora-38 fedora-39 fedora-40
-                          fedora-41
+                          fedora-41 fedora-42 fedora-43
                          )
 
         # Make them json
@@ -31,4 +31,4 @@ runs:
       shell: bash
       run: |
         set -ex
-        echo 'names=["ubuntu-25.04", "fedora-41"]' >> $GITHUB_OUTPUT
+        echo 'names=["ubuntu-25.04", "fedora-43"]' >> $GITHUB_OUTPUT

--- a/.github/scripts/compiler_configs.py
+++ b/.github/scripts/compiler_configs.py
@@ -22,14 +22,18 @@ configs = {
       'versions': [13, 14, 15]
     }      
   ],
-  'ubuntu-24.10': [
+  
+  # Ubuntu 23 and 24 no longer have DockerHub images, so we can't use them
+  # for testing.
+  
+  'ubuntu-25.04': [
     {
       'compiler': 'gcc',
-      'versions': [13, 14]
+      'versions': [13, 14, 15]
     },
     {
       'compiler': 'clang',
-      'versions': [16, 17, 18, 19]
+      'versions': [17, 18, 19, 20]    # clang-16 is not available in Ubuntu 25
     }
   ],
 

--- a/.github/scripts/compiler_configs.py
+++ b/.github/scripts/compiler_configs.py
@@ -88,6 +88,26 @@ configs = {
       'versions': [14]
     }
   ],
+  'fedora-42': [          # same compilers as 41, but has glibc-2.41
+    {
+      'compiler': 'clang',
+      'versions': [19]
+    },
+    {
+      'compiler': 'gcc',
+      'versions': [14]
+    }
+  ],
+    'fedora-43': [        # same compilers as 42, but has glibc-2.42
+    {
+      'compiler': 'clang',
+      'versions': [19]
+    },
+    {
+      'compiler': 'gcc',
+      'versions': [14]
+    }
+  ],
 }
 
 parser = argparse.ArgumentParser(

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -261,13 +261,15 @@ Currently, this is only set up to be run manually. In the future, it can be run 
 
 2. Add another entry to the `configs` dictionary in the config [script](scripts/compiler_configs.py) following the existing naming convention. There are several workflows that check for names of the format `<OS>-<version>`.
 
-4. Add any special handling (e.g., building dependencies from source) needed in **both** `docker/Dockerfile.<OS>` and the `build-base` job in `.github/workflows/refresh-containers.yaml`.
+3. Add any special handling (e.g., building dependencies from source) needed in **both** `docker/Dockerfile.<OS>` and the `build-base` job in `.github/workflows/refresh-containers.yaml`.
 
-5. Make a new PR with these changes.
+4. Make a new PR with these changes.
 
-6. Manually run the `refresh-containers` workflow from the GitHub web interface using your branch as the target branch.
+5. Manually run the `refresh-containers` workflow from the GitHub web interface using your branch as the target branch.
 
-7. Follow the GitHub [instructions](https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-an-organization-scoped-package-on-github) to add each container image to the Dyninst repository. The Dyninst user will need admin privileges to update and deploy containers from GitHub actions.
+6. Follow the GitHub [instructions](https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-an-organization-scoped-package-on-github) to add each container image to the Dyninst repository. The Dyninst user will need admin privileges to update and deploy containers from GitHub actions.
+
+7. Manually run the `compiler-multibuild`, `build-opts`, `spack-build`, and `system-libs` workflows against the PR's branch to check for any breakages.
 
 ## Adding a new compiler version
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -261,27 +261,13 @@ Currently, this is only set up to be run manually. In the future, it can be run 
 
 2. Add another entry to the `configs` dictionary in the config [script](scripts/compiler_configs.py) following the existing naming convention. There are several workflows that check for names of the format `<OS>-<version>`.
 
-3. Create a new base and dev container. For example to add ubuntu-X,
+4. Add any special handling (e.g., building dependencies from source) needed in **both** `docker/Dockerfile.<OS>` and the `build-base` job in `.github/workflows/refresh-containers.yaml`.
 
-```
-docker build -f docker/Dockerfile.ubuntu
-             -t ghcr.io/dyninst/amd64/ubuntu-X-base:latest
-             --build-arg build_jobs=2
-             --build-arg version=X
-             $PWD
+5. Make a new PR with these changes.
 
-docker push ghcr.io/dyninst/amd64/ubuntu-X-base:latest
+6. Manually run the `refresh-containers` workflow from the GitHub web interface using your branch as the target branch.
 
-docker build -f docker/Dockerfile
-             -t ghcr.io/dyninst/amd64/ubuntu-X:latest
-             --build-arg base=ghcr.io/dyninst/amd64/ubuntu-X-base:latest
-             --build-arg build_jobs=2
-             $PWD
-
-docker push ghcr.io/dyninst/amd64/ubuntu-X:latest
-```
-
-5. Follow the GitHub [instructions](https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-an-organization-scoped-package-on-github) to add each container image to the Dyninst repository. The Dyninst user will need admin privileges to update and deploy containers from GitHub actions.
+7. Follow the GitHub [instructions](https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-an-organization-scoped-package-on-github) to add each container image to the Dyninst repository. The Dyninst user will need admin privileges to update and deploy containers from GitHub actions.
 
 ## Adding a new compiler version
 

--- a/.github/workflows/compiler-multibuild.yaml
+++ b/.github/workflows/compiler-multibuild.yaml
@@ -96,40 +96,40 @@ jobs:
           build-type: ${{ matrix.build-type }}
           src-dir: "${GITHUB_WORKSPACE}/src"
 
-#######################################################################################
+######################################################################################
 #
 #  Build with C++11 to C++23 using the latest distributions
 #
 #  This doesn't test every possible os/compiler/std, but it makes sure Dyninst builds
 #  on -some- compiler for each standard version.
-#
-#  cxx-standards:
-#    runs-on: ubuntu-latest
-#    needs: [get-oses, get-compilers]
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os: ${{ fromJson(needs.get-oses.outputs.latest) }}
-#        compiler: ${{ fromJson(needs.get-compilers.outputs.all)}}
-#        std: [11, 14, 17, 20, 23]
-#    permissions:
-#      packages: read
-#    container:
-#      image: ghcr.io/dyninst/amd64/${{ matrix.os }}-base:latest
-#      credentials:
-#        username: ${{ github.actor }}
-#        password: ${{ secrets.github_token }}
-#    name: ${{ matrix.os }}, ${{ matrix.compiler }}, std=${{ matrix.std }}
-#    steps:
-#      - name: Checkout Dyninst
-#        uses: actions/checkout@v4
-#        with:
-#          path: "src"    # Relative to $GITHUB_WORKSPACE
-#
-#      - name: Build
-#        uses: ./src/.github/actions/build
-#        with:
-#          os: ${{ matrix.os }}
-#          compiler: ${{ matrix.compiler }}
-#          src-dir: "${GITHUB_WORKSPACE}/src"
-#          extra-cmake-flags: "-DDYNINST_CXX_LANGUAGE_STANDARD=${{ matrix.std }}"
+
+  cxx-standards:
+    runs-on: ubuntu-latest
+    needs: [get-oses, get-compilers]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.get-oses.outputs.latest) }}
+        compiler: ${{ fromJson(needs.get-compilers.outputs.all)}}
+        std: [11, 14, 17, 20, 23, 26]
+    permissions:
+      packages: read
+    container:
+      image: ghcr.io/dyninst/amd64/${{ matrix.os }}-base:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+    name: ${{ matrix.os }}, ${{ matrix.compiler }}, std=${{ matrix.std }}
+    steps:
+      - name: Checkout Dyninst
+        uses: actions/checkout@v4
+        with:
+          path: "src"    # Relative to $GITHUB_WORKSPACE
+
+      - name: Build
+        uses: ./src/.github/actions/build
+        with:
+          os: ${{ matrix.os }}
+          compiler: ${{ matrix.compiler }}
+          src-dir: "${GITHUB_WORKSPACE}/src"
+          extra-cmake-flags: "-DDYNINST_CXX_LANGUAGE_STANDARD=${{ matrix.std }}"

--- a/.github/workflows/refresh-containers.yaml
+++ b/.github/workflows/refresh-containers.yaml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Base containers
         uses: actions/delete-package-versions@v5
+        continue-on-error: true
         with:
           package-name: amd64/${{ matrix.os }}-base
           package-type: "container"

--- a/.github/workflows/refresh-containers.yaml
+++ b/.github/workflows/refresh-containers.yaml
@@ -31,6 +31,7 @@ jobs:
     steps:
       - name: Development containers
         uses: actions/delete-package-versions@v5
+        continue-on-error: true
         with:
           package-name: amd64/${{ matrix.os }}
           package-type: "container"

--- a/cmake/DyninstWarnings.cmake
+++ b/cmake/DyninstWarnings.cmake
@@ -163,7 +163,7 @@ if(HAS_CPP_FLAG_Wframe_larger_than AND NOT DYNINST_DISABLE_DIAGNOSTIC_SUPPRESSIO
       set(nonDebugMaxFrameSizeOverrideFinalizeOperands 30000)
     endif()
   elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-    if(${CMAKE_CXX_COMPILER_VERSION} MATCHES "^1[3-9](\.|$)")
+    if(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "22.0.0")
       set(debugMaxFrameSizeOverridePowerOpcodeTable 40000)
     else()
       set(debugMaxFrameSizeOverridePowerOpcodeTable 30000)

--- a/common/h/compiler_diagnostics.h
+++ b/common/h/compiler_diagnostics.h
@@ -91,7 +91,7 @@
  #if __GNUC__ >= 7 && __GNUC__ < 9
   #define DYNINST_SUPPRESS_CODE_DUPLICATED_BRANCHES        "-Wduplicated-branches"
  #endif
- #if __GNUC__ >= 12 && __GNUC__ < 15
+ #if __GNUC__ >= 12 && __GNUC__ < 16
   #define DYNINST_SUPPRESS_CODE_MAYBE_UNINITIALIZED        "-Wmaybe-uninitialized"
  #endif
 #elif defined(__clang__)

--- a/docker/README.md
+++ b/docker/README.md
@@ -61,21 +61,6 @@ $ cd /code
 
 ## Maintainers
 
-### Adding a new OS image
-
-1. Add the new OS and version as well as all new gcc and clang compiler versions to `configs` in `.github/scripts/compiler_configs.py`. 
-
-2. Update the list of OSes and versions in the `all` step in `.github/actions/os-versions/action.yaml`.
-
-3. Update the latest version in the `latest` step in `.github/actions/os-versions/action.yaml`.
-
-4. Add any special handling (e.g., building dependencies from source) needed in **both** `docker/Dockerfile.<OS>` and the `build-base` job in `.github/workflows/refresh-containers.yaml`.
-
-5. Make a new PR with these changes.
-
-6. Manually run the `refresh-containers` workflow from the GitHub web interface using your branch as the target branch.
-
-
 ### Adding a dependency
 
 Assuming all of the requisite CMake files are in place, a new dependency can be added to the container images. If

--- a/docker/README.md
+++ b/docker/README.md
@@ -63,17 +63,18 @@ $ cd /code
 
 ### Adding a new OS image
 
-1. Add the relevant information to 'build_base_images.sh'. For example, `make_image ubuntu 24.10`.
+1. Add the new OS and version as well as all new gcc and clang compiler versions to `configs` in `.github/scripts/compiler_configs.py`. 
 
-2. Run `build_base_images.sh --push` to build and push  _all_  container images.
+2. Update the list of OSes and versions in the `all` step in `.github/actions/os-versions/action.yaml`.
 
-3. Running the script above will print a complete list of supported OSes. These need to be added to the
-   GitHub "os:" fields in the workflow files dev-containers.yaml and pr-tests.yaml.
-   Make a PR to add these updated files.
+3. Update the latest version in the `latest` step in `.github/actions/os-versions/action.yaml`.
 
-4. After committing the PR above, the 'Build and Deploy Development Containers' workflow will update/generate
-   the associated development containers automatically on the next committed PR. It can be run manually via
-   the Github interface, if preferred.
+4. Add any special handling (e.g., building dependencies from source) needed in **both** `docker/Dockerfile.<OS>` and the `build-base` job in `.github/workflows/refresh-containers.yaml`.
+
+5. Make a new PR with these changes.
+
+6. Manually run the `refresh-containers` workflow from the GitHub web interface using your branch as the target branch.
+
 
 ### Adding a dependency
 

--- a/docker/build_peparse.sh
+++ b/docker/build_peparse.sh
@@ -4,6 +4,10 @@ set -ex
 
 git clone --depth=1 --branch=master https://github.com/trailofbits/pe-parse
 cd pe-parse
+
+# https://github.com/trailofbits/pe-parse/issues/187
+sed -i 's/-Werror//' cmake/compilation_flags.cmake
+
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
I have no idea why clang-16 has no package for Ubuntu 25. I haven't checked for a ppa, but we still have it in Fedora 37.

Ubuntu 25.10 is the same set of compilers, but has glibc 2.42. I didn't think it was really worthwhile to add it since Fedora 43 is effectively that same case.