### PR TITLE
[BPatch] Cleanup BPatch_point

### DIFF
--- a/dyninstAPI/h/BPatch_point.h
+++ b/dyninstAPI/h/BPatch_point.h
@@ -135,9 +135,6 @@ private:
     //  maybe we want BPatchSnippetHandle here
     Dyninst::PatchAPI::InstancePtr dynamic_point_monitor_func;
 
-    instPoint *getPoint() const {return point;}
-    instPoint *getPoint(BPatch_callWhen when) const;
-
     // If we're edge inst
     BPatch_edge *edge_;
 
@@ -162,7 +159,11 @@ public:
     BPatch_edge *edge() const { return edge_; }
     bool isReturnInstruction();
     static BPatch_procedureLocation convertInstPointType_t(int intType);
-    instPoint *llpoint() { return point; } 
+    instPoint *getPoint() {return point;}
+
+    instPoint *getPoint() const {return point;}
+    instPoint *getPoint(BPatch_callWhen when) const;
+
     Dyninst::Address getCallFallThroughAddr();
     bool patchPostCallArea();
     // End internal functions

--- a/dyninstAPI/src/hybridCallbacks.C
+++ b/dyninstAPI/src/hybridCallbacks.C
@@ -425,11 +425,11 @@ void HybridAnalysis::abruptEndCB(BPatch_point *point, void *)
     // not just a big chunk of zeroes, in which case the first
     // 00 00 instruction will probably raise an exception
     using namespace ParseAPI;
-    func_instance *pfunc = point->llpoint()->func();
+    func_instance *pfunc = point->getPoint()->func();
     CodeRegion *reg = pfunc->ifunc()->region();
     unsigned char * regptr = (unsigned char *) reg->getPtrToInstruction(reg->offset());
     Address regSize = reg->high() - reg->offset();
-    unsigned firstNonzero = point->llpoint()->block()->end() 
+    unsigned firstNonzero = point->getPoint()->block()->end() 
         - reg->offset() 
         - pfunc->obj()->codeBase();
     for (; firstNonzero < regSize; firstNonzero++) {
@@ -448,10 +448,10 @@ void HybridAnalysis::abruptEndCB(BPatch_point *point, void *)
     // parse, immediately after the current block
     vector<Address> *targets = new vector<Address>;
     Address nextInsn =0;
-    point->llpoint()->block()->setNotAbruptEnd();
+    point->getPoint()->block()->setNotAbruptEnd();
     getCFTargets(point,*targets);
     if (targets->empty()) {
-       nextInsn = point->llpoint()->block()->end();
+       nextInsn = point->getPoint()->block()->end();
     } else {
        nextInsn = (*targets)[0];
     }
@@ -754,8 +754,8 @@ void HybridAnalysis::badTransferCB(BPatch_point *point, void *returnValue)
         // we're returning from 
         pair<Block*, Address> returningCallB((Block*)NULL,0); 
         set<Block*> callBlocks;
-        getCallBlocks(returnAddr, point->llpoint()->func(), 
-                      point->llpoint()->block(), returningCallB, callBlocks);
+        getCallBlocks(returnAddr, point->getPoint()->func(), 
+                      point->getPoint()->block(), returningCallB, callBlocks);
 
         // 3.2.1 parse at returnAddr as the fallthrough of the preceding
         // call block, if there is one 
@@ -808,7 +808,7 @@ void HybridAnalysis::badTransferCB(BPatch_point *point, void *returnValue)
                           "instruction at %p %s[%d]\n", point->getAddress(), 
                           target,callPoints[0]->getAddress(),FILE__,__LINE__);
 
-                if (point->llpoint()->block()->llb()->isShared()) {
+                if (point->getPoint()->block()->llb()->isShared()) {
                     // because of pc emulation, if the return point is shared, 
                     // we may have flipped between functions that share the 
                     // return point, so use the call target function

--- a/dyninstAPI/src/hybridOverwrites.C
+++ b/dyninstAPI/src/hybridOverwrites.C
@@ -419,7 +419,7 @@ void HybridAnalysisOW::owLoop::instrumentOverwriteLoop(Address writeInsn)
             long st = 0;
             vector<Address> targs;
             if (hybridow_->hybrid_->getCallAndBranchTargets
-                ((*uIter)->llpoint()->block(), targs)) 
+                ((*uIter)->getPoint()->block(), targs)) 
             {
                 st = * targs.begin();
             }
@@ -761,7 +761,7 @@ BPatch_basicBlockLoop* HybridAnalysisOW::getWriteLoop
                 {
                     if ((*pIter)->isDynamic()) {
                         vector<Address> targs;
-                        if (!hybrid_->getCallAndBranchTargets((*pIter)->llpoint()->block(),targs)) {
+                        if (!hybrid_->getCallAndBranchTargets((*pIter)->getPoint()->block(),targs)) {
                             mal_printf("loop has an unresolved indirect transfer at %p\n", 
                                     (*pIter)->getAddress());
                             hasUnresolved = true;
@@ -887,7 +887,7 @@ bool HybridAnalysisOW::addFuncBlocks(owLoop *loop,
              pIter++) 
         {
             vector<Address> targs;
-            hybrid_->getCallAndBranchTargets((*pIter)->llpoint()->block(), targs);
+            hybrid_->getCallAndBranchTargets((*pIter)->getPoint()->block(), targs);
             if (1 != targs.size()) {
                 loop->unresExits_.insert(*pIter);
                 hasUnresolved = true;
@@ -974,7 +974,7 @@ bool HybridAnalysisOW::setLoopBlocks(owLoop *loop,
                 // We've already checked that the transfer is uniquely 
                 // resolved, add the target.
                 vector<Address> targs;
-                hybrid_->getCallAndBranchTargets((*pIter)->llpoint()->block(), targs);
+                hybrid_->getCallAndBranchTargets((*pIter)->getPoint()->block(), targs);
                 assert(targs.size() == 1); 
                 mal_printf("loop %d has a resolved indirect transfer at %p with "
                           "target %lx\n", loop->getID(), (*pIter)->getAddress(), 


### PR DESCRIPTION
This PR renames llPoint() to getPoint() and makes other getPoint interfaces public. 

Appropriate getPoint() is selected by the compiler based on constness.

This is currently required for #1987.