### PR TITLE
[AMDGPU][DataflowAPI] Add missing registers for gfx908

### DIFF
--- a/dataflowAPI/src/ABI.C
+++ b/dataflowAPI/src/ABI.C
@@ -106,6 +106,9 @@ ABI* ABI::getABI(Architecture arch){
 }
 
 ABI* ABI::getABI(int addr_width){
+#if defined(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
+    return getABI(Arch_amdgpu_gfx908);
+#endif
     if (globalABI_ == NULL){
         globalABI_ = new ABI();
 	globalABI_->addr_width = 4;

--- a/dataflowAPI/src/RegisterMap.C
+++ b/dataflowAPI/src/RegisterMap.C
@@ -1412,7 +1412,9 @@ RegisterMap &machRegIndex_amdgpu_gfx908() {
      {amdgpu_gfx908::acc252,616},
      {amdgpu_gfx908::acc253,617},
      {amdgpu_gfx908::acc254,618},
-     {amdgpu_gfx908::acc255,619}};
+     {amdgpu_gfx908::acc255,619},
+     {amdgpu_gfx908::exec_lo,620},
+     {amdgpu_gfx908::exec_hi,621}};
     }
     return *mrmap;
 }
@@ -2042,7 +2044,9 @@ RegisterMap &machRegIndex_amdgpu_gfx90a() {
      {amdgpu_gfx90a::acc252,616},
      {amdgpu_gfx90a::acc253,617},
      {amdgpu_gfx90a::acc254,618},
-     {amdgpu_gfx90a::acc255,619}};
+     {amdgpu_gfx90a::acc255,619},
+     {amdgpu_gfx90a::exec_lo,620},
+     {amdgpu_gfx90a::exec_hi,621}};
     }
     return *mrmap;
 }
@@ -2671,7 +2675,9 @@ RegisterMap &machRegIndex_amdgpu_gfx940() {
      {amdgpu_gfx940::acc252,616},
      {amdgpu_gfx940::acc253,617},
      {amdgpu_gfx940::acc254,618},
-     {amdgpu_gfx940::acc255,619}};
+     {amdgpu_gfx940::acc255,619},
+     {amdgpu_gfx940::exec_lo,620},
+     {amdgpu_gfx940::exec_hi,621}};
     }
     return *mrmap;
 }


### PR DESCRIPTION
DataflowAPI portion of #1987.
Requires #2003.