### PR TITLE
Fix unused function warning in x86-emit.C with i386 codegen on x86_64 host

### DIFF
--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -60,7 +60,7 @@
 const int EmitterIA32::mt_offset = -4;
 #if defined(DYNINST_CODEGEN_ARCH_X86_64)
 const int EmitterAMD64::mt_offset = -8;
-#endif
+
 
 static void emitXMMRegsSaveRestore(codeGen& gen, bool isRestore)
 {
@@ -96,6 +96,7 @@ static void emitXMMRegsSaveRestore(codeGen& gen, bool isRestore)
    }
    SET_PTR(insn, gen);
 }
+#endif
 
 static void emitSegPrefix(Register segReg, codeGen& gen)
 {


### PR DESCRIPTION
This was found by building on an x86 host with
-DDYNINST_CODEGEN_ARCH=i386.