### PR TITLE
Fix cast-align warnings in emitElfStatic

### DIFF
--- a/symtabAPI/src/emitElfStatic-ppc64.C
+++ b/symtabAPI/src/emitElfStatic-ppc64.C
@@ -50,6 +50,7 @@
 #include "debug.h"
 #include "common/src/arch-power.h"
 #include "elf.h"
+#include "unaligned_memory_access.h"
 
 using namespace Dyninst;
 using namespace Dyninst::SymtabAPI;
@@ -73,6 +74,13 @@ unsigned int setBits(unsigned int target, unsigned int pos, unsigned int len, un
 
     return target;
 }
+
+// The size of the return type of 'setBits' is used to determine the number of bytes
+// written to specific ELF fields. It's imperative they match the sizes of the types
+// provided by elfutils.
+static_assert(sizeof(decltype(setBits(0,0,0,0))) == sizeof(Elf32_Word), "setBits return type is incompatible with Elf32_Word");
+static_assert(sizeof(decltype(setBits(0,0,0,0))) == sizeof(Elf64_Word), "setBits return type is incompatible with Elf64_Word");
+
 
 #if defined(os_freebsd)
 #define R_X86_64_JUMP_SLOT R_X86_64_JMP_SLOT
@@ -349,11 +357,11 @@ bool emitElfStatic::archSpecificRelocation(Symtab* targetSymtab, Symtab* srcSymt
 
 	if (relocation_length == 64) {
 		char *td = (targetData + dest - (dest%8));
-		uint64_t target = relocation;
+		auto const target = static_cast<uint64_t>(relocation);
         	memcpy(td, &target, 2*sizeof(Elf64_Word));
 	} else {
 		char *td = (targetData + dest - (dest%4));
-	        unsigned int target = *((unsigned int *) td);
+	        auto target = Dyninst::read_memory_as<Elf64_Word>(td);
 	        target = setBits(target, relocation_pos, relocation_length, relocation);
         	memcpy(td, &target, sizeof(Elf64_Word));
 	}
@@ -670,13 +678,13 @@ default:
                        static_cast<unsigned long>(targetData[dest+3]));
 
   if (rel.getRelType() == R_PPC_REL24) {
-	unsigned int *td = (unsigned int *) targetData;
+	auto *td = reinterpret_cast<unsigned int*>(targetData);
 	unsigned int target;
 	target = td[dest/4];
 	target = setBits(target, relocation_pos, relocation_length, relocation);
         memcpy(&targetData[dest], &target, sizeof(Elf32_Word));
 	} else {
-	unsigned int *td = (unsigned int *) targetData;
+	auto *td = reinterpret_cast<unsigned int*>(targetData);
 	unsigned int target;
 	target = td[dest/4];
 	target = setBits(target, relocation_pos, relocation_length, relocation);
@@ -691,7 +699,7 @@ default:
                        static_cast<unsigned long>(targetData[dest+3]));
 	}
     if (branch_pred >= 0) {
-	unsigned int *td = (unsigned int *) targetData;
+	auto *td = reinterpret_cast<unsigned int*>(targetData);
 	unsigned int target;
 	target = td[dest/4];
 	target = setBits(target, 10, 1, branch_pred);
@@ -1091,7 +1099,7 @@ bool emitElfStatic::handleInterModuleSpecialCase(Symtab * /*target*/,
   // or create it. 
   //
 
-  unsigned int *td = (unsigned int *)(data + dest - (dest % 4));
+  auto *td = reinterpret_cast<unsigned int *>(data + dest - (dest % 4));
   unsigned int &call = td[0];
   unsigned int &post = td[1];
 

--- a/symtabAPI/src/emitElfStatic.C
+++ b/symtabAPI/src/emitElfStatic.C
@@ -588,7 +588,7 @@ bool emitElfStatic::createLinkMap(Symtab *target,
                       if(!relExist) {
                          // else create a new symbol
                          // Offset and name is all we care - offset should be value of the symbol
-                         Offset soffset = *((unsigned long *) (rawRegionData + entry*8));
+                         auto const soffset = Dyninst::read_memory_as<Offset>(rawRegionData + entry*8);
                          Symbol *newsym = new Symbol("dyntoc_entry",
                                                      Symbol::ST_UNKNOWN,
                                                      Symbol::SL_UNKNOWN,


### PR DESCRIPTION
These were found when compiling with clang-21.