### PR TITLE
Fix unused private variables in AstStackRemoveNode

### DIFF
--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -1087,6 +1087,9 @@ bool AstStackRemoveNode::generateCode_phase2(codeGen&, bool,
         Address &,
         Dyninst::Register &)
 {
+    (void)func_;
+    (void)canaryAfterPrologue_;
+    (void)canaryHeight_;
     return false;
 }
 


### PR DESCRIPTION
For architectures that don't support stack modifications (cap_stack_mods)- currently only x86/x86_64 do- these member variables are not used.

Found when compiling with clang-21.