### PR TITLE
Temporary fix for host-codegen separation on Power and AArch64

### DIFF
--- a/dyninstAPI/src/linux-aarch64.C
+++ b/dyninstAPI/src/linux-aarch64.C
@@ -45,6 +45,21 @@
 #include "dyninstAPI/src/function.h"
 #include "common/src/linuxHeaders.h"
 
+
+// FIXME: HOST+CODEGEN
+// This is a temporary fix as getMaxBranch is used for both host and codegen
+// This file is compiled when host architecture is AArch64. If codegen isn't for AArch64, we define the following:
+#if !defined(DYNINST_CODEGEN_ARCH_AARCH64)
+
+#define MAX_BRANCH_OFFSET      0x07ffffff  // 128MB  Used for B
+
+Address getMaxBranch() {
+    return MAX_BRANCH_OFFSET;
+}
+
+#endif
+
+
 #define DLOPEN_MODE (RTLD_NOW | RTLD_GLOBAL)
 
 const char DL_OPEN_FUNC_EXPORTED[] = "dlopen";

--- a/dyninstAPI/src/linux-power.C
+++ b/dyninstAPI/src/linux-power.C
@@ -45,6 +45,21 @@
 #include "dyninstAPI/src/function.h"
 #include "common/src/linuxHeaders.h"
 
+
+// FIXME: HOST+CODEGEN
+// This is a temporary fix as getMaxBranch is used for both host and codegen
+// This file is compiled when host architecture is Power. If codegen isn't for Power, we define the following:
+#if !defined(DYNINST_CODEGEN_ARCH_POWER)
+
+#define MAX_BRANCH      0x01fffffc
+
+Address getMaxBranch() {
+  return MAX_BRANCH;
+}
+
+#endif
+
+
 #define DLOPEN_MODE (RTLD_NOW | RTLD_GLOBAL)
 
 const char DL_OPEN_FUNC_EXPORTED[] = "dlopen";


### PR DESCRIPTION
The `getMaxBranch` function is defined in inst-<arch> files for x86, power and aarch64. It is used by both host and codegen for power and aarch64. When host and codegen arch are different (i.e building for AMDGPU), the definition will be missing for the host side. This PR is a crude fix to this issue until we figure out a cleaner solution.