### PR TITLE
Fix useless absolute value of unsigned values (Wabsolute-value)

### DIFF
--- a/dyninstAPI/src/Relocation/Widgets/PCWidget-aarch64.C
+++ b/dyninstAPI/src/Relocation/Widgets/PCWidget-aarch64.C
@@ -106,7 +106,7 @@ bool IPPatch::apply(codeGen &gen, CodeBuffer *) {
   // Load the offset into a scratch register
   std::vector<Register> exclude;
   exclude.push_back(30 /* LR */);
-  Register scratchReg = insnCodeGen::moveValueToReg(gen, labs(RAOffset), &exclude);
+  Register scratchReg = insnCodeGen::moveValueToReg(gen, RAOffset, &exclude);
   // Put the original RA into LR
   insnCodeGen::generateAddSubShifted(gen, RAOffset>0?insnCodeGen::Add:insnCodeGen::Sub,
           0, 0, scratchReg, 30, 30, true);

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -1096,7 +1096,7 @@ bool EmitterAARCH64::emitLoadRelative(Register dest, Address offset, Register ba
         std::vector<Register> exclude;
         exclude.push_back(baseReg);
         // mov sOffset to a reg
-        auto addReg = insnCodeGen::moveValueToReg(gen, labs(offset), &exclude);
+        auto addReg = insnCodeGen::moveValueToReg(gen, labs(sOffset), &exclude);
         // add/sub sOffset to baseReg
         insnCodeGen::generateAddSubShifted(gen,
                 sOffset>0?insnCodeGen::Add:insnCodeGen::Sub,
@@ -1280,7 +1280,7 @@ void EmitterAARCH64::emitLoadShared(opCode op, Register dest, const image_variab
         } else {
             std::vector<Register> exclude;
             exclude.push_back(baseReg);
-            auto addReg = insnCodeGen::moveValueToReg(gen, labs(varOffset), &exclude);
+            auto addReg = insnCodeGen::moveValueToReg(gen, varOffset, &exclude);
             insnCodeGen::generateAddSubShifted(gen,
                     (signed long long) varOffset>0?insnCodeGen::Add:insnCodeGen::Sub,
                     0, 0, addReg, baseReg, baseReg, true);
@@ -1322,7 +1322,7 @@ void EmitterAARCH64::emitStoreShared(Register source, const image_variable *var,
         std::vector<Register> exclude;
         exclude.push_back(baseReg);
         // mov offset to a reg
-        auto addReg = insnCodeGen::moveValueToReg(gen, labs(varOffset), &exclude);
+        auto addReg = insnCodeGen::moveValueToReg(gen, varOffset, &exclude);
         // add/sub offset to baseReg
         insnCodeGen::generateAddSubShifted(gen,
                 (signed long long) varOffset>0?insnCodeGen::Add:insnCodeGen::Sub,


### PR DESCRIPTION
This was found using clang-20.

---

This PR fixes the compiler warnings, but they have illuminated concerning uses of `Dyninst::Address`. It is defined to be an `unsigned long`, so subtraction to find an offset is not logically correct. You can see that in some places an `Address` getting cast to some signed type. Bizarrely, `Dyninst::Offset` is also an `unsigned long`. This means there is no uniform way to represent actual relative offsets. For example,

```c++
void EmitterAARCH64::emitStoreShared(Register source, const image_variable *var, bool is_local, int size, codeGen &gen) {
    // create or retrieve jump slot
    Address addr;
    int stackSize = 0;
    if(!is_local) {
        addr = getInterModuleVarAddr(var, gen);
    }
    else {
        addr = (Address)var->getOffset();    // <----- Is it an Offset or an Address?
    }

    // load register with address from jump slot
    Register baseReg = gen.rs()->getScratchRegister(gen, true);
    assert(baseReg != Null_Register && "cannot get a scratch register");

    emitMovePCToReg(baseReg, gen);
    Address varOffset = addr - gen.currAddr() + 4;    // <-------  This is definitely broken

    if(!is_local) {
      ...
    } else {
        std::vector<Register> exclude;
        exclude.push_back(baseReg);
        // mov offset to a reg
        auto addReg = insnCodeGen::moveValueToReg(gen, varOffset, &exclude);
        // add/sub offset to baseReg
        insnCodeGen::generateAddSubShifted(gen,

                (signed long long) varOffset>0?insnCodeGen::Add:insnCodeGen::Sub,
                ^^^^^ worrying cast

                0, 0, addReg, baseReg, baseReg, true);
```

This business of addresses, offsets, and relative offsets may need to get addressed sooner rather than later. It is not difficult to create some actual arithmetic types that have the proper relationships. Proliferating those types will definitely be a huge headache.