### PR TITLE
Fix offset calculations in EmitterAARCH64

### DIFF
--- a/dyninstAPI/src/Relocation/Widgets/PCWidget-aarch64.C
+++ b/dyninstAPI/src/Relocation/Widgets/PCWidget-aarch64.C
@@ -106,7 +106,7 @@ bool IPPatch::apply(codeGen &gen, CodeBuffer *) {
   // Load the offset into a scratch register
   std::vector<Register> exclude;
   exclude.push_back(30 /* LR */);
-  Register scratchReg = insnCodeGen::moveValueToReg(gen, RAOffset, &exclude);
+  Register scratchReg = insnCodeGen::moveValueToReg(gen, labs(static_cast<long int>(RAOffset)), &exclude);
   // Put the original RA into LR
   insnCodeGen::generateAddSubShifted(gen, RAOffset>0?insnCodeGen::Add:insnCodeGen::Sub,
           0, 0, scratchReg, 30, 30, true);

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -1260,7 +1260,7 @@ void EmitterAARCH64::emitLoadShared(opCode op, Register dest, const image_variab
         } else {
             std::vector<Register> exclude;
             exclude.push_back(baseReg);
-            auto addReg = insnCodeGen::moveValueToReg(gen, varOffset, &exclude);
+            auto addReg = insnCodeGen::moveValueToReg(gen, labs(static_cast<long int>(varOffset)), &exclude);
             insnCodeGen::generateAddSubShifted(gen,
                     (signed long long) varOffset>0?insnCodeGen::Add:insnCodeGen::Sub,
                     0, 0, addReg, baseReg, baseReg, true);
@@ -1302,7 +1302,7 @@ void EmitterAARCH64::emitStoreShared(Register source, const image_variable *var,
         std::vector<Register> exclude;
         exclude.push_back(baseReg);
         // mov offset to a reg
-        auto addReg = insnCodeGen::moveValueToReg(gen, varOffset, &exclude);
+        auto addReg = insnCodeGen::moveValueToReg(gen, labs(static_cast<long int>(varOffset)), &exclude);
         // add/sub offset to baseReg
         insnCodeGen::generateAddSubShifted(gen,
                 (signed long long) varOffset>0?insnCodeGen::Add:insnCodeGen::Sub,


### PR DESCRIPTION
'varOffset' is defined as

Address varOffset = addr - gen.currAddr() + 4;

When 'addr' is less than 'gen.currAddr()', this calculation underflows.
Since 'labs' takes a 'long int', the underflowed 'unsigned long' (that is
what 'Address' really is) gets converted to a signed value. Removing
this conversion and the subsequent absolute value caused 'varOffset'
to be treated as a large, positive number.

This was broken by 9b6dd2aa6b.