### PR TITLE
GitHubCI: patch build error in launchmon

### DIFF
--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -253,6 +253,8 @@ jobs:
           cd /
           git clone --depth=1 https://github.com/llnl/launchmon.git
           cd launchmon
+          wget https://patch-diff.githubusercontent.com/raw/LLNL/LaunchMON/pull/65.patch
+          git apply 65.patch
           ./bootstrap
           mkdir build
           cd build


### PR DESCRIPTION
This should be reverted once https://github.com/LLNL/LaunchMON/pull/65 is merged.