### PR TITLE
GitHubCI: disable HPCToolkit on Fedora

### DIFF
--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         os: ${{ fromJson(needs.get-oses.outputs.latest) }}
+         os: [ 'ubuntu-25.04' ]
     permissions:
       packages: read
     container:


### PR DESCRIPTION
spack fails to bootstrap on Fedora 43. This can be re-enabled once https://github.com/spack/spack/issues/51410 is resolved.