### PR TITLE
Remove makeSizeType from InstructionDecoderImpl interface

### DIFF
--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.C
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.C
@@ -56,11 +56,6 @@ namespace Dyninst {
 
 		using namespace std;
 
-		Result_Type InstructionDecoder_amdgpu_gfx908::makeSizeType(unsigned int) {
-			assert(0); //not implemented
-			return u32;
-		}
-
 		// ****************
 		// decoding opcodes
 		// ****************

--- a/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
+++ b/instructionAPI/src/AMDGPU/gfx908/InstructionDecoder-amdgpu-gfx908.h
@@ -84,7 +84,6 @@ namespace Dyninst {
 
 
             private:
-            virtual Result_Type makeSizeType(unsigned int opType);
 
             bool is64Bit{};
 

--- a/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.C
+++ b/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.C
@@ -54,10 +54,6 @@ namespace Dyninst {
         }
 
         using namespace std;
-        Result_Type InstructionDecoder_amdgpu_gfx90a::makeSizeType(unsigned int) {
-            assert(0); //not implemented
-            return u32;
-        }
 
         // ****************
         // decoding opcodes

--- a/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.h
+++ b/instructionAPI/src/AMDGPU/gfx90a/InstructionDecoder-amdgpu-gfx90a.h
@@ -84,7 +84,6 @@ namespace Dyninst {
 
 
             private:
-            virtual Result_Type makeSizeType(unsigned int opType);
 
             bool is64Bit{};
 

--- a/instructionAPI/src/AMDGPU/gfx940/InstructionDecoder-amdgpu-gfx940.C
+++ b/instructionAPI/src/AMDGPU/gfx940/InstructionDecoder-amdgpu-gfx940.C
@@ -54,10 +54,6 @@ namespace Dyninst {
         }
 
         using namespace std;
-        Result_Type InstructionDecoder_amdgpu_gfx940::makeSizeType(unsigned int) {
-            assert(0); //not implemented
-            return u32;
-        }
 
         // ****************
         // decoding opcodes

--- a/instructionAPI/src/AMDGPU/gfx940/InstructionDecoder-amdgpu-gfx940.h
+++ b/instructionAPI/src/AMDGPU/gfx940/InstructionDecoder-amdgpu-gfx940.h
@@ -84,7 +84,6 @@ namespace Dyninst {
 
 
             private:
-            virtual Result_Type makeSizeType(unsigned int opType);
 
             bool is64Bit{};
 

--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -513,11 +513,6 @@ void InstructionDecoder_aarch64::set32Mode()
     }
   }
 
-  Result_Type InstructionDecoder_aarch64::makeSizeType(unsigned int) {
-    assert(0); // not implemented
-    return u32;
-  }
-
   // ****************
   // decoding opcodes
   // ****************

--- a/instructionAPI/src/InstructionDecoder-aarch64.h
+++ b/instructionAPI/src/InstructionDecoder-aarch64.h
@@ -64,7 +64,6 @@ namespace Dyninst { namespace InstructionAPI {
     static const char* condInsnAliasMap(entryID);
 
   private:
-    virtual Result_Type makeSizeType(unsigned int opType);
 
     bool isPstateRead{}, isPstateWritten{};
     bool isFPInsn{}, isSIMDInsn{};

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -893,11 +893,6 @@ which are both 0).
     return makeRegisterExpression(makePowerRegID(ppc32::cr0, field<11, 15>(insn) >> 2));
   }
 
-  Result_Type InstructionDecoder_power::makeSizeType(unsigned int) {
-    assert(!"not implemented");
-    return u32;
-  }
-
   Expression::Ptr InstructionDecoder_power::makeSHExpr() {
     // For sradi instruction, the SH field is bit30 || bit16-20
     if(field<0, 5>(insn) == 31 && field<21, 29>(insn) == 413) {

--- a/instructionAPI/src/InstructionDecoder-power.h
+++ b/instructionAPI/src/InstructionDecoder-power.h
@@ -56,7 +56,6 @@ namespace Dyninst { namespace InstructionAPI {
     using InstructionDecoderImpl::makeRegisterExpression;
 
   private:
-    virtual Result_Type makeSizeType(unsigned int opType);
     Expression::Ptr makeMemRefIndex(Result_Type size);
     Expression::Ptr makeMemRefNonIndex(Result_Type size);
     Expression::Ptr makeRAExpr();

--- a/instructionAPI/src/InstructionDecoder-x86.h
+++ b/instructionAPI/src/InstructionDecoder-x86.h
@@ -72,7 +72,7 @@ namespace Dyninst { namespace InstructionAPI {
                                 bool isExtendedReg = false);
     Expression::Ptr decodeImmediate(unsigned int opType, const unsigned char* immStart,
                                     bool isSigned = false);
-    virtual Result_Type makeSizeType(unsigned int opType);
+    Result_Type makeSizeType(unsigned int opType);
 
   private:
     void doIA32Decode(InstructionDecoder::buffer& b);

--- a/instructionAPI/src/InstructionDecoderImpl.h
+++ b/instructionAPI/src/InstructionDecoderImpl.h
@@ -76,7 +76,6 @@ class InstructionDecoderImpl
         virtual Expression::Ptr makeRegisterExpression(MachRegister reg, unsigned int start , unsigned int end);
         virtual Expression::Ptr makeMaskRegisterExpression(MachRegister reg);
         virtual Expression::Ptr makeRegisterExpression(MachRegister reg, Result_Type extendFrom);
-        virtual Result_Type makeSizeType(unsigned int opType) = 0;
         // added to support ternary value 
         virtual Expression::Ptr makeTernaryExpression(Expression::Ptr cond, Expression::Ptr first, Expression::Ptr second, Result_Type resultType);
         //Instruction* makeInstruction(entryID opcode, const char* mnem, unsigned int decodedSize,const unsigned char* raw);


### PR DESCRIPTION
It's only used on x86, so move it there.

@wxrdnx Are you using this for RISC-V?