### PR TITLE
Checking for a null pointer

### DIFF
--- a/dyninstAPI/src/BPatch_edge.C
+++ b/dyninstAPI/src/BPatch_edge.C
@@ -117,6 +117,9 @@ BPatch_point *BPatch_edge::getPoint()
       BPatch_flowGraph *cfg = getFlowGraph();
       instPoint *ip = instPoint::edge(cfg->ll_func(),
                                       edge);
+      if (!ip) {
+          return point;
+      }
       AddressSpace *as = cfg->getllAddSpace();
       assert(as);
       


### PR DESCRIPTION
Sometimes a function returns a null pointer, which causes a segfault.