### PR TITLE
Deprecate Expression::getChildren

### DIFF
--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -60,13 +60,10 @@ void AbsRegionConverter::convertAll(InstructionAPI::Expression::Ptr expr,
 				    std::vector<AbsRegion> &regions) {
   // If we're a memory dereference, then convert us and all
   // used registers.
-  if (boost::dynamic_pointer_cast<Dereference>(expr)) {
-    std::vector<Expression::Ptr> tmp;
+  if (auto deref = boost::dynamic_pointer_cast<Dereference>(expr)) {
     // Strip dereference...
-    expr->getChildren(tmp);
-    for (std::vector<Expression::Ptr>::const_iterator i = tmp.begin();
-	 i != tmp.end(); ++i) {
-       regions.push_back(convert(*i, addr, func, block));
+    for(auto c : deref->getSubexpressions()) {
+       regions.push_back(convert(c, addr, func, block));
     }
   }
   

--- a/dyninstAPI/src/StackMod/StackAccess.C
+++ b/dyninstAPI/src/StackMod/StackAccess.C
@@ -689,8 +689,7 @@ bool getMemoryOffset(ParseAPI::Function *func,
 
             // If we have a dereference, extract the child
             if (dynamic_cast<InstructionAPI::Dereference*>(val.get())) {
-                vector<InstructionAPI::Expression::Ptr> children;
-                val->getChildren(children);
+                auto children = val->getSubexpressions();
                 if (children.size() == 1) {
                     val = children.front();
                 }

--- a/instructionAPI/doc/2-Abstractions.tex
+++ b/instructionAPI/doc/2-Abstractions.tex
@@ -117,7 +117,7 @@ instruction is represented using these objects.
 
 These ASTs may be searched for leaf elements or subtrees (via 
 \code{getUses} and \code{isUsed}) and traversed breadth-\/first or depth-\/first
-(via \code{getChildren}).
+(via \code{getSubexpressions}).
 
 Any node in these ASTs may be evaluated. Evaluation attempts to determine the
 value represented by a node. If successful, it will return that value and cache

--- a/instructionAPI/doc/API/BinaryFunction.tex
+++ b/instructionAPI/doc/API/BinaryFunction.tex
@@ -47,11 +47,10 @@ evaluable.
 }
 
 \begin{apient}
-void getChildren (vector< Expression::Ptr > & children) const
+std::vector<Expression::Ptr> getSubexpressions() const
 \end{apient}
 \apidesc{
-The children of a \code{BinaryFunction} are its two arguments.
-Appends the children of this BinaryFunction to \code{children}.
+Returns the left and right subexpressions.
 }
 
 \begin{apient}

--- a/instructionAPI/doc/API/Dereference.tex
+++ b/instructionAPI/doc/API/Dereference.tex
@@ -39,11 +39,10 @@ to be dereferenced and a type indicating how the memory at the address in questi
 }
 
 \begin{apient}
-virtual void getChildren (vector< Expression::Ptr > & children) const
+std::vector<Expression::Ptr> getSubexpressions() const
 \end{apient}
 \apidesc{
-A \code{Dereference} has one child, which represents the address being dereferenced.
-Appends the child of this \code{Dereference} to \code{children}.
+Returns the expression for the address being dereferenced.
 }
 
 \begin{apient}

--- a/instructionAPI/doc/API/Expression.tex
+++ b/instructionAPI/doc/API/Expression.tex
@@ -191,10 +191,8 @@ virtual void apply(Visitor *)
 }
 
 \begin{apient}
-virtual void getChildren(std::vector<Expression::Ptr> & children) const
+std::vector<Expression::Ptr> getSubexpressions() const
 \end{apient}
 \apidesc{
-    \code{getChildren} may be called on an \code{Expression} taking a vector of
-    \code{ExpressionPtr}s, rather than \code{Expression}Ptrs. All children
-    which are \code{Expression}s will be appended to \code{children}.
+Returns all subexpressions used by the current expression.
 }

--- a/instructionAPI/doc/API/Immediate.tex
+++ b/instructionAPI/doc/API/Immediate.tex
@@ -13,13 +13,6 @@ virtual bool isUsed(Expression::Ptr findMe) const
 \end{apient}
 
 \begin{apient}
-void getChildren(vector<Expression::Ptr> &) const
-\end{apient}
-\apidesc{
-By definition, an \code{Immediate} has no children.
-}
-
-\begin{apient}
 void getUses(set<Expression::Ptr> &)
 \end{apient}
 \apidesc{

--- a/instructionAPI/doc/API/MultiRegisterAST.tex
+++ b/instructionAPI/doc/API/MultiRegisterAST.tex
@@ -26,16 +26,6 @@ should not be constructed manually.
 MultiRegisterAST(std::vector<RegisterAST::Ptr> _in);
 \end{apient}
 
-
-\begin{apient}
-void getChildren (vector< Expression::Ptr > & children) const
-\end{apient}
-\apidesc{
-By definition, a \code{MultiRegister} object has no children.
-Since a \code{MultiRegister} has no children, the \code{children} parameter is unchanged by this
-method.
-}
-
 \begin{apient}
 void getUses (set< Expression::Ptr > & uses)
 \end{apient}

--- a/instructionAPI/doc/API/RegisterAST.tex
+++ b/instructionAPI/doc/API/RegisterAST.tex
@@ -17,12 +17,6 @@ are known.
 is Dyninst's register representation and should not be constructed manually. }
 
 \begin{apient}
-  void getChildren (vector< Expression::Ptr > & children) const
-\end{apient}
-\apidesc{ By definition, a \code{RegisterAST} object has no children. Since a \code{RegisterAST} has no children, 
-the \code{children} parameter is unchanged by this method. }
-
-\begin{apient}
   void getUses (set< Expression::Ptr > & uses)
 \end{apient}
 \apidesc{ By definition, the use set of a \code{RegisterAST} object is itself. This \code{RegisterAST} will be 

--- a/instructionAPI/doc/API/TernaryAST.tex
+++ b/instructionAPI/doc/API/TernaryAST.tex
@@ -21,14 +21,6 @@ are known.
 }
 
 \begin{apient}
-  void getChildren (vector< Expression::Ptr > & children) const
-\end{apient}
-\apidesc{
-  By definition, a TernaryAST has three children, the condition, the first and the second child.
-  and should all be added to the children.
-}
-
-\begin{apient}
   void getUses (set< Expression::Ptr > & uses)
 \end{apient}
 \apidesc{ By definition, add the use of all its children to.. }

--- a/instructionAPI/h/BinaryFunction.h
+++ b/instructionAPI/h/BinaryFunction.h
@@ -211,11 +211,8 @@ namespace Dyninst { namespace InstructionAPI {
 
     virtual const Result& eval() const override;
 
-    virtual void getChildren(std::vector<Expression::Ptr>& children) const override {
-      children.push_back(m_arg1);
-      children.push_back(m_arg2);
-
-      return;
+    std::vector<Expression::Ptr> getSubexpressions() const override {
+      return {m_arg1, m_arg2};
     }
 
     virtual void getUses(std::set<Expression::Ptr>& uses) override {

--- a/instructionAPI/h/Dereference.h
+++ b/instructionAPI/h/Dereference.h
@@ -53,9 +53,8 @@ namespace Dyninst { namespace InstructionAPI {
 
     virtual ~Dereference() {}
 
-    virtual void getChildren(std::vector<Expression::Ptr>& children) const override {
-      children.push_back(addressToDereference);
-      return;
+    std::vector<Expression::Ptr> getSubexpressions() const override {
+      return {addressToDereference};
     }
 
     virtual void getUses(std::set<Expression::Ptr>& uses) override {

--- a/instructionAPI/h/Expression.h
+++ b/instructionAPI/h/Expression.h
@@ -31,6 +31,7 @@
 #if !defined(VALUECOMPUTATION_H)
 #define VALUECOMPUTATION_H
 
+#include "compiler_annotations.h"
 #include "dyninst_visibility.h"
 #include "registers/MachRegister.h"
 #include "Result.h"
@@ -86,7 +87,13 @@ namespace Dyninst { namespace InstructionAPI {
     virtual bool bind(Expression* expr, const Result& value);
     virtual void apply(Visitor*) {}
 
-    virtual void getChildren(std::vector<Expression::Ptr>& children) const = 0;
+    DYNINST_DEPRECATED("Use getSubexpressions()")
+    void getChildren(std::vector<Expression::Ptr> &children) const {
+      auto se = getSubexpressions();
+      children.insert(children.end(), se.begin(), se.end());
+    }
+
+    virtual std::vector<Expression::Ptr> getSubexpressions() const { return {}; }
 
   protected:
     friend class MultiRegisterAST;

--- a/instructionAPI/h/Immediate.h
+++ b/instructionAPI/h/Immediate.h
@@ -44,8 +44,6 @@ namespace Dyninst { namespace InstructionAPI {
 
     virtual ~Immediate();
 
-    virtual void getChildren(std::vector<Expression::Ptr>&) const override;
-
     virtual void getUses(std::set<Expression::Ptr>&) override;
     virtual bool isUsed(Expression::Ptr findMe) const override;
 

--- a/instructionAPI/h/MultiRegister.h
+++ b/instructionAPI/h/MultiRegister.h
@@ -53,8 +53,6 @@ namespace Dyninst { namespace InstructionAPI {
     virtual ~MultiRegisterAST() = default;
     MultiRegisterAST(const MultiRegisterAST&) = default;
 
-    virtual void getChildren(std::vector<Expression::Ptr>& children) const override;
-
     virtual void getUses(std::set<Expression::Ptr>& uses) override;
 
     virtual bool isUsed(Expression::Ptr findMe) const override;

--- a/instructionAPI/h/Register.h
+++ b/instructionAPI/h/Register.h
@@ -58,8 +58,6 @@ namespace Dyninst { namespace InstructionAPI {
     virtual ~RegisterAST();
     RegisterAST(const RegisterAST&) = default;
 
-    virtual void getChildren(std::vector<Expression::Ptr>& children) const override;
-
     virtual void getUses(std::set<Expression::Ptr>& uses) override;
 
     virtual bool isUsed(Expression::Ptr findMe) const override;

--- a/instructionAPI/h/Ternary.h
+++ b/instructionAPI/h/Ternary.h
@@ -50,8 +50,6 @@ namespace Dyninst { namespace InstructionAPI {
 
     virtual ~TernaryAST();
 
-    virtual void getChildren(std::vector<Expression::Ptr>& children) const;
-
     virtual void getUses(std::set<Expression::Ptr>& uses);
 
     virtual bool isUsed(Expression::Ptr findMe) const;

--- a/instructionAPI/src/Immediate.C
+++ b/instructionAPI/src/Immediate.C
@@ -47,8 +47,6 @@ namespace Dyninst { namespace InstructionAPI {
 
   Immediate::~Immediate() {}
 
-  void Immediate::getChildren(std::vector<Expression::Ptr>&) const { return; }
-
   bool Immediate::isUsed(Expression::Ptr findMe) const { return *findMe == *this; }
 
   void Immediate::getUses(std::set<Expression::Ptr>&) { return; }

--- a/instructionAPI/src/MultiRegister.C
+++ b/instructionAPI/src/MultiRegister.C
@@ -58,8 +58,6 @@ namespace Dyninst { namespace InstructionAPI {
       : Expression(inputRegASTs[0]->getID(), inputRegASTs.size()), m_Regs{std::move(inputRegASTs)} {
   }
 
-  void MultiRegisterAST::getChildren(vector<Expression::Ptr>& /*children*/) const { return; }
-
   void MultiRegisterAST::getUses(set<Expression::Ptr>& uses) {
     for(const auto& m_Reg : m_Regs) {
       m_Reg->getUses(uses);

--- a/instructionAPI/src/Operand.C
+++ b/instructionAPI/src/Operand.C
@@ -112,24 +112,20 @@ namespace Dyninst { namespace InstructionAPI {
 
   DYNINST_EXPORT void
   Operand::addEffectiveReadAddresses(std::set<Expression::Ptr>& memAccessors) const {
-    if(m_isRead && boost::dynamic_pointer_cast<Dereference>(op_value)) {
-      std::vector<Expression::Ptr> tmp;
-      op_value->getChildren(tmp);
-      for(std::vector<Expression::Ptr>::const_iterator curKid = tmp.begin(); curKid != tmp.end();
-          ++curKid) {
-        memAccessors.insert(*curKid);
+    auto deref = boost::dynamic_pointer_cast<Dereference>(op_value);
+    if(deref && m_isRead) {
+      for(auto se : deref->getSubexpressions()) {
+        memAccessors.insert(se);
       }
     }
   }
 
   DYNINST_EXPORT void
   Operand::addEffectiveWriteAddresses(std::set<Expression::Ptr>& memAccessors) const {
-    if(m_isWritten && boost::dynamic_pointer_cast<Dereference>(op_value)) {
-      std::vector<Expression::Ptr> tmp;
-      op_value->getChildren(tmp);
-      for(std::vector<Expression::Ptr>::const_iterator curKid = tmp.begin(); curKid != tmp.end();
-          ++curKid) {
-        memAccessors.insert(*curKid);
+    auto deref = boost::dynamic_pointer_cast<Dereference>(op_value);
+    if(deref && m_isWritten) {
+      for(auto se : deref->getSubexpressions()) {
+        memAccessors.insert(se);
       }
     }
   }

--- a/instructionAPI/src/Register.C
+++ b/instructionAPI/src/Register.C
@@ -62,8 +62,6 @@ namespace Dyninst { namespace InstructionAPI {
 
   RegisterAST::~RegisterAST() {}
 
-  void RegisterAST::getChildren(vector<Expression::Ptr>& /*children*/) const { return; }
-
   void RegisterAST::getUses(set<Expression::Ptr>& uses) {
     uses.insert(shared_from_this());
     return;

--- a/instructionAPI/src/Ternary.C
+++ b/instructionAPI/src/Ternary.C
@@ -46,8 +46,6 @@ namespace Dyninst { namespace InstructionAPI {
 
   TernaryAST::~TernaryAST() {}
 
-  void TernaryAST::getChildren(vector<Expression::Ptr>& /*children*/) const { return; }
-
   void TernaryAST::getUses(set<Expression::Ptr>& uses) {
     uses.insert(shared_from_this());
     return;


### PR DESCRIPTION
Having in-out parameters makes callsites clunky- particularly for range-base for loops.

This needs https://github.com/dyninst/testsuite/pull/267 and https://github.com/dyninst/examples/pull/65 to pass CI.