### PR TITLE
Move maxInstructionLength into Instruction class

### DIFF
--- a/instructionAPI/doc/API/Instruction.tex
+++ b/instructionAPI/doc/API/Instruction.tex
@@ -48,6 +48,17 @@ enum InsnCategory {
 }
 \end{apient}
 
+\begin{apient}
+  static const unsigned int maxInstructionLength
+\end{apient}
+\apidesc{
+  The maximum number of bytes an instruction on \it{any} architecture
+  supported by Dyninst.
+  
+  The most common use is as the default instruction length for an
+  \code{InstructionDecoder}.  
+}
+
 
 \begin{apient}
 Instruction (Operation::Ptr what, 

--- a/instructionAPI/h/Instruction.h
+++ b/instructionAPI/h/Instruction.h
@@ -66,6 +66,8 @@ namespace Dyninst { namespace InstructionAPI {
     friend class InstructionDecoder_amdgpu_gfx90a;
     friend class InstructionDecoder_amdgpu_gfx940;
 
+    static const unsigned int maxInstructionLength = 16;
+
     struct CFT {
       Expression::Ptr target;
       bool isCall;

--- a/instructionAPI/h/InstructionDecoder.h
+++ b/instructionAPI/h/InstructionDecoder.h
@@ -42,7 +42,7 @@ namespace Dyninst { namespace InstructionAPI {
     friend class Instruction;
 
   public:
-    static const unsigned int maxInstructionLength = 16;
+    static constexpr auto maxInstructionLength = Instruction::maxInstructionLength;
 
     InstructionDecoder(const unsigned char* buffer, size_t size, Architecture arch);
     InstructionDecoder(const void* buffer, size_t size, Architecture arch);


### PR DESCRIPTION
This value is more closely associated with an Instruction than a decoder, so move it there. Although it was never documented, an alias is left in place.

I'm making this a distinct PR to make the change easier to find in the git history. I'll update it's type and value as discussed in https://github.com/dyninst/dyninst/pull/2052.