### PR TITLE
Clean up Operation default constructor

### DIFF
--- a/instructionAPI/h/Operation_impl.h
+++ b/instructionAPI/h/Operation_impl.h
@@ -65,7 +65,7 @@ namespace Dyninst { namespace InstructionAPI {
     DYNINST_EXPORT Operation(NS_x86::ia32_entry* e, NS_x86::ia32_prefixes* p = NULL,
                              ia32_locations* l = NULL, Architecture arch = Arch_none);
     DYNINST_EXPORT Operation(const Operation& o);
-    DYNINST_EXPORT Operation();
+    DYNINST_EXPORT Operation() = default;
     DYNINST_EXPORT Operation(entryID id, std::string m, Architecture arch);
 
     DYNINST_EXPORT const Operation& operator=(const Operation& o);
@@ -86,7 +86,7 @@ namespace Dyninst { namespace InstructionAPI {
 
     void updateMnemonic(std::string new_mnemonic) { mnemonic = std::move(new_mnemonic); }
 
-    bool isVectorInsn;
+    bool isVectorInsn{};
 
   private:
     std::once_flag data_initialized;
@@ -97,11 +97,11 @@ namespace Dyninst { namespace InstructionAPI {
     mutable VCSet otherEffAddrsRead;
     mutable VCSet otherEffAddrsWritten;
 
-    mutable entryID operationID;
-    Architecture archDecodedFrom;
-    prefixEntryID prefixID;
-    Result_Type addrWidth;
-    int segPrefix;
+    mutable entryID operationID{};
+    Architecture archDecodedFrom{};
+    prefixEntryID prefixID{};
+    Result_Type addrWidth{};
+    int segPrefix{};
     mutable std::string mnemonic;
   };
 }}

--- a/instructionAPI/src/Operation.C
+++ b/instructionAPI/src/Operation.C
@@ -56,15 +56,12 @@ namespace Dyninst { namespace InstructionAPI {
   }
 
   Operation::Operation(entryID id, std::string m, Architecture arch)
-      : operationID(id), archDecodedFrom(arch), prefixID(prefix_none) {
+      : operationID(id), archDecodedFrom(arch), mnemonic{std::move(m)} {
     switch(archDecodedFrom) {
       case Arch_x86:
       case Arch_ppc32: addrWidth = u32; break;
       default: addrWidth = u64; break;
     }
-    segPrefix = 0;
-    isVectorInsn = false;
-    mnemonic = m;
   }
 
   static bool getVectorizationInfo(ia32_entry* e) {
@@ -136,15 +133,6 @@ namespace Dyninst { namespace InstructionAPI {
     isVectorInsn = o.isVectorInsn;
     mnemonic = o.mnemonic;
     return *this;
-  }
-
-  Operation::Operation() {
-    operationID = e_No_Entry;
-    archDecodedFrom = Arch_none;
-    prefixID = prefix_none;
-    addrWidth = u64;
-    segPrefix = 0;
-    isVectorInsn = false;
   }
 
   const Operation::registerSet& Operation::implicitReads() {


### PR DESCRIPTION
Replacing the default ctor with default member initializers makes this cleaner.