### PR TITLE
GitHub CI: fix build-opts workflow

### DIFF
--- a/.github/workflows/build-opts.yaml
+++ b/.github/workflows/build-opts.yaml
@@ -44,7 +44,7 @@ jobs:
           opts+=("'ENABLE_STATIC_LIBS',")
           opts+=("'SW_ANALYSIS_STEPPER',")
           opts+=("'USE_OpenMP',")
-          opts+=("'DYNINST_ENABLE_FILEFORMAT_PE'")
+          opts+=("'DYNINST_ENABLE_FILEFORMAT_PE',")
           opts+=("'DYNINST_ENABLE_CAPSTONE'")
 
           echo "all=[ ${opts[*]} ]" >> $GITHUB_OUTPUT


### PR DESCRIPTION
I should have caught this in #2058. Or at least thought to run the build-opts workflow.