### PR TITLE
Fix detection of conditional jump in slicing

### DIFF
--- a/dataflowAPI/src/slicing.C
+++ b/dataflowAPI/src/slicing.C
@@ -1088,8 +1088,10 @@ Slicer::handleReturnDetails(
 
 static bool EndsWithConditionalJump(ParseAPI::Block *b) {
     bool cond = false;
-    for (auto eit = b->targets().begin(); eit != b->targets().end(); ++eit)
-        if ((*eit)->type() == COND_TAKEN) cond = true;
+    for (auto eit = b->targets().begin(); eit != b->targets().end(); ++eit) {
+      auto etype = (*eit)->type();
+      if(etype == COND_TAKEN || etype == COND_NOT_TAKEN) cond = true;
+    }
     return cond;
 }
 

--- a/dataflowAPI/src/slicing.C
+++ b/dataflowAPI/src/slicing.C
@@ -1090,8 +1090,8 @@ static bool EndsWithConditionalJump(ParseAPI::Block *b) {
     bool cond = false;
     for (auto eit = b->targets().begin(); eit != b->targets().end(); ++eit) {
       auto etype = (*eit)->type();
-      // Under current parsing implementation, it could be the case where only
-      // one of the edges are present when parsing the indirect control flow in the fallthrough block.
+      // During CFG construction, it could be the case where only
+      // one of the edges are present.
       if(etype == COND_TAKEN || etype == COND_NOT_TAKEN) cond = true;
     }
     return cond;

--- a/dataflowAPI/src/slicing.C
+++ b/dataflowAPI/src/slicing.C
@@ -1090,6 +1090,8 @@ static bool EndsWithConditionalJump(ParseAPI::Block *b) {
     bool cond = false;
     for (auto eit = b->targets().begin(); eit != b->targets().end(); ++eit) {
       auto etype = (*eit)->type();
+      // Under current parsing implementation, it could be the case where only
+      // one of the edges are present when parsing the indirect control flow in the fallthrough block.
       if(etype == COND_TAKEN || etype == COND_NOT_TAKEN) cond = true;
     }
     return cond;


### PR DESCRIPTION
Currently, in backward slicing, the detection of the conditional jump assumes both 
COND_TAKEN and COND_NOT_TAKEN are present.

However, under current parsing implementation, it could be the case where only 
one of the edges are present when parsing the indirect control flow in the fallthrough block.

As a result, when backward slicing on the jump table index, the slicer would miss the fact that 
predecessor block ends with a conditional jump instruction, and fail to compute the bound.

Paritally Fixes #2050 