### PR TITLE
GitHub CI: limit where known binary tests are run

### DIFF
--- a/.github/workflows/build-opts.yaml
+++ b/.github/workflows/build-opts.yaml
@@ -154,7 +154,7 @@ jobs:
           extra-cmake-flags: "-D${{ matrix.opt }}=${{ matrix.state }}"
           src-dir: "${GITHUB_WORKSPACE}/src"
           extra-libs: ${{ steps.extra-libs.outputs.value }}
-
+          tests: "REGRESSION"
 
 
 #############################################################################
@@ -231,6 +231,7 @@ jobs:
           extra-cmake-flags: ${{ steps.opts.outputs.opts }}
           src-dir: "${GITHUB_WORKSPACE}/src"
           extra-libs: ${{ steps.extra-libs.outputs.value }}
+          tests: "REGRESSION"
 
 
 #############################################################################
@@ -276,7 +277,7 @@ jobs:
           compiler: ${{ matrix.compiler }}
           extra-cmake-flags: ${{ steps.opts.outputs.opts }}
           src-dir: "${GITHUB_WORKSPACE}/src"
-
+          tests: "REGRESSION"
 
 #############################################################################
 #
@@ -320,6 +321,7 @@ jobs:
           extra-cmake-flags: "-DDYNINST_LINKER=${{ matrix.linker }}"
           extra-libs: ${{ matrix.extra-libs }}
           src-dir: "${GITHUB_WORKSPACE}/src"
+          tests: "REGRESSION"
 
 
 #############################################################################
@@ -373,4 +375,5 @@ jobs:
 #          extra-libs: ${{ steps.extra-libs.outputs.value }}
 #          extra-cmake-flags: "-DDYNINST_CXXSTDLIB=libc++"
 #          src-dir: "${GITHUB_WORKSPACE}/src"
+#          tests: "REGRESSION"
 #

--- a/.github/workflows/compiler-multibuild.yaml
+++ b/.github/workflows/compiler-multibuild.yaml
@@ -95,6 +95,7 @@ jobs:
           compiler-version: ${{ matrix.compiler-version }}
           build-type: ${{ matrix.build-type }}
           src-dir: "${GITHUB_WORKSPACE}/src"
+          tests: "REGRESSION"
 
 ######################################################################################
 #
@@ -133,3 +134,4 @@ jobs:
           compiler: ${{ matrix.compiler }}
           src-dir: "${GITHUB_WORKSPACE}/src"
           extra-cmake-flags: "-DDYNINST_CXX_LANGUAGE_STANDARD=${{ matrix.std }}"
+          tests: "REGRESSION"

--- a/.github/workflows/libabigail.yaml
+++ b/.github/workflows/libabigail.yaml
@@ -85,6 +85,7 @@ jobs:
           compiler: ${{ matrix.compiler }}
           src-dir: "${GITHUB_WORKSPACE}/src"
           install-dir: "${GITHUB_WORKSPACE}/install"
+          tests: "OFF"
 
       - name: Build Previous Dyninst
         if: ${{ matrix.compiler != 'gcc' }}
@@ -94,6 +95,7 @@ jobs:
           compiler: ${{ matrix.compiler }}
           src-dir: "/dyninst/src"
           install-dir: "/dyninst/install"
+          tests: "OFF"
 
       - name: Install dependencies (Ubuntu)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}


### PR DESCRIPTION
There's no need to run those tests when doing build tests. Running the unit, integration, and regression tests is needed to validate the build is usable.