### PR TITLE
GitHub CI: re-enable HPCtoolkit build on Fedora

### DIFF
--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         os: [ 'ubuntu-25.04' ]
+         os: [ ${{ fromJson(needs.get-oses.outputs.latest) }} ]
     permissions:
       packages: read
     container:


### PR DESCRIPTION
The bootstrapping issue in spack has been resolved.

Effectively reverts 8e070fff1204.