### PR TITLE
GitHub CI: fix yaml for hpctoolkit job

### DIFF
--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         os: [ ${{ fromJson(needs.get-oses.outputs.latest) }} ]
+         os: ${{ fromJson(needs.get-oses.outputs.latest) }}
     permissions:
       packages: read
     container:


### PR DESCRIPTION
Evidently the reason the CI interface wouldn't let me run the job is because of malformed yaml.