### PR TITLE
Prevent process create failure when threads are spawned in constructor functions

### DIFF
--- a/dyninstAPI/src/dynProcess.C
+++ b/dyninstAPI/src/dynProcess.C
@@ -963,8 +963,10 @@ bool PCProcess::insertBreakpointAtMain() {
     }
     Dyninst::Address addr = main_function_->addr();
 
-    // Create the breakpoint
+    // Create the breakpoint and mark it
     mainBrkPt_ = Breakpoint::newBreakpoint();
+    static const uintptr_t MAIN_BREAKPOINT_TAG = 0xDEB19001;
+    mainBrkPt_->setData((void*)MAIN_BREAKPOINT_TAG);
     if( !pcProc_->addBreakpoint(addr, mainBrkPt_) ) {
         startup_printf("%s[%d]: failed to insert a breakpoint at main entry: 0x%lx\n",
                 FILE__, __LINE__, addr);

--- a/dyninstAPI/src/pcEventHandler.C
+++ b/dyninstAPI/src/pcEventHandler.C
@@ -353,6 +353,15 @@ bool PCEventHandler::handleThreadCreate(EventNewThread::const_ptr ev, PCProcess 
   proccontrol_printf("%s[%d]: entering handleThreadCreate for %d/%d\n",
 		     FILE__, __LINE__, evProc->getPid(), ev->getLWP());
 
+    // Check if the thread still exists
+#if defined(os_linux) || defined(os_freebsd)
+    if (!ev->getNewThread()) {
+        proccontrol_printf("%s[%d]: thread %d/%d not found, it may have already exited. Ignoring thread create event.\n",
+            FILE__, __LINE__, evProc->getPid(), ev->getLWP());
+            return true;
+    }
+#endif
+
     if( !ev->getNewThread()->haveUserThreadInfo() ) {
         proccontrol_printf("%s[%d]: no user thread info for thread %d/%d, postponing thread create\n",
                 FILE__, __LINE__, evProc->getPid(), ev->getLWP());
@@ -407,6 +416,13 @@ bool PCEventHandler::handleThreadDestroy(EventThreadDestroy::const_ptr ev, PCPro
 			 FILE__, __LINE__, evProc->getPid(), ev->getThread()->getLWP()); 
         BPatch_process *bpproc = BPatch::bpatch->getProcessByPid(evProc->getPid());
         if( bpproc == NULL ) {
+#if defined(os_linux) || defined(os_freebsd)
+            if (ev->getEventType().code() == EventType::LWPDestroy) {
+                proccontrol_printf("%s[%d]: failed to locate process %d, for corresponding LWPDestroy event. It may have already exited. Ignoring event.\n",
+                    FILE__, __LINE__, evProc->getPid());
+                return true;
+            }
+#endif
             proccontrol_printf("%s[%d]: failed to locate BPatch_process for process %d\n",
                     FILE__, __LINE__, evProc->getPid());
             return false;

--- a/proccontrol/src/event.C
+++ b/proccontrol/src/event.C
@@ -535,6 +535,17 @@ Dyninst::LWP EventNewLWP::getLWP() const
 Thread::const_ptr EventNewLWP::getNewThread() const
 {
    int_thread *thr = getProcess()->llproc()->threadPool()->findThreadByLWP(lwp);
+   
+#if defined(os_linux) || defined(os_freebsd)
+   if (!thr) {
+      int pid = getProcess()->llproc()->getPid();
+      if (lwp != pid) {
+         pthrd_printf("Non-main thread %d/%d not found\n", pid, lwp);
+         return Thread::const_ptr();
+      }
+   }
+#endif
+
    assert(thr);
    return thr->thread();
 }

--- a/proccontrol/src/handler.C
+++ b/proccontrol/src/handler.C
@@ -1451,7 +1451,25 @@ Handler::handler_ret_t HandleBreakpoint::handleEvent(Event::ptr ev)
    if (!int_ebp->cb_bps.empty() && !ebp->suppressCB())
    {
       pthrd_printf("BP handler is setting user state to reflect breakpoint\n");
-      switch (ebp->getSyncType()) {
+      Event::SyncType effective_sync_type = ebp->getSyncType();
+      
+      /**
+       * If this is the main breakpoint, force it to use sync_process logic
+       * This avoids failure if multiple threads are created in constructor functions
+       **/
+      static const uintptr_t MAIN_BREAKPOINT_TAG = 0xDEB19001;
+      if (effective_sync_type == Event::sync_thread) {
+         for (std::set<Breakpoint::ptr>::iterator it = int_ebp->cb_bps.begin(); 
+              it != int_ebp->cb_bps.end(); ++it) {
+            if ((uintptr_t)(*it)->getData() == MAIN_BREAKPOINT_TAG) {
+               pthrd_printf("Detected main breakpoint, upgrading to sync_process\n");
+               effective_sync_type = Event::sync_process;
+               break;
+            }
+         }
+      }
+ 
+      switch (effective_sync_type) {
          case Event::sync_process: {
             int_threadPool *pool = proc->threadPool();
             for (int_threadPool::iterator i = pool->begin(); i != pool->end(); i++)


### PR DESCRIPTION
I was debugging an issue for `rocprofiler-systems` involving programs that use `libomptarget`. After some investigation, I was able to narrow down the issue to Dyninst crashing in `processCreate` when threads are spawned in constructor functions (`__attribute__((constructor))`).

**Minimal Reproducer**: Consider the program below:
```
#include <iostream>
#include <pthread.h>
#include <atomic>
#include <unistd.h>

std::atomic<bool> g_keep_running{true};

void* busy_thread(void* arg) {
    while (g_keep_running.load()) {}
    return nullptr;
}

// Spawn threads before main() using constructor attribute. Priority of 101 is not necessary here.
__attribute__((constructor(101)))
void spawn_threads_in_constructor() {
    std::cout << "[Constructor] Spawning thread before main()\n";
    
    pthread_t thread1;
    pthread_create(&thread1, nullptr, busy_thread, (void*)1);
    pthread_detach(thread1);
    g_keep_running.store(false);
}

int main() {
    std::cout << "[Main] Program started\n";
    std::cout << "[Main] Program ending\n";
    return 0;
}
```
And some other program that uses Dyninst (call it dyntest.cpp). In this case, I know the problem occurs in `processCreate`, so we can use:
```
int main(int argc, char* argv[]) {
    BPatch bpatch;
 
    const char* target = argv[1];
    const char* target_argv[] = {target, NULL};
    
    cout << "[MYDYNINSTPROGRAM] Creating process: " << target << endl;
    BPatch_process* app = bpatch.processCreate(target, target_argv);
    std::cerr << "[MYDYNINSTPROGRAM] Process created: " << app << endl;
   
    return 0;
}
```
**Problem 1**

When I pass in the first program, compiled using `amdclang++ program.cpp -o program`, into dyntest.cpp using `./dyntest ./program`, there is a *chance* (it depends on when the helper thread exits) that the following failure will be observed:

```
/usr/include/boost/smart_ptr/shared_ptr.hpp:784: typename boost::detail::sp_member_access<T>::type boost::shared_ptr<T>::operator->() const [with T = const Dyninst::ProcControlAPI::Process; typename boost::detail::sp_member_access<T>::type = const Dyninst::ProcControlAPI::Process*]: Assertion `px != 0' failed.
```

After some debugging and print statements, the failure is due to Dyninst failing to remove the breakpoint at main entry as the thread spawned in the constructor function has its user state as running. 
```
[DEBUG-PRINT] Breakpoint handler setting user states - Event sync type: sync_thread, Address: 0x201c50

[handler.C:2289-U] - Triggering callback for event 'Breakpoint'
[handler.C:2294-U] - Triggering callback #0 for event 'Breakpoint'
[140737348376960]pcEventMuxer.C[388]: removing breakpoint at main
[DEBUG-PRINT] process.C - hasRunningThread() - Thread 2732299/2732299: user=stopped, handler=stopped, generator=stopped
[DEBUG-PRINT] process.C - hasRunningThread() - Thread 2732299/2732314: user=RUNNING, handler=RUNNING, generator=RUNNING
[process.C:7078-U] - Error: User attempted to remove breakpoint on running process
[140737348376960]dynProcess.C[1052]: failed to remove breakpoint at main entry: 0x201c50
/usr/include/boost/smart_ptr/shared_ptr.hpp:784: typename boost::detail::sp_member_access<T>::type boost::shared_ptr<T>::operator->() const [with T = const Dyninst::ProcControlAPI::Process; typename boost::detail::sp_member_access<T>::type = const Dyninst::ProcControlAPI::Process*]: Assertion `px != 0' failed.
/home/rocm/dyninst/dyninstAPI_RT/src/RTlinux.c:434: dyninstTrapHandler: Assertion `hdr' failed.
```

To fix this, I suggest making the main breakpoint force a `sync_process`, that way all threads stop and the breakpoint can be removed.

**Problem 2**

Applying the fix for problem 1 allows the main breakpoint to be removed, but another issue arises. It is possible for the following error to occur:

```
/home/rocm/DyninstTest/multiple-thread-fix/proccontrol/src/event.C:538: virtual Dyninst::ProcControlAPI::Thread::const_ptr Dyninst::ProcControlAPI::EventNewLWP::getNewThread() const: Assertion `thr' failed.
```

From what I understand, an `LWPCreate` is put into the mailbox for Dyninst API to process. HOWEVER, if the helper thread exits before Dyninst can process this event, it will attempt to dereference a null pointer (see https://github.com/dyninst/dyninst/blob/master/dyninstAPI/src/pcEventHandler.C#L356).

To fix this, I suggest to check if the non-main `thr` in `EventNewLWP::getLWP()` is null and if it is an `LWPCreate`. If so, we return `Thread::const_ptr()` so that in `PCEventHandler::handleThreadCreate`, we can check for this and ignore the `LWPCreate` event as the thread has most likely exited.

We also need to handle the `LWPDestroy`. For this, I just return `true` in `PCEventHandler::handleThreadDestroy` if `bbproc == NULL` and the event is `LWPDestroy`. 

I made this fix only work for Linux because I am unsure if this would work on Windows.

**Fix Results**: 

With these fixes in, the program will not crash anymore in `processCreate`. Furthermore, LLVM OpenMP offload programs will also work as well (and so will `hsa` ones that call `hsa_init()` in the constructor function). 

**Note**: If you want a reproducer that fails more often, I recommend using some basic OpenMP program and compiling it so that it uses LLVM's `libomptarget` (it calls `hsa_init()` in its constructor assuming amdgpu). In their code, the constructor function should spawn 3 helper threads and has a constructor priority of 101.