### PR TITLE
Fix jump detection in instruction adapters

### DIFF
--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -473,7 +473,7 @@ bool IA_IAPI::isSysEnter() const
 
 bool IA_IAPI::isIndirectJump() const {
     Instruction ci = curInsn();
-    if(ci.isBranch()) return false;
+    if(!ci.isBranch()) return false;
     if(ci.allowsFallThrough()) return false;
     bool valid;
     Address target;

--- a/parseAPI/src/IA_x86.C
+++ b/parseAPI/src/IA_x86.C
@@ -809,7 +809,7 @@ bool IA_x86::isIATcall(std::string &calleeName) const
 
 bool IA_x86::isNopJump() const
 {
-    if (curInsn().isBranch()) {
+    if (!curInsn().isBranch()) {
         return false;
     }
     bool valid; Address addr;


### PR DESCRIPTION
Certain if predicates are missing a not, introduced in #1813 .

This fix the regression reported in #2050.