### PR TITLE
GitHub CI: force test directory

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -51,9 +51,11 @@ cmake --build ${build_dir} --parallel ${num_jobs} ${verbose}
 
 if ! test "${test_type}" = "OFF"; then
   export LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
-  ctest --test-dir ${build_dir} --no-tests=error --parallel 2 --output-on-failure
+  cd ${build_dir}
+  ctest --no-tests=error --parallel 2 --output-on-failure
 fi
 
 cmake --install ${build_dir}
 
+cd /
 rm -rf $build_dir


### PR DESCRIPTION
When run under GitHub's CI, ctest doesn't find the build directory specified by
'--test-dir' _and_ it doesn't raise an error even though '--no-tests=error'.
This fixes both.