### PR TITLE
Pin GHA dependencies by hash

### DIFF
--- a/.github/workflows/binary-tests.yaml
+++ b/.github/workflows/binary-tests.yaml
@@ -38,7 +38,7 @@ jobs:
       latest: ${{ steps.all.outputs.latest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -50,7 +50,7 @@ jobs:
       all: ${{ steps.compilers.outputs.value }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         
       - id: compilers
         shell: bash
@@ -78,7 +78,7 @@ jobs:
     name: Binary tests (${{ matrix.os }}, ${{ matrix.compiler }})
     steps:
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"  # relative to ${GITHUB_WORKSPACE}
 

--- a/.github/workflows/build-opts.yaml
+++ b/.github/workflows/build-opts.yaml
@@ -22,7 +22,7 @@ jobs:
       latest: ${{ steps.all.outputs.latest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -56,7 +56,7 @@ jobs:
       all: ${{ steps.compilers.outputs.value }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         
       - id: compilers
         shell: bash
@@ -128,7 +128,7 @@ jobs:
           fi
 
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"  # relative to ${GITHUB_WORKSPACE}
 
@@ -219,7 +219,7 @@ jobs:
           echo "value=${libs}" >> $GITHUB_OUTPUT
 
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"  # relative to ${GITHUB_WORKSPACE}
 
@@ -266,7 +266,7 @@ jobs:
           echo "opts=${opts[*]}" >> $GITHUB_OUTPUT
 
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"  # relative to ${GITHUB_WORKSPACE}
 
@@ -309,7 +309,7 @@ jobs:
     name: linkers (${{ matrix.os }}, ${{ matrix.compiler }}, ${{ matrix.linker }})
     steps:
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"  # relative to ${GITHUB_WORKSPACE}
 

--- a/.github/workflows/cmake-formatting.yaml
+++ b/.github/workflows/cmake-formatting.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.draft == false }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/codegen-cross-build.yaml
+++ b/.github/workflows/codegen-cross-build.yaml
@@ -32,7 +32,7 @@ jobs:
       latest: ${{ steps.all.outputs.latest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -44,7 +44,7 @@ jobs:
       all: ${{ steps.compilers.outputs.value }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         
       - id: compilers
         shell: bash
@@ -73,7 +73,7 @@ jobs:
     name: Codegen arch ${{ matrix.codegen_arch }} (${{ matrix.os }}, ${{ matrix.compiler }})
     steps:
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"  # relative to ${GITHUB_WORKSPACE}
 

--- a/.github/workflows/compiler-multibuild.yaml
+++ b/.github/workflows/compiler-multibuild.yaml
@@ -13,7 +13,7 @@ jobs:
       all:  ${{ steps.build-type.outputs.all }}
     steps:
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: build-type
         uses: ./.github/actions/build-types
@@ -25,7 +25,7 @@ jobs:
       latest: ${{ steps.all.outputs.latest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -37,7 +37,7 @@ jobs:
       matrix: ${{ steps.configs.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         
       - id: configs
         shell: bash
@@ -52,7 +52,7 @@ jobs:
       all: ${{ steps.compilers.outputs.value }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         
       - id: compilers
         shell: bash
@@ -83,7 +83,7 @@ jobs:
     name: ${{ matrix.os }}, ${{ matrix.compiler }}-${{ matrix.compiler-version }}, ${{ matrix.build-type }}
     steps:
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"  # relative to $GITHUB_WORKSPACE
 
@@ -123,7 +123,7 @@ jobs:
     name: ${{ matrix.os }}, ${{ matrix.compiler }}, std=${{ matrix.std }}
     steps:
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"    # Relative to $GITHUB_WORKSPACE
 

--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -13,7 +13,7 @@ jobs:
       latest: ${{ steps.all.outputs.latest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -35,7 +35,7 @@ jobs:
     name: HPCToolkit (${{ matrix.os }})
     steps:
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"  # relative to ${GITHUB_WORKSPACE}
 

--- a/.github/workflows/dependency-version.yaml
+++ b/.github/workflows/dependency-version.yaml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Version check
         shell: bash

--- a/.github/workflows/dev-containers.yaml
+++ b/.github/workflows/dev-containers.yaml
@@ -15,7 +15,7 @@ jobs:
       all: ${{ steps.all.outputs.all }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -32,10 +32,10 @@ jobs:
     name: Update dev containers
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: GHCR Login
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/libabigail.yaml
+++ b/.github/workflows/libabigail.yaml
@@ -34,7 +34,7 @@ jobs:
       latest: ${{ steps.all.outputs.latest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -46,7 +46,7 @@ jobs:
       all: ${{ steps.compilers.outputs.value }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         
       - id: compilers
         shell: bash
@@ -74,7 +74,7 @@ jobs:
     name: libabigail (${{ matrix.os }}, ${{ matrix.compiler }})
     steps:
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"  # relative to ${GITHUB_WORKSPACE}
 

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -31,7 +31,7 @@ jobs:
       all: ${{ steps.all.outputs.all }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -43,7 +43,7 @@ jobs:
       all: ${{ steps.compilers.outputs.value }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         
       - id: compilers
         shell: bash
@@ -73,7 +73,7 @@ jobs:
     name: PR tests (${{ matrix.os }}, ${{ matrix.compiler }}, ${{ matrix.install-dir }})
     steps:
       - name: Checkout Dyninst
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: "src"  # relative to ${GITHUB_WORKSPACE}
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Checkout Test Suite
         if: ${{ matrix.compiler != 'clang' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: dyninst/testsuite
           path: "testsuite"  # relative to ${GITHUB_WORKSPACE}
@@ -103,7 +103,7 @@ jobs:
           cmake --build . --parallel 2
 
       - name: Checkout Examples
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: dyninst/examples
           path: "examples"  # relative to ${GITHUB_WORKSPACE}
@@ -117,7 +117,7 @@ jobs:
           cmake --build . --parallel 2
 
       - name: Checkout External Tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: dyninst/external-tests
           path: "external-tests"  # relative to ${GITHUB_WORKSPACE}

--- a/.github/workflows/purge-workflows.yaml
+++ b/.github/workflows/purge-workflows.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@main
+        uses: Mattraks/delete-workflow-runs@5bf9a1dac5c4d041c029f0a8370ddf0c5cb5aeb7 # main
         with:
           token: ${{ secrets.github_token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/refresh-containers.yaml
+++ b/.github/workflows/refresh-containers.yaml
@@ -13,7 +13,7 @@ jobs:
       all: ${{ steps.all.outputs.all }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -30,7 +30,7 @@ jobs:
     name: Purge ${{ matrix.os }}
     steps:
       - name: Development containers
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
         continue-on-error: true
         with:
           package-name: amd64/${{ matrix.os }}
@@ -40,7 +40,7 @@ jobs:
           delete-only-untagged-versions: "true"
 
       - name: Base containers
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
         continue-on-error: true
         with:
           package-name: amd64/${{ matrix.os }}-base
@@ -60,10 +60,10 @@ jobs:
       packages: write
     name: Update base containers
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: GHCR Login
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -11,7 +11,7 @@ jobs:
       all: ${{ steps.all.outputs.all }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -22,7 +22,7 @@ jobs:
       value: ${{ steps.version.outputs.release }}
     steps:
       - id: version
-        uses: pozetroninc/github-action-get-latest-release@master
+        uses: pozetroninc/github-action-get-latest-release@53d33d213ee71c72360e3c829caf7cee94ec21e2 # master
         with:
           repository: "dyninst/dyninst"
           excludes: "prerelease, draft"
@@ -39,13 +39,13 @@ jobs:
       packages: write
     name: ${{ matrix.os }}, ${{ needs.get-latest-release-version.outputs.value }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: "dyninst/dyninst"
           ref: ${{ needs.get-latest-release-version.outputs.value }}
 
       - name: GHCR Login
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/spack-build.yaml
+++ b/.github/workflows/spack-build.yaml
@@ -13,7 +13,7 @@ jobs:
       latest: ${{ steps.all.outputs.latest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions
@@ -24,7 +24,7 @@ jobs:
       all: ${{ steps.compilers.outputs.value }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         
       - id: compilers
         shell: bash

--- a/.github/workflows/system-libs.yaml
+++ b/.github/workflows/system-libs.yaml
@@ -13,7 +13,7 @@ jobs:
       all: ${{ steps.all.outputs.all }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: all
         uses: ./.github/actions/os-versions


### PR DESCRIPTION
Hash-pinned dependencies are an important requirement enforced by the OpenSSF scorecard tool: https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

This commit pins all GitHub Actions workflows to a commit hash.