### PR TITLE
Don't run RISCV-64 decode tests unless decoder is present

### DIFF
--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -3,4 +3,7 @@ include_guard(GLOBAL)
 message(STATUS "Enabling integration tests")
 
 add_subdirectory(InstructionAPI/decoder/x86)
-add_subdirectory(InstructionAPI/decoder/riscv)
+
+if(DYNINST_ENABLE_CAPSTONE)
+  add_subdirectory(InstructionAPI/decoder/riscv)
+endif()


### PR DESCRIPTION
I think I missed this because my test platforms were all configured to use Capstone already because of testing my x86 decoder. Sorry about that.