### PR TITLE
cold clone symbols are not fncts, now type CODE

### DIFF
--- a/common/src/symbolDemangle.c
+++ b/common/src/symbolDemangle.c
@@ -37,17 +37,19 @@
 
 // Returns a malloc'd string that is the demangled symbol name.  THe caller is
 // responsible for the freeing this memory.  Returns NULL on malloc failure.
-// The symbol name symName is demangled using the cplus_demangle function after
-// first removing any versioning suffixes (first '@')
-// to create the mangled name.  If cplus_demangle fails, the mangled name
-// is returned unmodified.  If cplus_demangle succeeds and includeParams is
-// false, then any clone suffixes (the first '.' to the end of the mangled
-// name) are appended to the value from cplus_demangle.
+// First any dynamic linker version suffix (first '@' to the end of the string)
+// present is removed and the versionless name is formed.  Next the versionless
+// name is passed to libiberty's cplus_demangle function with appropriate
+// flags.  On failure the versionless name is returned unchanged.  Otherwise if
+// includeParams is false, then any clone suffixes (the first '.' to the end of
+// name) present are appended to the demangled name returned by cplus_demangle;
+// if includeParams is true, cplus_demangle includes clone information and the
+// demangled name is returned unmodified.
 //
-// Other than the removal of versioning suffixes, and appending any
-// clone suffixes if includeParams is false to the result, the result should be
-// equivalent to using c++filt.  Below are the c++filt and cplus_demangle
-// options
+// Other than the removal of the version suffix, and appending any clone
+// suffixes to the result if includeParams is false to the result, the result
+// should be equivalent to using c++filt.  Here are the c++filt and
+// cplus_demangle options used:
 //
 // includeParams	c++ filt opts	cplus_demangle opts
 // -------------	-------------	-------------------
@@ -57,7 +59,7 @@
 char *symbol_demangle(const char *symName, int includeParams)
 {
     int cloneOffset = -1;		// offset to clone suffix
-    int versionOffset = -1;	// offset to version suffix
+    int versionOffset = -1;		// offset to version suffix
     int lastOffset;			// offset to version suffix
 					//   if present, else null of symName
 

--- a/symtabAPI/doc/4-Definitions.tex
+++ b/symtabAPI/doc/4-Definitions.tex
@@ -13,26 +13,36 @@ The following definitions deal with the symbol table interface.
 \item[Function] A function represents a code object within the file represented by one or more symbols.
 \item[Variable] A variable represents a data object within the file represented by one or more symbols.
 \item[Module] A module represents a particular source file in cases where multiple files were compiled into a single binary object; if this information is not present, or if the binary object is a shared library, we use a single default module.
-\item[Archive] An archive represents a collection of binary objects stored in a single file (e.g., a static archive). 
+\item[Archive] An archive represents a collection of binary objects stored in a single file (e.g., a static archive).
 \item[Relocations] These provide the necessary information for inter-object references between two object files.
 \item[Exception Blocks] These contain the information necessary for run-time exception handling
 The following definitions deal with members of the Symbol class.
 \item[Mangled Name] A mangled name for a symbol provides a way of encoding additional information about a function, structure, class or another data type in a symbol name.
 It is a technique used to produce unique names for programming entities in many modern programming languages.
-For example, the method \emph{foo} of class C with signature \emph{int C::foo(int, int)} has a mangled name \emph{\_ZN1C3fooEii} when compiled with gcc.
-Mangled names may include a sequence of clone suffixes (begins with `.' that indicate a compiler synthesized function), and this may be followed by a version suffix (begins with `@').
+For example, in \verb!C++! the method \emph{foo} of class C with signature \emph{int C::foo(int, int)} has a mangled name \emph{\_ZN1C3fooEii} when using the Itanium \verb!C++! ABI (used by all platforms except Windows).
+
+Mangled names may also optionally include a sequence of clone suffixes (begins with `.'), and a version suffix (begins with `@') in that order.
+A clone sequence begins with a `.' and indicates a compiler synthesised function (or part thereof) derived from the function without the suffix.
+Multiple clone suffixes may exist if a clone is created from another clone.
+The structure of clone suffixes is `.\emph{clone\_name}' followed by an optional sequence of `.\emph{<digits>}'.
+An older style format exists without the `.\emph{clone\_name}'.
+The version suffix is used to support multiple versions of a symbol by the dynamic linker.
 \item[Pretty Name] A pretty name for a symbol is the demangled user-level symbolic name without type information for the function parameters and return types.
-For non-mangled names, the pretty name is the symbol name.
-Any function clone suffixes of the symbol are appended to the result of the demangler.
+Any version suffix is removed before demangling and is not included in the pretty name.
+For non-mangled names, the pretty name is the versionless name.
+Otherwise the the demangler result is returned with any function clone suffixes appended.
 For example, a symbol with a mangled name \emph{\_ZN1C3fooEii} for the method \emph{int C::foo(int, int)} has a pretty name \emph{C::foo}.
-Version suffixes are removed from the mangled name before conversion to the pretty name.
-The pretty name can be obtained by running the command line tool \code{c++filt} as \code{c++filt -i -p \emph{name}}, or using the libiberty library function \code{cplus\_demangle} with options of \code{DMGL\_AUTO | DMGL\_ANSI}.
+While \emph{\_ZN1C3fooEii.clone.0@VER\_1} has a pretty name \emph{C::foo.clone.0}.
+The pretty name without clone suffixes can be obtained by running the command line tool \code{c++filt -i -p \emph{name}}, or using the libiberty library function \code{cplus\_demangle(\emph{name}, DMGL\_AUTO | DMGL\_ANSI)}.
 \item[Typed Name] A typed name for a symbol is the demangled user-level symbolic name including type information for the function parameters.
-Typically, but not always, function return type information is not included. Any function clone information is also included.
-For non-mangled names, the typed name is the symbol name.
+Typically, but not always, function return type information is not included.
+Any version suffix is removed before demangling and is not included in the typed name.
+For non-mangled names, the typed name is the versionless name.
+Otherwise the the demangler result is returned.
+Clone suffixes are part of the typed name.
 For example, a symbol with a mangled name \emph{\_ZN1C3fooEii} for the method \emph{int C::foo(int, int)} has a typed name \emph{C::foo(int, int)}.
-Version suffixes are removed from the mangled name before conversion to the typed name.
-The typed name can be obtained by running the command line tool \code{c++filt} as \code{c++filt -i \emph{name}}, or using the libiberty library function \code{cplus\_demangle} with options of \code{DMGL\_AUTO | DMGL\_ANSI | DMGL\_PARAMS}.
+While \emph{\_ZN1C3fooEii.clone.0@VER\_1} has a pretty name \emph{C::foo(int, int) [clone .clone.0]}.
+The typed name can be obtained by running the command line tool \code{c++filt -i \emph{name}}, or using the libiberty library function \code{cplus\_demangle(\emph{name}, DMGL\_AUTO | DMGL\_ANSI | DMGL\_PARAMS)}.
 \item[Symbol Linkage] The symbol linkage for a symbol gives information on the visibility (binding) of this symbol, whether it is visible only in the object file where it is defined (local), if it is visible to all the object files that are being linked (global), or if its a weak alias to a global symbol.
 \item[Symbol Type] Symbol type for a symbol represents the category of symbols to which it belongs. It can be a function symbol or a variable symbol or a module symbol.
 The following definitions deal with the type and the local variable interface.

--- a/symtabAPI/doc/API/Symtab/Symbol.tex
+++ b/symtabAPI/doc/API/Symtab/Symbol.tex
@@ -16,6 +16,7 @@ ST\_SECTION & Region declaration \\
 ST\_TLS & Thread-local storage declaration \\
 ST\_DELETED & Deleted symbol \\
 ST\_NOTYPE & Miscellaneous symbol \\
+ST\_CODE & Part of a function but not an entry point \\
 \bottomrule
 \end{tabular}
 \end{center}
@@ -73,6 +74,9 @@ getSymtab & Symtab * & The Symtab that contains this symbol.  \\
 getPtrOffset & Offset & For binaries with an OPD section, the offset in the OPD that contains the function pointer data structure for this symbol. \\
 getLocalTOC & Offset & For platforms with a TOC register, the expected TOC for the object referred to by this symbol. \\
 isCommonStorage & bool & True if the symbol represents a common section (Fortran). \\
+getVersionSuffix & string & The dynamic version suffix including the initial `@'. Returns an empty string if not present. \\
+getCloneSuffix & string & The clone suffix including the initial `.'. Returns an empty string if not present. \\
+isColdClone & bool & True if the symbol's name has a clone that contains a `.cold' (code that belongs to the function name without the `.cold'). \\
 \bottomrule
 \end{tabular}
 

--- a/symtabAPI/h/Symbol.h
+++ b/symtabAPI/h/Symbol.h
@@ -90,6 +90,7 @@ class DYNINST_EXPORT Symbol : public AnnotatableSparse
       ST_TLS,
       ST_DELETED,
       ST_INDIRECT,
+      ST_CODE,
       ST_NOTYPE
    };
 
@@ -142,6 +143,13 @@ class DYNINST_EXPORT Symbol : public AnnotatableSparse
    std::string      getMangledName () const { return mangledName_; }
    std::string      getPrettyName() const;
    std::string      getTypedName() const;
+
+   std::string      getCloneSuffix() const  {return getCloneSuffix(getMangledName());}
+   std::string      getVersionSuffix() const  {return getVersionSuffix(getMangledName());}
+   bool             isColdClone() const  {return isColdClone(getMangledName());}
+   static std::string   getCloneSuffix(const std::string& s);
+   static std::string   getVersionSuffix(const std::string& s);
+   static bool          isColdClone(const std::string& s);
 
    Module *getModule() const { return module_; } 
    Symtab *getSymtab() const;

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -1653,7 +1653,7 @@ void ObjectELF::load_object(bool alloc_syms) {
     }
 }
 
-static Symbol::SymbolType pdelf_type(int elf_type) {
+static Symbol::SymbolType pdelf_type(int elf_type, const string &name) {
     switch (elf_type) {
         case STT_FILE:
             return Symbol::ST_MODULE;
@@ -1664,7 +1664,10 @@ static Symbol::SymbolType pdelf_type(int elf_type) {
         case STT_TLS:
             return Symbol::ST_TLS;
         case STT_FUNC:
-            return Symbol::ST_FUNCTION;
+            if (Symbol::isColdClone(name))
+                return Symbol::ST_CODE;
+            else
+                return Symbol::ST_FUNCTION;
         case STT_NOTYPE:
             return Symbol::ST_NOTYPE;
 #if defined(STT_GNU_IFUNC)
@@ -1893,7 +1896,7 @@ bool ObjectELF::parse_symbols(Elf_X_Data &symdata, Elf_X_Data &strdata,
 
             // resolve symbol elements
             string sname = &strs[syms.st_name(i)];
-            Symbol::SymbolType stype = pdelf_type(etype);
+            Symbol::SymbolType stype = pdelf_type(etype, sname);
             Symbol::SymbolLinkage slinkage = pdelf_linkage(ebinding);
             Symbol::SymbolVisibility svisibility = pdelf_visibility(evisibility);
             unsigned ssize = syms.st_size(i);
@@ -2096,7 +2099,7 @@ dyn_scnp, Elf_X_Data &symdata,
 
             // resolve symbol elements
             string sname = &strs[syms.st_name(i)];
-            Symbol::SymbolType stype = pdelf_type(etype);
+            Symbol::SymbolType stype = pdelf_type(etype, sname);
             Symbol::SymbolLinkage slinkage = pdelf_linkage(ebinding);
             Symbol::SymbolVisibility svisibility = pdelf_visibility(evisibility);
             unsigned ssize = syms.st_size(i);

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -147,6 +147,7 @@ static int elfSymType(Symbol *sym)
      case Symbol::ST_TLS: return STT_TLS;
      case Symbol::ST_NOTYPE : return STT_NOTYPE;
      case Symbol::ST_UNKNOWN: return sym->getInternalType();
+     case Symbol::ST_CODE: return STT_FUNC;	// in ELF, ST_CODE maps to STT_FUNC
 #if defined(STT_GNU_IFUNC)
      case Symbol::ST_INDIRECT: return STT_GNU_IFUNC;
 #endif


### PR DESCRIPTION
A symbol with a cold clone suffix is not a function entry point, but is part of the function without the suffix.  The new symbol type "ST_CODE" represents this type of symbol.

Without this change, cold function symbols are incorrectly treated as real functions.