### PR TITLE
Remove findTags

### DIFF
--- a/dyninstAPI/src/inst.C
+++ b/dyninstAPI/src/inst.C
@@ -61,18 +61,6 @@ unsigned getPrimitiveCost(const std::string &name)
    return 1;
 }
 
-
-// find any tags to associate semantic meaning to function
-unsigned findTags(const std::string ) {
-  return 0;
-#ifdef notdef
-  if (tagDict.defines(funcName))
-    return (tagDict[funcName]);
-  else
-    return 0;
-#endif
-}
-
 instMapping::instMapping(const instMapping *parIM,
                          AddressSpace *child) :
     func(parIM->func),

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -232,10 +232,6 @@ Dyninst::Register emitFuncCall(opCode op, codeGen &gen,
 
 int getInsnCost(opCode t);
 
-// TODO - what about mangled names ?
-// expects the symbol name advanced past the underscore
-extern unsigned findTags(const std::string funcName);
-
 extern Dyninst::Address getMaxBranch();
 
 // find these internal functions before finding any other functions


### PR DESCRIPTION
Its definition was commented out by f7b76cd496 in 1995 and its usage was removed by db8cb862cd9 in 1997.