### PR TITLE
Remove int_thread::changeLWP

### DIFF
--- a/proccontrol/src/int_process.h
+++ b/proccontrol/src/int_process.h
@@ -756,7 +756,6 @@ public:
    int_process *llproc() const;
 
    Dyninst::LWP getLWP() const;
-   void changeLWP(Dyninst::LWP new_lwp);
 
 #define RUNNING_STATE(S) (S == int_thread::running || S == int_thread::neonatal_intermediate)
    typedef enum {

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -3519,23 +3519,6 @@ int_thread *int_thread::createThread(int_process *proc,
    return newthr;
 }
 
-void int_thread::changeLWP(Dyninst::LWP new_lwp)
-{
-  pthrd_printf("Changing LWP of %d/%d to %d\n", llproc()->getPid(), lwp, new_lwp);
-
-  int_threadPool *tpool = llproc()->threadPool();
-  map<Dyninst::LWP, int_thread *>::iterator i = tpool->thrds_by_lwp.find(lwp);
-  assert(i != tpool->thrds_by_lwp.end());
-  tpool->thrds_by_lwp.erase(i);
-  tpool->thrds_by_lwp.insert(make_pair(new_lwp, this));
-
-  ProcPool()->condvar()->lock();
-  ProcPool()->rmThread(this);
-  lwp = new_lwp;
-  ProcPool()->addThread(llproc(), this);
-  ProcPool()->condvar()->unlock();
-}
-
 void int_thread::throwEventsBeforeContinue()
 {
   pthrd_printf("Checking thread %d/%d for events thrown before continue\n",


### PR DESCRIPTION
This was only used for BlueGene and should have been removed by cccad8ee9 in 2020.