### PR TITLE
Remove AstNode::labelNode(std::string)

### DIFF
--- a/dyninstAPI/src/ast.h
+++ b/dyninstAPI/src/ast.h
@@ -208,7 +208,6 @@ class AstNode : public Dyninst::PatchAPI::Snippet {
    static AstNodePtr stackGenericNode();
    bool allocateCanaryRegister(codeGen& gen, bool noCost, Dyninst::Register& reg, bool& needSaveAndRestore);
 
-   static AstNodePtr labelNode(std::string &label);
 
    static AstNodePtr operandNode(operandType ot, void *arg);
    static AstNodePtr operandNode(operandType ot, AstNodePtr ast);


### PR DESCRIPTION
This should have been removed by eac8cf2c8.

This should be merged after #2114.