### PR TITLE
Fix placement of newly created loadable sections

### DIFF
--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -482,7 +482,6 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
         ".dynsym", /*".dynstr",*/ ".rela.dyn", ".rela.plt", ".dynamic", ".symtab"};
     std::unordered_map<string, pair<unsigned, unsigned>> dataLinkInfo;
 
-    bool createdLoadableSections = false;
     unsigned scncount;
     unsigned sectionNumber = 0;
 
@@ -679,26 +678,26 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
     } // end of for each elf section
 
     //Insert new loadable sections at the end
-    if (!createdLoadableSections) {
-        createdLoadableSections = true;
-        insertPoint = scncount;
-        if (!createLoadableSections(newshdr, extraAlignSize, newNameIndexMapping,sectionNumber))
-            return false;
-        if (createNewPhdr && !movePHdrsFirst) {
-            sectionNumber++;
-            createNewPhdrRegion(newNameIndexMapping);
-        }
+    if (!createLoadableSections(newshdr, extraAlignSize, newNameIndexMapping,sectionNumber)){
+        rewrite_printf("Failed to create new loadable sections\n");
+        return false;
+    }
+    if (createNewPhdr && !movePHdrsFirst) {
+        sectionNumber++;
+        createNewPhdrRegion(newNameIndexMapping);
+    }
 
-        // Update the heap symbols, now that loadSecTotalSize is set
-        updateSymbols(dynsymData, dynStrData, loadSecTotalSize);
-        if (0 > elf_update(newElf, ELF_C_NULL)) {
-            return false;
-        }
+    // Update the heap symbols, now that loadSecTotalSize is set
+    updateSymbols(dynsymData, dynStrData, loadSecTotalSize);
+    if (0 > elf_update(newElf, ELF_C_NULL)) {
+        return false;
     }
 
     // Add non-loadable sections at the end of object file
-    if (!createNonLoadableSections(newshdr))
+    if (!createNonLoadableSections(newshdr)){
+        rewrite_printf("Failed to create new nonloadable sections\n");
         return false;
+    }
 
     if (0 > elf_update(newElf, ELF_C_NULL)) {
         return false;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -682,7 +682,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
         rewrite_printf("Failed to create new loadable sections\n");
         return false;
     }
-    if (createNewPhdr && !movePHdrsFirst) {
+    if (!movePHdrsFirst) {
         sectionNumber++;
         createNewPhdrRegion(newNameIndexMapping);
     }


### PR DESCRIPTION
Previously, Dyninst made the assumption that for the last PT_LOAD segment, the last section in it will have its addr + offset exactly matching the end of the segment (segment addr + offset).

However, we have seen binaries where such assumptions no longer holds.

This PR simply moves the logic of inserting the loadable sections right after the last section of the last data segment, to the last section, which should be permitted by the ELF standard.