### PR TITLE
Remove i386 MMX detection for instrumentation

### DIFF
--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -720,12 +720,7 @@ bool EmitterIA32::emitBTSaves(baseTramp* bt, codeGen &gen)
     // Pre-calculate space for temporaries and floating-point state.
     int extra_space = 0;
     if (useFPRs) {
-        if (gen.rs()->hasXMM) {
-            extra_space += TRAMP_FRAME_SIZE + 512;
-        } else {
-            extra_space += TRAMP_FRAME_SIZE + FSAVE_STATE_SIZE;
-        }
-
+      extra_space += TRAMP_FRAME_SIZE + 512;
     } else if (localSpace) {
         extra_space += TRAMP_FRAME_SIZE;
     }
@@ -745,23 +740,17 @@ bool EmitterIA32::emitBTSaves(baseTramp* bt, codeGen &gen)
     extra_space_check = extra_space;
 
     if (useFPRs) {
-        if (gen.rs()->hasXMM) {
-           // need to save the floating point state (x87, MMX, SSE)
-           // We're guaranteed to be 16-byte aligned now, so just
-           // emit the fxsave.
+       // need to save the floating point state (x87, MMX, SSE)
+       // We're guaranteed to be 16-byte aligned now, so just
+       // emit the fxsave.
 
-           // fxsave (%esp) ; 0x0f 0xae 0x04 0x24
-           GET_PTR(insn, gen);
-           append_memory_as_byte(insn, 0x0f);
-           append_memory_as_byte(insn, 0xae);
-           append_memory_as_byte(insn, 0x04);
-           append_memory_as_byte(insn, 0x24);
-           SET_PTR(insn, gen);
-        }
-        else {
-           emitOpRegRM(FSAVE, RealRegister(FSAVE_OP),
-                       RealRegister(REGNUM_ESP), 0, gen);
-        }
+       // fxsave (%esp) ; 0x0f 0xae 0x04 0x24
+       GET_PTR(insn, gen);
+       append_memory_as_byte(insn, 0x0f);
+       append_memory_as_byte(insn, 0xae);
+       append_memory_as_byte(insn, 0x04);
+       append_memory_as_byte(insn, 0x24);
+       SET_PTR(insn, gen);
     }
 
     return true;
@@ -789,19 +778,14 @@ bool EmitterIA32::emitBTRestores(baseTramp* bt,codeGen &gen)
     }
 
     if (useFPRs) {
-        if (gen.rs()->hasXMM) {
-            // restore saved FP state
-            // fxrstor (%rsp) ; 0x0f 0xae 0x04 0x24
-            GET_PTR(insn, gen);
-            append_memory_as_byte(insn, 0x0f);
-            append_memory_as_byte(insn, 0xae);
-            append_memory_as_byte(insn, 0x0c);
-            append_memory_as_byte(insn, 0x24);
-            SET_PTR(insn, gen);
-
-        } else
-           emitOpRegRM(FRSTOR, RealRegister(FRSTOR_OP),
-                       RealRegister(REGNUM_ESP), 0, gen);
+      // restore saved FP state
+      // fxrstor (%rsp) ; 0x0f 0xae 0x04 0x24
+      GET_PTR(insn, gen);
+      append_memory_as_byte(insn, 0x0f);
+      append_memory_as_byte(insn, 0xae);
+      append_memory_as_byte(insn, 0x0c);
+      append_memory_as_byte(insn, 0x24);
+      SET_PTR(insn, gen);
     }
 
     // Remove extra space allocated for temporaries and floating-point state

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -530,61 +530,12 @@ void registerSpace::initialize()
     
     if (inited) return;
     inited = true;
-    if(xmmCapable())
-    {
-      hasXMM = true;
-    }
-    
 
     initialize32();
 #if defined(DYNINST_CODEGEN_ARCH_X86_64)
     initialize64();
 #endif
 }
-
-/* This makes a call to the cpuid instruction, which returns an int where each bit is 
-   a feature.  Bit 24 contains whether fxsave is possible, meaning that xmm registers
-   are saved. */
-#if defined(os_windows)
-int cpuidCall() {
-#ifdef _WIN64
-    int result[4];
-    __cpuid(result, 1);
-    return result[4]; // edx
-#else
-    DWORD result = 0;
-    // Note: mov <target> <source>, so backwards from what gnu uses
-    _asm {
-        push ebx
-        mov eax, 1
-        cpuid
-        pop ebx
-        mov result, edx
-    }
-    return result;
-#endif
-}
-#endif
-
-#if defined(x86_64_unknown_linux2_4)              \
- || defined(os_freebsd) || defined(DYNINST_HOST_ARCH_X86_64) \
- || !defined(DYNINST_HOST_ARCH_X86) || !defined(DYNINST_CODEGEN_ARCH_I386)
-bool xmmCapable()
-{
-  return true;
-}
-#else
-bool xmmCapable()
-{
-  int features = cpuidCall();
-  char * ptr = (char *)&features;
-  ptr += 3;
-  if (0x1 & (*ptr))
-    return true;
-  else
-    return false;
-}
-#endif
 
 bool baseTramp::generateSaves(codeGen& gen, registerSpace*) {
    return gen.codeEmitter()->emitBTSaves(this, gen);

--- a/dyninstAPI/src/registerSpace.C
+++ b/dyninstAPI/src/registerSpace.C
@@ -69,8 +69,6 @@
 registerSpace *registerSpace::globalRegSpace_ = NULL;
 registerSpace *registerSpace::globalRegSpace64_ = NULL;
 
-bool registerSpace::hasXMM = false;
-
 void registerSlot::cleanSlot() {
     // number does not change
     refCount = 0;

--- a/dyninstAPI/src/registerSpace.h
+++ b/dyninstAPI/src/registerSpace.h
@@ -460,9 +460,6 @@ class registerSpace {
     unsigned addr_width;
 
  public:
-    static bool hasXMM;  // for Intel architectures, XMM registers
-
- public:
 #if defined(DYNINST_CODEGEN_ARCH_POWER)
     typedef enum { r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12,
                    r13, r14, r15, r16, r17, r18, r19, r20, r21, r22, r23,


### PR DESCRIPTION
This wouldn't compile for 32-bit Linux because 'xmmCapable' calls 'cpuidCall' which is only compiled on Windows. The Win64 version reads off the end of 'result', so that likely never worked. At this point, I'm quite confident that anyone rewriting Win32 binaries is likely doing so on i386 that supports MMX. This wouldn't work on non-x86 Win32 platforms because of the inline assembly.