### PR TITLE
Remove unused func_instance::setReturnValue(int)

### DIFF
--- a/dyninstAPI/src/function.h
+++ b/dyninstAPI/src/function.h
@@ -206,14 +206,6 @@ class func_instance : public patchTarget, public Dyninst::PatchAPI::PatchFunctio
   unsigned footprint(); // not const, calls ifunc()->extents()
   std::string get_name() const;
 
-#if defined(DYNINST_CODEGEN_ARCH_I386) || defined(DYNINST_CODEGEN_ARCH_X86_64)
-  //Replaces the function with a 'return val' statement.
-  // currently needed only on Linux/x86
-  // Defined in inst-x86.C
-  bool setReturnValue(int val);
-
-#endif
-
   ////////////////////////////////////////////////
   // Code overlapping
   ////////////////////////////////////////////////

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -2181,18 +2181,6 @@ int getMaxJumpSize()
   return JUMP_REL32_SZ;
 }
 
-// TODO: fix this so we don't screw future instrumentation of this
-// function. It's a cute little hack, but jeez.
-bool func_instance::setReturnValue(int val)
-{
-    codeGen gen(16);
-
-    emitMovImmToReg(RealRegister(REGNUM_EAX), val, gen);
-    emitSimpleInsn(0xc3, gen); //ret
-    
-    return proc()->writeTextSpace((void *) addr(), gen.used(), gen.start_ptr());
-}
-
 /**
  * Fills in an indirect function pointer at 'addr' to point to 'f'.
  **/


### PR DESCRIPTION
Its usage was removed by 7a737b6a09 in 2010.