### PR TITLE
Fix docker builds by adding missing libicu for peparse

### DIFF
--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -28,6 +28,7 @@ RUN yum update -y &&   \
       g++              \
       git              \
       glibc-static     \
+      libicu-devel     \
       libomp           \
       libstdc++-static \
       tbb-devel

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -38,6 +38,7 @@ RUN apt-get -qq update && \
       g++                     \
       git                     \
       libiberty-dev           \
+      libicu-dev              \
       libomp-dev              \
       pkg-config              \
       libtbb-dev


### PR DESCRIPTION
Since 3 weeks ago libicu is a required dependency of peparse.
https://github.com/trailofbits/pe-parse/commit/eb6da5021c17935d3d8f80d118e0a7ef6b1f1264
Fix docker builds which currently is broken by adding the missing transative dependency.