### PR TITLE
Remove unused parse_func_registers::specialPurposeRegisters

### DIFF
--- a/dyninstAPI/src/parse-cfg.h
+++ b/dyninstAPI/src/parse-cfg.h
@@ -188,7 +188,6 @@ class parse_func_registers {
  public:
   std::set<Register> generalPurposeRegisters;
   std::set<Register> floatingPointRegisters;
-  std::set<Register> specialPurposeRegisters;
 };
 
 class parse_func : public ParseAPI::Function


### PR DESCRIPTION
It was added by 7c2938c70 in 2006, but never used.