### PR TITLE
Add a synchronized breakpoint type

### DIFF
--- a/proccontrol/h/PCProcess.h
+++ b/proccontrol/h/PCProcess.h
@@ -129,6 +129,7 @@ class DYNINST_EXPORT Breakpoint
    static Breakpoint::ptr newTransferBreakpoint(Dyninst::Address to);
    static Breakpoint::ptr newTransferOffsetBreakpoint(signed long shift);
    static Breakpoint::ptr newHardwareBreakpoint(unsigned int mode, unsigned int size);
+   static Breakpoint::ptr newSynchronousBreakpoint();
 
    void *getData() const;
    void setData(void *p) const;
@@ -138,6 +139,8 @@ class DYNINST_EXPORT Breakpoint
 
    void setSuppressCallbacks(bool);
    bool suppressCallbacks() const;
+   
+   bool isSynchronous() const;
 };
 
 class DYNINST_EXPORT Library

--- a/proccontrol/src/int_process.h
+++ b/proccontrol/src/int_process.h
@@ -1303,6 +1303,10 @@ class int_breakpoint
    bool procstopper;
    bool suppress_callbacks;
    bool offset_transfer;
+
+   // all threads in process need to be synchronized at this breakpoint
+   bool is_proc_synchronous{false};
+
    std::set<Thread::const_ptr> thread_specific;
  public:
    int_breakpoint(Breakpoint::ptr up);
@@ -1329,6 +1333,9 @@ class int_breakpoint
 
    void setSuppressCallbacks(bool);
    bool suppressCallbacks(void) const;
+   
+   void makeSynchronous() { is_proc_synchronous = true; }
+   bool isSynchronous() const { return is_proc_synchronous; }
 
    bool isHW() const;
    unsigned getHWSize() const;

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -8253,6 +8253,13 @@ Breakpoint::ptr Breakpoint::newHardwareBreakpoint(unsigned int mode,
   return newbp;
 }
 
+Breakpoint::ptr Breakpoint::newSynchronousBreakpoint() {
+  Breakpoint::ptr newbp = Breakpoint::ptr(new Breakpoint());
+  newbp->llbreakpoint_ = new int_breakpoint(newbp);
+  newbp->llbreakpoint_->makeSynchronous();
+  return newbp;
+}
+
 void *Breakpoint::getData() const {
    return llbreakpoint_->getData();
 }
@@ -8278,6 +8285,10 @@ void Breakpoint::setSuppressCallbacks(bool b)
 bool Breakpoint::suppressCallbacks() const
 {
    return llbreakpoint_->suppressCallbacks();
+}
+
+bool Breakpoint::isSynchronous() const {
+  return llbreakpoint_->isSynchronous();
 }
 
 // Note: These locks are intentionally indirect and leaked!


### PR DESCRIPTION
This can be used to ensure that all threads in a process are stopped before the breakpoint is executed.

I'm adding this separately from #2131 since it contains additional fixes.