### PR TITLE
Remove parse_func::writesSPRs

### DIFF
--- a/dyninstAPI/src/parse-cfg.h
+++ b/dyninstAPI/src/parse-cfg.h
@@ -346,7 +346,6 @@ class parse_func : public ParseAPI::Function
    bool isLeafFunc();
 
    bool writesFPRs(unsigned level = 0);
-   bool writesSPRs(unsigned level = 0);
 
 
    void invalidateLiveness() { livenessCalculated_ = false; }


### PR DESCRIPTION
It was added by ad610d9a0c90 in 2006, but never implemented.