### PR TITLE
Fix CMake configuration errors when using system Boost library

### DIFF
--- a/cmake/tpls/DyninstBoost.cmake
+++ b/cmake/tpls/DyninstBoost.cmake
@@ -53,7 +53,9 @@ if(NOT TARGET Dyninst::Boost)
   target_include_directories(Dyninst::Boost SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})
   target_compile_definitions(Dyninst::Boost
                              INTERFACE BOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
+endif()
 
+if(NOT TARGET Dyninst::Boost_headers)
   # Just the headers (effectively a simplified Boost::headers target)
   add_library(Dyninst::Boost_headers INTERFACE IMPORTED)
   target_include_directories(Dyninst::Boost_headers SYSTEM

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_guard(GLOBAL)
 
 include(DyninstLibrary)
+include(DyninstBoost)
 
 configure_file(${PROJECT_SOURCE_DIR}/cmake/dyninstversion.h.in
                ${CMAKE_CURRENT_SOURCE_DIR}/h/dyninstversion.h)
@@ -166,7 +167,7 @@ dyninst_library(
   PRIVATE_HEADER_FILES ${_private_headers}
   SOURCE_FILES ${_sources}
   DEFINES COMMON_LIB
-  PUBLIC_DEPS Dyninst::TBB Dyninst::Boost
+  PUBLIC_DEPS Dyninst::TBB Dyninst::Boost Boost::thread Boost::filesystem
   PRIVATE_DEPS Dyninst::LibIberty OpenMP::OpenMP_CXX Dyninst::Valgrind Threads::Threads
 )
 # cmake-format: on


### PR DESCRIPTION
`common` library is missing Boost components, leaving some symbols unresolved at link time:
- `dyn_rwlock::lock_shared` uses `boost::mutex`, so it depends on `Boost::thread` library target.
- `Dyninst::filesystem` uses `boost::filesystem`, so it depends on `Boost::filesystem` library target.

`Dyninst::Boost_headers` target is not defined in some cases when Dyninst::Boost` is, producing errors at the end of configuration stage.