### PR TITLE
Fix return value in parse_func::IsLeafFunc

### DIFF
--- a/dyninstAPI/src/parse-cfg.C
+++ b/dyninstAPI/src/parse-cfg.C
@@ -398,7 +398,7 @@ bool parse_func::isLeafFunc() {
     if (!parsed())
         image_->analyzeIfNeeded();
 
-    return !callEdges().empty();
+    return callEdges().empty();
 }
 
 void parse_func::addParRegion(Address begin, Address end, parRegType t)


### PR DESCRIPTION
A leaf function is one that has _no_ call edges.