### PR TITLE
GitHub CI: don't autocancel container workflows

### DIFF
--- a/.github/workflows/dev-containers.yaml
+++ b/.github/workflows/dev-containers.yaml
@@ -7,10 +7,6 @@ on:
   workflow_dispatch:
   workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   get-oses:

--- a/.github/workflows/purge-workflows.yaml
+++ b/.github/workflows/purge-workflows.yaml
@@ -5,10 +5,6 @@ on:
     - cron: '0 5 1 * *'  # 5AM on the first of the month
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   purge:

--- a/.github/workflows/refresh-containers.yaml
+++ b/.github/workflows/refresh-containers.yaml
@@ -5,10 +5,6 @@ on:
     - cron: '0 3 25 * *'  # 3AM on the 25th of every month
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   get-oses:

--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -3,10 +3,6 @@ name: Build and deploy release containers
 on:
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   get-oses:


### PR DESCRIPTION
'Refresh base and dev containers' depends on
'Build and Deploy Development Containers'. 'Purge old workflow runs' isn't in that dependency chain, but it could be added to a longer workflow in the future. It doesn't matter if it is run multiple times.