### PR TITLE
Make Emitter::getInterModule(Func,Var)Addr overloadable

### DIFF
--- a/dyninstAPI/src/emit-aarch64.h
+++ b/dyninstAPI/src/emit-aarch64.h
@@ -168,6 +168,7 @@ public:
     virtual bool clobberAllFuncCall(registerSpace *rs, func_instance *callee);
 
     Address getInterModuleFuncAddr(func_instance *func, codeGen& gen) /* override */;
+    Address getInterModuleVarAddr(const image_variable *var, codeGen& gen) /* override */;
 
 protected:
     virtual bool emitCallInstruction(codeGen &, func_instance *,

--- a/dyninstAPI/src/emit-amdgpu.h
+++ b/dyninstAPI/src/emit-amdgpu.h
@@ -227,5 +227,6 @@ private:
   bool isValidSgprPair(Register regBlock) const;
 
   Address getInterModuleFuncAddr(func_instance *func, codeGen& gen) /* override */;
+  Address getInterModuleVarAddr(const image_variable *var, codeGen& gen) /* override */;
 };
 #endif

--- a/dyninstAPI/src/emit-power.h
+++ b/dyninstAPI/src/emit-power.h
@@ -118,6 +118,7 @@ class EmitterPOWER : public Emitter {
     void emitCallWithSaves(codeGen &gen, Address dest, bool saveToc, bool saveLR, bool saveR12);
     
     Address getInterModuleFuncAddr(func_instance *func, codeGen& gen) /* override */;
+    Address getInterModuleVarAddr(const image_variable *var, codeGen& gen) /* override */;
 
  protected:
     virtual bool emitCallInstruction(codeGen &, func_instance *,

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -2777,7 +2777,7 @@ Address Emitterx86::getInterModuleFuncAddr(func_instance *func, codeGen& gen)
     return relocation_address;
 }
 
-Address Emitter::getInterModuleVarAddr(const image_variable *var, codeGen& gen)
+Address Emitterx86::getInterModuleVarAddr(const image_variable *var, codeGen& gen)
 {
     AddressSpace *addrSpace = gen.addrSpace();
     BinaryEdit *binEdit = addrSpace->edit();

--- a/dyninstAPI/src/emit-x86.h
+++ b/dyninstAPI/src/emit-x86.h
@@ -69,6 +69,7 @@ class Emitterx86 : public Emitter {
         virtual bool emitCallInstruction(codeGen &, func_instance *, Register) = 0;
 
         Address getInterModuleFuncAddr(func_instance *func, codeGen& gen) /* override */;
+        Address getInterModuleVarAddr(const image_variable *var, codeGen& gen) /* override */;
 };
 
 // 32-bit class declared here since its implementation is in both inst-x86.C and emit-x86.C

--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -113,7 +113,7 @@ class Emitter {
     virtual bool clobberAllFuncCall(registerSpace *rs,func_instance *callee) = 0;
 
     virtual Address getInterModuleFuncAddr(func_instance *func, codeGen& gen) = 0;
-    Address getInterModuleVarAddr(const image_variable *var, codeGen& gen);
+    virtual Address getInterModuleVarAddr(const image_variable *var, codeGen& gen) = 0;
 
     virtual bool emitPLTCall(func_instance *, codeGen &) { assert(0); return false;}
     virtual bool emitPLTJump(func_instance *, codeGen &) { assert(0); return false;}

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -1232,7 +1232,7 @@ void EmitterAARCH64::emitStoreShared(Register source, const image_variable *var,
     assert(stackSize <= 0 && "stack not empty at the end");
 }
 
-Address Emitter::getInterModuleVarAddr(const image_variable *var, codeGen &gen) {
+Address EmitterAARCH64::getInterModuleVarAddr(const image_variable *var, codeGen &gen) {
     AddressSpace *addrSpace = gen.addrSpace();
     if (!addrSpace)
         assert(0 && "No AddressSpace associated with codeGen object");

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -127,7 +127,7 @@ Emitter *AddressSpace::getEmitter() {
   return &gfx908Emitter;
 }
 
-Address Emitter::getInterModuleVarAddr(const image_variable * /* var */, codeGen & /* gen */) {
+Address EmitterAmdgpuGfx908::getInterModuleVarAddr(const image_variable * /* var */, codeGen & /* gen */) {
   assert(!"Not implemented for AMDGPU");
   return 0;
 }

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -2679,7 +2679,7 @@ void EmitterPOWER::emitStoreShared(Dyninst::Register source, const image_variabl
   return;
 }
 
-Address Emitter::getInterModuleVarAddr(const image_variable *var, codeGen& gen)
+Address EmitterPOWER::getInterModuleVarAddr(const image_variable *var, codeGen& gen)
 {
     AddressSpace *addrSpace = gen.addrSpace();
     if (!addrSpace)


### PR DESCRIPTION
This makes the implementations architecture-specific without having possible symbol collisions when all architectures are linked together (a necessity for having architecture-independent codegen).