### PR TITLE
Add address translation support for RISCV64's PT_RISCV_ATTRIBUTES segment

### DIFF
--- a/common/src/addrtranslate-linux.C
+++ b/common/src/addrtranslate-linux.C
@@ -249,6 +249,9 @@ LoadedLib *AddressTranslateSysV::getAOut()
             case PT_NOTE:
             case PT_SHLIB:
             case PT_TLS:
+#ifdef PT_RISCV_ATTRIBUTES
+            case PT_RISCV_ATTRIBUTES:
+#endif
                break;
             default:
                done = true;


### PR DESCRIPTION
When compiling a simple binary on RISC-V Ubuntu 24.04 on the default GCC and Clang, RISCV_ATTRIBUTES are before the PT_LOAD.

```
ubuntu@ubuntu:~$ readelf -l tll

Elf file type is DYN (Position-Independent Executable file)
Entry point 0x990
There are 10 program headers, starting at offset 64

Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  PHDR           0x0000000000000040 0x0000000000000040 0x0000000000000040
                 0x0000000000000230 0x0000000000000230  R      0x8
  INTERP         0x0000000000000270 0x0000000000000270 0x0000000000000270
                 0x0000000000000021 0x0000000000000021  R      0x1
      [Requesting program interpreter: /lib/ld-linux-riscv64-lp64d.so.1]
  RISCV_ATTRIBUT 0x00000000000020d2 0x0000000000000000 0x0000000000000000
                 0x0000000000000053 0x0000000000000000  R      0x1
  LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000e88 0x0000000000000e88  R E    0x1000
  LOAD           0x0000000000001dd0 0x0000000000001dd0 0x0000000000001dd0
                 0x00000000000002b0 0x00000000000002e8  RW     0x1000
  DYNAMIC        0x0000000000001de8 0x0000000000001de8 0x0000000000001de8
                 0x00000000000001e0 0x00000000000001e0  RW     0x8
  NOTE           0x0000000000000294 0x0000000000000294 0x0000000000000294
                 0x0000000000000044 0x0000000000000044  R      0x4
  GNU_EH_FRAME   0x0000000000000dbc 0x0000000000000dbc 0x0000000000000dbc
                 0x000000000000002c 0x000000000000002c  R      0x4
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RW     0x10
  GNU_RELRO      0x0000000000001dd0 0x0000000000001dd0 0x0000000000001dd0
                 0x0000000000000230 0x0000000000000230  R      0x1
```

If this function find an unknown segment it will exit before setting the correct load_vaddr.

Segment name is define gated to support older libelf