### PR TITLE
Add regression test for DWARF5 inlined functions

### DIFF
--- a/tests/regression/symtabAPI/CMakeLists.txt
+++ b/tests/regression/symtabAPI/CMakeLists.txt
@@ -1,3 +1,4 @@
 include_guard(GLOBAL)
 
 add_subdirectory(Symtab/file_properties)
+add_subdirectory(DWARF)

--- a/tests/regression/symtabAPI/DWARF/CMakeLists.txt
+++ b/tests/regression/symtabAPI/DWARF/CMakeLists.txt
@@ -1,0 +1,12 @@
+include_guard(GLOBAL)
+
+include(DyninstBinaryTests)
+
+set(_targ dwarf5_inline_func)
+add_executable(${_targ} dwarf5_inline_func.cpp)
+target_compile_options(${_targ} PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(${_targ} PRIVATE symtabAPI)
+add_test(NAME instructionAPI_${_targ}_test
+         COMMAND ${_targ}
+                 "${DYNINST_TEST_BINARIES_DIR}/symtabAPI/DWARF/dwarf5_inline_func")
+set_tests_properties(instructionAPI_${_targ}_test PROPERTIES LABELS "regression")

--- a/tests/regression/symtabAPI/DWARF/dwarf5_inline_func.cpp
+++ b/tests/regression/symtabAPI/DWARF/dwarf5_inline_func.cpp
@@ -1,0 +1,38 @@
+#include "Symtab.h"
+
+#include <cstdlib>
+#include <iostream>
+
+// See test_binaries/symtabAPI/DWARF/dwarf5_inline_func
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <binary path>\n";
+    return EXIT_FAILURE;
+  }
+
+  namespace st = Dyninst::SymtabAPI;
+  st::Symtab *symtab;
+  if (!st::Symtab::openFile(symtab, argv[1])) {
+    std::cerr << "Unable to open '" << argv[1] << "'\n";
+    return EXIT_FAILURE;
+  }
+
+  constexpr auto offset_of_main = 0x1130;
+  auto inlined_target = "inl";
+
+  st::FunctionBase *f{};
+  symtab->getContainingInlinedFunction(offset_of_main, f);
+  
+  if (!f) {
+    std::cerr << "No inlined function found in 'main' (0x: " << std::hex
+              << offset_of_main << "\n";
+    return EXIT_FAILURE;
+  }
+
+  if (f->getName() != inlined_target) {
+    std::cerr << "Expected '" << inlined_target << "', but found '"
+              << f->getName() << "'\n";
+    return EXIT_FAILURE;
+  }
+}


### PR DESCRIPTION
See https://github.com/dyninst/dyninst/issues/1455 for details.

Requires https://github.com/dyninst/test_binaries/pull/2/changes.