### PR TITLE
Add explicit include of TBB version header

### DIFF
--- a/cmake/tpls/DyninstTBB.cmake
+++ b/cmake/tpls/DyninstTBB.cmake
@@ -49,4 +49,13 @@ message(STATUS "Found TBB ${TBB_VERSION}")
 get_target_property(_tmp TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
 message(STATUS "TBB include directories: ${_tmp}")
 
+# Starting with 2021.2, the version macros were extracted into 'version.h'
+# To retain support for earlier versions, we conditionally include it
+foreach(_dir ${_tmp})
+  if(EXISTS "${_dir}/tbb/version.h")
+    target_compile_definitions(Dyninst::TBB INTERFACE "DYNINST_TBB_HAS_VERSION_H")
+    break()
+  endif()
+endforeach()
+
 unset(_find_path_args)

--- a/common/h/concurrent.h
+++ b/common/h/concurrent.h
@@ -42,6 +42,11 @@
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/concurrent_vector.h>
 #include <tbb/concurrent_queue.h>
+
+#ifdef DYNINST_TBB_HAS_VERSION_H
+#include <tbb/version.h>
+#endif
+
 #include <boost/functional/hash.hpp>
 
 namespace Dyninst {


### PR DESCRIPTION
The latest version (2022.3.0, released 29-OCT-2025) doesn't have the implicit include anymore.