### PR TITLE
[dyninstAPI] Implement `BPatch_mod`

### DIFF
--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -686,6 +686,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
     case xorOp:
     case timesOp:
     case divOp:
+    case modOp:
     case orOp:
     case andOp:
     case eqOp:
@@ -836,6 +837,7 @@ bool operatorAST::canBeKept() const {
     case xorOp:
     case timesOp:
     case divOp:
+    case modOp:
     case neOp:
     case noOp:
     case orOp:

--- a/dyninstAPI/src/ASTs/operatorAST.h
+++ b/dyninstAPI/src/ASTs/operatorAST.h
@@ -82,6 +82,9 @@ public:
   static Ptr minus(codeGenASTPtr lhs, codeGenASTPtr rhs) {
     return boost::make_shared<operatorAST>(minusOp, std::move(lhs), std::move(rhs));
   }
+  static Ptr mod(codeGenASTPtr lhs, codeGenASTPtr rhs) {
+    return boost::make_shared<operatorAST>(modOp, std::move(lhs), std::move(rhs));
+  }
   static Ptr ne(codeGenASTPtr lhs, codeGenASTPtr rhs) {
     return boost::make_shared<operatorAST>(neOp, std::move(lhs), std::move(rhs));
   }

--- a/dyninstAPI/src/BPatch_snippet.C
+++ b/dyninstAPI/src/BPatch_snippet.C
@@ -430,8 +430,7 @@ BPatch_arithExpr::BPatch_arithExpr(BPatch_binOp op,
                         ast_wrapper = operatorAST::times(lop_ast, rop_ast);
                         break;
                 case BPatch_mod:
-                        /* XXX Not yet implemented. */
-                        assert(0);
+                        ast_wrapper = operatorAST::mod(lop_ast, rop_ast);
                         break;
                 case BPatch_ref:
          ast_wrapper = generateArrayRef(lOperand, rOperand);

--- a/dyninstAPI/src/codegen-aarch64.C
+++ b/dyninstAPI/src/codegen-aarch64.C
@@ -293,6 +293,27 @@ void insnCodeGen::generateMul(codeGen &gen, Dyninst::Register rm, Dyninst::Regis
     insnCodeGen::generate(gen, insn);
 }
 
+// Same encoding as MUL/MADD but with o0 bit (bit 15) set to 1.
+void insnCodeGen::generateMSub(codeGen &gen, Dyninst::Register rm,
+        Dyninst::Register rn, Dyninst::Register ra,
+        Dyninst::Register rd, bool is64bit) {
+    instruction insn;
+    insn.clear();
+
+    if(is64bit)
+        INSN_SET(insn, 31, 31, 1);
+
+    INSN_SET(insn, 21, 28, MULOp);
+    INSN_SET(insn, 15, 15, 1);       // o0=1: MSUB (vs o0=0: MADD/MUL)
+    INSN_SET(insn, 10, 14, ra);
+
+    INSN_SET(insn, 16, 20, rm);
+    INSN_SET(insn, 5, 9, rn);
+    INSN_SET(insn, 0, 4, rd);
+
+    insnCodeGen::generate(gen, insn);
+}
+
 //#sasha is rm or rn the denominator?
 void insnCodeGen::generateDiv(
         codeGen &gen, Dyninst::Register rm, Dyninst::Register rn, Dyninst::Register rd, bool is64bit, bool s)

--- a/dyninstAPI/src/codegen-aarch64.h
+++ b/dyninstAPI/src/codegen-aarch64.h
@@ -175,6 +175,9 @@ public:
 
     static void generateMul(codeGen &gen, Dyninst::Register rm, Dyninst::Register rn, Dyninst::Register rd, bool is64bit);
 
+    static void generateMSub(codeGen &gen, Dyninst::Register rm, Dyninst::Register rn,
+            Dyninst::Register ra, Dyninst::Register rd, bool is64bit);
+
     static void generateDiv(codeGen &gen, Dyninst::Register rm, Dyninst::Register rn, Dyninst::Register rd, bool is64bit, bool s);
 
     static void generateBitwiseOpShifted(codeGen &gen, BitwiseOp op, int shift,

--- a/dyninstAPI/src/emit-aarch64.h
+++ b/dyninstAPI/src/emit-aarch64.h
@@ -66,9 +66,13 @@ public:
 
     virtual void emitDiv(Register, Register, Register, codeGen &, bool) { assert(0); }
 
+    virtual void emitMod(Register, Register, Register, codeGen &, bool) { assert(0); }
+
     virtual void emitTimesImm(Register, Register, RegValue, codeGen &) { assert(0); }
 
     virtual void emitDivImm(Register, Register, RegValue, codeGen &, bool) { assert(0); }
+
+    virtual void emitModImm(Register, Register, RegValue, codeGen &, bool) { assert(0); }
 
     virtual void emitLoad(Register, Address, int, codeGen &);
 

--- a/dyninstAPI/src/emit-amdgpu.C
+++ b/dyninstAPI/src/emit-amdgpu.C
@@ -227,6 +227,11 @@ void EmitterAmdgpuGfx908::emitDiv(Register /* dest */, Register /* src1 */, Regi
   assert(!"emitDiv not implemented yet");
 }
 
+void EmitterAmdgpuGfx908::emitMod(Register /* dest */, Register /* src1 */, Register /* src2 */,
+                                  codeGen & /* gen */, bool /* s */) {
+  assert(!"emitMod not implemented yet");
+}
+
 void EmitterAmdgpuGfx908::emitTimesImm(Register dest, Register src1, RegValue src2imm,
                                        codeGen &gen) {
   assert(isValidSgpr(dest) && "dest must be a valid SGPR");
@@ -238,6 +243,11 @@ void EmitterAmdgpuGfx908::emitTimesImm(Register dest, Register src1, RegValue sr
 void EmitterAmdgpuGfx908::emitDivImm(Register /* dest */, Register /* src1 */,
                                      RegValue /* src2imm */, codeGen & /* gen */, bool /* s */) {
   assert(!"emitDivImm not implemented yet");
+}
+
+void EmitterAmdgpuGfx908::emitModImm(Register /* dest */, Register /* src1 */,
+                                     RegValue /* src2imm */, codeGen & /* gen */, bool /* s */) {
+  assert(!"emitModImm not implemented yet");
 }
 
 void EmitterAmdgpuGfx908::emitLoad(Register /* dest */, Address /* addr */, int /* size */,

--- a/dyninstAPI/src/emit-amdgpu.h
+++ b/dyninstAPI/src/emit-amdgpu.h
@@ -99,9 +99,13 @@ public:
 
   void emitDiv(Register dest, Register src1, Register src2, codeGen &gen, bool s);
 
+  void emitMod(Register dest, Register src1, Register src2, codeGen &gen, bool s);
+
   void emitTimesImm(Register dest, Register src1, RegValue src2imm, codeGen &gen);
 
   void emitDivImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s);
+
+  void emitModImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s);
 
   // TODO: Implementation requires full 'codeGen' and 'registerSpace' class to
   // allocate register. This method doesn't fit AMDGPU because addr needs to be

--- a/dyninstAPI/src/emit-power.h
+++ b/dyninstAPI/src/emit-power.h
@@ -61,8 +61,10 @@ class EmitterPOWER : public Emitter {
     virtual void emitRelOp(unsigned, Register, Register, Register, codeGen &, bool) { assert(0); }
     virtual void emitRelOpImm(unsigned, Register, Register, RegValue, codeGen &, bool) { assert(0); }
     virtual void emitDiv(Register, Register, Register, codeGen &, bool) { assert(0); }
+    virtual void emitMod(Register, Register, Register, codeGen &, bool) { assert(0); }
     virtual void emitTimesImm(Register, Register, RegValue, codeGen &) { assert(0); }
     virtual void emitDivImm(Register, Register, RegValue, codeGen &, bool) { assert(0); }
+    virtual void emitModImm(Register, Register, RegValue, codeGen &, bool) { assert(0); }
     virtual void emitLoad(Register, Address, int, codeGen &) { assert(0); }
     virtual void emitLoadConst(Register, Address, codeGen &) { assert(0); }
     virtual void emitLoadIndir(Register, Register, int, codeGen &) { assert(0); }

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -207,6 +207,23 @@ void EmitterIA32::emitDiv(Register dest, Register src1, Register src2, codeGen &
    gen.rs()->freeRegister(scratch);
 }
 
+void EmitterIA32::emitMod(Register dest, Register src1, Register src2, codeGen &gen, bool s)
+{
+   Register scratch = gen.rs()->allocateRegister(gen, true);
+   gen.rs()->loadVirtualToSpecific(src1, RealRegister(REGNUM_EAX), gen);
+   gen.rs()->makeRegisterAvail(RealRegister(REGNUM_EDX), gen);
+   gen.rs()->noteVirtualInReal(scratch, RealRegister(REGNUM_EDX));
+   RealRegister src2_r = gen.rs()->loadVirtual(src2, gen);
+   gen.rs()->makeRegisterAvail(RealRegister(REGNUM_EAX), gen);
+   emitSimpleInsn(0x99, gen);            //cdq (src1 -> eax:edx)
+   if (s)
+       emitOpExtReg(0xF7, 0x7, src2_r, gen); //idiv
+   else
+       emitOpExtReg(0xF7, 0x6, src2_r, gen); //div
+   gen.rs()->noteVirtualInReal(dest, RealRegister(REGNUM_EDX));  // remainder in EDX
+   gen.rs()->freeRegister(scratch);
+}
+
 void EmitterIA32::emitOpImm(unsigned opcode1, unsigned opcode2, Register dest, Register src1, 
                             RegValue src2imm, codeGen &gen)
 {
@@ -281,6 +298,28 @@ void EmitterIA32::emitDivImm(Register dest, Register src1, RegValue src2imm, cod
       emitDiv(dest, src1, src2, gen, s);
       gen.rs()->freeRegister(src2);
    }
+}
+
+void EmitterIA32::emitModImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s)
+{
+   int result;
+   if (src2imm == 1) {
+      RealRegister dest_r = gen.rs()->loadVirtualForWrite(dest, gen);
+      emitMovImmToReg(dest_r, 0, gen);
+      return;
+   }
+   if (!s && isPowerOf2(src2imm, result)) {
+      RealRegister src1_r = gen.rs()->loadVirtual(src1, gen);
+      RealRegister dest_r = gen.rs()->loadVirtualForWrite(dest, gen);
+      if (src1 != dest)
+         emitMovRegToReg(dest_r, src1_r, gen);
+      emitOpExtRegImm(0x81, 0x4, dest_r, src2imm - 1, gen);  // AND
+      return;
+   }
+   Register src2 = gen.rs()->allocateRegister(gen, true);
+   emitLoadConst(src2, src2imm, gen);
+   emitMod(dest, src1, src2, gen, s);
+   gen.rs()->freeRegister(src2);
 }
 
 void EmitterIA32::emitLoad(Register dest, Address addr, int size, codeGen &gen)
@@ -1364,6 +1403,49 @@ void EmitterAMD64::emitDiv(Register dest, Register src1, Register src2, codeGen 
       emitPopReg64(REGNUM_RDX, gen);
 }
 
+void EmitterAMD64::emitMod(Register dest, Register src1, Register src2, codeGen &gen, bool s)
+{
+   bool save_rdx = false;
+   if (!gen.rs()->isFreeRegister(REGNUM_RDX) && (dest != REGNUM_RDX)) {
+      save_rdx = true;
+      emitPushReg64(REGNUM_RDX, gen);
+   }
+   else {
+      gen.markRegDefined(REGNUM_RDX);
+   }
+
+   Register scratchReg = src2;
+   if (scratchReg == REGNUM_RDX) {
+      std::vector<Register> dontUse;
+      dontUse.push_back(REGNUM_RAX);
+      dontUse.push_back(src2);
+      dontUse.push_back(dest);
+      dontUse.push_back(src1);
+      scratchReg = gen.rs()->getScratchRegister(gen, dontUse);
+      emitMovRegToReg64(scratchReg, src2, true, gen);
+   }
+   gen.markRegDefined(scratchReg);
+
+   emitMovRegToReg64(REGNUM_RAX, src1, true, gen);
+   gen.markRegDefined(REGNUM_RAX);
+
+   emitSimpleInsn(0x48, gen); // REX.W
+   emitSimpleInsn(0x99, gen); // cqo
+
+   if (s) {
+       emitOpRegReg64(0xF7, 0x7, scratchReg, true, gen);
+   } else {
+       emitOpRegReg64(0xF7, 0x6, scratchReg, true, gen);
+   }
+
+   // mov %rdx, %dest (remainder instead of quotient)
+   emitMovRegToReg64(dest, REGNUM_RDX, true, gen);
+   gen.markRegDefined(dest);
+
+   if (save_rdx)
+      emitPopReg64(REGNUM_RDX, gen);
+}
+
 void EmitterAMD64::emitTimesImm(Register dest, Register src1, RegValue src2imm, codeGen &gen)
 {
    int result = -1;
@@ -1449,6 +1531,57 @@ void EmitterAMD64::emitDivImm(Register dest, Register src1, RegValue src2imm, co
       if (save_rdx)
          emitPopReg64(REGNUM_RDX, gen);
    }
+}
+
+void EmitterAMD64::emitModImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s)
+{
+   int result = -1;
+   gen.markRegDefined(dest);
+   if (src2imm == 1) {
+      emitMovImmToReg64(dest, 0, true, gen);
+      return;
+   }
+   if (!s && isPowerOf2(src2imm, result)) {
+      if (src1 != dest) {
+         emitMovRegToReg64(dest, src1, true, gen);
+      }
+      emitOpRegImm64(0x81, 0x4, dest, src2imm - 1, true, gen);  // AND
+      return;
+   }
+
+   bool save_rdx = false;
+   if (!gen.rs()->isFreeRegister(REGNUM_RDX) && (dest != REGNUM_RDX)) {
+      save_rdx = true;
+      emitPushReg64(REGNUM_RDX, gen);
+   }
+   else {
+      gen.markRegDefined(REGNUM_RDX);
+   }
+   emitMovRegToReg64(REGNUM_EAX, src1, true, gen);
+   gen.markRegDefined(REGNUM_RAX);
+   if (s) {
+       emitSimpleInsn(0x48, gen); // REX.W
+       emitSimpleInsn(0x99, gen);
+   } else {
+       emitMovImmToReg64(REGNUM_RDX, 0, true, gen);
+   }
+   emitPushImm(src2imm, gen);
+
+   if (s) {
+       emitOpRegRM64(0xF7, 0x7, REGNUM_RSP, 0, true, gen);
+   }
+   else {
+       emitOpRegRM64(0xF7, 0x6, REGNUM_RSP, 0, true, gen);
+   }
+
+   // mov %rdx, %dest (remainder instead of quotient)
+   emitMovRegToReg64(dest, REGNUM_RDX, true, gen);
+
+   emitOpRegImm8_64(0x83, 0x0, REGNUM_RSP, 8, true, gen);
+   gen.rs()->incStack(-8);
+
+   if (save_rdx)
+      emitPopReg64(REGNUM_RDX, gen);
 }
 
 void EmitterAMD64::emitLoad(Register dest, Address addr, int size, codeGen &gen)

--- a/dyninstAPI/src/emit-x86.h
+++ b/dyninstAPI/src/emit-x86.h
@@ -81,11 +81,13 @@ public:
     void emitOp(unsigned opcode, Register dest, Register src1, Register src2, codeGen &gen);
     void emitRelOp(unsigned op, Register dest, Register src1, Register src2, codeGen &gen, bool s);
     void emitDiv(Register dest, Register src1, Register src2, codeGen &gen, bool s);
+    void emitMod(Register dest, Register src1, Register src2, codeGen &gen, bool s);
     void emitOpImm(unsigned opcode1, unsigned opcode2, Register dest, Register src1, RegValue src2imm,
 			   codeGen &gen);
     void emitRelOpImm(unsigned op, Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s);
     void emitTimesImm(Register dest, Register src1, RegValue src1imm, codeGen &gen);
     void emitDivImm(Register dest, Register src1, RegValue src1imm, codeGen &gen, bool s);
+    void emitModImm(Register dest, Register src1, RegValue src1imm, codeGen &gen, bool s);
     void emitLoad(Register dest, Address addr, int size, codeGen &gen);
     void emitLoadConst(Register dest, Address imm, codeGen &gen);
     void emitLoadIndir(Register dest, Register addr_reg, int size, codeGen &gen);
@@ -194,11 +196,13 @@ public:
     void emitOp(unsigned op, Register dest, Register src1, Register src2, codeGen &gen);
     void emitRelOp(unsigned op, Register dest, Register src1, Register src2, codeGen &gen, bool s);
     void emitDiv(Register dest, Register src1, Register src2, codeGen &gen, bool s);
+    void emitMod(Register dest, Register src1, Register src2, codeGen &gen, bool s);
     void emitOpImm(unsigned opcode1, unsigned opcode2, Register dest, Register src1, RegValue src2imm,
 			   codeGen &gen);
     void emitRelOpImm(unsigned op, Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s);
     void emitTimesImm(Register dest, Register src1, RegValue src1imm, codeGen &gen);
     void emitDivImm(Register dest, Register src1, RegValue src1imm, codeGen &gen, bool s);
+    void emitModImm(Register dest, Register src1, RegValue src1imm, codeGen &gen, bool s);
     void emitLoad(Register dest, Address addr, int size, codeGen &gen);
     void emitLoadConst(Register dest, Address imm, codeGen &gen);
     void emitLoadIndir(Register dest, Register addr_reg, int size, codeGen &gen);

--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -63,10 +63,8 @@ class Emitter {
     virtual void emitRelOp(unsigned op, Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
     virtual void emitRelOpImm(unsigned op, Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
     virtual void emitDiv(Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
-    virtual void emitMod(Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
     virtual void emitTimesImm(Register dest, Register src1, RegValue src2imm, codeGen &gen) = 0;
     virtual void emitDivImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
-    virtual void emitModImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
     virtual void emitLoad(Register dest, Address addr, int size, codeGen &gen) = 0;
     virtual void emitLoadConst(Register dest, Address imm, codeGen &gen) = 0;
     virtual void emitLoadIndir(Register dest, Register addr_reg, int size, codeGen &gen) = 0;
@@ -133,6 +131,9 @@ class Emitter {
 
     // TODO : Make all targets use this instead of having this functionality floating around in the codebase.
     virtual void emitMovePCtoReg(Register /* reg */, codeGen & /* gen */) {}
+
+    virtual void emitMod(Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
+    virtual void emitModImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
 };
 
 #endif

--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -63,8 +63,10 @@ class Emitter {
     virtual void emitRelOp(unsigned op, Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
     virtual void emitRelOpImm(unsigned op, Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
     virtual void emitDiv(Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
+    virtual void emitMod(Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
     virtual void emitTimesImm(Register dest, Register src1, RegValue src2imm, codeGen &gen) = 0;
     virtual void emitDivImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
+    virtual void emitModImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
     virtual void emitLoad(Register dest, Address addr, int size, codeGen &gen) = 0;
     virtual void emitLoadConst(Register dest, Address imm, codeGen &gen) = 0;
     virtual void emitLoadIndir(Register dest, Register addr_reg, int size, codeGen &gen) = 0;

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -373,6 +373,14 @@ void emitImm(opCode op, Register src1, RegValue src2imm, Register dest,
                 insnCodeGen::generateDiv(gen, rm, src1, dest, true, s);
             }
             break;
+        case modOp:
+            {
+                Register rm = insnCodeGen::moveValueToReg(gen, src2imm);
+                Register scratch = gen.rs()->getScratchRegister(gen);
+                insnCodeGen::generateDiv(gen, rm, src1, scratch, true, s);
+                insnCodeGen::generateMSub(gen, scratch, rm, src1, dest, true);
+            }
+            break;
         case xorOp:
             {
                 Register rm = insnCodeGen::moveValueToReg(gen, src2imm);
@@ -887,6 +895,13 @@ void emitV(opCode op, Register src1, Register src2, Register dest,
         case divOp:
 	    insnCodeGen::generateDiv(gen, src2, src1, dest, true, s);
 	    break;
+        case modOp:
+            {
+                Register scratch = gen.rs()->getScratchRegister(gen);
+                insnCodeGen::generateDiv(gen, src2, src1, scratch, true, s);
+                insnCodeGen::generateMSub(gen, scratch, src2, src1, dest, true);
+            }
+            break;
         case lessOp:
         case leOp:
         case greaterOp:

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -680,6 +680,13 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
                   gen.width(), gen.point(), gen.addrSpace(), s);
             return;
         }
+    case modOp: {
+            Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen, noCost);
+            emitVload(loadConstOp, src2imm, dest2, dest2, gen, noCost);
+            emitV(op, src1, dest2, dest, gen, noCost, gen.rs(),
+                  gen.width(), gen.point(), gen.addrSpace(), s);
+            return;
+        }
         // Bool ops
     case orOp:
         iop = ORILop;
@@ -1613,6 +1620,40 @@ void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::R
                     instXop = DIVLSxop; // Extended opcode for signed division
                 else
                     instXop = DIVLUxop; // Extended opcode for unsigned division
+                break;
+
+                case modOp:
+                {
+                    // dest = src1 - (src1/src2)*src2
+
+                    // dest = src1 / src2
+                    insn.clear();
+                    XOFORM_OP_SET(insn, DIVSop);
+                    XOFORM_RT_SET(insn, dest);
+                    XOFORM_RA_SET(insn, src1);
+                    XOFORM_RB_SET(insn, src2);
+                    XOFORM_XO_SET(insn, s ? DIVLSxop : DIVLUxop);
+                    insnCodeGen::generate(gen, insn);
+
+                    // dest = dest * src2
+                    insn.clear();
+                    XOFORM_OP_SET(insn, MULSop);
+                    XOFORM_RT_SET(insn, dest);
+                    XOFORM_RA_SET(insn, dest);
+                    XOFORM_RB_SET(insn, src2);
+                    XOFORM_XO_SET(insn, MULLxop);
+                    insnCodeGen::generate(gen, insn);
+
+                    // dest = src1 - dest (SUBF computes RB - RA)
+                    insn.clear();
+                    XOFORM_OP_SET(insn, SFop);
+                    XOFORM_RT_SET(insn, dest);
+                    XOFORM_RA_SET(insn, dest);
+                    XOFORM_RB_SET(insn, src1);
+                    XOFORM_XO_SET(insn, SFxop);
+                    insnCodeGen::generate(gen, insn);
+                    return;
+                }
                 break;
 
             // Bool ops

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1494,6 +1494,10 @@ void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::R
            gen.codeEmitter()->emitDiv(dest, src1, src2, gen, s);
            return;
         }
+        case modOp: {
+           gen.codeEmitter()->emitMod(dest, src1, src2, gen, s);
+           return;
+        }
            // Bool ops
         case orOp:
            opcode = 0x0B; // OR 
@@ -1558,6 +1562,9 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
             return;
          case divOp:
             gen.codeEmitter()->emitDivImm(dest, src1, src2imm, gen, s);
+            return;
+         case modOp:
+            gen.codeEmitter()->emitModImm(dest, src1, src2imm, gen, s);
             return;
          // Bool ops
          case orOp:

--- a/dyninstAPI/src/opcode.h
+++ b/dyninstAPI/src/opcode.h
@@ -41,7 +41,6 @@ typedef enum {
    minusOp,
    timesOp,
    divOp,
-   modOp,
    lessOp,
    leOp,
    greaterOp,
@@ -76,6 +75,7 @@ typedef enum {
    branchOp,
    ifMCOp,
    xorOp,
+   modOp,
    undefOp
 } opCode;
 

--- a/dyninstAPI/src/opcode.h
+++ b/dyninstAPI/src/opcode.h
@@ -41,6 +41,7 @@ typedef enum {
    minusOp,
    timesOp,
    divOp,
+   modOp,
    lessOp,
    leOp,
    greaterOp,
@@ -86,6 +87,7 @@ inline std::string format_opcode(opCode op) {
       case xorOp: return "xor";
       case timesOp: return "times";
       case divOp: return "div";
+      case modOp: return "mod";
       case lessOp: return "less";
       case leOp: return "le";
       case greaterOp: return "greater";

--- a/tests/unit/dyninstAPI/emitter/x86_64.cpp
+++ b/tests/unit/dyninstAPI/emitter/x86_64.cpp
@@ -118,6 +118,25 @@ int main() {
     0x48, 0x83, 0xc4, 0x08                                // add rsp, 8
     }});
 
+  // Modulo rdx by rcx (remainder of rdx/rcx -> rax)
+  emitter->emitMod(REGNUM_EAX, REGNUM_EDX, REGNUM_ECX, gen, false);
+  failed |= !verify_emitter(gen, emitter_buffer_t<11>{{
+    0x48, 0x8b, 0xc2,   // mov rax, rdx       (src1 -> rax for div)
+    0x48, 0x99,         // cqo                (sign-extend rax -> rdx:rax)
+    0x48, 0xf7, 0xf1,   // div rcx            (rdx:rax / rcx -> quotient=rax, remainder=rdx)
+    0x48, 0x8b, 0xc2    // mov rax, rdx       (remainder -> dest)
+  }});
+
+  // Modulo rsi by 0x12345678, store remainder in rdx
+  emitter->emitModImm(REGNUM_EDX, REGNUM_ESI, 0x12345678, gen, false);
+  failed |= !verify_emitter(gen, emitter_buffer_t<26>{{
+    0x48, 0x8b, 0xc6,                                     // mov rax, rsi
+    0x48, 0xba, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,   // mov rdx, 0x0
+    0x68, 0x78, 0x56, 0x34, 0x12,                         // push 0x12345678
+    0x48, 0xf7, 0x34, 0x24,                               // div qword ptr [rsp]
+    0x48, 0x83, 0xc4, 0x08                                // add rsp, 8
+    }});
+
   // pushfq
   emitter->emitPushFlags(gen);
   failed |= !verify_emitter(gen, emitter_buffer_t<1>{{0x9c}});


### PR DESCRIPTION
I was doing some testing involving instrumenting functions after N calls. I wanted to use `BPatch_mod` but was met with the `assert(0)`. 

`BPatch_mod` is now a first-class opcode (`modOp`) with architecture-specific code generation, following the same convention as `BPatch_divide`/`divOp`.


### x86 (IA32 + AMD64)

`DIV`/`IDIV` computes both quotient (RAX) and remainder (RDX) in a single instruction. `emitDiv` reads RAX; `emitMod` reads RDX instead, requiring zero additional instructions. `emitModImm` adds fast paths for constant divisors: 
1. `mov dest, 0` for modulo 1,
2. `AND dest, (N-1)` for unsigned power-of-2. 
3. Other constants fall back to `IDIV`, consistent with `emitDivImm`.

### AArch64

No remainder instruction. Matching GCC/Clang output: `SDIV`/`UDIV` + `MSUB`. A `generateMSub` helper is added. `MSUB` shares the same encoding as `generateMul`/MADD, with bit 15 (`o0`) selecting subtract instead of add.

### Power

Scalar modulo instructions exist on POWER9+ (`modsw`/`moduw`) but GCC avoids them due to [performance issues with certain inputs](https://gcc.gnu.org/pipermail/gcc-patches/2023-June/620622.html). Matching GCC: `divw` + `mullw` + `subf`, using the same XOFORM encoding macros as `divOp`.

### AMDGPU

Marked as not implemented.

### Testing

**Emitter byte-encoding tests** (`tests/unit/dyninstAPI/emitter/x86_64.cpp`): Two new cases verify exact machine code for `emitMod` and `emitModImm`, alongside existing `emitDiv`/`emitDivImm` tests. These passed locally.

I have also tested with some other local (and simple) examples on `x86_64`
