### PR TITLE
Add caching to Emitter::clobberAllFuncCall

### DIFF
--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -99,6 +99,7 @@ set(_private_headers
     src/frame.h
     src/freebsd.h
     src/function.h
+    src/function_cache.h
     src/hybridAnalysis.h
     src/IAPI_to_AST.h
     src/image.h

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
@@ -32,6 +32,11 @@ namespace Dyninst { namespace DyninstAPI {
       return false;
     }
 
+    if(clobbered_functions.contains(callee)) {
+      return true;
+    }
+    clobbered_functions.insert(callee);
+
     if(writesFPRs(callee->ifunc())) {
       for(unsigned i = 0; i < rs->FPRs().size(); i++) {
         rs->FPRs()[i]->beenUsed = true;

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.h
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.h
@@ -37,6 +37,7 @@
 
 #include "ASTs/codeGenAST.h"
 #include "codegen/emitters/x86/Emitterx86.h"
+#include "function_cache.h"
 
 namespace Dyninst { namespace DyninstAPI {
 
@@ -161,6 +162,10 @@ namespace Dyninst { namespace DyninstAPI {
     bool emitXorRegRM(Register dest, Register base, int disp, codeGen &gen) override;
 
     bool emitXorRegSegReg(Register dest, Register base, int disp, codeGen &gen) override;
+
+ private:
+    // clobberAllFuncCall can be expensive, so don't re-analyze functions
+    Dyninst::DyninstAPI::function_cache clobbered_functions;
   };
 
 }}

--- a/dyninstAPI/src/emit-aarch64.h
+++ b/dyninstAPI/src/emit-aarch64.h
@@ -39,6 +39,7 @@
 #include "dyninstAPI/src/instPoint.h"
 #include "baseTramp.h"
 #include "dyninstAPI/src/emitter.h"
+#include "function_cache.h"
 
 class codeGen;
 
@@ -176,6 +177,10 @@ protected:
 
     virtual Register emitCallReplacement(opCode, codeGen &, bool,
                                          func_instance *);
+
+ private:
+    // clobberAllFuncCall can be expensive, so don't re-analyze functions
+    Dyninst::DyninstAPI::function_cache clobbered_functions;
 };
 
 class EmitterAARCH64Dyn : public EmitterAARCH64 {

--- a/dyninstAPI/src/emit-power.h
+++ b/dyninstAPI/src/emit-power.h
@@ -44,6 +44,7 @@
 #include "dyninstAPI/src/instPoint.h"
 #include "baseTramp.h"
 #include "dyninstAPI/src/emitter.h"
+#include "function_cache.h"
 
 class codeGen;
 class registerSpace;
@@ -125,6 +126,9 @@ class EmitterPOWER : public Emitter {
     virtual bool emitCallInstruction(codeGen &, func_instance *,
                                      bool, Address);
 
+ private:
+    // clobberAllFuncCall can be expensive, so don't re-analyze functions
+    Dyninst::DyninstAPI::function_cache clobbered_functions;
 };
 
 class EmitterPOWER32Dyn : public EmitterPOWER

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -851,11 +851,10 @@ bool EmitterAMD64::clobberAllFuncCall( registerSpace *rs,
 {
    if (callee == NULL) return false;
    
-   /* This will calculate the values if the first time around, otherwise
-      will check preparsed, stored values.
-      True - FP Writes are present
-      False - No FP Writes
-   */
+   if(clobbered_functions.contains(callee)) {
+     return true;
+   }
+   clobbered_functions.insert(callee);
 
    if (writesFPRs(callee->ifunc())) {
       for (unsigned i = 0; i < rs->FPRs().size(); i++) {

--- a/dyninstAPI/src/emit-x86.h
+++ b/dyninstAPI/src/emit-x86.h
@@ -43,6 +43,7 @@
 #include "common/src/arch-x86.h"
 #include "dyninstAPI/src/instPoint.h"
 #include "baseTramp.h"
+#include "function_cache.h"
 
 #include "dyninstAPI/src/emitter.h"
 #include "codegen/emitters/x86/Emitterx86.h"
@@ -141,6 +142,9 @@ public:
  protected:
     virtual bool emitCallInstruction(codeGen &gen, func_instance *target, Register ret) = 0;
 
+ private:
+    // clobberAllFuncCall can be expensive, so don't re-analyze functions
+    Dyninst::DyninstAPI::function_cache clobbered_functions;
 };
 
 class EmitterAMD64Dyn : public EmitterAMD64 {

--- a/dyninstAPI/src/function_cache.h
+++ b/dyninstAPI/src/function_cache.h
@@ -1,0 +1,60 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_DYNINSTAPI_FUNCTION_CACHE_H
+#define DYNINST_DYNINSTAPI_FUNCTION_CACHE_H
+
+#include "function.h"
+
+#include <vector>
+
+namespace Dyninst { namespace DyninstAPI {
+
+  class function_cache final {
+    std::vector<func_instance*> funcs;
+  public:
+    function_cache() {
+      funcs.reserve(10);
+    }
+    bool contains(func_instance *f) const {
+      auto cmp = [f](func_instance *c) {
+        return c->addr() == f->addr() &&
+               c->typedName() == f->typedName();
+      };
+      return std::find_if(funcs.begin(), funcs.end(), cmp) == funcs.end();
+    }
+    void insert(func_instance *f) {
+      funcs.push_back(f);
+    }
+  };
+
+}}
+
+#endif

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -478,6 +478,11 @@ bool EmitterAARCH64::clobberAllFuncCall(registerSpace *rs,
   if (!callee)
     return true;
 
+  if(clobbered_functions.contains(callee)) {
+    return true;
+  }
+  clobbered_functions.insert(callee);
+
   if (callee->ifunc()->isLeafFunc()) {
     auto const &regs = calcUsedRegs(callee->ifunc());
 

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -773,6 +773,11 @@ bool EmitterPOWER::clobberAllFuncCall( registerSpace *rs,
 {
   if (!callee) return true;
 
+  if(clobbered_functions.contains(callee)) {
+    return true;
+  }
+  clobbered_functions.insert(callee);
+
   /* usedRegs does calculations if not done before and returns
      whether or not the callee is a leaf function.
      if it is, we use the register info we gathered,

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -760,10 +760,6 @@ Dyninst::Register emitFuncCall(opCode op,
     return reg;
 }
 
-
-
-
-
 /*
  * emit code for op(src1,src2, dest)
  * ibuf is an instruction buffer where instructions are generated


### PR DESCRIPTION
The original caching was unwittingly removed by cc547f688 in 2026. This also moves the caching from func_instance into the emitter where it is actually used.

Fixes #2211

@kcossett-amd Could you re-run your tests with this PR? For some reason, proccontrol is failing to start a process on my local machine so I don't have numbers yet. I'll debug and make sure I'm seeing improvements.