### PR TITLE
Refactor check for encoding immediates in operationAST

### DIFF
--- a/dyninstAPI/src/ASTs/ast_helpers.h
+++ b/dyninstAPI/src/ASTs/ast_helpers.h
@@ -45,6 +45,4 @@
     }                                                                                              \
   } while(0)
 
-extern bool doNotOverflow(int64_t value);
-
 #endif

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -1,3 +1,4 @@
+#include "Architecture.h"
 #include "ast_helpers.h"
 #include "BPatch.h"
 #include "BPatch_addressSpace.h"
@@ -12,6 +13,7 @@
 #include "registerSpace.h"
 
 #include <iomanip>
+#include <limits>
 #include <sstream>
 
 namespace {
@@ -36,6 +38,8 @@ namespace {
     }
     return false;
   }
+
+  bool can_encode_directly(int64_t, Dyninst::Architecture);
 }
 
 namespace Dyninst { namespace DyninstAPI {
@@ -707,7 +711,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       REGISTER_CHECK(src1);
 
       if((roperand->getoType() == operandType::Constant) &&
-         doNotOverflow((int64_t)roperand->getOValue())) {
+         can_encode_directly((int64_t)roperand->getOValue(), gen.getArch())) {
         if(retReg == Dyninst::Null_Register) {
           retReg = allocateAndKeep(gen, noCost);
           ast_printf("Operator node, const RHS, allocated register %u\n", retReg.getId());
@@ -877,3 +881,39 @@ std::string operatorAST::format(std::string indent) {
 }
 
 }}
+
+namespace {
+
+  // Checks if an immediate `value` should be directly encoded into a instruction
+  bool can_encode_directly(int64_t value, Dyninst::Architecture arch) {
+    switch(arch) {
+      case Dyninst::Arch_x86:
+      case Dyninst::Arch_x86_64: {
+        constexpr auto min = std::numeric_limits<int32_t>::min();
+        constexpr auto max = std::numeric_limits<int32_t>::max();
+        return (min <= value) && (value <= max);
+      }
+
+      case Dyninst::Arch_aarch64: {
+        // ARMv8 has 16 bits for immediate values in the instruction MOV.
+        return (value >= 0) && (value <= 0xFFFF);
+      }
+
+      case Dyninst::Arch_ppc32:
+      case Dyninst::Arch_ppc64:
+        return (value <= 32767) && (value >= -32768);
+
+      case Dyninst::Arch_riscv64:
+      case Dyninst::Arch_none:
+      case Dyninst::Arch_aarch32:
+      case Dyninst::Arch_cuda:
+      case Dyninst::Arch_amdgpu_gfx908:
+      case Dyninst::Arch_amdgpu_gfx90a:
+      case Dyninst::Arch_amdgpu_gfx940:
+      case Dyninst::Arch_intelGen9:
+        return false;
+    }
+    return false;
+  }
+
+}

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -918,18 +918,6 @@ void emitV(opCode op, Register src1, Register src2, Register dest,
     return;
 }
 
-// This is used for checking wether immediate value should be encoded
-// into a instruction. In fact, only being used for loading constant
-// value into a register, and in ARMv8 there are 16 bits for immediate
-// values in the instruction MOV.
-// value here is never a negative value since constant values are saved
-// as void* in the AST operand.
-bool doNotOverflow(int64_t value)
-{
-    if ((value >= 0) && (value <= 0xFFFF)) return true;
-    else return false;
-}
-
 void emitLoadPreviousStackFrameRegister(Address register_num,
                                         Register dest,
                                         codeGen &gen,

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -102,11 +102,6 @@ void emitV(opCode /* op */, Register /* src1 */, Register /* src2 */, Register /
   assert(!"Not imeplemented for AMDGPU");
 }
 
-bool doNotOverflow(int64_t /* value */) {
-  assert(!"Not implemented for AMDGPU");
-  return false;
-}
-
 void emitLoadPreviousStackFrameRegister(Address /* register_num */, Register /* dest */,
                                         codeGen & /* gen */, int /* size */, bool) {}
 

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1710,15 +1710,6 @@ void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::R
   return;
 }
 
-
-
-bool doNotOverflow(int64_t value) {
-    if ( (value <= 32767) && (value >= -32768) ) return(true);
-    else return(false);
-
-}
-
-
 void emitLoadPreviousStackFrameRegister(Address register_num, 
                                         Dyninst::Register dest,
                                         codeGen &gen,

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -209,15 +209,6 @@ Address getMaxBranch() {
   return (Address)MAX_BRANCH;
 }
 
-
-bool doNotOverflow(int64_t value)
-{
-    if (value <= INT_MAX && value >= INT_MIN) return true;
-    return false;
-}
-
-
-
 /* build the MOD/RM byte of an instruction */
 static inline unsigned char makeModRMbyte(unsigned Mod, unsigned Reg,
                                           unsigned RM)


### PR DESCRIPTION
I am very dubious that these calculations are fully correct- particularly for x86. For now, I've just collected them all into one place to work toward cross-platform codegen.

Note that for AMDGPU, I converted the assert to a failing case in `can_encode_directly` since that will prevent immediate encoding.