### PR TITLE
[dyninstAPI] Implement isSharedLib for BPatch_object

### DIFF
--- a/dyninstAPI/h/BPatch_object.h
+++ b/dyninstAPI/h/BPatch_object.h
@@ -103,11 +103,11 @@ class DYNINST_EXPORT BPatch_object {
 
     // BPatch_object::name
     // Returns the file name of the object
-    std::string name();
+    std::string name() const;
 
     // BPatch_object::pathName
     // Returns the full pathname of the object
-    std::string pathName();
+    std::string pathName() const;
 
     // BPatch_object::isSharedLib
     // Returns true if this object represents a shared library

--- a/dyninstAPI/h/BPatch_object.h
+++ b/dyninstAPI/h/BPatch_object.h
@@ -109,6 +109,10 @@ class DYNINST_EXPORT BPatch_object {
     // Returns the full pathname of the object
     std::string pathName();
 
+    // BPatch_object::isSharedLib
+    // Returns true if this object represents a shared library
+    bool isSharedLib();
+
     
     // BPatch_object::offsetToAddr
     // Converts a file offset into an absolute address suitable for use in looking up

--- a/dyninstAPI/h/BPatch_object.h
+++ b/dyninstAPI/h/BPatch_object.h
@@ -111,7 +111,7 @@ class DYNINST_EXPORT BPatch_object {
 
     // BPatch_object::isSharedLib
     // Returns true if this object represents a shared library
-    bool isSharedLib();
+    bool isSharedLib() const;
 
     
     // BPatch_object::offsetToAddr

--- a/dyninstAPI/src/BPatch_object.C
+++ b/dyninstAPI/src/BPatch_object.C
@@ -73,11 +73,11 @@ AddressSpace *BPatch_object::ll_as() { return obj->proc(); }
 
 BPatch_addressSpace *BPatch_object::as() { return img->getAddressSpace(); }
 
-std::string BPatch_object::name() {
+std::string BPatch_object::name() const {
    return obj->fileName();
 }
 
-std::string BPatch_object::pathName() {
+std::string BPatch_object::pathName() const {
    return obj->fullName();
 }
 

--- a/dyninstAPI/src/BPatch_object.C
+++ b/dyninstAPI/src/BPatch_object.C
@@ -81,6 +81,10 @@ std::string BPatch_object::pathName() {
    return obj->fullName();
 }
 
+bool BPatch_object::isSharedLib() {
+   return obj->isSharedLib();
+}
+
 Dyninst::Address BPatch_object::fileOffsetToAddr(const Dyninst::Offset fileOffset) {
    // File offset, so duck into SymtabAPI to turn it into a "mem offset" 
    // (aka ELF shifted) address

--- a/dyninstAPI/src/BPatch_object.C
+++ b/dyninstAPI/src/BPatch_object.C
@@ -81,7 +81,7 @@ std::string BPatch_object::pathName() {
    return obj->fullName();
 }
 
-bool BPatch_object::isSharedLib() {
+bool BPatch_object::isSharedLib() const {
    return obj->isSharedLib();
 }
 


### PR DESCRIPTION
I've noticed that there exists `isSharedLib` checker for both `BPatch_module` and `BPatch_function`. However, none exists for `BPatch_object`.

It would be nice to not need to go to the module level to check this. And at the `BPatch_module` level, it returns:
`mod->obj()->isSharedLib();` 

**Reason**: I'd like to implement an option within `rocprofiler-systems` whose purpose is to filter out all shared libraries. From what I gather, I'd realistically only be left with the main executable, which I could find by just finding the executable name in the object list, but I figure that having an `isSharedLib` makes things clearer.
