### PR TITLE
Remove 'noCost' param from codegen interfaces

### DIFF
--- a/dyninstAPI/src/ASTs/actualAddressAST.C
+++ b/dyninstAPI/src/ASTs/actualAddressAST.C
@@ -16,7 +16,7 @@ bool actualAddressAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::A
     return false;
   }
 
-  emitVload(loadConstOp, gen.currAddr(), retReg, retReg, gen, noCost);
+  emitVload(loadConstOp, gen.currAddr(), retReg, retReg, gen);
 
   return true;
 }

--- a/dyninstAPI/src/ASTs/actualAddressAST.C
+++ b/dyninstAPI/src/ASTs/actualAddressAST.C
@@ -7,7 +7,7 @@
 
 namespace Dyninst { namespace DyninstAPI {
 
-bool actualAddressAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+bool actualAddressAST::generateCode_phase2(codeGen &gen, Dyninst::Address &,
                                             Dyninst::Register &retReg) {
   if(retReg == Dyninst::Null_Register) {
     retReg = allocateAndKeep(gen);

--- a/dyninstAPI/src/ASTs/actualAddressAST.C
+++ b/dyninstAPI/src/ASTs/actualAddressAST.C
@@ -10,7 +10,7 @@ namespace Dyninst { namespace DyninstAPI {
 bool actualAddressAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
                                             Dyninst::Register &retReg) {
   if(retReg == Dyninst::Null_Register) {
-    retReg = allocateAndKeep(gen, noCost);
+    retReg = allocateAndKeep(gen);
   }
   if(retReg == Dyninst::Null_Register) {
     return false;

--- a/dyninstAPI/src/ASTs/addressAST.h
+++ b/dyninstAPI/src/ASTs/addressAST.h
@@ -51,7 +51,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &,
                            Dyninst::Register &retReg) override;
 };
 
@@ -68,7 +68,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &,
                            Dyninst::Register &retReg) override;
 };
 

--- a/dyninstAPI/src/ASTs/atomicOperationAST.C
+++ b/dyninstAPI/src/ASTs/atomicOperationAST.C
@@ -32,7 +32,7 @@ std::string atomicOperationAST::format(std::string indent) {
 
 #if defined(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
 
-bool atomicOperationAST::generateCode_phase2(codeGen &gen, bool noCost, Address &retAddr,
+bool atomicOperationAST::generateCode_phase2(codeGen &gen, Address &retAddr,
                                                      Dyninst::Register &) {
   // This has 2 operands - variable and constant.
   // Codegen for atomic add has the following steps:
@@ -43,7 +43,7 @@ bool atomicOperationAST::generateCode_phase2(codeGen &gen, bool noCost, Address 
   bool ret = true;
 
   Dyninst::Register src0 = Dyninst::Null_Register;
-  if(!constant->generateCode_phase2(gen, noCost, retAddr, src0)) {
+  if(!constant->generateCode_phase2(gen, retAddr, src0)) {
     fprintf(stderr, "WARNING: failed in generateCode internals!\n");
     ret = false;
   }
@@ -100,7 +100,7 @@ bool atomicOperationAST::generateCode_phase2(codeGen &gen, bool noCost, Address 
   return ret;
 }
 #else
-bool atomicOperationAST::generateCode_phase2(codeGen &, bool, Dyninst::Address &,
+bool atomicOperationAST::generateCode_phase2(codeGen &, Dyninst::Address &,
                                                      Dyninst::Register &) {
   return false;
 }

--- a/dyninstAPI/src/ASTs/atomicOperationAST.h
+++ b/dyninstAPI/src/ASTs/atomicOperationAST.h
@@ -74,7 +74,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &retAddr,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
                            Dyninst::Register &) override;
   opCode opcode{};
   codeGenASTPtr variable{};

--- a/dyninstAPI/src/ASTs/codeGenAST.C
+++ b/dyninstAPI/src/ASTs/codeGenAST.C
@@ -146,7 +146,7 @@ bool codeGenAST::generateCode(codeGen &gen, bool noCost, Address &retAddr, Dynin
   }
 
   // note: this could return the value "(Address)(-1)" -- csserra
-  if(!generateCode_phase2(gen, noCost, retAddr, retReg)) {
+  if(!generateCode_phase2(gen, retAddr, retReg)) {
     fprintf(stderr, "WARNING: failed in generateCode internals!\n");
     ret = false;
   }

--- a/dyninstAPI/src/ASTs/codeGenAST.C
+++ b/dyninstAPI/src/ASTs/codeGenAST.C
@@ -73,7 +73,7 @@ void codeGenAST::cleanUseCount() {
 
 // Allocate a register and make it available for sharing if our
 // node is shared
-Dyninst::Register codeGenAST::allocateAndKeep(codeGen &gen, bool noCost) {
+Dyninst::Register codeGenAST::allocateAndKeep(codeGen &gen) {
   ast_printf("Allocating register for node %p, useCount %d\n", (void *)this, useCount);
   // Allocate a register
   Dyninst::Register dest = gen.rs()->allocateRegister(gen);

--- a/dyninstAPI/src/ASTs/codeGenAST.C
+++ b/dyninstAPI/src/ASTs/codeGenAST.C
@@ -76,7 +76,7 @@ void codeGenAST::cleanUseCount() {
 Dyninst::Register codeGenAST::allocateAndKeep(codeGen &gen, bool noCost) {
   ast_printf("Allocating register for node %p, useCount %d\n", (void *)this, useCount);
   // Allocate a register
-  Dyninst::Register dest = gen.rs()->allocateRegister(gen, noCost);
+  Dyninst::Register dest = gen.rs()->allocateRegister(gen);
 
   ast_printf("Allocator returned %u\n", dest.getId());
   assert(dest != Dyninst::Null_Register);

--- a/dyninstAPI/src/ASTs/codeGenAST.C
+++ b/dyninstAPI/src/ASTs/codeGenAST.C
@@ -115,7 +115,7 @@ Dyninst::Register codeGenAST::allocateAndKeep(codeGen &gen) {
 // currently available. In order to fix this problem, we will need to
 // implement a "virtual" register allocator - naim 11/06/96
 //
-bool codeGenAST::generateCode(codeGen &gen, bool noCost, Address &retAddr, Dyninst::Register &retReg) {
+bool codeGenAST::generateCode(codeGen &gen, Address &retAddr, Dyninst::Register &retReg) {
   static bool entered = false;
 
   bool ret = true;
@@ -162,10 +162,10 @@ bool codeGenAST::generateCode(codeGen &gen, bool noCost, Address &retAddr, Dynin
   return ret;
 }
 
-bool codeGenAST::generateCode(codeGen &gen, bool noCost) {
+bool codeGenAST::generateCode(codeGen &gen) {
   Address unused = ADDR_NULL;
   Dyninst::Register unusedReg = Dyninst::Null_Register;
-  bool ret = generateCode(gen, noCost, unused, unusedReg);
+  bool ret = generateCode(gen, unused, unusedReg);
   gen.rs()->freeRegister(unusedReg);
 
   return ret;
@@ -225,7 +225,7 @@ bool codeGenAST::generate(Point *point, Buffer &buffer) {
   gen.setPoint(ip);
   gen.setRegisterSpace(registerSpace::actualRegSpace(ip));
   gen.setAddrSpace(ip->proc());
-  if(!generateCode(gen, false)) {
+  if(!generateCode(gen)) {
     return false;
   }
 

--- a/dyninstAPI/src/ASTs/codeGenAST.h
+++ b/dyninstAPI/src/ASTs/codeGenAST.h
@@ -180,7 +180,7 @@ public:
     return NULL;
   }
 
-  virtual void emitVariableStore(opCode, Dyninst::Register, Dyninst::Register, codeGen &, bool,
+  virtual void emitVariableStore(opCode, Dyninst::Register, Dyninst::Register, codeGen &,
                                  registerSpace *, int, const instPoint *, AddressSpace *) {
     assert(!"Never call this on anything but an operand");
   }

--- a/dyninstAPI/src/ASTs/codeGenAST.h
+++ b/dyninstAPI/src/ASTs/codeGenAST.h
@@ -185,7 +185,7 @@ public:
     assert(!"Never call this on anything but an operand");
   }
 
-  virtual void emitVariableLoad(opCode, Dyninst::Register, Dyninst::Register, codeGen &, bool,
+  virtual void emitVariableLoad(opCode, Dyninst::Register, Dyninst::Register, codeGen &,
                                 registerSpace *, int, const instPoint *, AddressSpace *) {
     assert(!"Never call this on anything but an operand");
   }

--- a/dyninstAPI/src/ASTs/codeGenAST.h
+++ b/dyninstAPI/src/ASTs/codeGenAST.h
@@ -160,7 +160,7 @@ public:
 
   // Allocate a register and make it available for sharing if our
   // node is shared
-  Dyninst::Register allocateAndKeep(codeGen &gen, bool noCost);
+  Dyninst::Register allocateAndKeep(codeGen &gen);
 
   // Return all children of this node ([lre]operand, ..., operands[])
   std::vector<codeGenASTPtr> const &getChildren() const {

--- a/dyninstAPI/src/ASTs/codeGenAST.h
+++ b/dyninstAPI/src/ASTs/codeGenAST.h
@@ -86,14 +86,14 @@ public:
 
   virtual ~codeGenAST() = default;
 
-  virtual bool generateCode(codeGen &gen, bool noCost, Dyninst::Address &retAddr,
+  virtual bool generateCode(codeGen &gen, Dyninst::Address &retAddr,
                             Dyninst::Register &retReg);
 
-  virtual bool generateCode(codeGen &gen, bool noCost);
+  virtual bool generateCode(codeGen &gen);
 
-  virtual bool generateCode(codeGen &gen, bool noCost, Dyninst::Register &retReg) {
+  virtual bool generateCode(codeGen &gen, Dyninst::Register &retReg) {
     Dyninst::Address unused = Dyninst::ADDR_NULL;
-    return generateCode(gen, noCost, unused, retReg);
+    return generateCode(gen, unused, retReg);
   }
 
   virtual bool generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,

--- a/dyninstAPI/src/ASTs/codeGenAST.h
+++ b/dyninstAPI/src/ASTs/codeGenAST.h
@@ -96,7 +96,7 @@ public:
     return generateCode(gen, noCost, unused, retReg);
   }
 
-  virtual bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &retAddr,
+  virtual bool generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
                                    Dyninst::Register &retReg) = 0;
 
   // Perform whatever pre-processing steps are necessary.

--- a/dyninstAPI/src/ASTs/functionCallAST.C
+++ b/dyninstAPI/src/ASTs/functionCallAST.C
@@ -105,7 +105,7 @@ bool functionCallAST::generateCode_phase2(codeGen &gen, Address &,
       gen.tracker()->addKeptRegister(gen, this, retReg);
     }
   } else if(retReg != tmp) {
-    emitImm(orOp, tmp, 0, retReg, gen, noCost, gen.rs());
+    emitImm(orOp, tmp, 0, retReg, gen, gen.rs());
     gen.rs()->freeRegister(tmp);
   }
   decUseCount(gen);

--- a/dyninstAPI/src/ASTs/functionCallAST.C
+++ b/dyninstAPI/src/ASTs/functionCallAST.C
@@ -49,7 +49,7 @@ bool functionCallAST::initRegisters(codeGen &gen) {
   return ret;
 }
 
-bool functionCallAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
+bool functionCallAST::generateCode_phase2(codeGen &gen, Address &,
                                       Dyninst::Register &retReg) {
   // We call this anyway... not that we'll ever be kept.
   // Well... if we can somehow know a function is entirely

--- a/dyninstAPI/src/ASTs/functionCallAST.C
+++ b/dyninstAPI/src/ASTs/functionCallAST.C
@@ -76,9 +76,9 @@ bool functionCallAST::generateCode_phase2(codeGen &gen, Address &,
   Dyninst::Register tmp = 0;
 
   if(use_func && !callReplace_) {
-    tmp = emitFuncCall(callOp, gen, children, noCost, use_func);
+    tmp = emitFuncCall(callOp, gen, children, use_func);
   } else if(use_func && callReplace_) {
-    tmp = emitFuncCall(funcJumpOp, gen, children, noCost, use_func);
+    tmp = emitFuncCall(funcJumpOp, gen, children, use_func);
   } else {
     char msg[256];
     sprintf(msg, "%s[%d]:  internal error:  unable to find %s", __FILE__, __LINE__,

--- a/dyninstAPI/src/ASTs/functionCallAST.h
+++ b/dyninstAPI/src/ASTs/functionCallAST.h
@@ -102,7 +102,7 @@ public:
   bool initRegisters(codeGen &gen) override;
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &,
                            Dyninst::Register &retReg) override;
 
   void set_args(std::vector<codeGenASTPtr> &args) {

--- a/dyninstAPI/src/ASTs/genericStackAST.C
+++ b/dyninstAPI/src/ASTs/genericStackAST.C
@@ -15,14 +15,14 @@ std::string genericStackAST::format(std::string indent) {
 
 #ifndef cap_stack_mods
 
-bool genericStackAST::generateCode_phase2(codeGen &, bool, Dyninst::Address &,
+bool genericStackAST::generateCode_phase2(codeGen &, Dyninst::Address &,
                                               Dyninst::Register &) {
   return false;
 }
 
 #else
 
-bool genericStackAST::generateCode_phase2(codeGen &gen, bool, Dyninst::Address &,
+bool genericStackAST::generateCode_phase2(codeGen &gen, Dyninst::Address &,
                                               Dyninst::Register &) {
   gen.setInsertNaked(true);
   gen.setModifiedStackFrame(true);

--- a/dyninstAPI/src/ASTs/genericStackAST.h
+++ b/dyninstAPI/src/ASTs/genericStackAST.h
@@ -56,7 +56,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &,
                            Dyninst::Register &) override;
 };
 

--- a/dyninstAPI/src/ASTs/jumpTargetAST.C
+++ b/dyninstAPI/src/ASTs/jumpTargetAST.C
@@ -10,7 +10,7 @@
 
 namespace Dyninst { namespace DyninstAPI {
 
-bool dynamicJumpTargetAST::generateCode_phase2(codeGen &gen, bool noCost, Address &retAddr,
+bool dynamicJumpTargetAST::generateCode_phase2(codeGen &gen, Address &retAddr,
                                                Dyninst::Register &retReg) {
   if(gen.point()->type() != instPoint::PreCall && gen.point()->type() != instPoint::FuncExit &&
      gen.point()->type() != instPoint::PreInsn) {
@@ -46,7 +46,7 @@ bool dynamicJumpTargetAST::generateCode_phase2(codeGen &gen, bool noCost, Addres
     if(!gen.addrSpace()->getDynamicCallSiteArgs(insn, gen.point()->block()->last(), args)) {
       return false;
     }
-    if(!args[0]->generateCode_phase2(gen, noCost, retAddr, retReg)) {
+    if(!args[0]->generateCode_phase2(gen, retAddr, retReg)) {
       return false;
     }
     return true;

--- a/dyninstAPI/src/ASTs/jumpTargetAST.C
+++ b/dyninstAPI/src/ASTs/jumpTargetAST.C
@@ -21,7 +21,7 @@ bool dynamicJumpTargetAST::generateCode_phase2(codeGen &gen, bool noCost, Addres
   if(insn.isReturn()) {
     // if this is a return instruction our AST reads the top stack value
     if(retReg == Dyninst::Null_Register) {
-      retReg = allocateAndKeep(gen, noCost);
+      retReg = allocateAndKeep(gen);
     }
     if(retReg == Dyninst::Null_Register) {
       return false;

--- a/dyninstAPI/src/ASTs/jumpTargetAST.C
+++ b/dyninstAPI/src/ASTs/jumpTargetAST.C
@@ -28,11 +28,11 @@ bool dynamicJumpTargetAST::generateCode_phase2(codeGen &gen, bool noCost, Addres
     }
 
 #if defined(DYNINST_CODEGEN_ARCH_I386)
-    emitVload(loadRegRelativeOp, (Address)0, REGNUM_ESP, retReg, gen, noCost);
+    emitVload(loadRegRelativeOp, (Address)0, REGNUM_ESP, retReg, gen);
 #elif defined(DYNINST_CODEGEN_ARCH_X86_64)
-    emitVload(loadRegRelativeOp, (Address)0, REGNUM_RSP, retReg, gen, noCost);
+    emitVload(loadRegRelativeOp, (Address)0, REGNUM_RSP, retReg, gen);
 #elif defined(DYNINST_CODEGEN_ARCH_POWER) // KEVINTODO: untested
-    emitVload(loadRegRelativeOp, (Address)sizeof(Address), REG_SP, retReg, gen, noCost);
+    emitVload(loadRegRelativeOp, (Address)sizeof(Address), REG_SP, retReg, gen);
 #elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
     // #warning "This function is not implemented yet!"
     assert(0);

--- a/dyninstAPI/src/ASTs/jumpTargetAST.h
+++ b/dyninstAPI/src/ASTs/jumpTargetAST.h
@@ -51,7 +51,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &retAddr,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
                            Dyninst::Register &retReg) override;
 };
 

--- a/dyninstAPI/src/ASTs/memoryAccessAST.C
+++ b/dyninstAPI/src/ASTs/memoryAccessAST.C
@@ -88,7 +88,7 @@ bool memoryAccessAST::generateCode_phase2(codeGen &gen, Dyninst::Address &,
         assert(0);
       }
       start = ma->getStartAddr(which_);
-      emitASload(start, retReg, 0, gen, noCost);
+      emitASload(start, retReg, 0, gen);
       break;
     }
     case memoryType::BytesAccessed: {

--- a/dyninstAPI/src/ASTs/memoryAccessAST.C
+++ b/dyninstAPI/src/ASTs/memoryAccessAST.C
@@ -48,7 +48,7 @@ memoryAccessAST::memoryAccessAST(memoryType mem, unsigned which, int size_) : me
   doTypeCheck = BPatch::bpatch->isTypeChecked();
 }
 
-bool memoryAccessAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+bool memoryAccessAST::generateCode_phase2(codeGen &gen, Dyninst::Address &,
                                         Dyninst::Register &retReg) {
 
   RETURN_KEPT_REG(retReg);

--- a/dyninstAPI/src/ASTs/memoryAccessAST.C
+++ b/dyninstAPI/src/ASTs/memoryAccessAST.C
@@ -57,7 +57,7 @@ bool memoryAccessAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Ad
   const BPatch_addrSpec_NP *start;
   const BPatch_countSpec_NP *count;
   if(retReg == Dyninst::Null_Register) {
-    retReg = allocateAndKeep(gen, noCost);
+    retReg = allocateAndKeep(gen);
   }
   switch(mem_) {
     case memoryType::EffectiveAddr: {

--- a/dyninstAPI/src/ASTs/memoryAccessAST.C
+++ b/dyninstAPI/src/ASTs/memoryAccessAST.C
@@ -111,7 +111,7 @@ bool memoryAccessAST::generateCode_phase2(codeGen &gen, Dyninst::Address &,
         assert(0);
       }
       count = ma->getByteCount(which_);
-      emitCSload(count, retReg, gen, noCost);
+      emitCSload(count, retReg, gen);
       break;
     }
     default:

--- a/dyninstAPI/src/ASTs/memoryAccessAST.h
+++ b/dyninstAPI/src/ASTs/memoryAccessAST.h
@@ -76,7 +76,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &,
                            Dyninst::Register &retReg) override;
 
   memoryType mem_{};

--- a/dyninstAPI/src/ASTs/nullAST.C
+++ b/dyninstAPI/src/ASTs/nullAST.C
@@ -6,7 +6,7 @@
 
 namespace Dyninst { namespace DyninstAPI {
 
-bool nullAST::generateCode_phase2(codeGen &gen, bool, Dyninst::Address &retAddr,
+bool nullAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
                                       Dyninst::Register &retReg) {
   retAddr = Dyninst::ADDR_NULL;
   retReg = Dyninst::Null_Register;

--- a/dyninstAPI/src/ASTs/nullAST.h
+++ b/dyninstAPI/src/ASTs/nullAST.h
@@ -58,7 +58,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool, Dyninst::Address &retAddr,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
                            Dyninst::Register &retReg) override;
 };
 

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -168,7 +168,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
       break;
     case operandType::FrameAddr:
       addr = (Address)oValue;
-      temp = gen.rs()->allocateRegister(gen, noCost);
+      temp = gen.rs()->allocateRegister(gen);
       emitVload(loadFrameRelativeOp, addr, temp, retReg, gen, noCost, gen.rs(), size, gen.point(),
                 gen.addrSpace());
       gen.rs()->freeRegister(temp);

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -94,7 +94,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
       } else {
         tSize = sizeof(long);
       }
-      emitV(loadIndirOp, src, 0, retReg, gen, noCost, gen.rs(), tSize, gen.point(),
+      emitV(loadIndirOp, src, 0, retReg, gen, gen.rs(), tSize, gen.point(),
             gen.addrSpace());
       gen.rs()->freeRegister(src);
       break;

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -246,7 +246,7 @@ void operandAST::emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Re
 }
 
 void operandAST::emitVariableStore(opCode op, Dyninst::Register src1, Dyninst::Register src2,
-                                       codeGen &gen, bool noCost, registerSpace *rs, int size_,
+                                       codeGen &gen, registerSpace *rs, int size_,
                                        const instPoint *point, AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -114,7 +114,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
                        gen.addrSpace());
       break;
     case operandType::ReturnVal:
-      src = emitR(getRetValOp, 0, Dyninst::Null_Register, retReg, gen, noCost, gen.point(),
+      src = emitR(getRetValOp, 0, Dyninst::Null_Register, retReg, gen, gen.point(),
                   gen.addrSpace()->multithread_capable());
       REGISTER_CHECK(src);
       if(src != retReg) {
@@ -124,7 +124,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
       }
       break;
     case operandType::ReturnAddr:
-      src = emitR(getRetAddrOp, 0, Dyninst::Null_Register, retReg, gen, noCost, gen.point(),
+      src = emitR(getRetAddrOp, 0, Dyninst::Null_Register, retReg, gen, gen.point(),
                   gen.addrSpace()->multithread_capable());
       REGISTER_CHECK(src);
       if(src != retReg) {
@@ -151,7 +151,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
           assert(0);
           break;
       }
-      src = emitR(paramOp, (Address)oValue, Dyninst::Null_Register, retReg, gen, noCost,
+      src = emitR(paramOp, (Address)oValue, Dyninst::Null_Register, retReg, gen,
                   gen.point(), gen.addrSpace()->multithread_capable());
       REGISTER_CHECK(src);
       if(src != retReg) {

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -78,7 +78,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
 #else
     case operandType::Constant:
       assert(oVar == NULL);
-      emitVload(loadConstOp, (Address)oValue, retReg, retReg, gen, noCost, gen.rs(), size,
+      emitVload(loadConstOp, (Address)oValue, retReg, retReg, gen, gen.rs(), size,
                 gen.point(), gen.addrSpace());
       break;
 #endif
@@ -163,13 +163,13 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
     case operandType::DataAddr:
       assert(oVar == NULL);
       addr = reinterpret_cast<Address>(oValue);
-      emitVload(loadOp, addr, retReg, retReg, gen, noCost, NULL, size, gen.point(),
+      emitVload(loadOp, addr, retReg, retReg, gen, NULL, size, gen.point(),
                 gen.addrSpace());
       break;
     case operandType::FrameAddr:
       addr = (Address)oValue;
       temp = gen.rs()->allocateRegister(gen);
-      emitVload(loadFrameRelativeOp, addr, temp, retReg, gen, noCost, gen.rs(), size, gen.point(),
+      emitVload(loadFrameRelativeOp, addr, temp, retReg, gen, gen.rs(), size, gen.point(),
                 gen.addrSpace());
       gen.rs()->freeRegister(temp);
       break;
@@ -178,7 +178,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
       // This codeGenAST holds the register number, and loperand holds offset.
       assert(operand_);
       addr = (Address)operand_->getOValue();
-      emitVload(loadRegRelativeOp, addr, (long)oValue, retReg, gen, noCost, gen.rs(), size,
+      emitVload(loadRegRelativeOp, addr, (long)oValue, retReg, gen, gen.rs(), size,
                 gen.point(), gen.addrSpace());
       break;
     case operandType::ConstantString:
@@ -194,7 +194,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
       }
 
       if(!gen.addrSpace()->needsPIC()) {
-        emitVload(loadConstOp, addr, retReg, retReg, gen, noCost, gen.rs(), size, gen.point(),
+        emitVload(loadConstOp, addr, retReg, retReg, gen, gen.rs(), size, gen.point(),
                   gen.addrSpace());
       } else {
         gen.codeEmitter()->emitLoadShared(loadConstOp, retReg, NULL, true, size, gen, addr);
@@ -239,7 +239,7 @@ void operandAST::emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Re
                                       const instPoint *point, AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {
-    emitVload(op, var->getAddress(), src2, dest, gen, noCost, rs, size_, point, as);
+    emitVload(op, var->getAddress(), src2, dest, gen, rs, size_, point, as);
   } else {
     gen.codeEmitter()->emitLoadShared(op, dest, oVar, (var != NULL), size_, gen, 0);
   }

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -105,12 +105,12 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
       break;
     case operandType::variableAddr:
       assert(oVar);
-      emitVariableLoad(loadConstOp, retReg, retReg, gen, noCost, gen.rs(), size, gen.point(),
+      emitVariableLoad(loadConstOp, retReg, retReg, gen, gen.rs(), size, gen.point(),
                        gen.addrSpace());
       break;
     case operandType::variableValue:
       assert(oVar);
-      emitVariableLoad(loadOp, retReg, retReg, gen, noCost, gen.rs(), size, gen.point(),
+      emitVariableLoad(loadOp, retReg, retReg, gen, gen.rs(), size, gen.point(),
                        gen.addrSpace());
       break;
     case operandType::ReturnVal:
@@ -235,7 +235,7 @@ int_variable *operandAST::lookUpVar(AddressSpace *as) {
 }
 
 void operandAST::emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Register dest,
-                                      codeGen &gen, bool noCost, registerSpace *rs, int size_,
+                                      codeGen &gen, registerSpace *rs, int size_,
                                       const instPoint *point, AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -50,7 +50,7 @@ operandAST::operandAST(operandType ot, const image_variable *iv)
   }
 }
 
-bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
+bool operandAST::generateCode_phase2(codeGen &gen, Address &,
                                          Dyninst::Register &retReg) {
   RETURN_KEPT_REG(retReg);
 
@@ -83,7 +83,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
       break;
 #endif
     case operandType::DataIndir:
-      if(!operand_->generateCode_phase2(gen, noCost, addr, src)) {
+      if(!operand_->generateCode_phase2(gen, addr, src)) {
         ERROR_RETURN;
       }
       REGISTER_CHECK(src);

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -59,7 +59,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
 
   // Allocate a register to return
   if(retReg == Dyninst::Null_Register) {
-    retReg = allocateAndKeep(gen, noCost);
+    retReg = allocateAndKeep(gen);
   }
   Dyninst::Register temp;
   int tSize;

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -250,7 +250,7 @@ void operandAST::emitVariableStore(opCode op, Dyninst::Register src1, Dyninst::R
                                        const instPoint *point, AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {
-    emitVstore(op, src1, src2, var->getAddress(), gen, noCost, rs, size_, point, as);
+    emitVstore(op, src1, src2, var->getAddress(), gen, rs, size_, point, as);
   } else {
     gen.codeEmitter()->emitStoreShared(src1, oVar, (var != NULL), size_, gen);
   }

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -120,7 +120,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       if(src != retReg) {
         // Move src to retReg. Can't simply return src, since it was not
         // allocated properly
-        emitImm(orOp, src, 0, retReg, gen, noCost, gen.rs());
+        emitImm(orOp, src, 0, retReg, gen, gen.rs());
       }
       break;
     case operandType::ReturnAddr:
@@ -130,7 +130,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       if(src != retReg) {
         // Move src to retReg. Can't simply return src, since it was not
         // allocated properly
-        emitImm(orOp, src, 0, retReg, gen, noCost, gen.rs());
+        emitImm(orOp, src, 0, retReg, gen, gen.rs());
       }
       break;
     case operandType::Param:
@@ -157,7 +157,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       if(src != retReg) {
         // Move src to retReg. Can't simply return src, since it was not
         // allocated properly
-        emitImm(orOp, src, 0, retReg, gen, noCost, gen.rs());
+        emitImm(orOp, src, 0, retReg, gen, gen.rs());
       }
     } break;
     case operandType::DataAddr:

--- a/dyninstAPI/src/ASTs/operandAST.h
+++ b/dyninstAPI/src/ASTs/operandAST.h
@@ -169,7 +169,7 @@ public:
                          bool noCost, registerSpace *rs, int size, const instPoint *point,
                          AddressSpace *as) override;
   void emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Register dest, codeGen &gen,
-                        bool noCost, registerSpace *rs, int size, const instPoint *point,
+                        registerSpace *rs, int size, const instPoint *point,
                         AddressSpace *as) override;
 
   bool initRegisters(codeGen &gen) override;

--- a/dyninstAPI/src/ASTs/operandAST.h
+++ b/dyninstAPI/src/ASTs/operandAST.h
@@ -166,7 +166,7 @@ public:
   bool usesAppRegister() const override;
 
   void emitVariableStore(opCode op, Dyninst::Register src1, Dyninst::Register src2, codeGen &gen,
-                         bool noCost, registerSpace *rs, int size, const instPoint *point,
+                         registerSpace *rs, int size, const instPoint *point,
                          AddressSpace *as) override;
   void emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Register dest, codeGen &gen,
                         registerSpace *rs, int size, const instPoint *point,

--- a/dyninstAPI/src/ASTs/operandAST.h
+++ b/dyninstAPI/src/ASTs/operandAST.h
@@ -195,7 +195,7 @@ public:
 #endif
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &retAddr,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
                            Dyninst::Register &retReg) override;
   int_variable *lookUpVar(AddressSpace *as);
 

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -505,7 +505,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
           if(retReg == Dyninst::Null_Register) {
             retReg = allocateAndKeep(gen, noCost);
           }
-          Dyninst::Register temp = gen.rs()->getScratchRegister(gen, noCost);
+          Dyninst::Register temp = gen.rs()->getScratchRegister(gen);
           addr = (Dyninst::Address)loperand->getOValue();
           emitVload(loadFrameAddr, addr, temp, retReg, gen, noCost, gen.rs(), size, gen.point(),
                     gen.addrSpace());

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -477,7 +477,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       switch(loperand->getoType()) {
         case operandType::variableAddr:
           if(retReg == Dyninst::Null_Register) {
-            retReg = allocateAndKeep(gen, noCost);
+            retReg = allocateAndKeep(gen);
           }
           assert(loperand->getOVar());
           loperand->emitVariableLoad(loadConstOp, retReg, retReg, gen, noCost, gen.rs(), size,
@@ -485,7 +485,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
           break;
         case operandType::variableValue:
           if(retReg == Dyninst::Null_Register) {
-            retReg = allocateAndKeep(gen, noCost);
+            retReg = allocateAndKeep(gen);
           }
           assert(loperand->getOVar());
           loperand->emitVariableLoad(loadOp, retReg, retReg, gen, noCost, gen.rs(), size,
@@ -494,7 +494,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         case operandType::DataAddr: {
           addr = reinterpret_cast<Dyninst::Address>(loperand->getOValue());
           if(retReg == Dyninst::Null_Register) {
-            retReg = allocateAndKeep(gen, noCost);
+            retReg = allocateAndKeep(gen);
           }
           assert(!loperand->getOVar());
           emitVload(loadConstOp, addr, retReg, retReg, gen, noCost, gen.rs(), size, gen.point(),
@@ -503,7 +503,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         case operandType::FrameAddr: {
           // load the address fp + addr into dest
           if(retReg == Dyninst::Null_Register) {
-            retReg = allocateAndKeep(gen, noCost);
+            retReg = allocateAndKeep(gen);
           }
           Dyninst::Register temp = gen.rs()->getScratchRegister(gen);
           addr = (Dyninst::Address)loperand->getOValue();
@@ -516,7 +516,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
 
           // load the address reg + addr into dest
           if(retReg == Dyninst::Null_Register) {
-            retReg = allocateAndKeep(gen, noCost);
+            retReg = allocateAndKeep(gen);
           }
           addr = (Dyninst::Address)loperand->operand()->getOValue();
 
@@ -709,7 +709,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       if((roperand->getoType() == operandType::Constant) &&
          doNotOverflow((int64_t)roperand->getOValue())) {
         if(retReg == Dyninst::Null_Register) {
-          retReg = allocateAndKeep(gen, noCost);
+          retReg = allocateAndKeep(gen);
           ast_printf("Operator node, const RHS, allocated register %u\n", retReg.getId());
         } else {
           ast_printf("Operator node, const RHS, keeping register %u\n", retReg.getId());
@@ -730,7 +730,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         }
         REGISTER_CHECK(right_dest);
         if(retReg == Dyninst::Null_Register) {
-          retReg = allocateAndKeep(gen, noCost);
+          retReg = allocateAndKeep(gen);
         }
         emitV(op, src1, right_dest, retReg, gen, noCost, gen.rs(), size, gen.point(),
               gen.addrSpace(), signedOp);

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -630,18 +630,18 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         case operandType::ParamAtEntry: {
           boost::shared_ptr<operandAST> lnode =
               boost::dynamic_pointer_cast<operandAST>(loperand);
-          emitR(getParamOp, (Dyninst::Address)lnode->oValue, src1, src2, gen, noCost, gen.point(),
+          emitR(getParamOp, (Dyninst::Address)lnode->oValue, src1, src2, gen, gen.point(),
                 gen.addrSpace()->multithread_capable());
           loperand->decUseCount(gen);
           break;
         }
         case operandType::ReturnVal:
-          emitR(getRetValOp, Dyninst::Null_Register, src1, src2, gen, noCost, gen.point(),
+          emitR(getRetValOp, Dyninst::Null_Register, src1, src2, gen, gen.point(),
                 gen.addrSpace()->multithread_capable());
           loperand->decUseCount(gen);
           break;
         case operandType::ReturnAddr:
-          emitR(getRetAddrOp, Dyninst::Null_Register, src1, src2, gen, noCost, gen.point(),
+          emitR(getRetAddrOp, Dyninst::Null_Register, src1, src2, gen, gen.point(),
                 gen.addrSpace()->multithread_capable());
           break;
         default: {

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -714,7 +714,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           ast_printf("Operator node, const RHS, keeping register %u\n", retReg.getId());
         }
 
-        emitImm(op, src1, (RegValue)roperand->getOValue(), retReg, gen, noCost, gen.rs(), signedOp);
+        emitImm(op, src1, (RegValue)roperand->getOValue(), retReg, gen, gen.rs(), signedOp);
 
         if(src1 != Dyninst::Null_Register) {
           gen.rs()->freeRegister(src1);

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -149,7 +149,7 @@ bool operatorAST::generateOptimizedAssignment(codeGen &gen, int size_, bool noCo
 
 #endif
     int imm = (int)(long)roperand->getOValue();
-    emitStoreConst(laddr, (int)imm, gen, noCost);
+    emitStoreConst(laddr, (int)imm, gen);
     loperand->decUseCount(gen);
     roperand->decUseCount(gen);
     return true;

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -252,7 +252,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       // so we decrement its useCount by hand.
       // Would be nice to allow register branches...
       loperand->decUseCount(gen);
-      (void)emitA(branchOp, 0, 0, (Dyninst::Register)offset, gen, Dyninst::DyninstAPI::RegControl::rc_no_control, noCost);
+      (void)emitA(branchOp, 0, 0, (Dyninst::Register)offset, gen, Dyninst::DyninstAPI::RegControl::rc_no_control);
       retReg = Dyninst::Null_Register; // No return register
       break;
     }
@@ -268,7 +268,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       codeBufIndex_t ifIndex = gen.getIndex();
 
       size_t preif_patches_size = gen.allPatches().size();
-      codeBufIndex_t thenSkipStart = emitA(op, src1, 0, 0, gen, Dyninst::DyninstAPI::RegControl::rc_before_jump, noCost);
+      codeBufIndex_t thenSkipStart = emitA(op, src1, 0, 0, gen, Dyninst::DyninstAPI::RegControl::rc_before_jump);
 
       size_t postif_patches_size = gen.allPatches().size();
 
@@ -294,7 +294,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       if(eoperand) {
         gen.rs()->pushNewRegState(); // Create registerState for else
         preelse_patches_size = gen.allPatches().size();
-        elseSkipStart = emitA(branchOp, 0, 0, 0, gen, Dyninst::DyninstAPI::RegControl::rc_no_control, noCost);
+        elseSkipStart = emitA(branchOp, 0, 0, 0, gen, Dyninst::DyninstAPI::RegControl::rc_no_control);
         postelse_patches_size = gen.allPatches().size();
       }
 
@@ -318,7 +318,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
         // If/when we vectorize, we can do this in a two-pass arrangement
         (void)emitA(op, src1_copy, 0,
                     (Dyninst::Register)codeGen::getDisplacement(thenSkipStart, elseStartIndex), gen,
-                    Dyninst::DyninstAPI::RegControl::rc_no_control, noCost);
+                    Dyninst::DyninstAPI::RegControl::rc_no_control);
         // Now we can free the register
         // Dyninst::Register has already been freed; we're just re-using it.
         // gen.rs()->freeRegister(src1);
@@ -352,7 +352,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           gen.setIndex(elseSkipIndex);
           emitA(branchOp, 0, 0,
                 (Dyninst::Register)codeGen::getDisplacement(elseSkipStart, endIndex), gen,
-                Dyninst::DyninstAPI::RegControl::rc_no_control, noCost);
+                Dyninst::DyninstAPI::RegControl::rc_no_control);
           gen.setIndex(endIndex);
         }
       }
@@ -416,7 +416,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       codeBufIndex_t startIndex = gen.getIndex();
 
       size_t preif_patches_size = gen.allPatches().size();
-      codeBufIndex_t thenSkipStart = emitA(ifOp, src1, 0, 0, gen, Dyninst::DyninstAPI::RegControl::rc_before_jump, noCost);
+      codeBufIndex_t thenSkipStart = emitA(ifOp, src1, 0, 0, gen, Dyninst::DyninstAPI::RegControl::rc_before_jump);
 
       size_t postif_patches_size = gen.allPatches().size();
 
@@ -437,8 +437,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
 
       // END from ifOp
 
-      (void)emitA(branchOp, 0, 0, codeGen::getDisplacement(gen.getIndex(), top), gen, Dyninst::DyninstAPI::RegControl::rc_no_control,
-                  noCost);
+      (void)emitA(branchOp, 0, 0, codeGen::getDisplacement(gen.getIndex(), top), gen, Dyninst::DyninstAPI::RegControl::rc_no_control);
 
       // BEGIN from ifOp
 
@@ -462,7 +461,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
         // If/when we vectorize, we can do this in a two-pass arrangement
         (void)emitA(ifOp, src1_copy, 0,
                     (Dyninst::Register)codeGen::getDisplacement(thenSkipStart, elseStartIndex), gen,
-                    Dyninst::DyninstAPI::RegControl::rc_no_control, noCost);
+                    Dyninst::DyninstAPI::RegControl::rc_no_control);
         // Now we can free the register
         // Dyninst::Register has already been freed; we're just re-using it.
         // gen.rs()->freeRegister(src1);

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -570,7 +570,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       src2 = gen.rs()->allocateRegister(gen);
       switch(loperand->getoType()) {
         case operandType::variableValue:
-          loperand->emitVariableStore(storeOp, src1, src2, gen, noCost, gen.rs(), size, gen.point(),
+          loperand->emitVariableStore(storeOp, src1, src2, gen, gen.rs(), size, gen.point(),
                                       gen.addrSpace());
           loperand->decUseCount(gen);
           break;

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -111,7 +111,7 @@ bool operatorAST::initRegisters(codeGen &g) {
 
 #if defined(DYNINST_CODEGEN_ARCH_I386) || defined(DYNINST_CODEGEN_ARCH_X86_64)
 
-bool operatorAST::generateOptimizedAssignment(codeGen &gen, int size_, bool noCost) {
+bool operatorAST::generateOptimizedAssignment(codeGen &gen, int size_) {
   (void)size_;
   if(!(loperand && roperand)) {
     return false;
@@ -219,7 +219,7 @@ bool operatorAST::generateOptimizedAssignment(codeGen &gen, int size_, bool noCo
   return true;
 }
 #else
-bool operatorAST::generateOptimizedAssignment(codeGen &, int, bool) {
+bool operatorAST::generateOptimizedAssignment(codeGen &, int) {
   return false;
 }
 #endif
@@ -552,7 +552,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       if(!roperand) {
         return false;
       }
-      bool result = generateOptimizedAssignment(gen, size, noCost);
+      bool result = generateOptimizedAssignment(gen, size);
       if(result) {
         break;
       }

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -208,7 +208,7 @@ bool operatorAST::generateOptimizedAssignment(codeGen &gen, int size_, bool noCo
   if(roper->op == plusOp) {
     emitAddSignedImm(laddr, imm, gen);
   } else {
-    emitSubSignedImm(laddr, imm, gen, noCost);
+    emitSubSignedImm(laddr, imm, gen);
   }
 
   loperand->decUseCount(gen);

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -567,7 +567,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       // it, so we need to bump up their useCounts
       loperand->fixChildrenCounts();
 
-      src2 = gen.rs()->allocateRegister(gen, noCost);
+      src2 = gen.rs()->allocateRegister(gen);
       switch(loperand->getoType()) {
         case operandType::variableValue:
           loperand->emitVariableStore(storeOp, src1, src2, gen, noCost, gen.rs(), size, gen.point(),

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -480,7 +480,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
             retReg = allocateAndKeep(gen);
           }
           assert(loperand->getOVar());
-          loperand->emitVariableLoad(loadConstOp, retReg, retReg, gen, noCost, gen.rs(), size,
+          loperand->emitVariableLoad(loadConstOp, retReg, retReg, gen, gen.rs(), size,
                                      gen.point(), gen.addrSpace());
           break;
         case operandType::variableValue:
@@ -488,7 +488,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
             retReg = allocateAndKeep(gen);
           }
           assert(loperand->getOVar());
-          loperand->emitVariableLoad(loadOp, retReg, retReg, gen, noCost, gen.rs(), size,
+          loperand->emitVariableLoad(loadOp, retReg, retReg, gen, gen.rs(), size,
                                      gen.point(), gen.addrSpace());
           break;
         case operandType::DataAddr: {

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -224,7 +224,7 @@ bool operatorAST::generateOptimizedAssignment(codeGen &, int) {
 }
 #endif
 
-bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &retAddr,
+bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
                                           Dyninst::Register &retReg) {
   if(!loperand) {
     return false;
@@ -261,7 +261,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         return false;
       }
       // This ast cannot be shared because it doesn't return a register
-      if(!loperand->generateCode_phase2(gen, noCost, addr, src1)) {
+      if(!loperand->generateCode_phase2(gen, addr, src1)) {
         ERROR_RETURN;
       }
       REGISTER_CHECK(src1);
@@ -280,7 +280,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       // The flow of control forks. We need to add the forked node to
       // the path
       gen.tracker()->increaseConditionalLevel();
-      if(!roperand->generateCode_phase2(gen, noCost, addr, src2)) {
+      if(!roperand->generateCode_phase2(gen, addr, src2)) {
         ERROR_RETURN;
       }
       gen.rs()->freeRegister(src2);
@@ -329,7 +329,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       if(eoperand) {
         // If there's an else clause, we need to generate code for it.
         gen.tracker()->increaseConditionalLevel();
-        if(!eoperand->generateCode_phase2(gen, noCost, addr, src2)) {
+        if(!eoperand->generateCode_phase2(gen, addr, src2)) {
           ERROR_RETURN;
         }
         gen.rs()->freeRegister(src2);
@@ -383,7 +383,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         // Add the snippet to the tracker, as AM has indicated...
         gen.tracker()->increaseConditionalLevel();
         // generate code with the right path
-        if(!loperand->generateCode_phase2(gen, noCost, addr, src1)) {
+        if(!loperand->generateCode_phase2(gen, addr, src1)) {
           ERROR_RETURN;
         }
         gen.rs()->freeRegister(src1);
@@ -394,7 +394,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         emitJmpMC(cond, codeGen::getDisplacement(fromIndex, endIndex), gen);
         gen.setIndex(endIndex);
       } else {
-        if(!loperand->generateCode_phase2(gen, noCost, addr, src1)) {
+        if(!loperand->generateCode_phase2(gen, addr, src1)) {
           ERROR_RETURN;
         }
         gen.rs()->freeRegister(src1);
@@ -409,7 +409,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       codeBufIndex_t top = gen.getIndex();
 
       // BEGIN from ifOp
-      if(!loperand->generateCode_phase2(gen, noCost, addr, src1)) {
+      if(!loperand->generateCode_phase2(gen, addr, src1)) {
         ERROR_RETURN;
       }
       REGISTER_CHECK(src1);
@@ -428,7 +428,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       // The flow of control forks. We need to add the forked node to
       // the path
       gen.tracker()->increaseConditionalLevel();
-      if(!roperand->generateCode_phase2(gen, noCost, addr, src2)) {
+      if(!roperand->generateCode_phase2(gen, addr, src2)) {
         ERROR_RETURN;
       }
       gen.rs()->freeRegister(src2);
@@ -528,7 +528,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
           // taking address of pointer de-ref returns the original
           //    expression, so we simple generate the left child's
           //    code to get the address
-          if(!loperand->operand()->generateCode_phase2(gen, noCost, addr, retReg)) {
+          if(!loperand->operand()->generateCode_phase2(gen, addr, retReg)) {
             ERROR_RETURN;
           }
           // Broken refCounts?
@@ -536,7 +536,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         case operandType::origRegister:
           // Added 2NOV11 Bernat - some variables live in original registers,
           // and so we need to be able to dereference their contents.
-          if(!loperand->generateCode_phase2(gen, noCost, addr, retReg)) {
+          if(!loperand->generateCode_phase2(gen, addr, retReg)) {
             ERROR_RETURN;
           }
           break;
@@ -558,7 +558,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       }
 
       // This ast cannot be shared because it doesn't return a register
-      if(!roperand->generateCode_phase2(gen, noCost, addr, src1)) {
+      if(!roperand->generateCode_phase2(gen, addr, src1)) {
         fprintf(stderr, "ERROR: failure generating roperand\n");
         ERROR_RETURN;
       }
@@ -608,7 +608,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         case operandType::DataIndir: {
           // store to a an expression (e.g. an array or field use)
           // *(+ base offset) = src1
-          if(!loperand->operand()->generateCode_phase2(gen, noCost, addr, tmp)) {
+          if(!loperand->operand()->generateCode_phase2(gen, addr, tmp)) {
             ERROR_RETURN;
           }
           REGISTER_CHECK(tmp);
@@ -647,7 +647,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         default: {
           // Could be an error, could be an attempt to load based on an arithmetic expression
           // Generate the left hand side, store the right to that address
-          if(!loperand->generateCode_phase2(gen, noCost, addr, tmp)) {
+          if(!loperand->generateCode_phase2(gen, addr, tmp)) {
             ERROR_RETURN;
           }
           REGISTER_CHECK(tmp);
@@ -667,10 +667,10 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       if(!roperand) {
         return false;
       }
-      if(!roperand->generateCode_phase2(gen, noCost, addr, src1)) {
+      if(!roperand->generateCode_phase2(gen, addr, src1)) {
         ERROR_RETURN;
       }
-      if(!loperand->generateCode_phase2(gen, noCost, addr, src2)) {
+      if(!loperand->generateCode_phase2(gen, addr, src2)) {
         ERROR_RETURN;
       }
       REGISTER_CHECK(src1);
@@ -701,7 +701,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       bool signedOp = IsSignedOperation(loperand->getType(), roperand->getType());
       src1 = Dyninst::Null_Register;
       right_dest = Dyninst::Null_Register;
-      if(!loperand->generateCode_phase2(gen, noCost, addr, src1)) {
+      if(!loperand->generateCode_phase2(gen, addr, src1)) {
         ERROR_RETURN;
       }
       REGISTER_CHECK(src1);
@@ -725,7 +725,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         // refcounts manually
         roperand->decUseCount(gen);
       } else {
-        if(!roperand->generateCode_phase2(gen, noCost, addr, right_dest)) {
+        if(!roperand->generateCode_phase2(gen, addr, right_dest)) {
           ERROR_RETURN;
         }
         REGISTER_CHECK(right_dest);

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -497,7 +497,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
             retReg = allocateAndKeep(gen);
           }
           assert(!loperand->getOVar());
-          emitVload(loadConstOp, addr, retReg, retReg, gen, noCost, gen.rs(), size, gen.point(),
+          emitVload(loadConstOp, addr, retReg, retReg, gen, gen.rs(), size, gen.point(),
                     gen.addrSpace());
         } break;
         case operandType::FrameAddr: {
@@ -507,7 +507,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
           }
           Dyninst::Register temp = gen.rs()->getScratchRegister(gen);
           addr = (Dyninst::Address)loperand->getOValue();
-          emitVload(loadFrameAddr, addr, temp, retReg, gen, noCost, gen.rs(), size, gen.point(),
+          emitVload(loadFrameAddr, addr, temp, retReg, gen, gen.rs(), size, gen.point(),
                     gen.addrSpace());
           break;
         }
@@ -520,7 +520,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
           }
           addr = (Dyninst::Address)loperand->operand()->getOValue();
 
-          emitVload(loadRegRelativeAddr, addr, (long)loperand->getOValue(), retReg, gen, noCost,
+          emitVload(loadRegRelativeAddr, addr, (long)loperand->getOValue(), retReg, gen,
                     gen.rs(), size, gen.point(), gen.addrSpace());
           break;
         }
@@ -596,7 +596,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
           // This is cheating, but I need to pass 4 data values into emitVstore, and
           // it only allows for 3.  Prepare the dest address in scratch register src2.
 
-          emitVload(loadRegRelativeAddr, addr, (long)loperand->getOValue(), src2, gen, noCost,
+          emitVload(loadRegRelativeAddr, addr, (long)loperand->getOValue(), src2, gen,
                     gen.rs(), size, gen.point(), gen.addrSpace());
 
           // Same as DataIndir at this point.

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -577,7 +577,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         case operandType::DataAddr:
           addr = (Dyninst::Address)loperand->getOValue();
           assert(loperand->getOVar() == NULL);
-          emitVstore(storeOp, src1, src2, addr, gen, noCost, gen.rs(), size, gen.point(),
+          emitVstore(storeOp, src1, src2, addr, gen, gen.rs(), size, gen.point(),
                      gen.addrSpace());
           // We are not calling generateCode for the left branch,
           // so need to decrement the refcount by hand
@@ -585,7 +585,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
           break;
         case operandType::FrameAddr:
           addr = (Dyninst::Address)loperand->getOValue();
-          emitVstore(storeFrameRelativeOp, src1, src2, addr, gen, noCost, gen.rs(), size,
+          emitVstore(storeFrameRelativeOp, src1, src2, addr, gen, gen.rs(), size,
                      gen.point(), gen.addrSpace());
           loperand->decUseCount(gen);
           break;

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -600,7 +600,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
                     gen.rs(), size, gen.point(), gen.addrSpace());
 
           // Same as DataIndir at this point.
-          emitV(storeIndirOp, src1, 0, src2, gen, noCost, gen.rs(), size, gen.point(),
+          emitV(storeIndirOp, src1, 0, src2, gen, gen.rs(), size, gen.point(),
                 gen.addrSpace());
           loperand->decUseCount(gen);
           break;
@@ -614,7 +614,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
           REGISTER_CHECK(tmp);
 
           // tmp now contains address to store into
-          emitV(storeIndirOp, src1, 0, tmp, gen, noCost, gen.rs(), size, gen.point(),
+          emitV(storeIndirOp, src1, 0, tmp, gen, gen.rs(), size, gen.point(),
                 gen.addrSpace());
           gen.rs()->freeRegister(tmp);
           loperand->decUseCount(gen);
@@ -652,7 +652,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
           }
           REGISTER_CHECK(tmp);
 
-          emitV(storeIndirOp, src1, 0, tmp, gen, noCost, gen.rs(), size, gen.point(),
+          emitV(storeIndirOp, src1, 0, tmp, gen, gen.rs(), size, gen.point(),
                 gen.addrSpace());
           gen.rs()->freeRegister(tmp);
           break;
@@ -675,7 +675,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
       }
       REGISTER_CHECK(src1);
       REGISTER_CHECK(src2);
-      emitV(op, src1, 0, src2, gen, noCost, gen.rs(), size, gen.point(), gen.addrSpace());
+      emitV(op, src1, 0, src2, gen, gen.rs(), size, gen.point(), gen.addrSpace());
       gen.rs()->freeRegister(src1);
       gen.rs()->freeRegister(src2);
       retReg = Dyninst::Null_Register;
@@ -732,7 +732,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
         if(retReg == Dyninst::Null_Register) {
           retReg = allocateAndKeep(gen);
         }
-        emitV(op, src1, right_dest, retReg, gen, noCost, gen.rs(), size, gen.point(),
+        emitV(op, src1, right_dest, retReg, gen, gen.rs(), size, gen.point(),
               gen.addrSpace(), signedOp);
         if(src1 != Dyninst::Null_Register) {
           // Don't free inputs until afterwards; we have _no_ idea

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -206,7 +206,7 @@ bool operatorAST::generateOptimizedAssignment(codeGen &gen, int size_, bool noCo
 
   long int imm = (long int)const_oper->getOValue();
   if(roper->op == plusOp) {
-    emitAddSignedImm(laddr, imm, gen, noCost);
+    emitAddSignedImm(laddr, imm, gen);
   } else {
     emitSubSignedImm(laddr, imm, gen, noCost);
   }

--- a/dyninstAPI/src/ASTs/operatorAST.h
+++ b/dyninstAPI/src/ASTs/operatorAST.h
@@ -117,7 +117,7 @@ public:
   bool initRegisters(codeGen &gen) override;
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &retAddr,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
                            Dyninst::Register &retReg) override;
 
   bool generateOptimizedAssignment(codeGen &gen, int size);

--- a/dyninstAPI/src/ASTs/operatorAST.h
+++ b/dyninstAPI/src/ASTs/operatorAST.h
@@ -120,7 +120,7 @@ private:
   bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &retAddr,
                            Dyninst::Register &retReg) override;
 
-  bool generateOptimizedAssignment(codeGen &gen, int size, bool noCost);
+  bool generateOptimizedAssignment(codeGen &gen, int size);
 
   opCode op{};
   codeGenASTPtr loperand{};

--- a/dyninstAPI/src/ASTs/originalAddressAST.C
+++ b/dyninstAPI/src/ASTs/originalAddressAST.C
@@ -18,7 +18,7 @@ bool originalAddressAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst:
     return false;
   }
 
-  emitVload(loadConstOp, gen.point()->addr_compat(), retReg, retReg, gen, noCost);
+  emitVload(loadConstOp, gen.point()->addr_compat(), retReg, retReg, gen);
 
   return true;
 }

--- a/dyninstAPI/src/ASTs/originalAddressAST.C
+++ b/dyninstAPI/src/ASTs/originalAddressAST.C
@@ -6,7 +6,7 @@
 
 namespace Dyninst { namespace DyninstAPI {
 
-bool originalAddressAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+bool originalAddressAST::generateCode_phase2(codeGen &gen, Dyninst::Address &,
                                               Dyninst::Register &retReg) {
   RETURN_KEPT_REG(retReg);
 

--- a/dyninstAPI/src/ASTs/originalAddressAST.C
+++ b/dyninstAPI/src/ASTs/originalAddressAST.C
@@ -11,7 +11,7 @@ bool originalAddressAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst:
   RETURN_KEPT_REG(retReg);
 
   if(retReg == Dyninst::Null_Register) {
-    retReg = allocateAndKeep(gen, noCost);
+    retReg = allocateAndKeep(gen);
   }
 
   if(retReg == Dyninst::Null_Register) {

--- a/dyninstAPI/src/ASTs/scrambleRegistersAST.C
+++ b/dyninstAPI/src/ASTs/scrambleRegistersAST.C
@@ -10,14 +10,14 @@ namespace Dyninst { namespace DyninstAPI {
 
 #ifndef DYNINST_CODEGEN_ARCH_X86_64
 
-bool scrambleRegistersAST::generateCode_phase2(codeGen &, bool, Dyninst::Address &,
+bool scrambleRegistersAST::generateCode_phase2(codeGen &, Dyninst::Address &,
                                                    Dyninst::Register &) {
   return true;
 }
 
 #else
 
-bool scrambleRegistersAST::generateCode_phase2(codeGen &gen, bool, Address &,
+bool scrambleRegistersAST::generateCode_phase2(codeGen &gen, Address &,
                                                    Dyninst::Register &) {
   for(int i = 0; i < gen.rs()->numGPRs(); i++) {
     registerSlot *reg = gen.rs()->GPRs()[i];

--- a/dyninstAPI/src/ASTs/scrambleRegistersAST.h
+++ b/dyninstAPI/src/ASTs/scrambleRegistersAST.h
@@ -53,7 +53,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool, Dyninst::Address &, Dyninst::Register &) override;
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &, Dyninst::Register &) override;
 };
 
 }}

--- a/dyninstAPI/src/ASTs/sequenceAST.C
+++ b/dyninstAPI/src/ASTs/sequenceAST.C
@@ -10,7 +10,7 @@
 
 namespace Dyninst { namespace DyninstAPI {
 
-bool sequenceAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+bool sequenceAST::generateCode_phase2(codeGen &gen, Dyninst::Address &,
                                           Dyninst::Register &retReg) {
   RETURN_KEPT_REG(retReg);
   Dyninst::Register tmp = Dyninst::Null_Register;
@@ -21,7 +21,7 @@ bool sequenceAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
   }
 
   for(unsigned i = 0; i < children.size() - 1; i++) {
-    if(!children[i]->generateCode_phase2(gen, noCost, unused, tmp)) {
+    if(!children[i]->generateCode_phase2(gen, unused, tmp)) {
       ERROR_RETURN;
     }
     gen.rs()->freeRegister(tmp);
@@ -29,7 +29,7 @@ bool sequenceAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Addres
   }
 
   // We keep the last one
-  if(!children.back()->generateCode_phase2(gen, noCost, unused, retReg)) {
+  if(!children.back()->generateCode_phase2(gen, unused, retReg)) {
     ERROR_RETURN;
   }
 

--- a/dyninstAPI/src/ASTs/sequenceAST.h
+++ b/dyninstAPI/src/ASTs/sequenceAST.h
@@ -66,7 +66,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+  bool generateCode_phase2(codeGen &genw, Dyninst::Address &,
                            Dyninst::Register &retReg) override;
 };
 

--- a/dyninstAPI/src/ASTs/sequenceAST.h
+++ b/dyninstAPI/src/ASTs/sequenceAST.h
@@ -66,7 +66,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &genw, Dyninst::Address &,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &,
                            Dyninst::Register &retReg) override;
 };
 

--- a/dyninstAPI/src/ASTs/snippetAST.C
+++ b/dyninstAPI/src/ASTs/snippetAST.C
@@ -8,7 +8,7 @@
 
 namespace Dyninst { namespace DyninstAPI {
 
-bool snippetAST::generateCode_phase2(codeGen &gen, bool, Dyninst::Address &,
+bool snippetAST::generateCode_phase2(codeGen &gen, Dyninst::Address &,
                                          Dyninst::Register &) {
   Dyninst::Buffer buf(gen.currAddr(), 1024);
   if(!snip_->generate(gen.point(), buf)) {

--- a/dyninstAPI/src/ASTs/snippetAST.h
+++ b/dyninstAPI/src/ASTs/snippetAST.h
@@ -56,7 +56,7 @@ public:
 
   snippetAST(Dyninst::PatchAPI::SnippetPtr snippet) : snip_{std::move(snippet)} {}
 
-  bool generateCode_phase2(codeGen &gen, bool, Dyninst::Address &, Dyninst::Register &) override;
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &, Dyninst::Register &) override;
 
   Dyninst::PatchAPI::SnippetPtr snip_{};
 };

--- a/dyninstAPI/src/ASTs/stackAST.C
+++ b/dyninstAPI/src/ASTs/stackAST.C
@@ -16,7 +16,7 @@ bool stackAST::allocateCanaryRegister(codeGen &gen, bool noCost, Dyninst::Regist
   // Try to get a scratch register from the register space
   registerSpace *regSpace = registerSpace::actualRegSpace(point);
   bool realReg = true;
-  Dyninst::Register tmpReg = regSpace->getScratchRegister(gen, noCost, realReg);
+  Dyninst::Register tmpReg = regSpace->getScratchRegister(gen, realReg);
   if(tmpReg != Dyninst::Null_Register) {
     reg = tmpReg;
     needSaveAndRestore = false;
@@ -28,7 +28,7 @@ bool stackAST::allocateCanaryRegister(codeGen &gen, bool noCost, Dyninst::Regist
 
   // Couldn't find a dead register to use :-(
   registerSpace *deadRegSpace = registerSpace::optimisticRegSpace(gen.addrSpace());
-  reg = deadRegSpace->getScratchRegister(gen, noCost, realReg);
+  reg = deadRegSpace->getScratchRegister(gen, realReg);
   if(reg == Dyninst::Null_Register) {
     ast_printf("WARNING: using default allocateAndKeep in allocateCanaryRegister\n");
     reg = allocateAndKeep(gen, noCost);

--- a/dyninstAPI/src/ASTs/stackAST.C
+++ b/dyninstAPI/src/ASTs/stackAST.C
@@ -8,8 +8,8 @@
 
 namespace Dyninst { namespace DyninstAPI {
 
-bool stackAST::allocateCanaryRegister(codeGen &gen, bool noCost, Dyninst::Register &reg,
-                                          bool &needSaveAndRestore) {
+bool stackAST::allocateCanaryRegister(codeGen &gen, Dyninst::Register &reg,
+                                      bool &needSaveAndRestore) {
   // Let's see if we can find a dead register to use!
   instPoint *point = gen.point();
 

--- a/dyninstAPI/src/ASTs/stackAST.C
+++ b/dyninstAPI/src/ASTs/stackAST.C
@@ -31,7 +31,7 @@ bool stackAST::allocateCanaryRegister(codeGen &gen, bool noCost, Dyninst::Regist
   reg = deadRegSpace->getScratchRegister(gen, realReg);
   if(reg == Dyninst::Null_Register) {
     ast_printf("WARNING: using default allocateAndKeep in allocateCanaryRegister\n");
-    reg = allocateAndKeep(gen, noCost);
+    reg = allocateAndKeep(gen);
   }
   needSaveAndRestore = true;
   ast_printf("allocateCanaryRegister will require save&restore at 0x%lx\n", gen.point()->addr());

--- a/dyninstAPI/src/ASTs/stackAST.h
+++ b/dyninstAPI/src/ASTs/stackAST.h
@@ -47,8 +47,7 @@ public:
   };
 
 protected:
-  bool allocateCanaryRegister(codeGen &gen, bool noCost, Dyninst::Register &reg,
-                              bool &needSaveAndRestore);
+  bool allocateCanaryRegister(codeGen &gen, Dyninst::Register &reg, bool &needSaveAndRestore);
 };
 
 }}

--- a/dyninstAPI/src/ASTs/stackInsertionAST.C
+++ b/dyninstAPI/src/ASTs/stackInsertionAST.C
@@ -24,13 +24,13 @@ std::string stackInsertionAST::format(std::string indent) {
 
 #ifndef cap_stack_mods
 
-bool stackInsertionAST::generateCode_phase2(codeGen &, bool, Address &, Dyninst::Register &) {
+bool stackInsertionAST::generateCode_phase2(codeGen &, Address &, Dyninst::Register &) {
   return false;
 }
 
 #else
 
-bool stackInsertionAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+bool stackInsertionAST::generateCode_phase2(codeGen &gen, Dyninst::Address &,
                                              Dyninst::Register &) {
   // Turn off default basetramp instrumentation saves & restores
   gen.setInsertNaked(true);

--- a/dyninstAPI/src/ASTs/stackInsertionAST.C
+++ b/dyninstAPI/src/ASTs/stackInsertionAST.C
@@ -64,7 +64,7 @@ bool stackInsertionAST::generateCode_phase2(codeGen &gen, bool noCost, Dyninst::
     // 2. Ensures that the canary will get overwritten (rather than empty alignment space) in case
     // of an overflow
     if(gen.getArch() == Arch_x86_64) {
-      allocateCanaryRegister(gen, noCost, canaryReg, needSaveAndRestore);
+      allocateCanaryRegister(gen, canaryReg, needSaveAndRestore);
 
       int canarySize = 8;
       int off = AMD64_STACK_ALIGNMENT - canarySize; // canary

--- a/dyninstAPI/src/ASTs/stackInsertionAST.h
+++ b/dyninstAPI/src/ASTs/stackInsertionAST.h
@@ -62,7 +62,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &,
                            Dyninst::Register &) override;
 
   int size{};

--- a/dyninstAPI/src/ASTs/stackRemovalAST.C
+++ b/dyninstAPI/src/ASTs/stackRemovalAST.C
@@ -21,7 +21,7 @@ std::string stackRemovalAST::format(std::string indent) {
 
 #ifndef cap_stack_mods
 
-bool stackRemovalAST::generateCode_phase2(codeGen &, bool, Address &, Dyninst::Register &) {
+bool stackRemovalAST::generateCode_phase2(codeGen &, Address &, Dyninst::Register &) {
   (void)func_;
   (void)canaryAfterPrologue_;
   (void)canaryHeight_;
@@ -35,7 +35,7 @@ bool stackRemovalAST::generateCode_phase2(codeGen &, bool, Address &, Dyninst::R
 #include "RegisterConversion.h"
 #include "registers/MachRegister.h"
 
-bool stackRemovalAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
+bool stackRemovalAST::generateCode_phase2(codeGen &gen, Address &,
                                              Dyninst::Register &) {
   // Turn off default basetramp instrumentation saves & restores
   gen.setInsertNaked(true);

--- a/dyninstAPI/src/ASTs/stackRemovalAST.C
+++ b/dyninstAPI/src/ASTs/stackRemovalAST.C
@@ -61,7 +61,7 @@ bool stackRemovalAST::generateCode_phase2(codeGen &gen, bool noCost, Address &,
     Dyninst::Register canaryReg = Dyninst::Null_Register;
     bool needSaveAndRestore = true;
     if(gen.getArch() == Arch_x86_64) {
-      allocateCanaryRegister(gen, noCost, canaryReg, needSaveAndRestore);
+      allocateCanaryRegister(gen, canaryReg, needSaveAndRestore);
     } else {
       canaryReg = REGNUM_EDX;
       gen.rs()->noteVirtualInReal(canaryReg, RealRegister(canaryReg));

--- a/dyninstAPI/src/ASTs/stackRemovalAST.h
+++ b/dyninstAPI/src/ASTs/stackRemovalAST.h
@@ -71,7 +71,7 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &,
                            Dyninst::Register &) override;
 
   int size{};

--- a/dyninstAPI/src/ASTs/threadAST.h
+++ b/dyninstAPI/src/ASTs/threadAST.h
@@ -50,7 +50,7 @@ public:
   bool canBeKept() const override;
 
 private:
-  bool generateCode_phase2(codeGen &, bool, Dyninst::Address &, Dyninst::Register &) override {
+  bool generateCode_phase2(codeGen &, Dyninst::Address &, Dyninst::Register &) override {
     // No codegen needed
     return true;
   }

--- a/dyninstAPI/src/ASTs/variableAST.h
+++ b/dyninstAPI/src/ASTs/variableAST.h
@@ -99,9 +99,9 @@ public:
   }
 
 private:
-  bool generateCode_phase2(codeGen &gen, bool noCost, Dyninst::Address &addr,
+  bool generateCode_phase2(codeGen &gen, Dyninst::Address &addr,
                            Dyninst::Register &retReg) override {
-    return children[index]->generateCode_phase2(gen, noCost, addr, retReg);
+    return children[index]->generateCode_phase2(gen, addr, retReg);
   }
 
   std::vector<range_t> *ranges_{};

--- a/dyninstAPI/src/Relocation/Widgets/PCWidget-ppc.C
+++ b/dyninstAPI/src/Relocation/Widgets/PCWidget-ppc.C
@@ -69,7 +69,7 @@ bool PCWidget::PCtoReturnAddr(const codeGen &templ, const RelocBlock *t, CodeBuf
     std::vector<Register> excludeReg;  
     
     Address origRet = addr() + insn_.size();
-    Register scratch = gen.rs()->getScratchRegister(gen, true);
+    Register scratch = gen.rs()->getScratchRegister(gen);
     bool createFrame = false;
     if (scratch == Null_Register) {
       stackSize = insnCodeGen::createStackFrame(gen, 1, freeReg, excludeReg);
@@ -133,9 +133,9 @@ bool IPPatch::apply(codeGen &gen, CodeBuffer *) {
   std::vector<Register> freeReg;
   std::vector<Register> excludeReg;
     
-  Register scratchPCReg = gen.rs()->getScratchRegister(gen, true);
+  Register scratchPCReg = gen.rs()->getScratchRegister(gen);
   excludeReg.push_back(scratchPCReg);
-  Register scratchReg = gen.rs()->getScratchRegister(gen, excludeReg, true);
+  Register scratchReg = gen.rs()->getScratchRegister(gen, excludeReg);
     
   if ((scratchPCReg == Null_Register) && (scratchReg == Null_Register)) {
     excludeReg.clear();

--- a/dyninstAPI/src/codegen-aarch64.C
+++ b/dyninstAPI/src/codegen-aarch64.C
@@ -141,7 +141,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
         registerSpace *rs = registerSpace::actualRegSpace(point);
         gen.setRegisterSpace(rs);
 
-        scratch = rs->getScratchRegister(gen, true);
+        scratch = rs->getScratchRegister(gen);
     }
 
     if (scratch == Null_Register)
@@ -442,9 +442,9 @@ void insnCodeGen::generateMoveSP(codeGen &gen, Dyninst::Register rn, Dyninst::Re
 Dyninst::Register insnCodeGen::moveValueToReg(codeGen &gen, long int val, std::vector<Dyninst::Register> *exclude) {
     Dyninst::Register scratchReg;
     if(exclude)
-	    scratchReg = gen.rs()->getScratchRegister(gen, *exclude, true);
+	    scratchReg = gen.rs()->getScratchRegister(gen, *exclude);
     else
-	    scratchReg = gen.rs()->getScratchRegister(gen, true);
+	    scratchReg = gen.rs()->getScratchRegister(gen);
 
     if (scratchReg == Null_Register) {
         fprintf(stderr, " %s[%d] No scratch register available to generate add instruction!", FILE__, __LINE__);
@@ -810,7 +810,7 @@ bool insnCodeGen::modifyData(Dyninst::Address target,
         //If it's larger than |1MB|, move target to register and generate LDR
         else {
             // Get scratch register
-            Dyninst::Register scratch = gen.rs()->getScratchRegister(gen, true);
+            Dyninst::Register scratch = gen.rs()->getScratchRegister(gen);
             if(scratch == Null_Register)
                 assert(!"No scratch register available to load the target \
                         address into for a PC-relative data access using LDR/LDRSW!");

--- a/dyninstAPI/src/codegen-power.C
+++ b/dyninstAPI/src/codegen-power.C
@@ -522,7 +522,7 @@ void insnCodeGen::generateLongBranch(codeGen &gen,
   //   // code there and we don't want to hit that.
   //   registerSpace *rs = registerSpace::actualRegSpace(point);
   //   gen.setRegisterSpace(rs);
-  //   Dyninst::Register scratch = rs->getScratchRegister(gen, true);
+  //   Dyninst::Register scratch = rs->getScratchRegister(gen);
   //   // 
   //   assert(scratch == Null_Register);
 
@@ -993,7 +993,7 @@ int insnCodeGen::createStackFrame(codeGen &gen, int numRegs, std::vector<Dyninst
                 stack_size = saveGPRegisters(gen, gen.rs(), gpr_off, numRegs);
 		assert (stack_size == numRegs);
 		for (int i = 0; i < numRegs; i++){
-			Dyninst::Register scratchReg = gen.rs()->getScratchRegister(gen, excludeReg, true);
+			Dyninst::Register scratchReg = gen.rs()->getScratchRegister(gen, excludeReg);
 			assert (scratchReg != Null_Register);
 			freeReg.push_back(scratchReg);
 			excludeReg.push_back(scratchReg);

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
@@ -45,7 +45,7 @@ namespace Dyninst { namespace DyninstAPI {
     return true;
   }
 
-  void EmitterIA32::emitAddSignedImm(Address addr, int imm, codeGen &gen, bool /*noCost*/) {
+  void EmitterIA32::emitAddSignedImm(Address addr, int imm, codeGen &gen) {
     x86::emitAddMem(addr, imm, gen);
   }
 

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
@@ -402,7 +402,7 @@ namespace Dyninst { namespace DyninstAPI {
       assert(0);
     }
 
-    param_size = emitCallParams(gen, operands, callee, saves, noCost);
+    param_size = emitCallParams(gen, operands, callee, saves);
 
     Dyninst::Register ret = REGNUM_EAX;
 
@@ -419,7 +419,7 @@ namespace Dyninst { namespace DyninstAPI {
 
   int EmitterIA32::emitCallParams(codeGen &gen, const std::vector<codeGenASTPtr> &operands,
                                   func_instance * /*target*/,
-                                  std::vector<Dyninst::Register> & /*extra_saves*/, bool noCost) {
+                                  std::vector<Dyninst::Register> & /*extra_saves*/) {
     std::vector<Dyninst::Register> srcs;
     unsigned frame_size = 0;
     unsigned u;

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
@@ -426,7 +426,7 @@ namespace Dyninst { namespace DyninstAPI {
     for(u = 0; u < operands.size(); u++) {
       Address unused = ADDR_NULL;
       Dyninst::Register reg = Null_Register;
-      if(!operands[u]->generateCode_phase2(gen, noCost, unused, reg)) {
+      if(!operands[u]->generateCode_phase2(gen, unused, reg)) {
         assert(0);
       }
       assert(reg != Null_Register);

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
@@ -576,7 +576,7 @@ namespace Dyninst { namespace DyninstAPI {
   }
 
   void EmitterIA32::emitDiv(Register dest, Register src1, Register src2, codeGen &gen, bool s) {
-    Register scratch = gen.rs()->allocateRegister(gen, true);
+    Register scratch = gen.rs()->allocateRegister(gen);
     gen.rs()->loadVirtualToSpecific(src1, RealRegister(REGNUM_EAX), gen);
     gen.rs()->makeRegisterAvail(RealRegister(REGNUM_EDX), gen);
     gen.rs()->noteVirtualInReal(scratch, RealRegister(REGNUM_EDX));
@@ -615,7 +615,7 @@ namespace Dyninst { namespace DyninstAPI {
       }
 
     } else {
-      Register src2 = gen.rs()->allocateRegister(gen, true);
+      Register src2 = gen.rs()->allocateRegister(gen);
       emitLoadConst(src2, src2imm, gen);
       emitDiv(dest, src1, src2, gen, s);
       gen.rs()->freeRegister(src2);
@@ -785,7 +785,7 @@ namespace Dyninst { namespace DyninstAPI {
 
   void EmitterIA32::emitLoadOrigFrameRelative(Register dest, Address offset, codeGen &gen) {
     if(gen.bt()->createdFrame) {
-      Register scratch = gen.rs()->allocateRegister(gen, true);
+      Register scratch = gen.rs()->allocateRegister(gen);
       RealRegister scratch_r = gen.rs()->loadVirtualForWrite(scratch, gen);
       RealRegister dest_r = gen.rs()->loadVirtualForWrite(dest, gen);
       emitMovRMToReg(scratch_r, RealRegister(REGNUM_EBP), 0, gen);
@@ -910,7 +910,7 @@ namespace Dyninst { namespace DyninstAPI {
     RealRegister src1_r = gen.rs()->loadVirtual(src1, gen);
     RealRegister src2_r = gen.rs()->loadVirtual(src2, gen);
     RealRegister dest_r = gen.rs()->loadVirtualForWrite(dest, gen);
-    Register scratch = gen.rs()->allocateRegister(gen, true);
+    Register scratch = gen.rs()->allocateRegister(gen);
     RealRegister scratch_r = gen.rs()->loadVirtualForWrite(scratch, gen);
 
     emitOpRegReg(XOR_R32_RM32, dest_r, dest_r, gen); // XOR dest,dest
@@ -928,7 +928,7 @@ namespace Dyninst { namespace DyninstAPI {
   void EmitterIA32::emitRelOpImm(unsigned op, Register dest, Register src1, RegValue src2imm,
                                  codeGen &gen, bool s) {
 
-    Register src2 = gen.rs()->allocateRegister(gen, true);
+    Register src2 = gen.rs()->allocateRegister(gen);
     emitLoadConst(src2, src2imm, gen);
     emitRelOp(op, dest, src1, src2, gen, s);
     gen.rs()->freeRegister(src2);
@@ -1069,7 +1069,7 @@ namespace Dyninst { namespace DyninstAPI {
     }
 
     // temporary virtual register for storing destination address
-    Register dest = gen.rs()->allocateRegister(gen, false);
+    Register dest = gen.rs()->allocateRegister(gen);
     RealRegister dest_r = gen.rs()->loadVirtualForWrite(dest, gen);
     emitMovPCRMToReg(dest_r, addr - gen.currAddr(), gen, !is_local);
     emitStoreIndir(dest, source, 4, gen);

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
@@ -1038,7 +1038,7 @@ namespace Dyninst { namespace DyninstAPI {
     emitMovRegToRM(RealRegister(REGNUM_EBP), offset, src_r, gen);
   }
 
-  void EmitterIA32::emitStoreImm(Address addr, int imm, codeGen &gen, bool /*noCost*/) {
+  void EmitterIA32::emitStoreImm(Address addr, int imm, codeGen &gen) {
     emitMovImmToMem(addr, imm, gen);
   }
 

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.C
@@ -382,7 +382,7 @@ namespace Dyninst { namespace DyninstAPI {
   }
 
   Dyninst::Register EmitterIA32::emitCall(opCode op, codeGen &gen,
-                                          const std::vector<codeGenASTPtr> &operands, bool noCost,
+                                          const std::vector<codeGenASTPtr> &operands,
                                           func_instance *callee) {
     bool inInstrumentation = true;
     if(op != callOp) {

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.h
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.h
@@ -66,7 +66,7 @@ namespace Dyninst { namespace DyninstAPI {
                          std::vector<Register> &extra_saves);
 
     int emitCallParams(codeGen &gen, const std::vector<codeGenASTPtr> &operands, func_instance *target,
-                       std::vector<Register> &extra_saves, bool noCost);
+                       std::vector<Register> &extra_saves);
 
     bool emitCallRelative(Register, Address, Register, codeGen &) override;
 

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.h
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.h
@@ -60,7 +60,7 @@ namespace Dyninst { namespace DyninstAPI {
     bool emitBTSaves(baseTramp *bt, codeGen &gen) override;
 
     virtual Register emitCall(opCode op, codeGen &gen, const std::vector<codeGenASTPtr> &operands,
-                              bool noCost, func_instance *callee) override;
+                              func_instance *callee) override;
 
     bool emitCallCleanup(codeGen &gen, func_instance *target, int frame_size,
                          std::vector<Register> &extra_saves);

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.h
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.h
@@ -142,7 +142,7 @@ namespace Dyninst { namespace DyninstAPI {
     void emitStoreFrameRelative(Address offset, Register src, Register scratch, int size,
                                 codeGen &gen) override;
 
-    void emitStoreImm(Address addr, int imm, codeGen &gen, bool noCost) override;
+    void emitStoreImm(Address addr, int imm, codeGen &gen) override;
 
     void emitStoreIndir(Register addr_reg, Register src, int size, codeGen &gen) override;
 

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.h
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32.h
@@ -49,7 +49,7 @@ namespace Dyninst { namespace DyninstAPI {
 
     bool clobberAllFuncCall(registerSpace *rs, func_instance *callee) override;
 
-    void emitAddSignedImm(Address addr, int imm, codeGen &gen, bool noCost) override;
+    void emitAddSignedImm(Address addr, int imm, codeGen &gen) override;
 
     bool emitAdjustStackPointer(int index, codeGen &gen) override;
 

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32Dyn.C
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32Dyn.C
@@ -20,8 +20,8 @@ namespace Dyninst { namespace DyninstAPI {
     gen.rs()->makeRegisterAvail(RealRegister(REGNUM_ECX), gen);
     gen.rs()->makeRegisterAvail(RealRegister(REGNUM_EDX), gen);
 
-    Register placeholder1 = gen.rs()->allocateRegister(gen, true);
-    Register placeholder2 = gen.rs()->allocateRegister(gen, true);
+    Register placeholder1 = gen.rs()->allocateRegister(gen);
+    Register placeholder2 = gen.rs()->allocateRegister(gen);
     gen.rs()->noteVirtualInReal(ret, RealRegister(REGNUM_EAX));
     gen.rs()->noteVirtualInReal(placeholder1, RealRegister(REGNUM_ECX));
     gen.rs()->noteVirtualInReal(placeholder2, RealRegister(REGNUM_EDX));

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32Stat.C
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32Stat.C
@@ -19,8 +19,8 @@ namespace Dyninst { namespace DyninstAPI {
     //  emitMovPCRMToReg below doesn't try to allocate them.
     //  Associate the return value into EAX now for the same reason.
     //  These shouldn't generate to any acutal code.
-    Register placeholder1 = gen.rs()->allocateRegister(gen, true);
-    Register placeholder2 = gen.rs()->allocateRegister(gen, true);
+    Register placeholder1 = gen.rs()->allocateRegister(gen);
+    Register placeholder2 = gen.rs()->allocateRegister(gen);
     gen.rs()->noteVirtualInReal(ret, RealRegister(REGNUM_EAX));
     gen.rs()->noteVirtualInReal(placeholder1, RealRegister(REGNUM_ECX));
     gen.rs()->noteVirtualInReal(placeholder2, RealRegister(REGNUM_EDX));

--- a/dyninstAPI/src/dynProcess.C
+++ b/dyninstAPI/src/dynProcess.C
@@ -1831,7 +1831,7 @@ bool PCProcess::postIRPC(codeGenASTPtr action, void *userData,
    }
    
    Register resultReg = Null_Register;
-   if( !action->generateCode(irpcBuf, false, resultReg) ) {
+   if( !action->generateCode(irpcBuf, resultReg) ) {
       proccontrol_printf("%s[%d]: failed to generate code from AST\n",
                          FILE__, __LINE__);
       return false;

--- a/dyninstAPI/src/emit-aarch64.C
+++ b/dyninstAPI/src/emit-aarch64.C
@@ -197,7 +197,7 @@ void EmitterAARCH64::emitGetParam(
 void EmitterAARCH64::emitRelOpImm(
         unsigned opcode, Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s)
 {
-    //Register src2 = gen.rs()->allocateRegister(gen, true);
+    //Register src2 = gen.rs()->allocateRegister(gen);
     Register src2 = gen.rs()->getScratchRegister(gen);
     emitLoadConst(src2, src2imm, gen);
 

--- a/dyninstAPI/src/emit-aarch64.h
+++ b/dyninstAPI/src/emit-aarch64.h
@@ -147,7 +147,7 @@ public:
         return true;
     }
 
-    virtual void emitStoreImm(Address, int, codeGen &, bool) { assert(0); }
+    virtual void emitStoreImm(Address, int, codeGen &) { assert(0); }
 
     virtual void emitAddSignedImm(Address, int, codeGen &, bool) { assert(0); }
 

--- a/dyninstAPI/src/emit-aarch64.h
+++ b/dyninstAPI/src/emit-aarch64.h
@@ -149,7 +149,7 @@ public:
 
     virtual void emitStoreImm(Address, int, codeGen &) { assert(0); }
 
-    virtual void emitAddSignedImm(Address, int, codeGen &, bool) { assert(0); }
+    virtual void emitAddSignedImm(Address, int, codeGen &) { assert(0); }
 
     virtual bool emitPush(codeGen &, Register) {
         assert(0);

--- a/dyninstAPI/src/emit-aarch64.h
+++ b/dyninstAPI/src/emit-aarch64.h
@@ -118,7 +118,7 @@ public:
 
     // This one we actually use now.
     virtual Register emitCall(opCode, codeGen &, const std::vector <Dyninst::DyninstAPI::codeGenASTPtr> &,
-                              bool, func_instance *);
+                              func_instance *);
 
     virtual void emitGetRetVal(Register, bool, codeGen &) { assert(0); }
 

--- a/dyninstAPI/src/emit-aarch64.h
+++ b/dyninstAPI/src/emit-aarch64.h
@@ -175,7 +175,7 @@ protected:
     virtual bool emitCallInstruction(codeGen &, func_instance *,
                                      bool, Address);
 
-    virtual Register emitCallReplacement(opCode, codeGen &, bool,
+    virtual Register emitCallReplacement(opCode, codeGen &,
                                          func_instance *);
 
  private:
@@ -212,7 +212,7 @@ protected:
     virtual bool emitCallInstruction(codeGen &, func_instance *, bool,
                                      Address);
 
-    virtual Register emitCallReplacement(opCode, codeGen &, bool,
+    virtual Register emitCallReplacement(opCode, codeGen &,
                                          func_instance *) {
         assert(0 && "emitCallReplacement not implemented for binary rewriter");
     }

--- a/dyninstAPI/src/emit-amdgpu.C
+++ b/dyninstAPI/src/emit-amdgpu.C
@@ -505,8 +505,7 @@ bool EmitterAmdgpuGfx908::emitBTRestores(baseTramp * /* bt */, codeGen & /* gen 
   return false;
 }
 
-void EmitterAmdgpuGfx908::emitStoreImm(Address /* addr */, int /* imm */, codeGen & /* gen */,
-                                       bool /* noCost */) {
+void EmitterAmdgpuGfx908::emitStoreImm(Address /* addr */, int /* imm */, codeGen & /* gen */) {
   assert(!"emitStoreImm not implemented yet");
 }
 

--- a/dyninstAPI/src/emit-amdgpu.C
+++ b/dyninstAPI/src/emit-amdgpu.C
@@ -451,7 +451,7 @@ bool EmitterAmdgpuGfx908::emitMoveRegToReg(registerSlot * /* src */, registerSlo
 
 Register EmitterAmdgpuGfx908::emitCall(opCode /* op */, codeGen & /* gen */,
                                        const std::vector<Dyninst::DyninstAPI::codeGenASTPtr> & /* operands */,
-                                       bool /* noCost */, func_instance * /* callee */) {
+                                       func_instance * /* callee */) {
   assert(!"emitCall not implemented yet");
   return 0;
 }

--- a/dyninstAPI/src/emit-amdgpu.C
+++ b/dyninstAPI/src/emit-amdgpu.C
@@ -509,8 +509,7 @@ void EmitterAmdgpuGfx908::emitStoreImm(Address /* addr */, int /* imm */, codeGe
   assert(!"emitStoreImm not implemented yet");
 }
 
-void EmitterAmdgpuGfx908::emitAddSignedImm(Address /* addr */, int /* imm */, codeGen & /* gen */,
-                                           bool /* noCost */) {
+void EmitterAmdgpuGfx908::emitAddSignedImm(Address /* addr */, int /* imm */, codeGen & /* gen */) {
   assert(!"emitAddSignedImm not implemented yet");
 }
 

--- a/dyninstAPI/src/emit-amdgpu.h
+++ b/dyninstAPI/src/emit-amdgpu.h
@@ -153,7 +153,7 @@ public:
 
   bool emitMoveRegToReg(registerSlot *src, registerSlot *dest, codeGen &gen);
 
-  Register emitCall(opCode op, codeGen &gen, const std::vector<Dyninst::DyninstAPI::codeGenASTPtr> &operands, bool noCost,
+  Register emitCall(opCode op, codeGen &gen, const std::vector<Dyninst::DyninstAPI::codeGenASTPtr> &operands,
                     func_instance *callee);
 
   void emitGetRetVal(Register dest, bool addr_of, codeGen &gen);

--- a/dyninstAPI/src/emit-amdgpu.h
+++ b/dyninstAPI/src/emit-amdgpu.h
@@ -182,9 +182,8 @@ public:
   void emitStoreImm(Address addr, int imm, codeGen &gen);
 
   // TODO: Implementation requires full 'codeGen' and 'registerSpace' class to
-  // allocate register. ALSO FIXME: bool noCost seems like a redundant
-  // parameter.
-  void emitAddSignedImm(Address addr, int imm, codeGen &gen, bool noCost);
+  // allocate register.
+  void emitAddSignedImm(Address addr, int imm, codeGen &gen);
 
   bool emitPush(codeGen &, Register);
 

--- a/dyninstAPI/src/emit-amdgpu.h
+++ b/dyninstAPI/src/emit-amdgpu.h
@@ -179,7 +179,7 @@ public:
   bool emitBTRestores(baseTramp *bt, codeGen &gen);
 
   // TODO: requires allocating / deallocating register (see next comment).
-  void emitStoreImm(Address addr, int imm, codeGen &gen, bool noCost);
+  void emitStoreImm(Address addr, int imm, codeGen &gen);
 
   // TODO: Implementation requires full 'codeGen' and 'registerSpace' class to
   // allocate register. ALSO FIXME: bool noCost seems like a redundant

--- a/dyninstAPI/src/emit-power.h
+++ b/dyninstAPI/src/emit-power.h
@@ -115,7 +115,7 @@ class EmitterPOWER : public Emitter {
     
     virtual bool clobberAllFuncCall(registerSpace *rs,func_instance *callee);
 
-    virtual Register emitCallReplacement(opCode, codeGen &, bool,
+    virtual Register emitCallReplacement(opCode, codeGen &,
                                          func_instance *);
     void emitCallWithSaves(codeGen &gen, Address dest, bool saveToc, bool saveLR, bool saveR12);
     
@@ -150,7 +150,7 @@ class EmitterPOWER32Stat : public EmitterPOWER
  protected:
     virtual bool emitCallInstruction(codeGen &, func_instance *, bool,
                                      Address);
-    virtual Register emitCallReplacement(opCode, codeGen &, bool,
+    virtual Register emitCallReplacement(opCode, codeGen &,
                                          func_instance *) {
         assert(0 && "emitCallReplacement not implemented for binary rewriter");
     }
@@ -183,7 +183,7 @@ class EmitterPOWER64Stat : public EmitterPOWER {
  protected:
     virtual bool emitCallInstruction(codeGen &, func_instance *, bool,
                                      Address);
-    virtual Register emitCallReplacement(opCode, codeGen &, bool,
+    virtual Register emitCallReplacement(opCode, codeGen &,
                                          func_instance *) {
         assert(0 && "emitCallReplacement not implemented for binary rewriter");
     }

--- a/dyninstAPI/src/emit-power.h
+++ b/dyninstAPI/src/emit-power.h
@@ -107,7 +107,7 @@ class EmitterPOWER : public Emitter {
     virtual void emitRestoreFlagsFromStackSlot(codeGen &) { assert(0); }
     virtual bool emitBTSaves(baseTramp*, codeGen &) { assert(0); return true;}
     virtual bool emitBTRestores(baseTramp*, codeGen &) { assert(0); return true; }
-    virtual void emitStoreImm(Address, int, codeGen &, bool) { assert(0); }
+    virtual void emitStoreImm(Address, int, codeGen &) { assert(0); }
     virtual void emitAddSignedImm(Address, int, codeGen &, bool) { assert(0); }
     virtual bool emitPush(codeGen &, Register) { assert(0); return true;}
     virtual bool emitPop(codeGen &, Register) { assert(0); return true;}

--- a/dyninstAPI/src/emit-power.h
+++ b/dyninstAPI/src/emit-power.h
@@ -94,7 +94,7 @@ class EmitterPOWER : public Emitter {
 
     // This one we actually use now.
     virtual Register emitCall(opCode, codeGen &, const std::vector<Dyninst::DyninstAPI::codeGenASTPtr> &,
-			      bool, func_instance *);
+			      func_instance *);
 
     virtual void emitGetRetVal(Register, bool, codeGen &) { assert(0); }
     virtual void emitGetRetAddr(Register, codeGen &) { assert(0); }

--- a/dyninstAPI/src/emit-power.h
+++ b/dyninstAPI/src/emit-power.h
@@ -108,7 +108,7 @@ class EmitterPOWER : public Emitter {
     virtual bool emitBTSaves(baseTramp*, codeGen &) { assert(0); return true;}
     virtual bool emitBTRestores(baseTramp*, codeGen &) { assert(0); return true; }
     virtual void emitStoreImm(Address, int, codeGen &) { assert(0); }
-    virtual void emitAddSignedImm(Address, int, codeGen &, bool) { assert(0); }
+    virtual void emitAddSignedImm(Address, int, codeGen &) { assert(0); }
     virtual bool emitPush(codeGen &, Register) { assert(0); return true;}
     virtual bool emitPop(codeGen &, Register) { assert(0); return true;}
     virtual bool emitAdjustStackPointer(int, codeGen &) { assert(0); return true;}

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -1903,7 +1903,7 @@ void EmitterAMD64::emitStoreImm(Address addr, int imm, codeGen &gen)
    }
 }
 
-void EmitterAMD64::emitAddSignedImm(Address addr, int imm, codeGen &gen,bool noCost)
+void EmitterAMD64::emitAddSignedImm(Address addr, int imm, codeGen &gen)
 {
    if (!isImm64bit(addr) && !isImm64bit(imm)) {
       Dyninst::DyninstAPI::x86::emitAddMem(addr, imm, gen);

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -1889,7 +1889,7 @@ bool EmitterAMD64::emitBTRestores(baseTramp* bt, codeGen &gen)
     return true;
 }
 
-void EmitterAMD64::emitStoreImm(Address addr, int imm, codeGen &gen, bool noCost) 
+void EmitterAMD64::emitStoreImm(Address addr, int imm, codeGen &gen)
 {
    if (!isImm64bit(addr) && !isImm64bit(imm)) {
       emitMovImmToMem(addr, imm, gen);

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -876,7 +876,7 @@ bool EmitterAMD64::clobberAllFuncCall( registerSpace *rs,
 static Register amd64_arg_regs[] = {REGNUM_RDI, REGNUM_RSI, REGNUM_RDX, REGNUM_RCX, REGNUM_R8, REGNUM_R9};
 #define AMD64_ARG_REGS (sizeof(amd64_arg_regs) / sizeof(Register))
 Register EmitterAMD64::emitCall(opCode op, codeGen &gen, const std::vector<Dyninst::DyninstAPI::codeGenASTPtr> &operands,
-                                bool noCost, func_instance *callee)
+                                func_instance *callee)
 {
    assert(op == callOp);
    std::vector <Register> srcs;

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -1057,7 +1057,7 @@ Register EmitterAMD64::emitCall(opCode op, codeGen &gen, const std::vector<Dynin
    // allocate a (virtual) register to store the return value
    // We do this now because the state is correct again in the RS.
 
-   Register ret = gen.rs()->allocateRegister(gen, noCost);
+   Register ret = gen.rs()->allocateRegister(gen);
    gen.markRegDefined(ret);
    emitMovRegToReg64(ret, REGNUM_EAX, true, gen);
 
@@ -1895,7 +1895,7 @@ void EmitterAMD64::emitStoreImm(Address addr, int imm, codeGen &gen, bool noCost
       emitMovImmToMem(addr, imm, gen);
    }
    else {
-      Register r = gen.rs()->allocateRegister(gen, noCost);
+      Register r = gen.rs()->allocateRegister(gen);
       gen.markRegDefined(r);
       emitMovImmToReg64(r, addr, true, gen);
       emitMovImmToRM64(r, 0, imm, true, gen);
@@ -1909,7 +1909,7 @@ void EmitterAMD64::emitAddSignedImm(Address addr, int imm, codeGen &gen,bool noC
       Dyninst::DyninstAPI::x86::emitAddMem(addr, imm, gen);
    }
    else {
-      Register r = gen.rs()->allocateRegister(gen, noCost);      
+      Register r = gen.rs()->allocateRegister(gen);
       gen.markRegDefined(r);
       emitMovImmToReg64(r, addr, true, gen);
       emitAddRM64(r, imm, true, gen);
@@ -1991,7 +1991,7 @@ void EmitterAMD64::emitStoreShared(Register source, const image_variable *var, b
   }
   
   // temporary virtual register for storing destination address
-  Register dest = gen.rs()->allocateRegister(gen, false); 
+  Register dest = gen.rs()->allocateRegister(gen);
   gen.markRegDefined(dest);
  
   // load register with address from jump slot

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -977,7 +977,6 @@ Register EmitterAMD64::emitCall(opCode op, codeGen &gen, const std::vector<Dynin
       if(u >= (int)AMD64_ARG_REGS)
       {
          if (!operands[u]->generateCode_phase2(gen,
-                                               noCost,
                                                unused,
                                                reg)) assert(0);
          assert(reg != Null_Register);
@@ -995,7 +994,6 @@ Register EmitterAMD64::emitCall(opCode op, codeGen &gen, const std::vector<Dynin
          }
          gen.markRegDefined(reg);
          if (!operands[u]->generateCode_phase2(gen,
-                                               noCost,
                                                unused,
                                                reg)) assert(0);
 	 if (reg != amd64_arg_regs[u]) {

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -987,7 +987,7 @@ Register EmitterAMD64::emitCall(opCode op, codeGen &gen, const std::vector<Dynin
       }
       else
       {
-          if (gen.rs()->allocateSpecificRegister(gen, (unsigned) amd64_arg_regs[u], true))
+          if (gen.rs()->allocateSpecificRegister(gen, (unsigned) amd64_arg_regs[u]))
             reg = amd64_arg_regs[u];
          else {
             cerr << "Error: tried to allocate register " << amd64_arg_regs[u] << " and failed!" << endl;

--- a/dyninstAPI/src/emit-x86.h
+++ b/dyninstAPI/src/emit-x86.h
@@ -111,7 +111,7 @@ public:
     // See comment on 32-bit emitCall
     virtual Register emitCall(opCode op, codeGen &gen,
                               const std::vector<codeGenASTPtr> &operands,
-                              bool noCost, func_instance *callee);
+                              func_instance *callee);
     void emitGetRetVal(Register dest, bool addr_of, codeGen &gen);
     void emitGetRetAddr(Register dest, codeGen &gen);
     void emitGetParam(Register dest, Register param_num, instPoint::Type pt_type, opCode op, bool addr_of, codeGen &gen);

--- a/dyninstAPI/src/emit-x86.h
+++ b/dyninstAPI/src/emit-x86.h
@@ -123,7 +123,7 @@ public:
     void emitStackAlign(int offset, codeGen &gen);
     bool emitBTSaves(baseTramp* bt, codeGen &gen);
     bool emitBTRestores(baseTramp* bt, codeGen &gen);
-    void emitStoreImm(Address addr, int imm, codeGen &gen, bool noCost);
+    void emitStoreImm(Address addr, int imm, codeGen &gen);
     void emitAddSignedImm(Address addr, int imm, codeGen &gen, bool noCost);
     bool emitPush(codeGen &gen, Register pushee);
     bool emitPop(codeGen &gen, Register popee);

--- a/dyninstAPI/src/emit-x86.h
+++ b/dyninstAPI/src/emit-x86.h
@@ -124,7 +124,7 @@ public:
     bool emitBTSaves(baseTramp* bt, codeGen &gen);
     bool emitBTRestores(baseTramp* bt, codeGen &gen);
     void emitStoreImm(Address addr, int imm, codeGen &gen);
-    void emitAddSignedImm(Address addr, int imm, codeGen &gen, bool noCost);
+    void emitAddSignedImm(Address addr, int imm, codeGen &gen);
     bool emitPush(codeGen &gen, Register pushee);
     bool emitPop(codeGen &gen, Register popee);
 

--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -105,7 +105,7 @@ class Emitter {
     virtual void emitRestoreFlagsFromStackSlot(codeGen &gen) = 0;
     virtual bool emitBTSaves(baseTramp* bt, codeGen &gen) = 0;
     virtual bool emitBTRestores(baseTramp* bt, codeGen &gen) = 0;
-    virtual void emitStoreImm(Address addr, int imm, codeGen &gen, bool noCost) = 0;
+    virtual void emitStoreImm(Address addr, int imm, codeGen &gen) = 0;
     virtual void emitAddSignedImm(Address addr, int imm, codeGen &gen, bool noCost) = 0;
     virtual bool emitPush(codeGen &, Register) = 0;
     virtual bool emitPop(codeGen &, Register) = 0;

--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -92,7 +92,7 @@ class Emitter {
     virtual bool emitMoveRegToReg(registerSlot *src, registerSlot *dest, codeGen &gen) = 0;
 
     virtual Register emitCall(opCode op, codeGen &gen, const std::vector<Dyninst::DyninstAPI::codeGenASTPtr> &operands,
-			      bool noCost, func_instance *callee) = 0;
+			      func_instance *callee) = 0;
 
     virtual void emitGetRetVal(Register dest, bool addr_of, codeGen &gen) = 0;
     virtual void emitGetRetAddr(Register dest, codeGen &gen) = 0;

--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -106,7 +106,7 @@ class Emitter {
     virtual bool emitBTSaves(baseTramp* bt, codeGen &gen) = 0;
     virtual bool emitBTRestores(baseTramp* bt, codeGen &gen) = 0;
     virtual void emitStoreImm(Address addr, int imm, codeGen &gen) = 0;
-    virtual void emitAddSignedImm(Address addr, int imm, codeGen &gen, bool noCost) = 0;
+    virtual void emitAddSignedImm(Address addr, int imm, codeGen &gen) = 0;
     virtual bool emitPush(codeGen &, Register) = 0;
     virtual bool emitPop(codeGen &, Register) = 0;
     virtual bool emitAdjustStackPointer(int index, codeGen &gen) = 0;

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -503,7 +503,7 @@ bool EmitterAARCH64::clobberAllFuncCall(registerSpace *rs,
 
 Register emitFuncCall(opCode op,
                       codeGen &gen,
-                      std::vector <codeGenASTPtr> &operands, bool noCost,
+                      std::vector <codeGenASTPtr> &operands,
                       func_instance *callee) {
     return gen.emitter()->emitCall(op, gen, operands, noCost, callee);
 }

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -775,8 +775,7 @@ void MovePCToReg(Register dest, codeGen &gen) {
 // Yuhan(02/04/19): Load in destination the effective address given
 // by the address descriptor. Used for memory access stuff.
 void emitASload(const BPatch_addrSpec_NP *as, Register dest, int stackShift,
-                codeGen &gen,
-                bool) {
+                codeGen &gen) {
 
     // Haven't implemented non-zero shifts yet
     assert(stackShift == 0);

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -575,7 +575,7 @@ Register EmitterAARCH64::emitCall(opCode op,
             reg = registerSpace::r0 + id;
 
         Address unnecessary = ADDR_NULL;
-        if (!operands[id]->generateCode_phase2(gen, false, unnecessary, reg))
+        if (!operands[id]->generateCode_phase2(gen, unnecessary, reg))
             assert(0);
         assert(reg!=Null_Register);
     }

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -814,8 +814,7 @@ void emitASload(const BPatch_addrSpec_NP *as, Register dest, int stackShift,
         insnCodeGen::generateAddSubImmediate(gen, insnCodeGen::Add, 0, imm, dest, dest, true);	
 }
 
-void emitCSload(const BPatch_addrSpec_NP *, Register, codeGen &,
-                bool) {
+void emitCSload(const BPatch_addrSpec_NP *, Register, codeGen &) {
     assert(0); //Not implemented
 }
 

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -930,8 +930,7 @@ bool doNotOverflow(int64_t value)
 void emitLoadPreviousStackFrameRegister(Address register_num,
                                         Register dest,
                                         codeGen &gen,
-                                        int /*size*/,
-                                        bool)
+                                        int /*size*/)
 {
     gen.codeEmitter()->emitLoadOrigRegister(register_num, dest, gen);
 }

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -179,7 +179,7 @@ unsigned EmitterAARCH64SaveRegs::saveSPRegisters(
 
     for(std::vector<registerSlot *>::iterator itr = spRegs.begin(); itr != spRegs.end(); itr++) {
         registerSlot *cur = *itr;
-        saveSPR(gen, theRegSpace->getScratchRegister(gen, true), regMap[cur], -4*GPRSIZE_32);
+        saveSPR(gen, theRegSpace->getScratchRegister(gen), regMap[cur], -4*GPRSIZE_32);
         theRegSpace->markSavedRegister(cur->number, offset);
 
         offset += 4*GPRSIZE_32;
@@ -276,7 +276,7 @@ unsigned EmitterAARCH64RestoreRegs::restoreSPRegisters(
 
     for(std::vector<registerSlot *>::iterator itr = spRegs.begin(); itr != spRegs.end(); itr++) {
         registerSlot *cur = *itr;
-        restoreSPR(gen, theRegSpace->getScratchRegister(gen, true), regMap[cur], 4*GPRSIZE_32);
+        restoreSPR(gen, theRegSpace->getScratchRegister(gen), regMap[cur], 4*GPRSIZE_32);
         ret++;
     }
 
@@ -1044,7 +1044,7 @@ bool EmitterAARCH64Stat::emitPLTCall(func_instance *callee, codeGen &gen) {
     Address dest = getInterModuleFuncAddr(callee, gen);
     long varOffset = dest - gen.currAddr();
 
-    Register baseReg = gen.rs()->getScratchRegister(gen, true);
+    Register baseReg = gen.rs()->getScratchRegister(gen);
     assert(baseReg != Null_Register && "cannot get a scratch register");
     emitMovePCToReg(baseReg, gen);
 
@@ -1080,7 +1080,7 @@ bool EmitterAARCH64Stat::emitPLTJump(func_instance *callee, codeGen &gen) {
     Address dest = getInterModuleFuncAddr(callee, gen);
     long varOffset = dest - gen.currAddr();
 
-    Register baseReg = gen.rs()->getScratchRegister(gen, true);
+    Register baseReg = gen.rs()->getScratchRegister(gen);
     assert(baseReg != Null_Register && "cannot get a scratch register");
     emitMovePCToReg(baseReg, gen);
 
@@ -1161,7 +1161,7 @@ void EmitterAARCH64::emitLoadShared(opCode op, Register dest, const image_variab
     }
 
     // load register with address from jump slot
-    Register baseReg = gen.rs()->getScratchRegister(gen, true);
+    Register baseReg = gen.rs()->getScratchRegister(gen);
     assert(baseReg != Null_Register && "cannot get a scratch register");
 
     emitMovePCToReg(baseReg, gen);
@@ -1209,7 +1209,7 @@ void EmitterAARCH64::emitStoreShared(Register source, const image_variable *var,
     }
 
     // load register with address from jump slot
-    Register baseReg = gen.rs()->getScratchRegister(gen, true);
+    Register baseReg = gen.rs()->getScratchRegister(gen);
     assert(baseReg != Null_Register && "cannot get a scratch register");
 
     emitMovePCToReg(baseReg, gen);
@@ -1218,7 +1218,7 @@ void EmitterAARCH64::emitStoreShared(Register source, const image_variable *var,
     if(!is_local) {
         std::vector<Register> exclude;
         exclude.push_back(baseReg);
-        Register scratchReg1 = gen.rs()->getScratchRegister(gen, exclude, true);
+        Register scratchReg1 = gen.rs()->getScratchRegister(gen, exclude);
         assert(scratchReg1 != Null_Register && "cannot get a scratch register");
         emitLoadRelative(scratchReg1, varOffset, baseReg, gen.width(), gen);
         emitStoreRelative(source, 0, scratchReg1, size, gen);

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -350,7 +350,7 @@ void popStack(codeGen &gen)
 
 //TODO: 32-/64-bit regs?
 void emitImm(opCode op, Register src1, RegValue src2imm, Register dest, 
-        codeGen &gen, bool /*noCost*/, registerSpace * /* rs */, bool s)
+        codeGen &gen, registerSpace * /* rs */, bool s)
 {
     switch(op) {
         case plusOp:

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -571,7 +571,7 @@ Register EmitterAARCH64::emitCall(opCode op,
     for(size_t id = 0; id < operands.size(); id++)
     {
         Register reg = Null_Register;
-        if (gen.rs()->allocateSpecificRegister(gen, registerSpace::r0 + id, true))
+        if (gen.rs()->allocateSpecificRegister(gen, registerSpace::r0 + id))
             reg = registerSpace::r0 + id;
 
         Address unnecessary = ADDR_NULL;

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -860,7 +860,7 @@ void emitVload(opCode op, Address src1, Register src2, Register dest,
 }
 
 void emitVstore(opCode op, Register src1, Register /*src2*/, Address dest,
-        codeGen &gen, bool,
+        codeGen &gen,
         registerSpace * /* rs */, int size,
         const instPoint * /* location */, AddressSpace *)
 {

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -395,7 +395,7 @@ void emitImm(opCode op, Register src1, RegValue src2imm, Register dest,
         case eqOp:
             {
                 Register scratch = gen.rs()->getScratchRegister(gen);
-                emitVload(loadConstOp, src2imm, 0, scratch, gen, true);
+                emitVload(loadConstOp, src2imm, 0, scratch, gen);
                 emitV(op, src1, scratch, dest, gen);
             }
             break;
@@ -821,7 +821,7 @@ void emitCSload(const BPatch_addrSpec_NP *, Register, codeGen &,
 }
 
 void emitVload(opCode op, Address src1, Register src2, Register dest,
-               codeGen &gen, bool /*noCost*/,
+               codeGen &gen,
                registerSpace * /*rs*/, int size,
                const instPoint * /* location */, AddressSpace *)
 {

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -510,7 +510,6 @@ Register emitFuncCall(opCode op,
 
 Register EmitterAARCH64::emitCallReplacement(opCode,
                                              codeGen &,
-                                             bool,
                                              func_instance *) {
     assert(0); //Not implemented
     return 0;

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -667,7 +667,7 @@ codeBufIndex_t emitA(opCode op, Register src1, Register, long dest,
 }
 
 Register emitR(opCode op, Register src1, Register src2, Register dest,
-               codeGen &gen, bool /*noCost*/,
+               codeGen &gen,
                const instPoint *, bool /*for_MT*/)
 {
     registerSlot *regSlot = NULL;

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -505,7 +505,7 @@ Register emitFuncCall(opCode op,
                       codeGen &gen,
                       std::vector <codeGenASTPtr> &operands,
                       func_instance *callee) {
-    return gen.emitter()->emitCall(op, gen, operands, noCost, callee);
+    return gen.emitter()->emitCall(op, gen, operands, callee);
 }
 
 Register EmitterAARCH64::emitCallReplacement(opCode,
@@ -524,7 +524,6 @@ Register EmitterAARCH64::emitCallReplacement(opCode,
 Register EmitterAARCH64::emitCall(opCode op,
                                   codeGen &gen,
                                   const std::vector<codeGenASTPtr> &operands,
-                                  bool,
                                   func_instance *callee) 
 {
     //#sasha This function implementation is experimental.

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -640,7 +640,7 @@ Register EmitterAARCH64::emitCall(opCode op,
 
 
 codeBufIndex_t emitA(opCode op, Register src1, Register, long dest,
-        codeGen &gen, Dyninst::DyninstAPI::RegControl rc, bool)
+        codeGen &gen, Dyninst::DyninstAPI::RegControl rc)
 {
     codeBufIndex_t retval = 0;
 

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -396,7 +396,7 @@ void emitImm(opCode op, Register src1, RegValue src2imm, Register dest,
             {
                 Register scratch = gen.rs()->getScratchRegister(gen);
                 emitVload(loadConstOp, src2imm, 0, scratch, gen, true);
-                emitV(op, src1, scratch, dest, gen, true);
+                emitV(op, src1, scratch, dest, gen);
             }
             break;
         case neOp:
@@ -877,7 +877,7 @@ void emitVstore(opCode op, Register src1, Register /*src2*/, Address dest,
 }
 
 void emitV(opCode op, Register src1, Register src2, Register dest,
-        codeGen &gen, bool /*noCost*/,
+        codeGen &gen,
            registerSpace * /*rs*/, int size,
            const instPoint * /* location */, AddressSpace *proc, bool s) 
 {

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -85,7 +85,7 @@ void emitCSload(const BPatch_addrSpec_NP *, Register, codeGen &, bool) {
 }
 
 void emitVload(opCode /* op */, Address /* src1 */, Register /* src2 */, Register /* dest */,
-               codeGen & /* gen */, bool /*noCost*/, registerSpace * /*rs*/, int /* size */,
+               codeGen & /* gen */, registerSpace * /*rs*/, int /* size */,
                const instPoint * /* location */, AddressSpace *) {
   assert(!"Not imeplemented for AMDGPU");
 }

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -91,7 +91,7 @@ void emitVload(opCode /* op */, Address /* src1 */, Register /* src2 */, Registe
 }
 
 void emitVstore(opCode /* op */, Register /* src1 */, Register /*src2*/, Address /* dest */,
-                codeGen & /* gen */, bool, registerSpace * /* rs */, int /* size */,
+                codeGen & /* gen */, registerSpace * /* rs */, int /* size */,
                 const instPoint * /* location */, AddressSpace *) {
   assert(!"Not imeplemented for AMDGPU");
 }

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -108,7 +108,7 @@ bool doNotOverflow(int64_t /* value */) {
 }
 
 void emitLoadPreviousStackFrameRegister(Address /* register_num */, Register /* dest */,
-                                        codeGen & /* gen */, int /* size */, bool) {}
+                                        codeGen & /* gen */, int /* size */) {}
 
 void emitStorePreviousStackFrameRegister(Address, Register, codeGen &, int, bool) {}
 

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -66,7 +66,7 @@ codeBufIndex_t emitA(opCode /* op */, Register /* src1 */, Register, long /* des
 }
 
 Register emitR(opCode /* op */, Register /* src1 */, Register /* src2 */, Register /* dest */,
-               codeGen & /* gen */, bool /*noCost*/, const instPoint *, bool /*for_MT*/) {
+               codeGen & /* gen */, const instPoint *, bool /*for_MT*/) {
   assert(!"Not implemented for AMDGPU");
   return 0;
 }

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -97,7 +97,7 @@ void emitVstore(opCode /* op */, Register /* src1 */, Register /*src2*/, Address
 }
 
 void emitV(opCode /* op */, Register /* src1 */, Register /* src2 */, Register /* dest */,
-           codeGen & /* gen */, bool /*noCost*/, registerSpace * /*rs*/, int /* size */,
+           codeGen & /* gen */, registerSpace * /*rs*/, int /* size */,
            const instPoint * /* location */, AddressSpace * /* proc */, bool /* s */) {
   assert(!"Not imeplemented for AMDGPU");
 }

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -47,13 +47,13 @@ void emitImm(opCode /* op */, Register /* src1 */, RegValue /* src2imm */, Regis
   assert(!"Not implemented for AMDGPU");
 }
 
-Register emitFuncCall(opCode, codeGen &, std::vector<codeGenASTPtr> &, bool, Address) {
+Register emitFuncCall(opCode, codeGen &, std::vector<codeGenASTPtr> &, Address) {
   assert(!"Not implemented for AMDGPU");
   return 0;
 }
 
 Register emitFuncCall(opCode /* op */, codeGen & /* gen */,
-                      std::vector<codeGenASTPtr> & /* operands */, bool /* noCost */,
+                      std::vector<codeGenASTPtr> & /* operands */,
                       func_instance * /* callee */) {
   assert(!"Not implemented for AMDGPU");
   return 0;

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -76,7 +76,7 @@ void emitJmpMC(int /*condition*/, int /*offset*/, codeGen &) {
 }
 
 void emitASload(const BPatch_addrSpec_NP * /* as */, Register /* dest */, int /* stackShift */,
-                codeGen & /* gen */, bool) {
+                codeGen & /* gen */) {
   assert(!"Not imeplemented for AMDGPU");
 }
 

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -80,7 +80,7 @@ void emitASload(const BPatch_addrSpec_NP * /* as */, Register /* dest */, int /*
   assert(!"Not imeplemented for AMDGPU");
 }
 
-void emitCSload(const BPatch_addrSpec_NP *, Register, codeGen &, bool) {
+void emitCSload(const BPatch_addrSpec_NP *, Register, codeGen &) {
   assert(!"Not imeplemented for AMDGPU");
 }
 

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -43,7 +43,7 @@ using codeGenASTPtr = Dyninst::DyninstAPI::codeGenASTPtr;
 
 // TODO: ALL THESE MUST GO AWAY ENTIRELY AS CODEGEN MATURES
 void emitImm(opCode /* op */, Register /* src1 */, RegValue /* src2imm */, Register /* dest */,
-             codeGen & /* gen */, bool /*noCost*/, registerSpace * /* rs */, bool /* s */) {
+             codeGen & /* gen */, registerSpace * /* rs */, bool /* s */) {
   assert(!"Not implemented for AMDGPU");
 }
 

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -60,7 +60,7 @@ Register emitFuncCall(opCode /* op */, codeGen & /* gen */,
 }
 
 codeBufIndex_t emitA(opCode /* op */, Register /* src1 */, Register, long /* dest */,
-                     codeGen & /* gen */, Dyninst::DyninstAPI::RegControl /* rc */, bool) {
+                     codeGen & /* gen */, Dyninst::DyninstAPI::RegControl /* rc */) {
   assert(!"Not implemented for AMDGPU");
   return 0;
 }

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1124,7 +1124,7 @@ Dyninst::Register EmitterPOWER::emitCall(opCode ocode,
 
  
 codeBufIndex_t emitA(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, long dest,
-	      codeGen &gen, Dyninst::DyninstAPI::RegControl, bool /*noCost*/)
+	      codeGen &gen, Dyninst::DyninstAPI::RegControl)
 {
     codeBufIndex_t retval = 0;
     switch (op) {

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1719,8 +1719,7 @@ bool doNotOverflow(int64_t value) {
 void emitLoadPreviousStackFrameRegister(Address register_num, 
                                         Dyninst::Register dest,
                                         codeGen &gen,
-                                        int /*size*/,
-                                        bool noCost)
+                                        int /*size*/)
 {
     // As of 10/24/2007, the size parameter is still incorrect.
     // Luckily, we know implicitly what size they actually want.

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1488,7 +1488,7 @@ void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Registe
 }
 
 void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, Address dest,
-		codeGen &gen, bool noCost, 
+		codeGen &gen,
                 registerSpace * /* rs */, int size,
                 const instPoint * /* location */, AddressSpace *proc)
 {

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1335,7 +1335,7 @@ static inline void moveGPR2531toGPR(codeGen &gen,
 // another. The original value may need to be restored from stack...
 // VG(03/15/02): Made functionality more obvious by adding the above functions
 static inline void emitAddOriginal(Dyninst::Register src, Dyninst::Register acc,
-                                   codeGen &gen, bool noCost)
+                                   codeGen &gen)
 {
     bool nr = needsRestore(src);
     Dyninst::Register temp;
@@ -1388,12 +1388,12 @@ void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackS
   // If ra is used in the address spec, allocate a temp register and
   // get the value of ra from stack into it
   if(ra > -1)
-      emitAddOriginal(ra, dest, gen, noCost);
+      emitAddOriginal(ra, dest, gen);
 
   // If rb is used in the address spec, allocate a temp register and
   // get the value of ra from stack into it
   if(rb > -1)
-    emitAddOriginal(rb, dest, gen, noCost);
+    emitAddOriginal(rb, dest, gen);
 
 }
 

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -642,7 +642,7 @@ unsigned restoreSPRegisters(codeGen &gen,
 }
 
 void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Register dest,
-             codeGen &gen, bool noCost, registerSpace * /* rs */, bool s)
+             codeGen &gen, registerSpace * /* rs */, bool s)
 {
     int iop=-1;
     int result=-1;
@@ -1461,7 +1461,7 @@ void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Registe
     break;
   case loadRegRelativeAddr:
     gen.rs()->readProgramRegister(gen, src2, dest, size);
-    emitImm(plusOp, dest, src1, dest, gen, false);
+    emitImm(plusOp, dest, src1, dest, gen);
     break;
   case loadRegRelativeOp:
     gen.rs()->readProgramRegister(gen, src2, dest, size);
@@ -1742,7 +1742,7 @@ void emitLoadPreviousStackFrameRegister(Address register_num,
 
         // Get address (SP + offset) and stick in register dest.
         emitImm(plusOp ,(Dyninst::Register) REG_SP, (RegValue) offset, dest,
-                gen, noCost, gen.rs());
+                gen, gen.rs());
         // Load LR into register dest
         emitV(loadIndirOp, dest, 0, dest, gen, gen.rs(),
               gen.width(), gen.point(), gen.addrSpace());
@@ -1757,7 +1757,7 @@ void emitLoadPreviousStackFrameRegister(Address register_num,
 
         // Get address (SP + offset) and stick in register dest.
         emitImm(plusOp ,(Dyninst::Register) REG_SP, (RegValue) offset, dest,
-                gen, noCost, gen.rs());
+                gen, gen.rs());
         // Load LR into register dest
         emitV(loadIndirOp, dest, 0, dest, gen, gen.rs(),
               gen.width(), gen.point(), gen.addrSpace());

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -668,7 +668,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
         else {
             Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
             emitVload(loadConstOp, src2imm, dest2, dest2, gen, noCost);
-            emitV(op, src1, dest2, dest, gen, noCost, gen.rs(), 
+            emitV(op, src1, dest2, dest, gen, gen.rs(),
                   gen.width(), gen.point(), gen.addrSpace(), s);
             return;
         }
@@ -677,7 +677,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
     case divOp: {
             Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
             emitVload(loadConstOp, src2imm, dest2, dest2, gen, noCost);
-            emitV(op, src1, dest2, dest, gen, noCost, gen.rs(),
+            emitV(op, src1, dest2, dest, gen, gen.rs(),
                   gen.width(), gen.point(), gen.addrSpace(), s);
             return;
         }
@@ -698,7 +698,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
     default:
         Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
         emitVload(loadConstOp, src2imm, dest2, dest2, gen, noCost);
-        emitV(op, src1, dest2, dest, gen, noCost, gen.rs(),
+        emitV(op, src1, dest2, dest, gen, gen.rs(),
               gen.width(), gen.point(), gen.addrSpace(), s);
         return;
         break;
@@ -1360,7 +1360,7 @@ static inline void emitAddOriginal(Dyninst::Register src, Dyninst::Register acc,
     
     // add temp to dest;
     // writes at gen+base and updates base, we must update insn...
-    emitV(plusOp, temp, acc, acc, gen, noCost, 0);
+    emitV(plusOp, temp, acc, acc, gen, 0);
     
     if(nr)
         gen.rs()->freeRegister(temp);
@@ -1531,7 +1531,7 @@ void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, A
 }
 
 void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dest,
-           codeGen &gen, bool /*noCost*/,
+           codeGen &gen,
            registerSpace * /*rs*/, int size,
            const instPoint * /* location */, AddressSpace *proc, bool s)
 {
@@ -1746,7 +1746,7 @@ void emitLoadPreviousStackFrameRegister(Address register_num,
         emitImm(plusOp ,(Dyninst::Register) REG_SP, (RegValue) offset, dest,
                 gen, noCost, gen.rs());
         // Load LR into register dest
-        emitV(loadIndirOp, dest, 0, dest, gen, noCost, gen.rs(),
+        emitV(loadIndirOp, dest, 0, dest, gen, gen.rs(),
               gen.width(), gen.point(), gen.addrSpace());
         break;
 
@@ -1761,7 +1761,7 @@ void emitLoadPreviousStackFrameRegister(Address register_num,
         emitImm(plusOp ,(Dyninst::Register) REG_SP, (RegValue) offset, dest,
                 gen, noCost, gen.rs());
         // Load LR into register dest
-        emitV(loadIndirOp, dest, 0, dest, gen, noCost, gen.rs(),
+        emitV(loadIndirOp, dest, 0, dest, gen, gen.rs(),
               gen.width(), gen.point(), gen.addrSpace());
       break;
 

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1396,8 +1396,7 @@ void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackS
 
 }
 
-void emitCSload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, codeGen &gen,
-		bool noCost)
+void emitCSload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, codeGen &gen)
 {
   emitASload(as, dest, 0, gen);
 }

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -832,7 +832,6 @@ void EmitterPOWER::emitCallWithSaves(codeGen &gen, Address dest, bool saveToc, b
 
 Dyninst::Register EmitterPOWER::emitCallReplacement(opCode ocode,
                                            codeGen &gen,
-                                           bool /* noCost */,
                                            func_instance *callee) {
     // This takes care of the special case where we are replacing an existing
     // linking branch instruction.
@@ -898,7 +897,7 @@ Dyninst::Register EmitterPOWER::emitCall(opCode ocode,
     // if false we're in function call replacement
 
     if (ocode == funcJumpOp)
-	return emitCallReplacement(ocode, gen, noCost, callee);
+	return emitCallReplacement(ocode, gen, callee);
 
     //  Sanity check for NULL address argument
     if (!callee) {

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -808,7 +808,7 @@ Dyninst::Register emitFuncCall(opCode op,
                       codeGen &gen,
                       std::vector<codeGenASTPtr> &operands,
                       func_instance *callee) {
-    return gen.emitter()->emitCall(op, gen, operands, noCost, callee);
+    return gen.emitter()->emitCall(op, gen, operands, callee);
 }
 
 void EmitterPOWER::emitCallWithSaves(codeGen &gen, Address dest, bool saveToc, bool saveLR, bool saveR12) {
@@ -891,7 +891,6 @@ Dyninst::Register EmitterPOWER::emitCallReplacement(opCode ocode,
 Dyninst::Register EmitterPOWER::emitCall(opCode ocode,
                                 codeGen &gen,
                                 const std::vector<codeGenASTPtr> &operands,
-                                bool noCost,
                                 func_instance *callee) {
     bool inInstrumentation = true;
 

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -667,7 +667,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
         }
         else {
             Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
-            emitVload(loadConstOp, src2imm, dest2, dest2, gen, noCost);
+            emitVload(loadConstOp, src2imm, dest2, dest2, gen);
             emitV(op, src1, dest2, dest, gen, gen.rs(),
                   gen.width(), gen.point(), gen.addrSpace(), s);
             return;
@@ -676,7 +676,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
         
     case divOp: {
             Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
-            emitVload(loadConstOp, src2imm, dest2, dest2, gen, noCost);
+            emitVload(loadConstOp, src2imm, dest2, dest2, gen);
             emitV(op, src1, dest2, dest, gen, gen.rs(),
                   gen.width(), gen.point(), gen.addrSpace(), s);
             return;
@@ -697,7 +697,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
         break;
     default:
         Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
-        emitVload(loadConstOp, src2imm, dest2, dest2, gen, noCost);
+        emitVload(loadConstOp, src2imm, dest2, dest2, gen);
         emitV(op, src1, dest2, dest, gen, gen.rs(),
               gen.width(), gen.point(), gen.addrSpace(), s);
         return;
@@ -817,9 +817,9 @@ void EmitterPOWER::emitCallWithSaves(codeGen &gen, Address dest, bool saveToc, b
     if (saveLR) {}
     if (saveR12) {}
 
-    emitVload(loadConstOp, dest, 0, 0, gen, false);
+    emitVload(loadConstOp, dest, 0, 0, gen);
     insnCodeGen::generateMoveToLR(gen, 0);
-    emitVload(loadConstOp, dest, 12, 12, gen, false);
+    emitVload(loadConstOp, dest, 12, 12, gen);
     instruction brl(BRLraw);
     insnCodeGen::generate(gen,brl);
     inst_printf("Generated BRL\n");
@@ -857,7 +857,7 @@ Dyninst::Register EmitterPOWER::emitCallReplacement(opCode ocode,
     }
 
     // Load register with address.
-    emitVload(loadConstOp, callee->addr(), freeReg, freeReg, gen, false);
+    emitVload(loadConstOp, callee->addr(), freeReg, freeReg, gen);
 
     // Move to link register.
     insnCodeGen::generate(gen,mtlr);
@@ -865,7 +865,7 @@ Dyninst::Register EmitterPOWER::emitCallReplacement(opCode ocode,
     Address toc_new = gen.addrSpace()->proc()->getTOCoffsetInfo(callee);
     if (toc_new) {
         // Set up the new TOC value
-        emitVload(loadConstOp, toc_new, freeReg, freeReg, gen, false);
+        emitVload(loadConstOp, toc_new, freeReg, freeReg, gen);
     }
 
     // blr - branch through the link reg.
@@ -876,7 +876,7 @@ Dyninst::Register EmitterPOWER::emitCallReplacement(opCode ocode,
     Address toc_orig = gen.addrSpace()->proc()->getTOCoffsetInfo(caller);
     if (toc_new) {
         // Restore the original TOC value.
-        emitVload(loadConstOp, toc_orig, freeReg, freeReg, gen, false);
+        emitVload(loadConstOp, toc_orig, freeReg, freeReg, gen);
     }
 
     // What to return here?
@@ -1111,7 +1111,7 @@ Dyninst::Register EmitterPOWER::emitCall(opCode ocode,
     
     if (!inInstrumentation && setTOC) {
         // Need to reset the TOC
-        emitVload(loadConstOp, caller_toc, 2, 2, gen, false);
+        emitVload(loadConstOp, caller_toc, 2, 2, gen);
 
         // Also store toc_orig [r2] into the TOC save area [40(r1)].
         // Subsequent code will look for it there.
@@ -1383,7 +1383,7 @@ void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackS
 
   // emit code to load the immediate (constant offset) into dest; this
   // writes at gen+base and updates base, we must update insn...
-  emitVload(loadConstOp, (Address)imm, dest, dest, gen, noCost);
+  emitVload(loadConstOp, (Address)imm, dest, dest, gen);
   
   // If ra is used in the address spec, allocate a temp register and
   // get the value of ra from stack into it
@@ -1404,7 +1404,7 @@ void emitCSload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, codeGen &g
 }
 
 void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Register dest,
-               codeGen &gen, bool /*noCost*/, 
+               codeGen &gen,
                registerSpace * /*rs*/, int size,
                const instPoint * /* location */, AddressSpace *proc)
 {
@@ -2507,7 +2507,7 @@ bool EmitterPOWER::emitCallInstruction(codeGen &gen, func_instance *callee, bool
         // Use scratchReg to set destination of the call...
         inst_printf("[EmitterPOWER::EmitCallInstruction] needLongBranch, Emitting VLOAD  Callee: 0x%lx, ScratchReg: %u\n",
                     callee->addr(), (unsigned) scratchReg);
-        emitVload(loadConstOp, callee->addr(), scratchReg, scratchReg, gen, false);
+        emitVload(loadConstOp, callee->addr(), scratchReg, scratchReg, gen);
         insnCodeGen::generateMoveToLR(gen, scratchReg);
 
         inst_printf("Generated LR value in %d\n", scratchReg);
@@ -2519,13 +2519,13 @@ bool EmitterPOWER::emitCallInstruction(codeGen &gen, func_instance *callee, bool
         inst_printf("[EmitterPOWER::EmitCallInstruction] Setting TOC anchor, toc_anchor: %lx, register: 2(fixed)\n",
                     (uint64_t)toc_anchor);
         // Set up the new TOC value
-        emitVload(loadConstOp, toc_anchor, 2, 2, gen, false);
+        emitVload(loadConstOp, toc_anchor, 2, 2, gen);
         inst_printf("Set new TOC\n");
     }
 
     // ALL dynamic; call instruction generation
     if (needLongBranch) {
-        emitVload(loadConstOp, callee->addr(), 12, 12, gen, false);
+        emitVload(loadConstOp, callee->addr(), 12, 12, gen);
         instruction brl(BRLraw);
         insnCodeGen::generate(gen,brl);
         inst_printf("Generated BRL\n");
@@ -2533,7 +2533,7 @@ bool EmitterPOWER::emitCallInstruction(codeGen &gen, func_instance *callee, bool
     else {
         inst_printf("[EmitterPOWER::EmitCallInstruction] Generating Call, curAddress: %lx, calleeAddr: %lx\n",
                      gen.currAddr(), callee->addr());
-        emitVload(loadConstOp, callee->addr(), 12, 12, gen, false);
+        emitVload(loadConstOp, callee->addr(), 12, 12, gen);
         insnCodeGen::generateCall(gen, gen.currAddr(), callee->addr());
 
         inst_printf("Generated short call from 0x%lx to 0x%lx\n",

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1162,7 +1162,7 @@ codeBufIndex_t emitA(opCode op, Dyninst::Register src1, Dyninst::Register /*src2
 }
 
 Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dest,
-               codeGen &gen, bool /*noCost*/,
+               codeGen &gen,
                const instPoint * /*location*/, bool /*for_MT*/)
 {
 

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1399,7 +1399,7 @@ void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackS
 void emitCSload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, codeGen &gen,
 		bool noCost)
 {
-  emitASload(as, dest, 0, gen, noCost);
+  emitASload(as, dest, 0, gen);
 }
 
 void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Register dest,

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -996,7 +996,7 @@ Dyninst::Register EmitterPOWER::emitCall(opCode ocode,
         
         Dyninst::Register reg = Null_Register;
         // Try to allocate the correct parameter register
-        if (gen.rs()->allocateSpecificRegister(gen, registerSpace::r3 + u, true))
+        if (gen.rs()->allocateSpecificRegister(gen, registerSpace::r3 + u))
             reg = registerSpace::r3 + u;
 	Address unused = ADDR_NULL;
 	if (!operands[u]->generateCode_phase2( gen, false, unused, reg)) assert(0);

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -666,7 +666,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
             return;
         }
         else {
-            Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen, noCost);
+            Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
             emitVload(loadConstOp, src2imm, dest2, dest2, gen, noCost);
             emitV(op, src1, dest2, dest, gen, noCost, gen.rs(), 
                   gen.width(), gen.point(), gen.addrSpace(), s);
@@ -675,7 +675,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
         break;
         
     case divOp: {
-            Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen, noCost);
+            Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
             emitVload(loadConstOp, src2imm, dest2, dest2, gen, noCost);
             emitV(op, src1, dest2, dest, gen, noCost, gen.rs(),
                   gen.width(), gen.point(), gen.addrSpace(), s);
@@ -696,7 +696,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
         return;
         break;
     default:
-        Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen, noCost);
+        Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
         emitVload(loadConstOp, src2imm, dest2, dest2, gen, noCost);
         emitV(op, src1, dest2, dest, gen, noCost, gen.rs(),
               gen.width(), gen.point(), gen.addrSpace(), s);
@@ -1494,7 +1494,7 @@ void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, A
 {
     if (op == storeOp) {
 	// temp register to hold base address for store (added 6/26/96 jkh)
-	Dyninst::Register temp = gen.rs()->getScratchRegister(gen, noCost);
+	Dyninst::Register temp = gen.rs()->getScratchRegister(gen);
 
         insnCodeGen::loadPartialImmIntoReg(gen, temp, (long)dest);
         if (size == 1)
@@ -2149,12 +2149,12 @@ bool EmitterPOWER32Stat::emitCallInstruction(codeGen& gen, func_instance* callee
 }
 
 bool EmitterPOWER32Stat::emitPLTCommon(func_instance *callee, bool call, codeGen &gen) {
-  Dyninst::Register scratchReg = gen.rs()->getScratchRegister(gen, true);
+  Dyninst::Register scratchReg = gen.rs()->getScratchRegister(gen);
   if (scratchReg == Null_Register) return false;
 
   Dyninst::Register scratchLR = Null_Register;
   std::vector<Dyninst::Register> excluded; excluded.push_back(scratchReg);
-  scratchLR = gen.rs()->getScratchRegister(gen, excluded, true);
+  scratchLR = gen.rs()->getScratchRegister(gen, excluded);
   if (scratchLR == Null_Register) {
     if (scratchReg == registerSpace::r0) return false;
     // We can use r0 for this, since it's volatile. 
@@ -2214,12 +2214,12 @@ bool EmitterPOWER32Stat::emitTOCJump(block_instance *block, codeGen &gen) {
 
 
 bool EmitterPOWER32Stat::emitTOCCommon(block_instance *block, bool call, codeGen &gen) {
-  Dyninst::Register scratchReg = gen.rs()->getScratchRegister(gen, true);
+  Dyninst::Register scratchReg = gen.rs()->getScratchRegister(gen);
   if (scratchReg == Null_Register) return false;
 
   Dyninst::Register scratchLR = Null_Register;
   std::vector<Dyninst::Register> excluded; excluded.push_back(scratchReg);
-  scratchLR = gen.rs()->getScratchRegister(gen, excluded, true);
+  scratchLR = gen.rs()->getScratchRegister(gen, excluded);
   if (scratchLR == Null_Register) {
     if (scratchReg == registerSpace::r0) return false;
     // We can use r0 for this, since it's volatile. 
@@ -2563,7 +2563,7 @@ void EmitterPOWER::emitLoadShared(opCode op, Dyninst::Register dest, const image
 
    inst_printf("emitLoadShared addr 0x%lx curr adress 0x%lx offset %lu 0x%lx size %d\n", 
    	addr, gen.currAddr(), addr - gen.currAddr()+4, addr - gen.currAddr()+4, size);
-   Dyninst::Register scratchReg = gen.rs()->getScratchRegister(gen, true);
+   Dyninst::Register scratchReg = gen.rs()->getScratchRegister(gen);
 
    if (scratchReg == Null_Register) {
    	std::vector<Dyninst::Register> freeReg;
@@ -2624,7 +2624,7 @@ void EmitterPOWER::emitStoreShared(Dyninst::Register source, const image_variabl
    		addr, gen.currAddr(), addr - gen.currAddr()+4, addr - gen.currAddr()+4, size);
 
    // load register with address from jump slot
-   Dyninst::Register scratchReg = gen.rs()->getScratchRegister(gen, true);
+   Dyninst::Register scratchReg = gen.rs()->getScratchRegister(gen);
    if (scratchReg == Null_Register) {
    	std::vector<Dyninst::Register> freeReg;
         std::vector<Dyninst::Register> excludeReg;
@@ -2642,7 +2642,7 @@ void EmitterPOWER::emitStoreShared(Dyninst::Register source, const image_variabl
    if(!is_local) {
         std::vector<Dyninst::Register> exclude;
         exclude.push_back(scratchReg);
-   	Dyninst::Register scratchReg1 = gen.rs()->getScratchRegister(gen, exclude, true);
+   	Dyninst::Register scratchReg1 = gen.rs()->getScratchRegister(gen, exclude);
    	if (scratchReg1 == Null_Register) {
    		std::vector<Dyninst::Register> freeReg;
         	std::vector<Dyninst::Register> excludeReg;

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1083,7 +1083,7 @@ Dyninst::Register EmitterPOWER::emitCall(opCode ocode,
     Dyninst::Register retReg = Null_Register;
     if (inInstrumentation) {
         // get a register to keep the return value in.
-        retReg = gen.rs()->allocateRegister(gen, noCost);        
+        retReg = gen.rs()->allocateRegister(gen);
         // put the return value from register 3 to the newly allocated register.
         insnCodeGen::generateImm(gen, ORILop, 3, retReg, 0);
     }
@@ -1342,7 +1342,7 @@ static inline void emitAddOriginal(Dyninst::Register src, Dyninst::Register acc,
     
     if(nr) {
         // this needs gen because it uses emitV...
-        temp = gen.rs()->allocateRegister(gen, noCost);
+        temp = gen.rs()->allocateRegister(gen);
         
         // Emit code to restore the original ra register value in temp.
         // The offset compensates for the gap 0, 3, 4, ...

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -999,7 +999,7 @@ Dyninst::Register EmitterPOWER::emitCall(opCode ocode,
         if (gen.rs()->allocateSpecificRegister(gen, registerSpace::r3 + u))
             reg = registerSpace::r3 + u;
 	Address unused = ADDR_NULL;
-	if (!operands[u]->generateCode_phase2( gen, false, unused, reg)) assert(0);
+	if (!operands[u]->generateCode_phase2( gen, unused, reg)) assert(0);
 	assert(reg != Null_Register);
 	srcs.push_back(reg);
     }
@@ -1369,8 +1369,7 @@ static inline void emitAddOriginal(Dyninst::Register src, Dyninst::Register acc,
 // VG(11/07/01): Load in destination the effective address given
 // by the address descriptor. Used for memory access stuff.
 void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackShift,
-		codeGen &gen,
-		bool noCost)
+		codeGen &gen)
 {
   // Haven't implemented non-zero shifts yet
   assert(stackShift == 0);

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -806,7 +806,7 @@ bool EmitterPOWER::clobberAllFuncCall( registerSpace *rs,
 
 Dyninst::Register emitFuncCall(opCode op,
                       codeGen &gen,
-                      std::vector<codeGenASTPtr> &operands, bool noCost,
+                      std::vector<codeGenASTPtr> &operands,
                       func_instance *callee) {
     return gen.emitter()->emitCall(op, gen, operands, noCost, callee);
 }

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1341,7 +1341,7 @@ bool writeFunctionPtr(AddressSpace *p, Address addr, func_instance *f)
 }
 
 bool emitStoreConst(Address addr, int imm, codeGen &gen, bool noCost) {
-   gen.codeEmitter()->emitStoreImm(addr, imm, gen, noCost);
+   gen.codeEmitter()->emitStoreImm(addr, imm, gen);
    return true;
 }
 

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -755,7 +755,7 @@ Dyninst::Register emitFuncCall(opCode op,
                       std::vector<codeGenASTPtr> &operands, 
                       func_instance *callee)
 {
-    Dyninst::Register reg = gen.codeEmitter()->emitCall(op, gen, operands, noCost, callee);
+    Dyninst::Register reg = gen.codeEmitter()->emitCall(op, gen, operands, callee);
     return reg;
 }
 

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1298,8 +1298,7 @@ bool emitPop(RealRegister reg, codeGen &gen) {
 void emitLoadPreviousStackFrameRegister(Address register_num,
                                         Dyninst::Register dest,
                                         codeGen &gen,
-                                        int,
-                                        bool){
+                                        int){
     gen.codeEmitter()->emitLoadOrigRegister(register_num, dest, gen);
 }
 

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -767,7 +767,7 @@ Dyninst::Register emitFuncCall(opCode op,
  */
 
 codeBufIndex_t emitA(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, long dest,
-                     codeGen &gen, Dyninst::DyninstAPI::RegControl rc, bool /*noCost*/)
+                     codeGen &gen, Dyninst::DyninstAPI::RegControl rc)
 {
    // retval is the address of the jump (if one is created). 
    // It's always the _start_ of the jump, which means that if we need

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1340,7 +1340,7 @@ bool writeFunctionPtr(AddressSpace *p, Address addr, func_instance *f)
    return p->writeDataSpace((void *) addr, sizeof(Address), &val_to_write);   
 }
 
-bool emitStoreConst(Address addr, int imm, codeGen &gen, bool noCost) {
+bool emitStoreConst(Address addr, int imm, codeGen &gen) {
    gen.codeEmitter()->emitStoreImm(addr, imm, gen);
    return true;
 }

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1052,7 +1052,7 @@ void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest,
 }
 
 void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Register dest,
-               codeGen &gen, bool /*noCost*/, 
+               codeGen &gen,
                registerSpace * /*rs*/, int size,
                const instPoint * /* location */, AddressSpace * /* proc */)
 {

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1025,7 +1025,7 @@ void restoreGPRtoGPR(RealRegister src, RealRegister dest, codeGen &gen)
 
 // VG(11/07/01): Load in destination the effective address given
 // by the address descriptor. Used for memory access stuff.
-void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackShift, codeGen &gen, bool /* noCost */)
+void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackShift, codeGen &gen)
 {
     // TODO 16-bit registers, rep hacks
     long imm = as->getImm();

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1094,7 +1094,7 @@ void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Registe
 }
 
 void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, Address dest,
-                codeGen &gen, bool /*noCost*/, registerSpace * /*rs*/, 
+                codeGen &gen, registerSpace * /*rs*/,
                 int size,
                 const instPoint * /* location */, AddressSpace * /* proc */)
 {

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -502,7 +502,7 @@ void emitMovPCRMToReg(RealRegister dest, int offset, codeGen &gen, bool deref_re
          pc_reg = dest;
       }
       else {
-         gen.rs()->pc_rel_reg = gen.rs()->allocateRegister(gen, true);
+         gen.rs()->pc_rel_reg = gen.rs()->allocateRegister(gen);
          pc_reg = gen.rs()->loadVirtualForWrite(gen.rs()->pc_rel_reg, gen);
       }
       gen.rs()->pc_rel_offset() = used + 5;

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -798,7 +798,7 @@ codeBufIndex_t emitA(opCode op, Dyninst::Register src1, Dyninst::Register /*src2
 }
 
 Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dest,
-               codeGen &gen, bool noCost,
+               codeGen &gen,
                const instPoint *location, bool /*for_multithreaded*/)
 {
    bool get_addr_of = (src2 != Null_Register);

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1350,7 +1350,7 @@ bool emitAddSignedImm(Address addr, long int imm, codeGen &gen) {
    return true;
 }
 
-bool emitSubSignedImm(Address addr, long int imm, codeGen &gen, bool noCost) {
+bool emitSubSignedImm(Address addr, long int imm, codeGen &gen) {
    gen.codeEmitter()->emitAddSignedImm(addr, imm * -1, gen);
    return true;
 }

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -753,7 +753,6 @@ unsigned char jccOpcodeFromRelOp(unsigned op, bool s)
 Dyninst::Register emitFuncCall(opCode op,
                       codeGen &gen,
                       std::vector<codeGenASTPtr> &operands, 
-                      bool noCost,
                       func_instance *callee)
 {
     Dyninst::Register reg = gen.codeEmitter()->emitCall(op, gen, operands, noCost, callee);

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -833,7 +833,7 @@ Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src
           abort();                  // unexpected op for this emit!
     }
     assert(get_addr_of);
-    emitV(storeIndirOp, src2, 0, dest, gen, noCost, gen.rs(), 
+    emitV(storeIndirOp, src2, 0, dest, gen, gen.rs(),
           gen.addrSpace()->getAddressWidth(), gen.point(), gen.addrSpace());
     return(dest);
 }
@@ -1117,7 +1117,7 @@ void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, Addre
 }
 
 void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dest,
-           codeGen &gen, bool /*noCost*/, 
+           codeGen &gen,
            registerSpace * /*rs*/, int size,
            const instPoint * /* location */, AddressSpace * /* proc */, bool s)
 {

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1039,7 +1039,7 @@ void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackS
 
 
 void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest,
-		codeGen &gen, bool /* noCost */ )
+		codeGen &gen)
 {
    // VG(7/30/02): different from ASload on this platform, no LEA business
 

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -960,7 +960,7 @@ Dyninst::Register restoreGPRtoReg(RealRegister reg, codeGen &gen, RealRegister *
          dest = gen.rs()->getScratchRegister(gen);
       }
       else {
-         dest = gen.rs()->getScratchRegister(gen, false, true);
+         dest = gen.rs()->getScratchRegister(gen, true);
       }
    }
    

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1345,13 +1345,13 @@ bool emitStoreConst(Address addr, int imm, codeGen &gen, bool noCost) {
    return true;
 }
 
-bool emitAddSignedImm(Address addr, long int imm, codeGen &gen, bool noCost) {
-   gen.codeEmitter()->emitAddSignedImm(addr, imm, gen, noCost);
+bool emitAddSignedImm(Address addr, long int imm, codeGen &gen) {
+   gen.codeEmitter()->emitAddSignedImm(addr, imm, gen);
    return true;
 }
 
 bool emitSubSignedImm(Address addr, long int imm, codeGen &gen, bool noCost) {
-   gen.codeEmitter()->emitAddSignedImm(addr, imm * -1, gen, noCost);
+   gen.codeEmitter()->emitAddSignedImm(addr, imm * -1, gen);
    return true;
 }
 

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1207,7 +1207,7 @@ void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::R
 }
 
 void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Register dest,
-             codeGen &gen, bool, registerSpace *, bool s)
+             codeGen &gen, registerSpace *, bool s)
 {
    if (op ==  storeOp) {
        // this doesn't seem to ever be called from ast.C (or anywhere) - gq

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -225,7 +225,7 @@ bool writeFunctionPtr(AddressSpace *p, Dyninst::Address addr, func_instance *f);
 //Store constant in memory at address
 bool emitStoreConst(Dyninst::Address addr, int imm, codeGen &gen, bool noCost);
 //Add constant to memory at address
-bool emitAddSignedImm(Dyninst::Address addr, long int imm, codeGen &gen, bool noCost);
+bool emitAddSignedImm(Dyninst::Address addr, long int imm, codeGen &gen);
 //Subtract constant from memory at address
 bool emitSubSignedImm(Dyninst::Address addr, long int imm, codeGen &gen, bool noCost);
 

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -154,7 +154,7 @@ codeBufIndex_t emitA(opCode op, Dyninst::Register src1, Dyninst::Register src2, 
 // for operations requiring a Dyninst::Register to be returned
 // (e.g., getRetValOp, getRetAddrOp, getParamOp)
 Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dst,
-               codeGen &gen, bool noCost, 
+               codeGen &gen,
                const instPoint *location, bool for_multithreaded);
 
 // for general arithmetic and logic operations which return nothing

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -189,7 +189,7 @@ void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, c
 
 // and the retyped original emitImm companion
 void     emitImm(opCode op, Dyninst::Register src, Dyninst::RegValue src2imm, Dyninst::Register dst,
-                 codeGen &gen, bool noCost,
+                 codeGen &gen,
                  registerSpace *rs = NULL, bool s = true);
 
 

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -201,7 +201,7 @@ typedef BPatch_addrSpec_NP BPatch_countSpec_NP;
 
 void emitJmpMC(int condition, int offset, codeGen &gen);
 
-void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackShift, codeGen &gen, bool noCost);
+void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackShift, codeGen &gen);
 
 void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest, codeGen &gen, bool noCost);
 

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -223,7 +223,7 @@ bool writeFunctionPtr(AddressSpace *p, Dyninst::Address addr, func_instance *f);
  * false if the platform can't perform any optimizations.
  **/
 //Store constant in memory at address
-bool emitStoreConst(Dyninst::Address addr, int imm, codeGen &gen, bool noCost);
+bool emitStoreConst(Dyninst::Address addr, int imm, codeGen &gen);
 //Add constant to memory at address
 bool emitAddSignedImm(Dyninst::Address addr, long int imm, codeGen &gen);
 //Subtract constant from memory at address

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -149,7 +149,7 @@ public:
 // The return value is a magic "hand this in when we update" black box;
 // emitA handles emission of things like ifs that need to be updated later.
 codeBufIndex_t emitA(opCode op, Dyninst::Register src1, Dyninst::Register src2, long dst,
-                     codeGen &gen, Dyninst::DyninstAPI::RegControl rc, bool noCost);
+                     codeGen &gen, Dyninst::DyninstAPI::RegControl rc);
 
 // for operations requiring a Dyninst::Register to be returned
 // (e.g., getRetValOp, getRetAddrOp, getParamOp)

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -208,7 +208,6 @@ void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest, codeGen &
 // VG(11/06/01): moved here and added location
 Dyninst::Register emitFuncCall(opCode op, codeGen &gen,
                       std::vector<Dyninst::DyninstAPI::codeGenASTPtr> &operands,
-					  bool noCost, 
                       func_instance *func);
 
 extern Dyninst::Address getMaxBranch();

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -203,7 +203,7 @@ void emitJmpMC(int condition, int offset, codeGen &gen);
 
 void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackShift, codeGen &gen);
 
-void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest, codeGen &gen, bool noCost);
+void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest, codeGen &gen);
 
 // VG(11/06/01): moved here and added location
 Dyninst::Register emitFuncCall(opCode op, codeGen &gen,

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -227,7 +227,7 @@ bool emitStoreConst(Dyninst::Address addr, int imm, codeGen &gen, bool noCost);
 //Add constant to memory at address
 bool emitAddSignedImm(Dyninst::Address addr, long int imm, codeGen &gen);
 //Subtract constant from memory at address
-bool emitSubSignedImm(Dyninst::Address addr, long int imm, codeGen &gen, bool noCost);
+bool emitSubSignedImm(Dyninst::Address addr, long int imm, codeGen &gen);
 
 inline bool isPowerOf2(int value, int &result) {
   if(value <= 0) {

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -159,7 +159,7 @@ Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src
 
 // for general arithmetic and logic operations which return nothing
 void     emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dst,
-               codeGen &gen, bool noCost, 
+               codeGen &gen,
                registerSpace *rs = NULL, int size = 4,
                const instPoint * location = NULL, AddressSpace * proc = NULL, bool s = true);
 

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -165,7 +165,7 @@ void     emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dynins
 
 // for loadOp and loadConstOp (reading from an Dyninst::Address)
 void     emitVload(opCode op, Dyninst::Address src1, Dyninst::Register src2, Dyninst::Register dst,
-                   codeGen &gen, bool noCost, 
+                   codeGen &gen,
                    registerSpace *rs = NULL, int size = 4, 
                    const instPoint * location = NULL, AddressSpace * proc = NULL);
 
@@ -177,7 +177,7 @@ void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, D
 
 // for loadOp and loadConstOp (reading from an Dyninst::Address)
 void     emitVload(opCode op, const image_variable* src1, Dyninst::Register src2, Dyninst::Register dst,
-                   codeGen &gen, bool noCost, 
+                   codeGen &gen,
                    registerSpace *rs = NULL, int size = 4, 
                    const instPoint * location = NULL, AddressSpace * proc = NULL);
 

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -171,7 +171,7 @@ void     emitVload(opCode op, Dyninst::Address src1, Dyninst::Register src2, Dyn
 
 // for storeOp (writing to an Dyninst::Address)
 void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Address dst,
-                    codeGen &gen, bool noCost, 
+                    codeGen &gen,
                     registerSpace *rs = NULL, int size = 4, 
                     const instPoint * location = NULL, AddressSpace * proc = NULL);
 
@@ -183,7 +183,7 @@ void     emitVload(opCode op, const image_variable* src1, Dyninst::Register src2
 
 // for storeOp (writing to an Dyninst::Address)
 void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, const image_variable* dst,
-                    codeGen &gen, bool noCost, 
+                    codeGen &gen,
                     registerSpace *rs = NULL, int size = 4, 
                     const instPoint * location = NULL, AddressSpace * proc = NULL);
 

--- a/dyninstAPI/src/registerSpace/registerSpace.C
+++ b/dyninstAPI/src/registerSpace/registerSpace.C
@@ -225,7 +225,7 @@ bool registerSpace::allocateSpecificRegister(codeGen &gen, Register num,
 	return false;
     }
     else if (reg->keptValue) {
-      if (!stealRegister(num, gen, noCost)) {
+      if (!stealRegister(num, gen)) {
 	regalloc_printf("Error: register has cached value, unable to steal!\n");
 	return false;
       }
@@ -302,7 +302,7 @@ Register registerSpace::getScratchRegister(codeGen &gen, std::vector<Register> &
     // Still?
     if (toUse == NULL) {
         for (unsigned i = 0; i < couldBeStolen.size(); i++) {
-            if (stealRegister(couldBeStolen[i]->number, gen, noCost)) {
+            if (stealRegister(couldBeStolen[i]->number, gen)) {
                 toUse = couldBeStolen[i];
                 break;
             }
@@ -340,7 +340,7 @@ Register registerSpace::allocateRegister(codeGen &gen,
   return reg;
 }
 
-bool registerSpace::stealRegister(Register reg, codeGen &gen, bool /*noCost*/) {
+bool registerSpace::stealRegister(Register reg, codeGen &gen) {
     // Can be made a return false; this for correctness.
     assert(registers_[reg]->refCount == 0);
     assert(registers_[reg]->keptValue == true);

--- a/dyninstAPI/src/registerSpace/registerSpace.C
+++ b/dyninstAPI/src/registerSpace/registerSpace.C
@@ -198,8 +198,7 @@ void registerSpace::createRegSpaceInt(std::vector<registerSlot *> &registers,
 
 }
 
-bool registerSpace::allocateSpecificRegister(codeGen &gen, Register num,
-					     bool noCost)
+bool registerSpace::allocateSpecificRegister(codeGen &gen, Register num)
 {
   regalloc_printf("Allocating specific register %u\n", num.getId());
 

--- a/dyninstAPI/src/registerSpace/registerSpace.C
+++ b/dyninstAPI/src/registerSpace/registerSpace.C
@@ -239,12 +239,12 @@ bool registerSpace::allocateSpecificRegister(codeGen &gen, Register num)
     return true;
 }
 
-Register registerSpace::getScratchRegister(codeGen &gen, bool noCost, bool realReg) {
+Register registerSpace::getScratchRegister(codeGen &gen, bool realReg) {
     std::vector<Register> empty;
-    return getScratchRegister(gen, empty, noCost, realReg);
+    return getScratchRegister(gen, empty, realReg);
 }
 
-Register registerSpace::getScratchRegister(codeGen &gen, std::vector<Register> &excluded, bool noCost, bool realReg) {
+Register registerSpace::getScratchRegister(codeGen &gen, std::vector<Register> &excluded, bool realReg) {
   std::vector<registerSlot *> couldBeStolen;
   std::vector<registerSlot *> couldBeSpilled;
 
@@ -326,7 +326,7 @@ Register registerSpace::allocateRegister(codeGen &gen,
 					 bool realReg)
 {
   regalloc_printf("Allocating and retaining register...\n");
-  Register reg = getScratchRegister(gen, noCost, realReg);
+  Register reg = getScratchRegister(gen, realReg);
   regalloc_printf("retaining register %u\n", reg.getId());
   if (reg == Null_Register) return Null_Register;
   if (realReg) {

--- a/dyninstAPI/src/registerSpace/registerSpace.C
+++ b/dyninstAPI/src/registerSpace/registerSpace.C
@@ -322,7 +322,6 @@ Register registerSpace::getScratchRegister(codeGen &gen, std::vector<Register> &
 }
 
 Register registerSpace::allocateRegister(codeGen &gen,
-                                         bool noCost,
 					 bool realReg)
 {
   regalloc_printf("Allocating and retaining register...\n");

--- a/dyninstAPI/src/registerSpace/registerSpace.C
+++ b/dyninstAPI/src/registerSpace/registerSpace.C
@@ -563,8 +563,7 @@ bool registerSpace::readProgramRegister(codeGen &gen,
     emitLoadPreviousStackFrameRegister((Address)source,
                                        destination,
                                        gen,
-                                       size,
-                                       true);
+                                       size);
     return true;
 #elif defined(DYNINST_CODEGEN_ARCH_AARCH64)
 //#warning "This fucntion is not implemented yet!"

--- a/dyninstAPI/src/registerSpace/registerSpace.h
+++ b/dyninstAPI/src/registerSpace/registerSpace.h
@@ -244,7 +244,7 @@ class registerSpace {
     registerSlot *findRegister(Dyninst::Register reg);
     registerSlot *findRegister(RealRegister reg);
 
-    bool stealRegister(Dyninst::Register reg, codeGen &gen, bool noCost);
+    bool stealRegister(Dyninst::Register reg, codeGen &gen);
 
     bool markSavedRegister(registerSlot *num, int offsetFromFP);
 

--- a/dyninstAPI/src/registerSpace/registerSpace.h
+++ b/dyninstAPI/src/registerSpace/registerSpace.h
@@ -96,7 +96,7 @@ class registerSpace {
                               unsigned size);
 
 
-    Dyninst::Register allocateRegister(codeGen &gen, bool noCost, bool realReg = false);
+    Dyninst::Register allocateRegister(codeGen &gen, bool realReg = false);
     bool allocateSpecificRegister(codeGen &gen, Dyninst::Register r);
 
     bool canAllocate(Dyninst::Register reg) const;

--- a/dyninstAPI/src/registerSpace/registerSpace.h
+++ b/dyninstAPI/src/registerSpace/registerSpace.h
@@ -97,7 +97,7 @@ class registerSpace {
 
 
     Dyninst::Register allocateRegister(codeGen &gen, bool noCost, bool realReg = false);
-    bool allocateSpecificRegister(codeGen &gen, Dyninst::Register r, bool noCost = true);
+    bool allocateSpecificRegister(codeGen &gen, Dyninst::Register r);
 
     bool canAllocate(Dyninst::Register reg) const;
     Dyninst::Register allocateGprBlock(Dyninst::RegKind regKind, uint32_t numRegs, Dyninst::Alignment alignment);

--- a/dyninstAPI/src/registerSpace/registerSpace.h
+++ b/dyninstAPI/src/registerSpace/registerSpace.h
@@ -329,6 +329,6 @@ class registerSpace {
 };
 
 void emitLoadPreviousStackFrameRegister(Dyninst::Address register_num, Dyninst::Register dest,
-                                        codeGen &gen, int size, bool noCost);
+                                        codeGen &gen, int size);
 
 #endif

--- a/dyninstAPI/src/registerSpace/registerSpace.h
+++ b/dyninstAPI/src/registerSpace/registerSpace.h
@@ -106,10 +106,10 @@ class registerSpace {
 
     // Like allocate, but don't keep it around; if someone else tries to
     // allocate they might get this one.
-    Dyninst::Register getScratchRegister(codeGen &gen, bool noCost = true, bool realReg = false);
+    Dyninst::Register getScratchRegister(codeGen &gen, bool realReg = false);
     // Like the above, but excluding a set of registers (that we don't want
     // to touch)
-    Dyninst::Register getScratchRegister(codeGen &gen, std::vector<Dyninst::Register> &excluded, bool noCost = true, bool realReg = false);
+    Dyninst::Register getScratchRegister(codeGen &gen, std::vector<Dyninst::Register> &excluded, bool realReg = false);
 
     // For now, we save registers elsewhere and mark them here.
     bool markSavedRegister(Dyninst::Register num, int offsetFromFP);

--- a/dyninstAPI/src/trampolines/baseTramp.C
+++ b/dyninstAPI/src/trampolines/baseTramp.C
@@ -395,7 +395,7 @@ bool baseTramp::generateCodeInlined(codeGen &gen,
        generateSaves(gen, gen.rs());
    }
 
-   if (!baseTrampAST->generateCode(gen, false)) {
+   if (!baseTrampAST->generateCode(gen)) {
       fprintf(stderr, "Gripe: base tramp creation failed\n");
       retval = false;
    }

--- a/tests/unit/dyninstAPI/emitter/x86_64.cpp
+++ b/tests/unit/dyninstAPI/emitter/x86_64.cpp
@@ -196,7 +196,7 @@ int main() {
   failed |= !verify_emitter(gen, emitter_buffer_t<7>{{0x48, 0x81, 0xc4, 0xa0, 0x91, 0x0, 0x0}});
 
   // add qword ptr [0x12345678], 0x04
-  emitter->emitAddSignedImm(0x12345678, 0x4, gen, false);
+  emitter->emitAddSignedImm(0x12345678, 0x4, gen);
   failed |= !verify_emitter(gen, emitter_buffer_t<9>{{0x48, 0x83, 0x04, 0x25, 0x78, 0x56, 0x34, 0x12, 0x04}});
 
   // Load BPatch_countSpec_NP (I don't actually know what this is supposed to do)

--- a/tests/unit/dyninstAPI/emitter/x86_64.cpp
+++ b/tests/unit/dyninstAPI/emitter/x86_64.cpp
@@ -43,7 +43,7 @@ int main() {
   }});
 
   // Store an immediate value at a fixed address
-  emitter->emitStoreImm(0x12345678, 0x9abcdef, gen, false);
+  emitter->emitStoreImm(0x12345678, 0x9abcdef, gen);
   failed |= !verify_emitter(gen, emitter_buffer_t<11>{{
     // mov dword ptr [0x12345678], 0x9abcdef
     0xc7, 0x04, 0x25, 0x78, 0x56, 0x34, 0x12, 0xef, 0xcd, 0xab, 0x09


### PR DESCRIPTION
It's not exactly clear where it came from or when it was removed, but all of the current interfaces have always ignored it.