### PR TITLE
Remove codegen callOptions type

### DIFF
--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -62,7 +62,6 @@ class registerSpace;
 class AddressSpace;
 class image_variable;
 
-typedef enum { callNoArgs, callRecordType, callFullArgs } callOptions;
 typedef enum { callPreInsn, callPostInsn, callBranchTargetInsn, callUnset } callWhen;
 typedef enum { orderFirstAtPoint, orderLastAtPoint } callOrder;
 


### PR DESCRIPTION
It was added by a65441575 in 1994, but never used.