### PR TITLE
Remove unused variables from codegen emitter interfaces

### DIFF
--- a/dyninstAPI/src/ASTs/codeGenAST.h
+++ b/dyninstAPI/src/ASTs/codeGenAST.h
@@ -186,7 +186,7 @@ public:
   }
 
   virtual void emitVariableLoad(opCode, Dyninst::Register, Dyninst::Register, codeGen &,
-                                int, const instPoint *, AddressSpace *) {
+                                int, AddressSpace *) {
     assert(!"Never call this on anything but an operand");
   }
 

--- a/dyninstAPI/src/ASTs/codeGenAST.h
+++ b/dyninstAPI/src/ASTs/codeGenAST.h
@@ -181,7 +181,7 @@ public:
   }
 
   virtual void emitVariableStore(opCode, Dyninst::Register, Dyninst::Register, codeGen &,
-                                 int, const instPoint *, AddressSpace *) {
+                                 int, AddressSpace *) {
     assert(!"Never call this on anything but an operand");
   }
 

--- a/dyninstAPI/src/ASTs/codeGenAST.h
+++ b/dyninstAPI/src/ASTs/codeGenAST.h
@@ -186,7 +186,7 @@ public:
   }
 
   virtual void emitVariableLoad(opCode, Dyninst::Register, Dyninst::Register, codeGen &,
-                                registerSpace *, int, const instPoint *, AddressSpace *) {
+                                int, const instPoint *, AddressSpace *) {
     assert(!"Never call this on anything but an operand");
   }
 

--- a/dyninstAPI/src/ASTs/codeGenAST.h
+++ b/dyninstAPI/src/ASTs/codeGenAST.h
@@ -181,7 +181,7 @@ public:
   }
 
   virtual void emitVariableStore(opCode, Dyninst::Register, Dyninst::Register, codeGen &,
-                                 registerSpace *, int, const instPoint *, AddressSpace *) {
+                                 int, const instPoint *, AddressSpace *) {
     assert(!"Never call this on anything but an operand");
   }
 

--- a/dyninstAPI/src/ASTs/functionCallAST.C
+++ b/dyninstAPI/src/ASTs/functionCallAST.C
@@ -105,7 +105,7 @@ bool functionCallAST::generateCode_phase2(codeGen &gen, Address &,
       gen.tracker()->addKeptRegister(gen, this, retReg);
     }
   } else if(retReg != tmp) {
-    emitImm(orOp, tmp, 0, retReg, gen, gen.rs());
+    emitImm(orOp, tmp, 0, retReg, gen);
     gen.rs()->freeRegister(tmp);
   }
   decUseCount(gen);

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -105,12 +105,12 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       break;
     case operandType::variableAddr:
       assert(oVar);
-      emitVariableLoad(loadConstOp, retReg, retReg, gen, size, gen.point(),
+      emitVariableLoad(loadConstOp, retReg, retReg, gen, size,
                        gen.addrSpace());
       break;
     case operandType::variableValue:
       assert(oVar);
-      emitVariableLoad(loadOp, retReg, retReg, gen, size, gen.point(),
+      emitVariableLoad(loadOp, retReg, retReg, gen, size,
                        gen.addrSpace());
       break;
     case operandType::ReturnVal:
@@ -234,7 +234,7 @@ int_variable *operandAST::lookUpVar(AddressSpace *as) {
 
 void operandAST::emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Register dest,
                                       codeGen &gen, int size_,
-                                      const instPoint *point, AddressSpace *as) {
+                                      AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {
     emitVload(op, var->getAddress(), src2, dest, gen, size_, as);

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -248,7 +248,7 @@ void operandAST::emitVariableStore(opCode op, Dyninst::Register src1, Dyninst::R
                                        const instPoint *point, AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {
-    emitVstore(op, src1, src2, var->getAddress(), gen, size_, point, as);
+    emitVstore(op, src1, src2, var->getAddress(), gen, size_, as);
   } else {
     gen.codeEmitter()->emitStoreShared(src1, oVar, (var != NULL), size_, gen);
   }

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -94,7 +94,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       } else {
         tSize = sizeof(long);
       }
-      emitV(loadIndirOp, src, 0, retReg, gen, gen.rs(), tSize, gen.point(),
+      emitV(loadIndirOp, src, 0, retReg, gen, tSize, gen.point(),
             gen.addrSpace());
       gen.rs()->freeRegister(src);
       break;

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -244,7 +244,7 @@ void operandAST::emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Re
 }
 
 void operandAST::emitVariableStore(opCode op, Dyninst::Register src1, Dyninst::Register src2,
-                                       codeGen &gen, registerSpace *rs, int size_,
+                                       codeGen &gen, int size_,
                                        const instPoint *point, AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -119,7 +119,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       if(src != retReg) {
         // Move src to retReg. Can't simply return src, since it was not
         // allocated properly
-        emitImm(orOp, src, 0, retReg, gen, gen.rs());
+        emitImm(orOp, src, 0, retReg, gen);
       }
       break;
     case operandType::ReturnAddr:
@@ -128,7 +128,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       if(src != retReg) {
         // Move src to retReg. Can't simply return src, since it was not
         // allocated properly
-        emitImm(orOp, src, 0, retReg, gen, gen.rs());
+        emitImm(orOp, src, 0, retReg, gen);
       }
       break;
     case operandType::Param:
@@ -155,7 +155,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       if(src != retReg) {
         // Move src to retReg. Can't simply return src, since it was not
         // allocated properly
-        emitImm(orOp, src, 0, retReg, gen, gen.rs());
+        emitImm(orOp, src, 0, retReg, gen);
       }
     } break;
     case operandType::DataAddr:

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -245,7 +245,7 @@ void operandAST::emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Re
 
 void operandAST::emitVariableStore(opCode op, Dyninst::Register src1, Dyninst::Register src2,
                                        codeGen &gen, int size_,
-                                       const instPoint *point, AddressSpace *as) {
+                                       AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {
     emitVstore(op, src1, src2, var->getAddress(), gen, size_, as);

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -248,7 +248,7 @@ void operandAST::emitVariableStore(opCode op, Dyninst::Register src1, Dyninst::R
                                        const instPoint *point, AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {
-    emitVstore(op, src1, src2, var->getAddress(), gen, rs, size_, point, as);
+    emitVstore(op, src1, src2, var->getAddress(), gen, size_, point, as);
   } else {
     gen.codeEmitter()->emitStoreShared(src1, oVar, (var != NULL), size_, gen);
   }

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -78,7 +78,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
 #else
     case operandType::Constant:
       assert(oVar == NULL);
-      emitVload(loadConstOp, (Address)oValue, retReg, retReg, gen, gen.rs(), size,
+      emitVload(loadConstOp, (Address)oValue, retReg, retReg, gen, size,
                 gen.point(), gen.addrSpace());
       break;
 #endif
@@ -161,13 +161,13 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
     case operandType::DataAddr:
       assert(oVar == NULL);
       addr = reinterpret_cast<Address>(oValue);
-      emitVload(loadOp, addr, retReg, retReg, gen, NULL, size, gen.point(),
+      emitVload(loadOp, addr, retReg, retReg, gen, size, gen.point(),
                 gen.addrSpace());
       break;
     case operandType::FrameAddr:
       addr = (Address)oValue;
       temp = gen.rs()->allocateRegister(gen);
-      emitVload(loadFrameRelativeOp, addr, temp, retReg, gen, gen.rs(), size, gen.point(),
+      emitVload(loadFrameRelativeOp, addr, temp, retReg, gen, size, gen.point(),
                 gen.addrSpace());
       gen.rs()->freeRegister(temp);
       break;
@@ -176,7 +176,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       // This codeGenAST holds the register number, and loperand holds offset.
       assert(operand_);
       addr = (Address)operand_->getOValue();
-      emitVload(loadRegRelativeOp, addr, (long)oValue, retReg, gen, gen.rs(), size,
+      emitVload(loadRegRelativeOp, addr, (long)oValue, retReg, gen, size,
                 gen.point(), gen.addrSpace());
       break;
     case operandType::ConstantString:
@@ -192,7 +192,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       }
 
       if(!gen.addrSpace()->needsPIC()) {
-        emitVload(loadConstOp, addr, retReg, retReg, gen, gen.rs(), size, gen.point(),
+        emitVload(loadConstOp, addr, retReg, retReg, gen, size, gen.point(),
                   gen.addrSpace());
       } else {
         gen.codeEmitter()->emitLoadShared(loadConstOp, retReg, NULL, true, size, gen, addr);
@@ -237,7 +237,7 @@ void operandAST::emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Re
                                       const instPoint *point, AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {
-    emitVload(op, var->getAddress(), src2, dest, gen, rs, size_, point, as);
+    emitVload(op, var->getAddress(), src2, dest, gen, size_, point, as);
   } else {
     gen.codeEmitter()->emitLoadShared(op, dest, oVar, (var != NULL), size_, gen, 0);
   }

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -114,8 +114,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
                        gen.addrSpace());
       break;
     case operandType::ReturnVal:
-      src = emitR(getRetValOp, 0, Dyninst::Null_Register, retReg, gen, gen.point(),
-                  gen.addrSpace()->multithread_capable());
+      src = emitR(getRetValOp, 0, Dyninst::Null_Register, retReg, gen, gen.point());
       REGISTER_CHECK(src);
       if(src != retReg) {
         // Move src to retReg. Can't simply return src, since it was not
@@ -124,8 +123,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       }
       break;
     case operandType::ReturnAddr:
-      src = emitR(getRetAddrOp, 0, Dyninst::Null_Register, retReg, gen, gen.point(),
-                  gen.addrSpace()->multithread_capable());
+      src = emitR(getRetAddrOp, 0, Dyninst::Null_Register, retReg, gen, gen.point());
       REGISTER_CHECK(src);
       if(src != retReg) {
         // Move src to retReg. Can't simply return src, since it was not
@@ -152,7 +150,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
           break;
       }
       src = emitR(paramOp, (Address)oValue, Dyninst::Null_Register, retReg, gen,
-                  gen.point(), gen.addrSpace()->multithread_capable());
+                  gen.point());
       REGISTER_CHECK(src);
       if(src != retReg) {
         // Move src to retReg. Can't simply return src, since it was not

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -105,12 +105,12 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       break;
     case operandType::variableAddr:
       assert(oVar);
-      emitVariableLoad(loadConstOp, retReg, retReg, gen, gen.rs(), size, gen.point(),
+      emitVariableLoad(loadConstOp, retReg, retReg, gen, size, gen.point(),
                        gen.addrSpace());
       break;
     case operandType::variableValue:
       assert(oVar);
-      emitVariableLoad(loadOp, retReg, retReg, gen, gen.rs(), size, gen.point(),
+      emitVariableLoad(loadOp, retReg, retReg, gen, size, gen.point(),
                        gen.addrSpace());
       break;
     case operandType::ReturnVal:
@@ -233,7 +233,7 @@ int_variable *operandAST::lookUpVar(AddressSpace *as) {
 }
 
 void operandAST::emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Register dest,
-                                      codeGen &gen, registerSpace *rs, int size_,
+                                      codeGen &gen, int size_,
                                       const instPoint *point, AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -94,7 +94,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       } else {
         tSize = sizeof(long);
       }
-      emitV(loadIndirOp, src, 0, retReg, gen, tSize, gen.point(),
+      emitV(loadIndirOp, src, 0, retReg, gen, tSize,
             gen.addrSpace());
       gen.rs()->freeRegister(src);
       break;

--- a/dyninstAPI/src/ASTs/operandAST.C
+++ b/dyninstAPI/src/ASTs/operandAST.C
@@ -79,7 +79,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
     case operandType::Constant:
       assert(oVar == NULL);
       emitVload(loadConstOp, (Address)oValue, retReg, retReg, gen, size,
-                gen.point(), gen.addrSpace());
+                gen.addrSpace());
       break;
 #endif
     case operandType::DataIndir:
@@ -161,13 +161,13 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
     case operandType::DataAddr:
       assert(oVar == NULL);
       addr = reinterpret_cast<Address>(oValue);
-      emitVload(loadOp, addr, retReg, retReg, gen, size, gen.point(),
+      emitVload(loadOp, addr, retReg, retReg, gen, size,
                 gen.addrSpace());
       break;
     case operandType::FrameAddr:
       addr = (Address)oValue;
       temp = gen.rs()->allocateRegister(gen);
-      emitVload(loadFrameRelativeOp, addr, temp, retReg, gen, size, gen.point(),
+      emitVload(loadFrameRelativeOp, addr, temp, retReg, gen, size,
                 gen.addrSpace());
       gen.rs()->freeRegister(temp);
       break;
@@ -177,7 +177,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       assert(operand_);
       addr = (Address)operand_->getOValue();
       emitVload(loadRegRelativeOp, addr, (long)oValue, retReg, gen, size,
-                gen.point(), gen.addrSpace());
+                gen.addrSpace());
       break;
     case operandType::ConstantString:
       // XXX This is for the std::string type.  If/when we fix the std::string type
@@ -192,7 +192,7 @@ bool operandAST::generateCode_phase2(codeGen &gen, Address &,
       }
 
       if(!gen.addrSpace()->needsPIC()) {
-        emitVload(loadConstOp, addr, retReg, retReg, gen, size, gen.point(),
+        emitVload(loadConstOp, addr, retReg, retReg, gen, size,
                   gen.addrSpace());
       } else {
         gen.codeEmitter()->emitLoadShared(loadConstOp, retReg, NULL, true, size, gen, addr);
@@ -237,7 +237,7 @@ void operandAST::emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Re
                                       const instPoint *point, AddressSpace *as) {
   int_variable *var = lookUpVar(as);
   if(var && !as->needsPIC(var)) {
-    emitVload(op, var->getAddress(), src2, dest, gen, size_, point, as);
+    emitVload(op, var->getAddress(), src2, dest, gen, size_, as);
   } else {
     gen.codeEmitter()->emitLoadShared(op, dest, oVar, (var != NULL), size_, gen, 0);
   }

--- a/dyninstAPI/src/ASTs/operandAST.h
+++ b/dyninstAPI/src/ASTs/operandAST.h
@@ -166,7 +166,7 @@ public:
   bool usesAppRegister() const override;
 
   void emitVariableStore(opCode op, Dyninst::Register src1, Dyninst::Register src2, codeGen &gen,
-                         int size, const instPoint *point,
+                         int size,
                          AddressSpace *as) override;
   void emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Register dest, codeGen &gen,
                         int size,

--- a/dyninstAPI/src/ASTs/operandAST.h
+++ b/dyninstAPI/src/ASTs/operandAST.h
@@ -169,7 +169,7 @@ public:
                          registerSpace *rs, int size, const instPoint *point,
                          AddressSpace *as) override;
   void emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Register dest, codeGen &gen,
-                        registerSpace *rs, int size, const instPoint *point,
+                        int size, const instPoint *point,
                         AddressSpace *as) override;
 
   bool initRegisters(codeGen &gen) override;

--- a/dyninstAPI/src/ASTs/operandAST.h
+++ b/dyninstAPI/src/ASTs/operandAST.h
@@ -169,7 +169,7 @@ public:
                          registerSpace *rs, int size, const instPoint *point,
                          AddressSpace *as) override;
   void emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Register dest, codeGen &gen,
-                        int size, const instPoint *point,
+                        int size,
                         AddressSpace *as) override;
 
   bool initRegisters(codeGen &gen) override;

--- a/dyninstAPI/src/ASTs/operandAST.h
+++ b/dyninstAPI/src/ASTs/operandAST.h
@@ -166,7 +166,7 @@ public:
   bool usesAppRegister() const override;
 
   void emitVariableStore(opCode op, Dyninst::Register src1, Dyninst::Register src2, codeGen &gen,
-                         registerSpace *rs, int size, const instPoint *point,
+                         int size, const instPoint *point,
                          AddressSpace *as) override;
   void emitVariableLoad(opCode op, Dyninst::Register src2, Dyninst::Register dest, codeGen &gen,
                         int size,

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -603,7 +603,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
                     gen.rs(), size, gen.point(), gen.addrSpace());
 
           // Same as DataIndir at this point.
-          emitV(storeIndirOp, src1, 0, src2, gen, size, gen.point(),
+          emitV(storeIndirOp, src1, 0, src2, gen, size,
                 gen.addrSpace());
           loperand->decUseCount(gen);
           break;
@@ -617,7 +617,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           REGISTER_CHECK(tmp);
 
           // tmp now contains address to store into
-          emitV(storeIndirOp, src1, 0, tmp, gen, size, gen.point(),
+          emitV(storeIndirOp, src1, 0, tmp, gen, size,
                 gen.addrSpace());
           gen.rs()->freeRegister(tmp);
           loperand->decUseCount(gen);
@@ -655,7 +655,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           }
           REGISTER_CHECK(tmp);
 
-          emitV(storeIndirOp, src1, 0, tmp, gen, size, gen.point(),
+          emitV(storeIndirOp, src1, 0, tmp, gen, size,
                 gen.addrSpace());
           gen.rs()->freeRegister(tmp);
           break;
@@ -678,7 +678,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       }
       REGISTER_CHECK(src1);
       REGISTER_CHECK(src2);
-      emitV(op, src1, 0, src2, gen, size, gen.point(), gen.addrSpace());
+      emitV(op, src1, 0, src2, gen, size, gen.addrSpace());
       gen.rs()->freeRegister(src1);
       gen.rs()->freeRegister(src2);
       retReg = Dyninst::Null_Register;
@@ -735,7 +735,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
         if(retReg == Dyninst::Null_Register) {
           retReg = allocateAndKeep(gen);
         }
-        emitV(op, src1, right_dest, retReg, gen, size, gen.point(),
+        emitV(op, src1, right_dest, retReg, gen, size,
               gen.addrSpace(), signedOp);
         if(src1 != Dyninst::Null_Register) {
           // Don't free inputs until afterwards; we have _no_ idea

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -580,7 +580,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
         case operandType::DataAddr:
           addr = (Dyninst::Address)loperand->getOValue();
           assert(loperand->getOVar() == NULL);
-          emitVstore(storeOp, src1, src2, addr, gen, size, gen.point(),
+          emitVstore(storeOp, src1, src2, addr, gen, size,
                      gen.addrSpace());
           // We are not calling generateCode for the left branch,
           // so need to decrement the refcount by hand
@@ -589,7 +589,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
         case operandType::FrameAddr:
           addr = (Dyninst::Address)loperand->getOValue();
           emitVstore(storeFrameRelativeOp, src1, src2, addr, gen, size,
-                     gen.point(), gen.addrSpace());
+                     gen.addrSpace());
           loperand->decUseCount(gen);
           break;
         case operandType::RegOffset: {

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -573,7 +573,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       src2 = gen.rs()->allocateRegister(gen);
       switch(loperand->getoType()) {
         case operandType::variableValue:
-          loperand->emitVariableStore(storeOp, src1, src2, gen, size, gen.point(),
+          loperand->emitVariableStore(storeOp, src1, src2, gen, size,
                                       gen.addrSpace());
           loperand->decUseCount(gen);
           break;

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -633,19 +633,16 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
         case operandType::ParamAtEntry: {
           boost::shared_ptr<operandAST> lnode =
               boost::dynamic_pointer_cast<operandAST>(loperand);
-          emitR(getParamOp, (Dyninst::Address)lnode->oValue, src1, src2, gen, gen.point(),
-                gen.addrSpace()->multithread_capable());
+          emitR(getParamOp, (Dyninst::Address)lnode->oValue, src1, src2, gen, gen.point());
           loperand->decUseCount(gen);
           break;
         }
         case operandType::ReturnVal:
-          emitR(getRetValOp, Dyninst::Null_Register, src1, src2, gen, gen.point(),
-                gen.addrSpace()->multithread_capable());
+          emitR(getRetValOp, Dyninst::Null_Register, src1, src2, gen, gen.point());
           loperand->decUseCount(gen);
           break;
         case operandType::ReturnAddr:
-          emitR(getRetAddrOp, Dyninst::Null_Register, src1, src2, gen, gen.point(),
-                gen.addrSpace()->multithread_capable());
+          emitR(getRetAddrOp, Dyninst::Null_Register, src1, src2, gen, gen.point());
           break;
         default: {
           // Could be an error, could be an attempt to load based on an arithmetic expression

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -573,7 +573,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       src2 = gen.rs()->allocateRegister(gen);
       switch(loperand->getoType()) {
         case operandType::variableValue:
-          loperand->emitVariableStore(storeOp, src1, src2, gen, gen.rs(), size, gen.point(),
+          loperand->emitVariableStore(storeOp, src1, src2, gen, size, gen.point(),
                                       gen.addrSpace());
           loperand->decUseCount(gen);
           break;

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -603,7 +603,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
                     gen.rs(), size, gen.point(), gen.addrSpace());
 
           // Same as DataIndir at this point.
-          emitV(storeIndirOp, src1, 0, src2, gen, gen.rs(), size, gen.point(),
+          emitV(storeIndirOp, src1, 0, src2, gen, size, gen.point(),
                 gen.addrSpace());
           loperand->decUseCount(gen);
           break;
@@ -617,7 +617,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           REGISTER_CHECK(tmp);
 
           // tmp now contains address to store into
-          emitV(storeIndirOp, src1, 0, tmp, gen, gen.rs(), size, gen.point(),
+          emitV(storeIndirOp, src1, 0, tmp, gen, size, gen.point(),
                 gen.addrSpace());
           gen.rs()->freeRegister(tmp);
           loperand->decUseCount(gen);
@@ -655,7 +655,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           }
           REGISTER_CHECK(tmp);
 
-          emitV(storeIndirOp, src1, 0, tmp, gen, gen.rs(), size, gen.point(),
+          emitV(storeIndirOp, src1, 0, tmp, gen, size, gen.point(),
                 gen.addrSpace());
           gen.rs()->freeRegister(tmp);
           break;
@@ -678,7 +678,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       }
       REGISTER_CHECK(src1);
       REGISTER_CHECK(src2);
-      emitV(op, src1, 0, src2, gen, gen.rs(), size, gen.point(), gen.addrSpace());
+      emitV(op, src1, 0, src2, gen, size, gen.point(), gen.addrSpace());
       gen.rs()->freeRegister(src1);
       gen.rs()->freeRegister(src2);
       retReg = Dyninst::Null_Register;
@@ -735,7 +735,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
         if(retReg == Dyninst::Null_Register) {
           retReg = allocateAndKeep(gen);
         }
-        emitV(op, src1, right_dest, retReg, gen, gen.rs(), size, gen.point(),
+        emitV(op, src1, right_dest, retReg, gen, size, gen.point(),
               gen.addrSpace(), signedOp);
         if(src1 != Dyninst::Null_Register) {
           // Don't free inputs until afterwards; we have _no_ idea

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -580,7 +580,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
         case operandType::DataAddr:
           addr = (Dyninst::Address)loperand->getOValue();
           assert(loperand->getOVar() == NULL);
-          emitVstore(storeOp, src1, src2, addr, gen, gen.rs(), size, gen.point(),
+          emitVstore(storeOp, src1, src2, addr, gen, size, gen.point(),
                      gen.addrSpace());
           // We are not calling generateCode for the left branch,
           // so need to decrement the refcount by hand
@@ -588,7 +588,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           break;
         case operandType::FrameAddr:
           addr = (Dyninst::Address)loperand->getOValue();
-          emitVstore(storeFrameRelativeOp, src1, src2, addr, gen, gen.rs(), size,
+          emitVstore(storeFrameRelativeOp, src1, src2, addr, gen, size,
                      gen.point(), gen.addrSpace());
           loperand->decUseCount(gen);
           break;

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -484,7 +484,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           }
           assert(loperand->getOVar());
           loperand->emitVariableLoad(loadConstOp, retReg, retReg, gen, size,
-                                     gen.point(), gen.addrSpace());
+                                     gen.addrSpace());
           break;
         case operandType::variableValue:
           if(retReg == Dyninst::Null_Register) {
@@ -492,7 +492,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           }
           assert(loperand->getOVar());
           loperand->emitVariableLoad(loadOp, retReg, retReg, gen, size,
-                                     gen.point(), gen.addrSpace());
+                                     gen.addrSpace());
           break;
         case operandType::DataAddr: {
           addr = reinterpret_cast<Dyninst::Address>(loperand->getOValue());

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -500,7 +500,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
             retReg = allocateAndKeep(gen);
           }
           assert(!loperand->getOVar());
-          emitVload(loadConstOp, addr, retReg, retReg, gen, size, gen.point(),
+          emitVload(loadConstOp, addr, retReg, retReg, gen, size,
                     gen.addrSpace());
         } break;
         case operandType::FrameAddr: {
@@ -510,7 +510,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           }
           Dyninst::Register temp = gen.rs()->getScratchRegister(gen);
           addr = (Dyninst::Address)loperand->getOValue();
-          emitVload(loadFrameAddr, addr, temp, retReg, gen, size, gen.point(),
+          emitVload(loadFrameAddr, addr, temp, retReg, gen, size,
                     gen.addrSpace());
           break;
         }
@@ -524,7 +524,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           addr = (Dyninst::Address)loperand->operand()->getOValue();
 
           emitVload(loadRegRelativeAddr, addr, (long)loperand->getOValue(), retReg, gen,
-                    size, gen.point(), gen.addrSpace());
+                    size, gen.addrSpace());
           break;
         }
         case operandType::DataIndir:
@@ -600,7 +600,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           // it only allows for 3.  Prepare the dest address in scratch register src2.
 
           emitVload(loadRegRelativeAddr, addr, (long)loperand->getOValue(), src2, gen,
-                    size, gen.point(), gen.addrSpace());
+                    size, gen.addrSpace());
 
           // Same as DataIndir at this point.
           emitV(storeIndirOp, src1, 0, src2, gen, size,

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -500,7 +500,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
             retReg = allocateAndKeep(gen);
           }
           assert(!loperand->getOVar());
-          emitVload(loadConstOp, addr, retReg, retReg, gen, gen.rs(), size, gen.point(),
+          emitVload(loadConstOp, addr, retReg, retReg, gen, size, gen.point(),
                     gen.addrSpace());
         } break;
         case operandType::FrameAddr: {
@@ -510,7 +510,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           }
           Dyninst::Register temp = gen.rs()->getScratchRegister(gen);
           addr = (Dyninst::Address)loperand->getOValue();
-          emitVload(loadFrameAddr, addr, temp, retReg, gen, gen.rs(), size, gen.point(),
+          emitVload(loadFrameAddr, addr, temp, retReg, gen, size, gen.point(),
                     gen.addrSpace());
           break;
         }
@@ -524,7 +524,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           addr = (Dyninst::Address)loperand->operand()->getOValue();
 
           emitVload(loadRegRelativeAddr, addr, (long)loperand->getOValue(), retReg, gen,
-                    gen.rs(), size, gen.point(), gen.addrSpace());
+                    size, gen.point(), gen.addrSpace());
           break;
         }
         case operandType::DataIndir:
@@ -600,7 +600,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           // it only allows for 3.  Prepare the dest address in scratch register src2.
 
           emitVload(loadRegRelativeAddr, addr, (long)loperand->getOValue(), src2, gen,
-                    gen.rs(), size, gen.point(), gen.addrSpace());
+                    size, gen.point(), gen.addrSpace());
 
           // Same as DataIndir at this point.
           emitV(storeIndirOp, src1, 0, src2, gen, size,

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -483,7 +483,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
             retReg = allocateAndKeep(gen);
           }
           assert(loperand->getOVar());
-          loperand->emitVariableLoad(loadConstOp, retReg, retReg, gen, gen.rs(), size,
+          loperand->emitVariableLoad(loadConstOp, retReg, retReg, gen, size,
                                      gen.point(), gen.addrSpace());
           break;
         case operandType::variableValue:
@@ -491,7 +491,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
             retReg = allocateAndKeep(gen);
           }
           assert(loperand->getOVar());
-          loperand->emitVariableLoad(loadOp, retReg, retReg, gen, gen.rs(), size,
+          loperand->emitVariableLoad(loadOp, retReg, retReg, gen, size,
                                      gen.point(), gen.addrSpace());
           break;
         case operandType::DataAddr: {

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -715,7 +715,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           ast_printf("Operator node, const RHS, keeping register %u\n", retReg.getId());
         }
 
-        emitImm(op, src1, (RegValue)roperand->getOValue(), retReg, gen, gen.rs(), signedOp);
+        emitImm(op, src1, (RegValue)roperand->getOValue(), retReg, gen, signedOp);
 
         if(src1 != Dyninst::Null_Register) {
           gen.rs()->freeRegister(src1);

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -256,7 +256,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       // so we decrement its useCount by hand.
       // Would be nice to allow register branches...
       loperand->decUseCount(gen);
-      (void)emitA(branchOp, 0, 0, (Dyninst::Register)offset, gen, Dyninst::DyninstAPI::RegControl::rc_no_control);
+      (void)emitA(branchOp, 0, (Dyninst::Register)offset, gen, Dyninst::DyninstAPI::RegControl::rc_no_control);
       retReg = Dyninst::Null_Register; // No return register
       break;
     }
@@ -272,7 +272,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       codeBufIndex_t ifIndex = gen.getIndex();
 
       size_t preif_patches_size = gen.allPatches().size();
-      codeBufIndex_t thenSkipStart = emitA(op, src1, 0, 0, gen, Dyninst::DyninstAPI::RegControl::rc_before_jump);
+      codeBufIndex_t thenSkipStart = emitA(op, src1, 0, gen, Dyninst::DyninstAPI::RegControl::rc_before_jump);
 
       size_t postif_patches_size = gen.allPatches().size();
 
@@ -298,7 +298,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       if(eoperand) {
         gen.rs()->pushNewRegState(); // Create registerState for else
         preelse_patches_size = gen.allPatches().size();
-        elseSkipStart = emitA(branchOp, 0, 0, 0, gen, Dyninst::DyninstAPI::RegControl::rc_no_control);
+        elseSkipStart = emitA(branchOp, 0, 0, gen, Dyninst::DyninstAPI::RegControl::rc_no_control);
         postelse_patches_size = gen.allPatches().size();
       }
 
@@ -320,7 +320,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
         // call emit again now with correct offset.
         // This backtracks over current code.
         // If/when we vectorize, we can do this in a two-pass arrangement
-        (void)emitA(op, src1_copy, 0,
+        (void)emitA(op, src1_copy,
                     (Dyninst::Register)codeGen::getDisplacement(thenSkipStart, elseStartIndex), gen,
                     Dyninst::DyninstAPI::RegControl::rc_no_control);
         // Now we can free the register
@@ -354,7 +354,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
           }
         } else {
           gen.setIndex(elseSkipIndex);
-          emitA(branchOp, 0, 0,
+          emitA(branchOp, 0,
                 (Dyninst::Register)codeGen::getDisplacement(elseSkipStart, endIndex), gen,
                 Dyninst::DyninstAPI::RegControl::rc_no_control);
           gen.setIndex(endIndex);
@@ -420,7 +420,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       codeBufIndex_t startIndex = gen.getIndex();
 
       size_t preif_patches_size = gen.allPatches().size();
-      codeBufIndex_t thenSkipStart = emitA(ifOp, src1, 0, 0, gen, Dyninst::DyninstAPI::RegControl::rc_before_jump);
+      codeBufIndex_t thenSkipStart = emitA(ifOp, src1, 0, gen, Dyninst::DyninstAPI::RegControl::rc_before_jump);
 
       size_t postif_patches_size = gen.allPatches().size();
 
@@ -441,7 +441,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
 
       // END from ifOp
 
-      (void)emitA(branchOp, 0, 0, codeGen::getDisplacement(gen.getIndex(), top), gen, Dyninst::DyninstAPI::RegControl::rc_no_control);
+      (void)emitA(branchOp, 0, codeGen::getDisplacement(gen.getIndex(), top), gen, Dyninst::DyninstAPI::RegControl::rc_no_control);
 
       // BEGIN from ifOp
 
@@ -463,7 +463,7 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
         // call emit again now with correct offset.
         // This backtracks over current code.
         // If/when we vectorize, we can do this in a two-pass arrangement
-        (void)emitA(ifOp, src1_copy, 0,
+        (void)emitA(ifOp, src1_copy,
                     (Dyninst::Register)codeGen::getDisplacement(thenSkipStart, elseStartIndex), gen,
                     Dyninst::DyninstAPI::RegControl::rc_no_control);
         // Now we can free the register

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -858,7 +858,7 @@ void emitVload(opCode op, Address src1, Register src2, Register dest,
 void emitVstore(opCode op, Register src1, Register /*src2*/, Address dest,
         codeGen &gen,
         int size,
-        const instPoint * /* location */, AddressSpace *)
+        AddressSpace *)
 {
     if (op ==  storeOp) {
         // [dest] = src1

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -350,7 +350,7 @@ void popStack(codeGen &gen)
 
 //TODO: 32-/64-bit regs?
 void emitImm(opCode op, Register src1, RegValue src2imm, Register dest, 
-        codeGen &gen, registerSpace * /* rs */, bool s)
+        codeGen &gen, bool s)
 {
     switch(op) {
         case plusOp:

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -819,7 +819,7 @@ void emitCSload(const BPatch_addrSpec_NP *, Register, codeGen &) {
 void emitVload(opCode op, Address src1, Register src2, Register dest,
                codeGen &gen,
                int size,
-               const instPoint * /* location */, AddressSpace *)
+               AddressSpace *)
 {
     switch(op)
     {

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -818,7 +818,7 @@ void emitCSload(const BPatch_addrSpec_NP *, Register, codeGen &) {
 
 void emitVload(opCode op, Address src1, Register src2, Register dest,
                codeGen &gen,
-               registerSpace * /*rs*/, int size,
+               int size,
                const instPoint * /* location */, AddressSpace *)
 {
     switch(op)

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -637,7 +637,7 @@ Register EmitterAARCH64::emitCall(opCode op,
 }
 
 
-codeBufIndex_t emitA(opCode op, Register src1, Register, long dest,
+codeBufIndex_t emitA(opCode op, Register src1, long dest,
         codeGen &gen, Dyninst::DyninstAPI::RegControl rc)
 {
     codeBufIndex_t retval = 0;

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -666,7 +666,7 @@ codeBufIndex_t emitA(opCode op, Register src1, long dest,
 
 Register emitR(opCode op, Register src1, Register src2, Register dest,
                codeGen &gen,
-               const instPoint *, bool /*for_MT*/)
+               const instPoint *)
 {
     registerSlot *regSlot = NULL;
     unsigned addrWidth = gen.width();

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -857,7 +857,7 @@ void emitVload(opCode op, Address src1, Register src2, Register dest,
 
 void emitVstore(opCode op, Register src1, Register /*src2*/, Address dest,
         codeGen &gen,
-        registerSpace * /* rs */, int size,
+        int size,
         const instPoint * /* location */, AddressSpace *)
 {
     if (op ==  storeOp) {
@@ -874,7 +874,7 @@ void emitVstore(opCode op, Register src1, Register /*src2*/, Address dest,
 
 void emitV(opCode op, Register src1, Register src2, Register dest,
         codeGen &gen,
-           registerSpace * /*rs*/, int size,
+           int size,
            const instPoint * /* location */, AddressSpace *proc, bool s) 
 {
     switch(op){

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -875,7 +875,7 @@ void emitVstore(opCode op, Register src1, Register /*src2*/, Address dest,
 void emitV(opCode op, Register src1, Register src2, Register dest,
         codeGen &gen,
            int size,
-           const instPoint * /* location */, AddressSpace *proc, bool s) 
+           AddressSpace *proc, bool s)
 {
     switch(op){
         case plusOp:

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -92,7 +92,7 @@ void emitVload(opCode /* op */, Address /* src1 */, Register /* src2 */, Registe
 
 void emitVstore(opCode /* op */, Register /* src1 */, Register /*src2*/, Address /* dest */,
                 codeGen & /* gen */, int /* size */,
-                const instPoint * /* location */, AddressSpace *) {
+                AddressSpace *) {
   assert(!"Not imeplemented for AMDGPU");
 }
 

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -85,7 +85,7 @@ void emitCSload(const BPatch_addrSpec_NP *, Register, codeGen &) {
 }
 
 void emitVload(opCode /* op */, Address /* src1 */, Register /* src2 */, Register /* dest */,
-               codeGen & /* gen */, registerSpace * /*rs*/, int /* size */,
+               codeGen & /* gen */, int /* size */,
                const instPoint * /* location */, AddressSpace *) {
   assert(!"Not imeplemented for AMDGPU");
 }

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -91,7 +91,7 @@ void emitVload(opCode /* op */, Address /* src1 */, Register /* src2 */, Registe
 }
 
 void emitVstore(opCode /* op */, Register /* src1 */, Register /*src2*/, Address /* dest */,
-                codeGen & /* gen */, registerSpace * /* rs */, int /* size */,
+                codeGen & /* gen */, int /* size */,
                 const instPoint * /* location */, AddressSpace *) {
   assert(!"Not imeplemented for AMDGPU");
 }

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -86,7 +86,7 @@ void emitCSload(const BPatch_addrSpec_NP *, Register, codeGen &) {
 
 void emitVload(opCode /* op */, Address /* src1 */, Register /* src2 */, Register /* dest */,
                codeGen & /* gen */, int /* size */,
-               const instPoint * /* location */, AddressSpace *) {
+               AddressSpace *) {
   assert(!"Not imeplemented for AMDGPU");
 }
 

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -59,7 +59,7 @@ Register emitFuncCall(opCode /* op */, codeGen & /* gen */,
   return 0;
 }
 
-codeBufIndex_t emitA(opCode /* op */, Register /* src1 */, Register, long /* dest */,
+codeBufIndex_t emitA(opCode /* op */, Register /* src1 */, long /* dest */,
                      codeGen & /* gen */, Dyninst::DyninstAPI::RegControl /* rc */) {
   assert(!"Not implemented for AMDGPU");
   return 0;

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -97,7 +97,7 @@ void emitVstore(opCode /* op */, Register /* src1 */, Register /*src2*/, Address
 }
 
 void emitV(opCode /* op */, Register /* src1 */, Register /* src2 */, Register /* dest */,
-           codeGen & /* gen */, registerSpace * /*rs*/, int /* size */,
+           codeGen & /* gen */, int /* size */,
            const instPoint * /* location */, AddressSpace * /* proc */, bool /* s */) {
   assert(!"Not imeplemented for AMDGPU");
 }

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -66,7 +66,7 @@ codeBufIndex_t emitA(opCode /* op */, Register /* src1 */, long /* dest */,
 }
 
 Register emitR(opCode /* op */, Register /* src1 */, Register /* src2 */, Register /* dest */,
-               codeGen & /* gen */, const instPoint *, bool /*for_MT*/) {
+               codeGen & /* gen */, const instPoint *) {
   assert(!"Not implemented for AMDGPU");
   return 0;
 }

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -43,7 +43,7 @@ using codeGenASTPtr = Dyninst::DyninstAPI::codeGenASTPtr;
 
 // TODO: ALL THESE MUST GO AWAY ENTIRELY AS CODEGEN MATURES
 void emitImm(opCode /* op */, Register /* src1 */, RegValue /* src2imm */, Register /* dest */,
-             codeGen & /* gen */, registerSpace * /* rs */, bool /* s */) {
+             codeGen & /* gen */, bool /* s */) {
   assert(!"Not implemented for AMDGPU");
 }
 

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -98,7 +98,7 @@ void emitVstore(opCode /* op */, Register /* src1 */, Register /*src2*/, Address
 
 void emitV(opCode /* op */, Register /* src1 */, Register /* src2 */, Register /* dest */,
            codeGen & /* gen */, int /* size */,
-           const instPoint * /* location */, AddressSpace * /* proc */, bool /* s */) {
+           AddressSpace * /* proc */, bool /* s */) {
   assert(!"Not imeplemented for AMDGPU");
 }
 

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1401,7 +1401,7 @@ void emitCSload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, codeGen &g
 
 void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Register dest,
                codeGen &gen,
-               registerSpace * /*rs*/, int size,
+               int size,
                const instPoint * /* location */, AddressSpace *proc)
 {
   switch(op) {

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1121,7 +1121,7 @@ Dyninst::Register EmitterPOWER::emitCall(opCode ocode,
 }
 
  
-codeBufIndex_t emitA(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, long dest,
+codeBufIndex_t emitA(opCode op, Dyninst::Register src1, long dest,
 	      codeGen &gen, Dyninst::DyninstAPI::RegControl)
 {
     codeBufIndex_t retval = 0;

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1402,7 +1402,7 @@ void emitCSload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, codeGen &g
 void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Register dest,
                codeGen &gen,
                int size,
-               const instPoint * /* location */, AddressSpace *proc)
+               AddressSpace *proc)
 {
   switch(op) {
   case loadConstOp:

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -669,7 +669,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
             Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
             emitVload(loadConstOp, src2imm, dest2, dest2, gen);
             emitV(op, src1, dest2, dest, gen,
-                  gen.width(), gen.point(), gen.addrSpace(), s);
+                  gen.width(), gen.addrSpace(), s);
             return;
         }
         break;
@@ -678,7 +678,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
             Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
             emitVload(loadConstOp, src2imm, dest2, dest2, gen);
             emitV(op, src1, dest2, dest, gen,
-                  gen.width(), gen.point(), gen.addrSpace(), s);
+                  gen.width(), gen.addrSpace(), s);
             return;
         }
         // Bool ops
@@ -699,7 +699,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
         Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
         emitVload(loadConstOp, src2imm, dest2, dest2, gen);
         emitV(op, src1, dest2, dest, gen,
-              gen.width(), gen.point(), gen.addrSpace(), s);
+              gen.width(), gen.addrSpace(), s);
         return;
         break;
     }
@@ -1529,7 +1529,7 @@ void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, A
 void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dest,
            codeGen &gen,
            int size,
-           const instPoint * /* location */, AddressSpace *proc, bool s)
+           AddressSpace *proc, bool s)
 {
 
     assert ((op!=branchOp) && (op!=ifOp));         // !emitA
@@ -1733,7 +1733,7 @@ void emitLoadPreviousStackFrameRegister(Address register_num,
                 gen, gen.rs());
         // Load LR into register dest
         emitV(loadIndirOp, dest, 0, dest, gen,
-              gen.width(), gen.point(), gen.addrSpace());
+              gen.width(), gen.addrSpace());
         break;
 
     case registerSpace::ctr:
@@ -1748,7 +1748,7 @@ void emitLoadPreviousStackFrameRegister(Address register_num,
                 gen, gen.rs());
         // Load LR into register dest
         emitV(loadIndirOp, dest, 0, dest, gen,
-              gen.width(), gen.point(), gen.addrSpace());
+              gen.width(), gen.addrSpace());
       break;
 
     default:

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -668,7 +668,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
         else {
             Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
             emitVload(loadConstOp, src2imm, dest2, dest2, gen);
-            emitV(op, src1, dest2, dest, gen, gen.rs(),
+            emitV(op, src1, dest2, dest, gen,
                   gen.width(), gen.point(), gen.addrSpace(), s);
             return;
         }
@@ -677,7 +677,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
     case divOp: {
             Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
             emitVload(loadConstOp, src2imm, dest2, dest2, gen);
-            emitV(op, src1, dest2, dest, gen, gen.rs(),
+            emitV(op, src1, dest2, dest, gen,
                   gen.width(), gen.point(), gen.addrSpace(), s);
             return;
         }
@@ -698,7 +698,7 @@ void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Regis
     default:
         Dyninst::Register dest2 = gen.rs()->getScratchRegister(gen);
         emitVload(loadConstOp, src2imm, dest2, dest2, gen);
-        emitV(op, src1, dest2, dest, gen, gen.rs(),
+        emitV(op, src1, dest2, dest, gen,
               gen.width(), gen.point(), gen.addrSpace(), s);
         return;
         break;
@@ -1528,7 +1528,7 @@ void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, A
 
 void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dest,
            codeGen &gen,
-           registerSpace * /*rs*/, int size,
+           int size,
            const instPoint * /* location */, AddressSpace *proc, bool s)
 {
 
@@ -1732,7 +1732,7 @@ void emitLoadPreviousStackFrameRegister(Address register_num,
         emitImm(plusOp ,(Dyninst::Register) REG_SP, (RegValue) offset, dest,
                 gen, gen.rs());
         // Load LR into register dest
-        emitV(loadIndirOp, dest, 0, dest, gen, gen.rs(),
+        emitV(loadIndirOp, dest, 0, dest, gen,
               gen.width(), gen.point(), gen.addrSpace());
         break;
 
@@ -1747,7 +1747,7 @@ void emitLoadPreviousStackFrameRegister(Address register_num,
         emitImm(plusOp ,(Dyninst::Register) REG_SP, (RegValue) offset, dest,
                 gen, gen.rs());
         // Load LR into register dest
-        emitV(loadIndirOp, dest, 0, dest, gen, gen.rs(),
+        emitV(loadIndirOp, dest, 0, dest, gen,
               gen.width(), gen.point(), gen.addrSpace());
       break;
 

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1161,7 +1161,7 @@ codeBufIndex_t emitA(opCode op, Dyninst::Register src1, long dest,
 
 Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dest,
                codeGen &gen,
-               const instPoint * /*location*/, bool /*for_MT*/)
+               const instPoint * /*location*/)
 {
 
     registerSlot *regSlot = NULL;

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1485,7 +1485,7 @@ void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Registe
 
 void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, Address dest,
 		codeGen &gen,
-                registerSpace * /* rs */, int size,
+                int size,
                 const instPoint * /* location */, AddressSpace *proc)
 {
     if (op == storeOp) {

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1486,7 +1486,7 @@ void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Registe
 void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, Address dest,
 		codeGen &gen,
                 int size,
-                const instPoint * /* location */, AddressSpace *proc)
+                AddressSpace *proc)
 {
     if (op == storeOp) {
 	// temp register to hold base address for store (added 6/26/96 jkh)

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -642,7 +642,7 @@ unsigned restoreSPRegisters(codeGen &gen,
 }
 
 void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Register dest,
-             codeGen &gen, registerSpace * /* rs */, bool s)
+             codeGen &gen, bool s)
 {
     int iop=-1;
     int result=-1;
@@ -1730,7 +1730,7 @@ void emitLoadPreviousStackFrameRegister(Address register_num,
 
         // Get address (SP + offset) and stick in register dest.
         emitImm(plusOp ,(Dyninst::Register) REG_SP, (RegValue) offset, dest,
-                gen, gen.rs());
+                gen);
         // Load LR into register dest
         emitV(loadIndirOp, dest, 0, dest, gen,
               gen.width(), gen.addrSpace());
@@ -1745,7 +1745,7 @@ void emitLoadPreviousStackFrameRegister(Address register_num,
 
         // Get address (SP + offset) and stick in register dest.
         emitImm(plusOp ,(Dyninst::Register) REG_SP, (RegValue) offset, dest,
-                gen, gen.rs());
+                gen);
         // Load LR into register dest
         emitV(loadIndirOp, dest, 0, dest, gen,
               gen.width(), gen.addrSpace());

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1084,7 +1084,7 @@ void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Registe
 }
 
 void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, Address dest,
-                codeGen &gen, registerSpace * /*rs*/,
+                codeGen &gen,
                 int size,
                 const instPoint * /* location */, AddressSpace * /* proc */)
 {

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1043,7 +1043,7 @@ void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest,
 
 void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Register dest,
                codeGen &gen,
-               registerSpace * /*rs*/, int size,
+               int size,
                const instPoint * /* location */, AddressSpace * /* proc */)
 {
    if (op == loadConstOp) {

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1197,7 +1197,7 @@ void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::R
 }
 
 void emitImm(opCode op, Dyninst::Register src1, RegValue src2imm, Dyninst::Register dest,
-             codeGen &gen, registerSpace *, bool s)
+             codeGen &gen, bool s)
 {
    if (op ==  storeOp) {
        // this doesn't seem to ever be called from ast.C (or anywhere) - gq

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -756,7 +756,7 @@ Dyninst::Register emitFuncCall(opCode op,
  * base is the next free position on ibuf where code is to be generated
  */
 
-codeBufIndex_t emitA(opCode op, Dyninst::Register src1, Dyninst::Register /*src2*/, long dest,
+codeBufIndex_t emitA(opCode op, Dyninst::Register src1, long dest,
                      codeGen &gen, Dyninst::DyninstAPI::RegControl rc)
 {
    // retval is the address of the jump (if one is created). 

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -789,7 +789,7 @@ codeBufIndex_t emitA(opCode op, Dyninst::Register src1, long dest,
 
 Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dest,
                codeGen &gen,
-               const instPoint *location, bool /*for_multithreaded*/)
+               const instPoint *location)
 {
    bool get_addr_of = (src2 != Null_Register);
    switch (op) {

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1086,7 +1086,7 @@ void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Registe
 void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, Address dest,
                 codeGen &gen,
                 int size,
-                const instPoint * /* location */, AddressSpace * /* proc */)
+                AddressSpace * /* proc */)
 {
    if (op ==  storeOp) {
       // [dest] = src1

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -824,7 +824,7 @@ Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src
     }
     assert(get_addr_of);
     emitV(storeIndirOp, src2, 0, dest, gen,
-          gen.addrSpace()->getAddressWidth(), gen.point(), gen.addrSpace());
+          gen.addrSpace()->getAddressWidth(), gen.addrSpace());
     return(dest);
 }
 
@@ -1109,7 +1109,7 @@ void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, Addre
 void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dest,
            codeGen &gen,
            int size,
-           const instPoint * /* location */, AddressSpace * /* proc */, bool s)
+           AddressSpace * /* proc */, bool s)
 {
     assert ((op!=branchOp) && (op!=ifOp));         // !emitA
     assert ((op!=getRetValOp) && (op!=getRetAddrOp) && 

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1044,7 +1044,7 @@ void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest,
 void emitVload(opCode op, Address src1, Dyninst::Register src2, Dyninst::Register dest,
                codeGen &gen,
                int size,
-               const instPoint * /* location */, AddressSpace * /* proc */)
+               AddressSpace * /* proc */)
 {
    if (op == loadConstOp) {
       // dest is a temporary

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -823,7 +823,7 @@ Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src
           abort();                  // unexpected op for this emit!
     }
     assert(get_addr_of);
-    emitV(storeIndirOp, src2, 0, dest, gen, gen.rs(),
+    emitV(storeIndirOp, src2, 0, dest, gen,
           gen.addrSpace()->getAddressWidth(), gen.point(), gen.addrSpace());
     return(dest);
 }
@@ -1108,7 +1108,7 @@ void emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, Addre
 
 void emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dest,
            codeGen &gen,
-           registerSpace * /*rs*/, int size,
+           int size,
            const instPoint * /* location */, AddressSpace * /* proc */, bool s)
 {
     assert ((op!=branchOp) && (op!=ifOp));         // !emitA

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -83,7 +83,7 @@ Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src
 void     emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dst,
                codeGen &gen,
                int size = 4,
-               const instPoint * location = NULL, AddressSpace * proc = NULL, bool s = true);
+               AddressSpace * proc = NULL, bool s = true);
 
 // for loadOp and loadConstOp (reading from an Dyninst::Address)
 void     emitVload(opCode op, Dyninst::Address src1, Dyninst::Register src2, Dyninst::Register dst,

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -77,7 +77,7 @@ codeBufIndex_t emitA(opCode op, Dyninst::Register src1, long dst,
 // (e.g., getRetValOp, getRetAddrOp, getParamOp)
 Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dst,
                codeGen &gen,
-               const instPoint *location, bool for_multithreaded);
+               const instPoint *location);
 
 // for general arithmetic and logic operations which return nothing
 void     emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dst,

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -89,7 +89,7 @@ void     emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dynins
 void     emitVload(opCode op, Dyninst::Address src1, Dyninst::Register src2, Dyninst::Register dst,
                    codeGen &gen,
                    int size = 4,
-                   const instPoint * location = NULL, AddressSpace * proc = NULL);
+                   AddressSpace * proc = NULL);
 
 // for storeOp (writing to an Dyninst::Address)
 void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Address dst,

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -95,7 +95,7 @@ void     emitVload(opCode op, Dyninst::Address src1, Dyninst::Register src2, Dyn
 void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Address dst,
                     codeGen &gen,
                     int size = 4,
-                    const instPoint * location = NULL, AddressSpace * proc = NULL);
+                    AddressSpace * proc = NULL);
 
 // for storeOp (writing to an Dyninst::Address)
 void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, const image_variable* dst,

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -82,7 +82,7 @@ Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src
 // for general arithmetic and logic operations which return nothing
 void     emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Register dst,
                codeGen &gen,
-               registerSpace *rs = NULL, int size = 4,
+               int size = 4,
                const instPoint * location = NULL, AddressSpace * proc = NULL, bool s = true);
 
 // for loadOp and loadConstOp (reading from an Dyninst::Address)

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -97,12 +97,6 @@ void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, D
                     registerSpace *rs = NULL, int size = 4, 
                     const instPoint * location = NULL, AddressSpace * proc = NULL);
 
-// for loadOp and loadConstOp (reading from an Dyninst::Address)
-void     emitVload(opCode op, const image_variable* src1, Dyninst::Register src2, Dyninst::Register dst,
-                   codeGen &gen,
-                   registerSpace *rs = NULL, int size = 4, 
-                   const instPoint * location = NULL, AddressSpace * proc = NULL);
-
 // for storeOp (writing to an Dyninst::Address)
 void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, const image_variable* dst,
                     codeGen &gen,

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -97,12 +97,6 @@ void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, D
                     int size = 4,
                     AddressSpace * proc = NULL);
 
-// for storeOp (writing to an Dyninst::Address)
-void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, const image_variable* dst,
-                    codeGen &gen,
-                    registerSpace *rs = NULL, int size = 4, 
-                    const instPoint * location = NULL, AddressSpace * proc = NULL);
-
 // and the retyped original emitImm companion
 void     emitImm(opCode op, Dyninst::Register src, Dyninst::RegValue src2imm, Dyninst::Register dst,
                  codeGen &gen,

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -88,7 +88,7 @@ void     emitV(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dynins
 // for loadOp and loadConstOp (reading from an Dyninst::Address)
 void     emitVload(opCode op, Dyninst::Address src1, Dyninst::Register src2, Dyninst::Register dst,
                    codeGen &gen,
-                   registerSpace *rs = NULL, int size = 4, 
+                   int size = 4,
                    const instPoint * location = NULL, AddressSpace * proc = NULL);
 
 // for storeOp (writing to an Dyninst::Address)

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -70,7 +70,7 @@ func_instance *getFunction(instPoint *point);
 
 // The return value is a magic "hand this in when we update" black box;
 // emitA handles emission of things like ifs that need to be updated later.
-codeBufIndex_t emitA(opCode op, Dyninst::Register src1, Dyninst::Register src2, long dst,
+codeBufIndex_t emitA(opCode op, Dyninst::Register src1, long dst,
                      codeGen &gen, Dyninst::DyninstAPI::RegControl rc);
 
 // for operations requiring a Dyninst::Register to be returned

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -94,7 +94,7 @@ void     emitVload(opCode op, Dyninst::Address src1, Dyninst::Register src2, Dyn
 // for storeOp (writing to an Dyninst::Address)
 void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, Dyninst::Address dst,
                     codeGen &gen,
-                    registerSpace *rs = NULL, int size = 4, 
+                    int size = 4,
                     const instPoint * location = NULL, AddressSpace * proc = NULL);
 
 // for storeOp (writing to an Dyninst::Address)

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -100,7 +100,7 @@ void     emitVstore(opCode op, Dyninst::Register src1, Dyninst::Register src2, D
 // and the retyped original emitImm companion
 void     emitImm(opCode op, Dyninst::Register src, Dyninst::RegValue src2imm, Dyninst::Register dst,
                  codeGen &gen,
-                 registerSpace *rs = NULL, bool s = true);
+                 bool s = true);
 
 
 //#include "dyninstAPI/h/BPatch_memoryAccess_NP.h"


### PR DESCRIPTION
This wasn't part of #2216 because that one removes one variable with hundreds of references. This PR removes many variables with only a few references each.

Requires #2216 #2218