### PR TITLE
Remove getFunction(instPoint*) from inst.h

### DIFF
--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -54,12 +54,6 @@ class registerSpace;
 class AddressSpace;
 class image_variable;
 
-/* Utility functions */
-
-
-/* return the function asociated with a point. */
-func_instance *getFunction(instPoint *point);
-
 /*
  * Generate an instruction.
  * Previously this was handled by the polymorphic "emit" function, which


### PR DESCRIPTION
This was added by a65441575 in 1994, but I don't think it was every implemented.

Requires #2218