### PR TITLE
Replace free emitter functions with calls to Emitter members

### DIFF
--- a/dyninstAPI/src/ASTs/functionCallAST.C
+++ b/dyninstAPI/src/ASTs/functionCallAST.C
@@ -76,9 +76,9 @@ bool functionCallAST::generateCode_phase2(codeGen &gen, Address &,
   Dyninst::Register tmp = 0;
 
   if(use_func && !callReplace_) {
-    tmp = emitFuncCall(callOp, gen, children, use_func);
+    tmp = gen.emitter()->emitCall(callOp, gen, children, use_func);
   } else if(use_func && callReplace_) {
-    tmp = emitFuncCall(funcJumpOp, gen, children, use_func);
+    tmp = gen.emitter()->emitCall(funcJumpOp, gen, children, use_func);
   } else {
     char msg[256];
     sprintf(msg, "%s[%d]:  internal error:  unable to find %s", __FILE__, __LINE__,
@@ -93,7 +93,7 @@ bool functionCallAST::generateCode_phase2(codeGen &gen, Address &,
     // Happens in function replacement... didn't allocate
     // a return register.
   } else if(retReg == Dyninst::Null_Register) {
-    // emitFuncCall allocated tmp; we can use it, but let's see
+    // emitCall allocated tmp; we can use it, but let's see
     //  if we should keep it around.
     retReg = tmp;
     // from allocateAndKeep:

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -212,7 +212,7 @@ bool operatorAST::generateOptimizedAssignment(codeGen &gen, int size_) {
   if(roper->op == plusOp) {
     emitAddSignedImm(laddr, imm, gen);
   } else {
-    emitSubSignedImm(laddr, imm, gen);
+    gen.codeEmitter()->emitAddSignedImm(laddr, -imm, gen);
   }
 
   loperand->decUseCount(gen);

--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -153,7 +153,7 @@ bool operatorAST::generateOptimizedAssignment(codeGen &gen, int size_) {
 
 #endif
     int imm = (int)(long)roperand->getOValue();
-    emitStoreConst(laddr, (int)imm, gen);
+    gen.codeEmitter()->emitStoreImm(laddr, imm, gen);
     loperand->decUseCount(gen);
     roperand->decUseCount(gen);
     return true;
@@ -210,7 +210,7 @@ bool operatorAST::generateOptimizedAssignment(codeGen &gen, int size_) {
 
   long int imm = (long int)const_oper->getOValue();
   if(roper->op == plusOp) {
-    emitAddSignedImm(laddr, imm, gen);
+    gen.codeEmitter()->emitAddSignedImm(laddr, imm, gen);
   } else {
     gen.codeEmitter()->emitAddSignedImm(laddr, -imm, gen);
   }

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -494,13 +494,6 @@ bool EmitterAARCH64::clobberAllFuncCall(registerSpace *rs,
   return false;
 }
 
-Register emitFuncCall(opCode op,
-                      codeGen &gen,
-                      std::vector <codeGenASTPtr> &operands,
-                      func_instance *callee) {
-    return gen.emitter()->emitCall(op, gen, operands, callee);
-}
-
 Register EmitterAARCH64::emitCallReplacement(opCode,
                                              codeGen &,
                                              func_instance *) {

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -47,18 +47,6 @@ void emitImm(opCode /* op */, Register /* src1 */, RegValue /* src2imm */, Regis
   assert(!"Not implemented for AMDGPU");
 }
 
-Register emitFuncCall(opCode, codeGen &, std::vector<codeGenASTPtr> &, Address) {
-  assert(!"Not implemented for AMDGPU");
-  return 0;
-}
-
-Register emitFuncCall(opCode /* op */, codeGen & /* gen */,
-                      std::vector<codeGenASTPtr> & /* operands */,
-                      func_instance * /* callee */) {
-  assert(!"Not implemented for AMDGPU");
-  return 0;
-}
-
 codeBufIndex_t emitA(opCode /* op */, Register /* src1 */, long /* dest */,
                      codeGen & /* gen */, Dyninst::DyninstAPI::RegControl /* rc */) {
   assert(!"Not implemented for AMDGPU");

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -790,13 +790,6 @@ bool EmitterPOWER::clobberAllFuncCall( registerSpace *rs,
 }
 
 
-Dyninst::Register emitFuncCall(opCode op,
-                      codeGen &gen,
-                      std::vector<codeGenASTPtr> &operands,
-                      func_instance *callee) {
-    return gen.emitter()->emitCall(op, gen, operands, callee);
-}
-
 void EmitterPOWER::emitCallWithSaves(codeGen &gen, Address dest, bool saveToc, bool saveLR, bool saveR12) {
     // Save the values onto the stack.... (might be needed).
     if (saveToc) {}

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -731,16 +731,6 @@ unsigned char jccOpcodeFromRelOp(unsigned op, bool s)
    return 0x0;
 }
 
-// this function just multiplexes between the 32-bit and 64-bit versions
-Dyninst::Register emitFuncCall(opCode op,
-                      codeGen &gen,
-                      std::vector<codeGenASTPtr> &operands, 
-                      func_instance *callee)
-{
-    Dyninst::Register reg = gen.codeEmitter()->emitCall(op, gen, operands, callee);
-    return reg;
-}
-
 /*
  * emit code for op(src1,src2, dest)
  * ibuf is an instruction buffer where instructions are generated

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1330,11 +1330,6 @@ bool emitAddSignedImm(Address addr, long int imm, codeGen &gen) {
    return true;
 }
 
-bool emitSubSignedImm(Address addr, long int imm, codeGen &gen) {
-   gen.codeEmitter()->emitAddSignedImm(addr, imm * -1, gen);
-   return true;
-}
-
 Emitter *AddressSpace::getEmitter() 
 {
    static Dyninst::DyninstAPI::EmitterIA32Dyn emitter32Dyn;

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1320,11 +1320,6 @@ bool writeFunctionPtr(AddressSpace *p, Address addr, func_instance *f)
    return p->writeDataSpace((void *) addr, sizeof(Address), &val_to_write);   
 }
 
-bool emitStoreConst(Address addr, int imm, codeGen &gen) {
-   gen.codeEmitter()->emitStoreImm(addr, imm, gen);
-   return true;
-}
-
 bool emitAddSignedImm(Address addr, long int imm, codeGen &gen) {
    gen.codeEmitter()->emitAddSignedImm(addr, imm, gen);
    return true;

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -125,10 +125,6 @@ bool writeFunctionPtr(AddressSpace *p, Dyninst::Address addr, func_instance *f);
  **/
 //Store constant in memory at address
 bool emitStoreConst(Dyninst::Address addr, int imm, codeGen &gen);
-//Add constant to memory at address
-bool emitAddSignedImm(Dyninst::Address addr, long int imm, codeGen &gen);
-//Subtract constant from memory at address
-bool emitSubSignedImm(Dyninst::Address addr, long int imm, codeGen &gen);
 
 inline bool isPowerOf2(int value, int &result) {
   if(value <= 0) {

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -109,11 +109,6 @@ void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackS
 
 void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest, codeGen &gen);
 
-// VG(11/06/01): moved here and added location
-Dyninst::Register emitFuncCall(opCode op, codeGen &gen,
-                      std::vector<Dyninst::DyninstAPI::codeGenASTPtr> &operands,
-                      func_instance *func);
-
 // find these internal functions before finding any other functions
 // extern std::unordered_map<std::string, unsigned> tagDict;
 

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -119,13 +119,6 @@ Dyninst::Register emitFuncCall(opCode op, codeGen &gen,
 
 bool writeFunctionPtr(AddressSpace *p, Dyninst::Address addr, func_instance *f);
 
-/**
- * A set of optimized emiters for common idioms.  Return 
- * false if the platform can't perform any optimizations.
- **/
-//Store constant in memory at address
-bool emitStoreConst(Dyninst::Address addr, int imm, codeGen &gen);
-
 inline bool isPowerOf2(int value, int &result) {
   if(value <= 0) {
     return (false);


### PR DESCRIPTION
These wrappers aren't doing anything except forwarding to the emitter, so remove them from the interface.