### PR TITLE
Extract x86-only emitJmpMC

### DIFF
--- a/dyninstAPI/src/ASTs/operatorAST.C
+++ b/dyninstAPI/src/ASTs/operatorAST.C
@@ -40,6 +40,8 @@ namespace {
   }
 
   bool can_encode_directly(int64_t, Dyninst::Architecture);
+
+  void emitJmpMC(int condition, int offset, codeGen &gen);
 }
 
 namespace Dyninst { namespace DyninstAPI {
@@ -377,26 +379,28 @@ bool operatorAST::generateCode_phase2(codeGen &gen, Dyninst::Address &retAddr,
       BPatch_point *bpoint = bproc->findOrCreateBPPoint(
           NULL, gen.point(), BPatch_point::convertInstPointType_t(gen.point()->type()));
 
-      const BPatch_memoryAccess *ma = bpoint->getMemoryAccess();
-      assert(ma);
-      int cond = ma->conditionCode_NP();
-      if(cond > -1) {
-        codeBufIndex_t startIndex = gen.getIndex();
-        emitJmpMC(cond, 0 /* target, changed later */, gen);
-        codeBufIndex_t fromIndex = gen.getIndex();
-        // Add the snippet to the tracker, as AM has indicated...
-        gen.tracker()->increaseConditionalLevel();
-        // generate code with the right path
-        if(!loperand->generateCode_phase2(gen, addr, src1)) {
-          ERROR_RETURN;
+      if(gen.getArch() == Dyninst::Arch_x86 || gen.getArch() == Dyninst::Arch_x86_64) {
+        const BPatch_memoryAccess *ma = bpoint->getMemoryAccess();
+        assert(ma);
+        int cond = ma->conditionCode_NP();
+        if(cond > -1) {
+          codeBufIndex_t startIndex = gen.getIndex();
+          emitJmpMC(cond, 0 /* target, changed later */, gen);
+          codeBufIndex_t fromIndex = gen.getIndex();
+          // Add the snippet to the tracker, as AM has indicated...
+          gen.tracker()->increaseConditionalLevel();
+          // generate code with the right path
+          if(!loperand->generateCode_phase2(gen, addr, src1)) {
+            ERROR_RETURN;
+          }
+          gen.rs()->freeRegister(src1);
+          gen.tracker()->decreaseAndClean(gen);
+          codeBufIndex_t endIndex = gen.getIndex();
+          // call emit again now with correct offset.
+          gen.setIndex(startIndex);
+          emitJmpMC(cond, codeGen::getDisplacement(fromIndex, endIndex), gen);
+          gen.setIndex(endIndex);
         }
-        gen.rs()->freeRegister(src1);
-        gen.tracker()->decreaseAndClean(gen);
-        codeBufIndex_t endIndex = gen.getIndex();
-        // call emit again now with correct offset.
-        gen.setIndex(startIndex);
-        emitJmpMC(cond, codeGen::getDisplacement(fromIndex, endIndex), gen);
-        gen.setIndex(endIndex);
       } else {
         if(!loperand->generateCode_phase2(gen, addr, src1)) {
           ERROR_RETURN;
@@ -910,6 +914,29 @@ namespace {
         return false;
     }
     return false;
+  }
+
+  // VG(8/15/02): Emit the jcc over a conditional snippet
+  void emitJmpMC(int condition, int offset, codeGen &gen) {
+#if defined(DYNINST_CODEGEN_ARCH_I386) || defined(DYNINST_CODEGEN_ARCH_X86_64)
+    // What we want:
+    //   mov eax, [original EFLAGS]
+    //   push eax
+    //   popfd
+    //   jCC target   ; CC = !condition (we jump on the negated condition)
+
+    assert(condition >= 0 && condition <= 0x0F);
+
+    // bperr("OC: %x, NC: %x\n", condition, condition ^ 0x01);
+    condition ^= 0x01; // flip last bit to negate the tttn condition
+
+    gen.codeEmitter()->emitRestoreFlagsFromStackSlot(gen);
+    emitJcc(condition, offset, gen);
+#else
+    (void)condition;
+    (void)offset;
+    (void)gen;
+#endif
   }
 
 }

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -725,12 +725,6 @@ Register emitR(opCode op, Register src1, Register src2, Register dest,
     return reg;
 }
 
-void emitJmpMC(int /*condition*/, int /*offset*/, codeGen &) {
-    assert(0); //Not implemented
-    // Not needed for memory instrumentation, otherwise TBD
-}
-
-
 // VG(03/15/02): Restore mutatee value of GPR reg to dest GPR
 static inline void restoreGPRtoGPR(codeGen &gen,
                                    Register reg, Register dest) {

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -71,10 +71,6 @@ Register emitR(opCode /* op */, Register /* src1 */, Register /* src2 */, Regist
   return 0;
 }
 
-void emitJmpMC(int /*condition*/, int /*offset*/, codeGen &) {
-  assert(!"Not implemented for AMDGPU");
-}
-
 void emitASload(const BPatch_addrSpec_NP * /* as */, Register /* dest */, int /* stackShift */,
                 codeGen & /* gen */) {
   assert(!"Not imeplemented for AMDGPU");

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1240,12 +1240,6 @@ Dyninst::Register emitR(opCode op, Dyninst::Register src1, Dyninst::Register src
     return Null_Register;
 }
 
-void emitJmpMC(int /*condition*/, int /*offset*/, codeGen &)
-{
-  // Not needed for memory instrumentation, otherwise TBD
-}
-
-
 // VG(11/16/01): Say if we have to restore a register to get its original value
 static inline bool needsRestore(Dyninst::Register x)
 {

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -831,24 +831,6 @@ void emitSHL(RealRegister dest, unsigned char pos, codeGen &gen)
 }
 
 
-// VG(8/15/02): Emit the jcc over a conditional snippet
-void emitJmpMC(int condition, int offset, codeGen &gen)
-{
-    // What we want: 
-    //   mov eax, [original EFLAGS]
-    //   push eax
-    //   popfd
-    //   jCC target   ; CC = !condition (we jump on the negated condition)
-    
-    assert(condition >= 0 && condition <= 0x0F);
-    
-    //bperr("OC: %x, NC: %x\n", condition, condition ^ 0x01);
-    condition ^= 0x01; // flip last bit to negate the tttn condition
-    
-    gen.codeEmitter()->emitRestoreFlagsFromStackSlot(gen);
-    emitJcc(condition, offset, gen);
-}
-
 stackItemLocation getHeightOf(stackItem sitem, codeGen &gen)
 {
    int offset = 0;

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -103,8 +103,6 @@ typedef BPatch_addrSpec_NP BPatch_countSpec_NP;
 
 // Don't need the above: countSpec is typedefed to addrSpec
 
-void emitJmpMC(int condition, int offset, codeGen &gen);
-
 void emitASload(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackShift, codeGen &gen);
 
 void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest, codeGen &gen);


### PR DESCRIPTION
Once platform-independent codegen is in place, this can be put into some x86 namespace and directly called.