### PR TITLE
Extract writeFunctionPtr from codegen into PCProcess

### DIFF
--- a/dyninstAPI/src/dynProcess-aarch64.C
+++ b/dyninstAPI/src/dynProcess-aarch64.C
@@ -83,4 +83,9 @@ bool PCProcess::bindPLTEntry(const SymtabAPI::relocationEntry &, Address,
     return false;
 }
 
+bool writeFunctionPtr(AddressSpace *p, Address addr, func_instance *f) {
+    Address val_to_write = f->addr();
+    return p->writeDataSpace((void *) addr, sizeof(Address), &val_to_write);
+    return false;
+}
 

--- a/dyninstAPI/src/dynProcess-power.C
+++ b/dyninstAPI/src/dynProcess-power.C
@@ -82,3 +82,22 @@ bool PCProcess::bindPLTEntry(const SymtabAPI::relocationEntry &entry, Address ba
    fprintf(stderr, "[PCProcess::bindPLTEntry] Relocation Entry location target: %lx, relocation: %lx - base_addr: %lx, original_function: %lx, original_name: %s, new_target: %lx\n", entry.target_addr(), entry.rel_addr(), base_addr, origFunc->getPtrAddress(), origFunc->name().c_str(), target_addr);
    return true;
 }
+
+bool writeFunctionPtr(AddressSpace *p, Address addr, func_instance *f)
+{
+    // 64-bit ELF PowerPC Linux uses r2 for TOC base register
+    if (p->getAddressWidth() == sizeof(uint64_t)) {
+        Address val_to_write = f->addr();
+        // Use function descriptor address, if available.
+        if (f->getPtrAddress()) val_to_write = f->getPtrAddress();
+        return p->writeDataSpace((void *) addr,
+                                 sizeof(val_to_write), &val_to_write);
+    }
+    else {
+        // Originally copied from inst-x86.C
+        // 32-bit ELF PowerPC Linux mutatee
+        uint32_t val_to_write = (uint32_t)f->addr();
+        return p->writeDataSpace((void *) addr,
+                                 sizeof(val_to_write), &val_to_write);
+    }
+}

--- a/dyninstAPI/src/dynProcess-x86.C
+++ b/dyninstAPI/src/dynProcess-x86.C
@@ -127,4 +127,13 @@ bool PCProcess::hasBeenBound(const relocationEntry &entry,
     return false;
 }
 
+/**
+ * Fills in an indirect function pointer at 'addr' to point to 'f'.
+ **/
+bool writeFunctionPtr(AddressSpace *p, Address addr, func_instance *f)
+{
+   Address val_to_write = f->addr();
+   return p->writeDataSpace((void *) addr, sizeof(Address), &val_to_write);
+}
+
 #endif

--- a/dyninstAPI/src/dynProcess.h
+++ b/dyninstAPI/src/dynProcess.h
@@ -717,4 +717,6 @@ class DynWandererHelper : public Dyninst::Stackwalker::WandererHelper {
     virtual ~DynWandererHelper();
 };
 
+bool writeFunctionPtr(AddressSpace *p, Dyninst::Address addr, func_instance *f);
+
 #endif

--- a/dyninstAPI/src/inst-aarch64.C
+++ b/dyninstAPI/src/inst-aarch64.C
@@ -931,12 +931,6 @@ bool AddressSpace::getDynamicCallSiteArgs(InstructionAPI::Instruction i,
     return true;
 }
 
-bool writeFunctionPtr(AddressSpace *p, Address addr, func_instance *f) {
-    Address val_to_write = f->addr();
-    return p->writeDataSpace((void *) addr, sizeof(Address), &val_to_write);
-    return false;
-}
-
 Emitter *AddressSpace::getEmitter() {
     static EmitterAARCH64Stat emitter64Stat;
     static EmitterAARCH64Dyn emitter64Dyn;

--- a/dyninstAPI/src/inst-amdgpu.C
+++ b/dyninstAPI/src/inst-amdgpu.C
@@ -101,11 +101,6 @@ bool AddressSpace::getDynamicCallSiteArgs(InstructionAPI::Instruction /* i */, A
   return false;
 }
 
-bool writeFunctionPtr(AddressSpace * /* p */, Address /* addr */, func_instance * /* f */) {
-  assert(!"Not implemented for AMDGPU");
-  return false;
-}
-
 Emitter *AddressSpace::getEmitter() {
   static EmitterAmdgpuGfx908 gfx908Emitter;
   return &gfx908Emitter;

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -1785,25 +1785,6 @@ bool AddressSpace::getDynamicCallSiteArgs(InstructionAPI::Instruction i,
     }
 }
 
-bool writeFunctionPtr(AddressSpace *p, Address addr, func_instance *f)
-{
-    // 64-bit ELF PowerPC Linux uses r2 for TOC base register
-    if (p->getAddressWidth() == sizeof(uint64_t)) {
-        Address val_to_write = f->addr();
-        // Use function descriptor address, if available.
-        if (f->getPtrAddress()) val_to_write = f->getPtrAddress();
-        return p->writeDataSpace((void *) addr,
-                                 sizeof(val_to_write), &val_to_write);
-    }
-    else {
-        // Originally copied from inst-x86.C
-        // 32-bit ELF PowerPC Linux mutatee
-        uint32_t val_to_write = (uint32_t)f->addr();
-        return p->writeDataSpace((void *) addr,
-                                 sizeof(val_to_write), &val_to_write);
-    }
-}
-
 Emitter *AddressSpace::getEmitter() 
 {
     static EmitterPOWER32Dyn emitter32Dyn;

--- a/dyninstAPI/src/inst-x86.C
+++ b/dyninstAPI/src/inst-x86.C
@@ -1301,15 +1301,6 @@ int getMaxJumpSize()
   return JUMP_REL32_SZ;
 }
 
-/**
- * Fills in an indirect function pointer at 'addr' to point to 'f'.
- **/
-bool writeFunctionPtr(AddressSpace *p, Address addr, func_instance *f)
-{
-   Address val_to_write = f->addr();
-   return p->writeDataSpace((void *) addr, sizeof(Address), &val_to_write);   
-}
-
 bool emitAddSignedImm(Address addr, long int imm, codeGen &gen) {
    gen.codeEmitter()->emitAddSignedImm(addr, imm, gen);
    return true;

--- a/dyninstAPI/src/inst.h
+++ b/dyninstAPI/src/inst.h
@@ -112,8 +112,6 @@ void emitCSload(const BPatch_countSpec_NP *as, Dyninst::Register dest, codeGen &
 // find these internal functions before finding any other functions
 // extern std::unordered_map<std::string, unsigned> tagDict;
 
-bool writeFunctionPtr(AddressSpace *p, Dyninst::Address addr, func_instance *f);
-
 inline bool isPowerOf2(int value, int &result) {
   if(value <= 0) {
     return (false);


### PR DESCRIPTION
That's where it's used. The AMDGPU version is explicitly removed because dynamic instrumentation isn't supported there, so that code will never get called.