### PR TITLE
Clean up Emitter class

### DIFF
--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -36,20 +36,19 @@
 #ifndef _EMITTER_H
 #define _EMITTER_H
 
-#include <assert.h>
+#include "baseTramp.h"
 #include "BPatch_memoryAccess_NP.h"
 #include "codeGenAST.h"
-#include <vector>
 #include "codegen/RegControl.h"
 #include "common/src/headers.h"
-#include "dyninstAPI/src/instPoint.h"
-#include "baseTramp.h"
+#include "instPoint.h"
+
+#include <cassert>
+#include <vector>
 
 class codeGen;
-class registerSpace;
-class baseTramp;
-
 class registerSlot;
+class registerSpace;
 
 // class for encapsulating
 // platform dependent code generation functions

--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -28,11 +28,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/*
- * emit-x86.h - x86 & AMD64 code generators
- * $Id: emitter.h,v 1.10 2008/03/25 19:24:29 bernat Exp $
- */
-
 #ifndef _EMITTER_H
 #define _EMITTER_H
 
@@ -50,8 +45,6 @@ class codeGen;
 class registerSlot;
 class registerSpace;
 
-// class for encapsulating
-// platform dependent code generation functions
 class Emitter {
 public:
   virtual ~Emitter() {}

--- a/dyninstAPI/src/emitter.h
+++ b/dyninstAPI/src/emitter.h
@@ -54,87 +54,100 @@ class registerSlot;
 // class for encapsulating
 // platform dependent code generation functions
 class Emitter {
+public:
+  virtual ~Emitter() {}
 
- public:
-    virtual ~Emitter() {}
-    virtual codeBufIndex_t emitIf(Register expr_reg, Register target, Dyninst::DyninstAPI::RegControl rc, codeGen &gen) = 0;
-    virtual void emitOp(unsigned opcode, Register dest, Register src1, Register src2, codeGen &gen) = 0;
-    virtual void emitOpImm(unsigned opcode1, unsigned opcode2, Register dest, Register src1, RegValue src2imm,
-			   codeGen &gen) = 0;
-    virtual void emitOpImmSimple(unsigned /* op */, Register /* dest */, Register /* src1 */, RegValue /* src2imm */, codeGen & /* gen */) {}
-    virtual void emitRelOp(unsigned op, Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
-    virtual void emitRelOpImm(unsigned op, Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
-    virtual void emitDiv(Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
-    virtual void emitTimesImm(Register dest, Register src1, RegValue src2imm, codeGen &gen) = 0;
-    virtual void emitDivImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
-    virtual void emitLoad(Register dest, Address addr, int size, codeGen &gen) = 0;
-    virtual void emitLoadConst(Register dest, Address imm, codeGen &gen) = 0;
-    virtual void emitLoadIndir(Register dest, Register addr_reg, int size, codeGen &gen) = 0;
-    virtual bool emitCallRelative(Register, Address, Register, codeGen &) = 0;
-    virtual bool emitLoadRelative(Register dest, Address offset, Register base, int size, codeGen &gen) = 0;
-    virtual void emitLoadShared(opCode op, Register dest, const image_variable *var, bool is_local, int size, codeGen &gen, Address offset) = 0;
+  /*** Function calls and arguments ***/
+  virtual bool clobberAllFuncCall(registerSpace *rs,func_instance *callee) = 0;
+  virtual Register emitCall(opCode op, codeGen &gen, const std::vector<Dyninst::DyninstAPI::codeGenASTPtr> &operands, func_instance *callee) = 0;
+  virtual void emitGetParam(Register dest, Register param_num, instPoint::Type pt_type, opCode op, bool addr_of, codeGen &gen) = 0;
+  virtual bool emitPLTCall(func_instance *, codeGen &) { assert(0); return false;}
+  virtual bool emitPLTJump(func_instance *, codeGen &) { assert(0); return false;}
+  virtual Address getInterModuleFuncAddr(func_instance *func, codeGen& gen) = 0;
+  virtual Address getInterModuleVarAddr(const image_variable *var, codeGen& gen) = 0;
 
-    virtual void emitLoadFrameAddr(Register dest, Address offset, codeGen &gen) = 0;
 
-    // These implicitly use the stored original/non-inst value
-    virtual void emitLoadOrigFrameRelative(Register dest, Address offset, codeGen &gen) = 0;
-    virtual void emitLoadOrigRegRelative(Register dest, Address offset, Register base, codeGen &gen, bool store) = 0;
-    virtual void emitLoadOrigRegister(Address register_num, Register dest, codeGen &gen) = 0;
-    
-    virtual void emitStoreOrigRegister(Address register_num, Register dest, codeGen &gen) = 0;
+  /*** Arithmetic ***/
+  virtual void emitTimesImm(Register dest, Register src1, RegValue src2imm, codeGen &gen) = 0;
 
-    virtual void emitStore(Address addr, Register src, int size, codeGen &gen) = 0;
-    virtual void emitStoreIndir(Register addr_reg, Register src, int size, codeGen &gen) = 0;
-    virtual void emitStoreFrameRelative(Address offset, Register src, Register scratch, int size, codeGen &gen) = 0;
-    virtual void emitStoreRelative(Register source, Address offset, Register base, int size, codeGen &gen) = 0;
-    virtual void emitStoreShared(Register source, const image_variable *var, bool is_local, int size, codeGen &gen) = 0;
 
-    virtual bool emitMoveRegToReg(Register src, Register dest, codeGen &gen) = 0;
-    virtual bool emitMoveRegToReg(registerSlot *src, registerSlot *dest, codeGen &gen) = 0;
+  /*** Basic load operations ***/
+  virtual void emitLoad(Register dest, Address addr, int size, codeGen &gen) = 0;
+  virtual void emitLoadConst(Register dest, Address imm, codeGen &gen) = 0;
+  virtual void emitLoadIndir(Register dest, Register addr_reg, int size, codeGen &gen) = 0;
+  // These implicitly use the stored original/non-inst value
+  virtual void emitLoadOrigRegRelative(Register dest, Address offset, Register base, codeGen &gen, bool store) = 0;
+  virtual void emitLoadOrigRegister(Address register_num, Register dest, codeGen &gen) = 0;
+  virtual bool emitLoadRelative(Register dest, Address offset, Register base, int size, codeGen &gen) = 0;
+  virtual void emitLoadShared(opCode op, Register dest, const image_variable *var, bool is_local, int size, codeGen &gen, Address offset) = 0;
 
-    virtual Register emitCall(opCode op, codeGen &gen, const std::vector<Dyninst::DyninstAPI::codeGenASTPtr> &operands,
-			      func_instance *callee) = 0;
 
-    virtual void emitGetRetVal(Register dest, bool addr_of, codeGen &gen) = 0;
-    virtual void emitGetRetAddr(Register dest, codeGen &gen) = 0;
-    virtual void emitGetParam(Register dest, Register param_num, instPoint::Type pt_type, opCode op, bool addr_of, codeGen &gen) = 0;
-    virtual void emitASload(int ra, int rb, int sc, long imm, Register dest, int stackShift, codeGen &gen) = 0;
-    virtual void emitAddrSpecLoad(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackShift, codeGen &gen) = 0;
-    virtual void emitCSload(int ra, int rb, int sc, long imm, Register dest, codeGen &gen) = 0;
-    virtual void emitCountSpecLoad(const BPatch_countSpec_NP *as, Dyninst::Register dest, codeGen &gen) = 0;
-    virtual void emitPushFlags(codeGen &gen) = 0;
-    virtual void emitRestoreFlags(codeGen &gen, unsigned offset) = 0;
-    // Built-in offset...
-    virtual void emitRestoreFlagsFromStackSlot(codeGen &gen) = 0;
-    virtual bool emitBTSaves(baseTramp* bt, codeGen &gen) = 0;
-    virtual bool emitBTRestores(baseTramp* bt, codeGen &gen) = 0;
-    virtual void emitStoreImm(Address addr, int imm, codeGen &gen) = 0;
-    virtual void emitAddSignedImm(Address addr, int imm, codeGen &gen) = 0;
-    virtual bool emitPush(codeGen &, Register) = 0;
-    virtual bool emitPop(codeGen &, Register) = 0;
-    virtual bool emitAdjustStackPointer(int index, codeGen &gen) = 0;
-    
-    virtual bool clobberAllFuncCall(registerSpace *rs,func_instance *callee) = 0;
+  /*** Basic store operations ***/
+  virtual void emitStore(Address addr, Register src, int size, codeGen &gen) = 0;
+  virtual void emitStoreIndir(Register addr_reg, Register src, int size, codeGen &gen) = 0;
+  virtual void emitStoreRelative(Register source, Address offset, Register base, int size, codeGen &gen) = 0;
+  virtual void emitStoreShared(Register source, const image_variable *var, bool is_local, int size, codeGen &gen) = 0;
 
-    virtual Address getInterModuleFuncAddr(func_instance *func, codeGen& gen) = 0;
-    virtual Address getInterModuleVarAddr(const image_variable *var, codeGen& gen) = 0;
 
-    virtual bool emitPLTCall(func_instance *, codeGen &) { assert(0); return false;}
-    virtual bool emitPLTJump(func_instance *, codeGen &) { assert(0); return false;}
+  /*** For BPatch_memoryAccess ***/
+  virtual void emitAddrSpecLoad(const BPatch_addrSpec_NP *as, Dyninst::Register dest, int stackShift, codeGen &gen) = 0;
+  virtual void emitASload(int ra, int rb, int sc, long imm, Register dest, int stackShift, codeGen &gen) = 0;
+  virtual void emitCountSpecLoad(const BPatch_countSpec_NP *as, Dyninst::Register dest, codeGen &gen) = 0;
+  virtual void emitCSload(int ra, int rb, int sc, long imm, Register dest, codeGen &gen) = 0;
 
-    virtual bool emitTOCJump(block_instance *, codeGen &) { assert(0); return false; }
-    virtual bool emitTOCCall(block_instance *, codeGen &) { assert(0); return false; }
 
-    virtual void emitNops(unsigned /* numNops */, codeGen & /* gen */) {}
-    virtual void emitEndProgram(codeGen & /* gen */) {}
-    virtual void emitMovLiteral(Register /* reg */, uint32_t /* value */, codeGen & /* gen */) {}
-    virtual void emitConditionalBranch(bool /* onConditionTrue */, int16_t /* wordOffset */,
-                                     codeGen & /* gen */) {}
-    virtual void emitShortJump(int16_t /* wordOffset */, codeGen & /* gen */) {}
-    virtual void emitLongJump(Register /* reg */, uint64_t /* fromAddress */, uint64_t /* toAddress */, codeGen & /* gen */) {}
+  /*** Register-direct operations ***/
+  // TODO : Make all targets use this instead of having this functionality floating around in the codebase.
+  virtual void emitMovePCtoReg(Register /* reg */, codeGen & /* gen */) {}
+  virtual bool emitMoveRegToReg(Register src, Register dest, codeGen &gen) = 0;
+  virtual bool emitMoveRegToReg(registerSlot *src, registerSlot *dest, codeGen &gen) = 0;
 
-    // TODO : Make all targets use this instead of having this functionality floating around in the codebase.
-    virtual void emitMovePCtoReg(Register /* reg */, codeGen & /* gen */) {}
+
+  /*** Generic operations ***/
+  virtual void emitOp(unsigned opcode, Register dest, Register src1, Register src2, codeGen &gen) = 0;
+  virtual void emitOpImm(unsigned opcode1, unsigned opcode2, Register dest, Register src1, RegValue src2imm, codeGen &gen) = 0;
+  virtual void emitRelOp(unsigned op, Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
+  virtual void emitRelOpImm(unsigned op, Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
+
+  /*** Complete if/then/else operation ***/
+  virtual codeBufIndex_t emitIf(Register expr_reg, Register target, Dyninst::DyninstAPI::RegControl rc, codeGen &gen) = 0;
+
+
+  /*** AMDGPU-only ***/
+  virtual void emitEndProgram(codeGen & /* gen */) {}
+  virtual void emitNops(unsigned /* numNops */, codeGen & /* gen */) {}
+  virtual void emitConditionalBranch(bool /* onConditionTrue */, int16_t /* wordOffset */, codeGen & /* gen */) {}
+  virtual void emitLongJump(Register /* reg */, uint64_t /* fromAddress */, uint64_t /* toAddress */, codeGen & /* gen */) {}
+  virtual void emitShortJump(int16_t /* wordOffset */, codeGen & /* gen */) {}
+  virtual void emitMovLiteral(Register /* reg */, uint32_t /* value */, codeGen & /* gen */) {}
+  virtual void emitOpImmSimple(unsigned /* op */, Register /* dest */, Register /* src1 */, RegValue /* src2imm */, codeGen & /* gen */) {}
+
+
+  /*** x86-only ***/
+  virtual void emitAddSignedImm(Address addr, int imm, codeGen &gen) = 0;
+  virtual void emitDiv(Register dest, Register src1, Register src2, codeGen &gen, bool s) = 0;
+  virtual void emitDivImm(Register dest, Register src1, RegValue src2imm, codeGen &gen, bool s) = 0;
+  virtual void emitGetRetAddr(Register dest, codeGen &gen) = 0;
+  virtual void emitGetRetVal(Register dest, bool addr_of, codeGen &gen) = 0;
+  virtual void emitLoadFrameAddr(Register dest, Address offset, codeGen &gen) = 0;
+  virtual void emitLoadOrigFrameRelative(Register dest, Address offset, codeGen &gen) = 0;
+  virtual void emitRestoreFlags(codeGen &gen, unsigned offset) = 0;
+  virtual void emitRestoreFlagsFromStackSlot(codeGen &gen) = 0; // Built-in offset...
+  virtual void emitStoreFrameRelative(Address offset, Register src, Register scratch, int size, codeGen &gen) = 0;
+  virtual void emitStoreImm(Address addr, int imm, codeGen &gen) = 0;
+  virtual void emitStoreOrigRegister(Address register_num, Register dest, codeGen &gen) = 0;
+  virtual bool emitAdjustStackPointer(int index, codeGen &gen) = 0;
+  virtual bool emitPop(codeGen &, Register) = 0;
+  virtual bool emitPush(codeGen &, Register) = 0;
+  virtual void emitPushFlags(codeGen &gen) = 0;
+  virtual bool emitBTRestores(baseTramp* bt, codeGen &gen) = 0;
+  virtual bool emitBTSaves(baseTramp* bt, codeGen &gen) = 0;
+
+
+  /*** PowerPC-only ***/
+  virtual bool emitCallRelative(Register, Address, Register, codeGen &) = 0;
+  virtual bool emitTOCCall(block_instance *, codeGen &) { assert(0); return false; }
+  virtual bool emitTOCJump(block_instance *, codeGen &) { assert(0); return false; }
 };
 
 #endif


### PR DESCRIPTION
Below is a table of which members of Emitter are implemented on the supported platforms (except RISCV). There are two big takeaways:

1. Most of Emitter is x86-specific
2. ppc64le is deeply lacking functionality. For example, `emitOp` drives a lot of functionality on the other platforms.

Overall, I would say this class sits in an odd position between trying to be platform-agnostic and providing useful features. My guess would be that deconstructing the `emitA/V/etc.` functions will likely replace most of the members here. I'm not sure what will happen when compared against `insnCodeGen`. The ultimate goal is to distill a unified interface that every platform supports (or can be made to support) that is driven by the needs of the AST classes.


X means "not implemented"

| function                      | i386 | AMD64 | AMDGPU | aarch64 | ppc64le |
|-------------------------------|------|-------|--------|---------|---------|
| clobberAllFuncCall            |      |       |   X    |         |         |
| emitCall                      |      |       |        |         |         |
| emitCallRelative              |   X  |   X   |   X    |   X     |   [1]   |
| emitGetParam                  |      |       |   X    |         |    X    |
| emitGetRetAddr                |      |       |   X    |   X     |    X    |
| emitGetRetVal                 |      |       |   X    |   X     |    X    |
| emitPLTCall                   |      |       |   X    |         |         |
| emitPLTJump                   |      |       |   X    |         |         |
| getInterModuleFuncAddr        |      |       |   X    |         |         |
| getInterModuleVarAddr         |      |       |   X    |         |         |
| emitAddSignedImm              |      |       |   X    |   X     |    X    |
| emitDiv                       |      |       |   X    |   X     |    X    |
| emitDivImm                    |      |       |   X    |   X     |    X    |
| emitTimesImm                  |      |       |        |   X     |    X    |
| emitLoad                      |      |       |   X    |         |    X    |
| emitLoadConst                 |      |       |        |         |    X    |
| emitLoadFrameAddr             |      |       |   X    |    X    |    X    |
| emitLoadIndir                 |      |       |        |         |    X    |
| emitLoadOrigFrameRelative     |      |       |   X    |    X    |    X    |
| emitLoadOrigRegRelative       |      |       |   X    |         |    X    |
| emitLoadOrigRegister          |      |       |   X    |         |    X    |
| emitLoadRelative              |  X   |       |        |         |         |
| emitLoadShared                |      |       |   X    |         |         |
| emitStore                     |      |       |   X    |         |    X    |
| emitStoreFrameRelative        |      |       |   X    |    X    |    X    |
| emitStoreImm                  |      |       |   X    |    X    |    X    |
| emitStoreIndir                |      |       |        |         |    X    |
| emitStoreOrigRegister         |  X   |       |   X    |    X    |    X    |
| emitStoreRelative             |  X   |       |        |         |         |
| emitStoreShared               |      |       |   X    |         |         |
| emitAddrSpecLoad              |      |       |   X    |         |         |
| emitASload                    |      |       |   X    |    X    |    X    |
| emitCountSpecLoad             |      |       |   X    |    X    |         |
| emitCSload                    |      |       |   X    |    X    |    X    |
| emitAdjustStackPointer        |      |       |   X    |    X    |    X    |
| emitPop                       |      |       |   X    |    X    |    X    |
| emitPush                      |      |       |   X    |    X    |    X    |
| emitPushFlags                 |      |       |   X    |    X    |    X    |
| emitBTRestores                |      |       |   X    |    X    |    X    |
| emitBTSaves                   |      |       |   X    |    X    |    X    |
| emitConditionalBranch         |  X   |   X   |        |    X    |    X    |
| emitLongJump                  |  X   |   X   |        |    X    |    X    |
| emitShortJump                 |  X   |   X   |        |    X    |    X    |
| emitMovLiteral                |  X   |   X   |        |    X    |    X    |
| emitMovePCtoReg               |  X   |   X   |   X    |    X    |    X    |
| emitMoveRegToReg              |      |       |        |    X    |    X    |
| emitMoveRegToReg(registerSlot)|  X   |       |   X    |    X    |         |
| emitOp                        |      |       |   X    |         |    X    |
| emitOpImm                     |      |       |   X    |    X    |    X    |
| emitOpImmSimple               |  X   |   X   |        |    X    |    X    |
| emitRelOp                     |      |       |        |         |    X    |
| emitRelOpImm                  |      |       |   X    |         |    X    |
| emitIf                        |      |       |   X    |         |    X    |
| emitEndProgram                |  X   |   X   |        |    X    |    X    |
| emitNops                      |  X   |   X   |        |    X    |    X    |
| emitRestoreFlags              |  X   |       |   X    |    X    |    X    |
| emitRestoreFlagsFromStackSlot |      |       |   X    |    X    |    X    |
| emitTOCCall                   |  X   |   X   |   X    |    X    |         |
| emitTOCJump                   |  X   |   X   |   X    |    X    |         |

[1] 32-bit PPC only
