### PR TITLE
Explicitly look in lib64 when searching for third-party libraries

### DIFF
--- a/cmake/Modules/FindLibDW.cmake
+++ b/cmake/Modules/FindLibDW.cmake
@@ -79,7 +79,7 @@ else()
   find_library(
     LibDW_LIBRARIES
     NAMES libdw dw
-    PATH_SUFFIXES elfutils ${_find_path_args})
+    PATH_SUFFIXES elfutils lib64 ${_find_path_args})
 
   if(EXISTS "${LibDW_INCLUDE_DIRS}/version.h")
     file(STRINGS "${LibDW_INCLUDE_DIRS}/version.h" _version_line

--- a/cmake/Modules/FindLibELF.cmake
+++ b/cmake/Modules/FindLibELF.cmake
@@ -79,7 +79,7 @@ else()
   find_library(
     LibELF_LIBRARIES
     NAMES libelf elf
-    PATH_SUFFIXES elfutils ${_find_path_args})
+    PATH_SUFFIXES elfutils lib64 ${_find_path_args})
 
   macro(_check_libelf_version _file)
     file(STRINGS ${_file} _version_line REGEX "^#define _ELFUTILS_VERSION[ \t]+[0-9]+")

--- a/cmake/Modules/FindLibIberty.cmake
+++ b/cmake/Modules/FindLibIberty.cmake
@@ -48,7 +48,7 @@ mark_as_advanced(LibIberty_INCLUDE_DIRS)
 find_library(
   LibIberty_LIBRARIES
   NAMES libiberty iberty
-  PATH_SUFFIXES libiberty ${_find_path_args})
+  PATH_SUFFIXES libiberty lib64 ${_find_path_args})
 mark_as_advanced(LibIberty_LIBRARIES)
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/Modules/FindThread_DB.cmake
+++ b/cmake/Modules/FindThread_DB.cmake
@@ -32,7 +32,10 @@ cmake_policy(SET CMP0074 NEW) # Use <Package>_ROOT
 
 find_path(Thread_DB_INCLUDE_DIRS NAMES thread_db.h)
 
-find_library(Thread_DB_LIBRARIES NAMES thread_db)
+find_library(
+  Thread_DB_LIBRARIES
+  NAMES thread_db
+  PATH_SUFFIXES lib64)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/cmake/Modules/FindValgrind.cmake
+++ b/cmake/Modules/FindValgrind.cmake
@@ -68,7 +68,7 @@ else()
   find_path(
     Valgrind_INCLUDE_DIRS
     NAMES valgrind.h
-    PATH_SUFFIXES valgrind ${_find_path_args})
+    PATH_SUFFIXES valgrind lib64 ${_find_path_args})
 
   macro(_check_valgrind_version _file)
     file(STRINGS ${_file} _version_line REGEX "^#define __VALGRIND_MAJOR__[ \t]+[0-9]+")


### PR DESCRIPTION
I found that cmake won't search this subdir on some systems that use lib64 (as opposed to lib).