### PR TITLE
Remove BPatch_shadowExpr

### DIFF
--- a/dyninstAPI/h/BPatch_snippet.h
+++ b/dyninstAPI/h/BPatch_snippet.h
@@ -129,7 +129,6 @@ class DYNINST_EXPORT BPatch_snippet {
     friend class BPatch_sequence;
     friend class BPatch_insnExpr;
     friend class BPatch_stopThreadExpr;
-    friend class BPatch_shadowExpr;
     friend class BPatch_utilExpr;
     friend class BPatch_atomicOperationStmt;
     friend Dyninst::BPatch_codeGenASTPtr generateArrayRef(const BPatch_snippet &lOperand,
@@ -530,20 +529,6 @@ typedef enum {
     BPatch_interpAsTarget,
     BPatch_interpAsReturnAddr,
 } BPatch_stInterpret;
-
-class DYNINST_EXPORT BPatch_shadowExpr : public BPatch_snippet {
- public:
-  // BPatch_stopThreadExpr 
-  //  This snippet type stops the thread that executes it.  It
-  //  evaluates a calculation snippet and triggers a callback to the
-  //  user program with the result of the calculation and a pointer to
-  //  the BPatch_point at which the snippet was inserted
-  BPatch_shadowExpr(bool entry, 
-		    const BPatchStopThreadCallback &cb,
-		    const BPatch_snippet &calculation,
-		    bool useCache = false,
-		    BPatch_stInterpret interp = BPatch_noInterp);
-};
 
 class DYNINST_EXPORT BPatch_stopThreadExpr : public BPatch_snippet {
  public:

--- a/dyninstAPI/src/BPatch_snippet.C
+++ b/dyninstAPI/src/BPatch_snippet.C
@@ -1590,39 +1590,6 @@ BPatch_stopThreadExpr::BPatch_stopThreadExpr(
     ast_wrapper->setTypeChecking(BPatch::bpatch->isTypeChecked());
 }
 
-
-BPatch_shadowExpr::BPatch_shadowExpr
-      (bool entry,
-      const BPatchStopThreadCallback &bp_cb,
-       const BPatch_snippet &calculation,
-       bool useCache,
-       BPatch_stInterpret interp)
-{
-    codeGenASTPtr idNode;
-    codeGenASTPtr icNode;
-    constructorHelper(bp_cb, useCache, interp, idNode, icNode);
-
-    // set up funcCall args
-    std::vector<codeGenASTPtr> ast_args;
-    if (entry) {
-        ast_args.push_back(operandAST::Constant((void *)1));
-    }
-    else {
-        ast_args.push_back(operandAST::Constant((void *)0));
-    }
-    ast_args.back()->setType(BPatch::bpatch->type_Untyped);
-
-    ast_args.push_back(AddressAST::actual());
-    ast_args.push_back(idNode);
-    ast_args.push_back(icNode);
-    ast_args.push_back(calculation.ast_wrapper);
-
-    // create func call & set type
-    ast_wrapper = functionCallAST::namedCall("RThandleShadow", ast_args);
-    ast_wrapper->setType(BPatch::bpatch->type_Untyped);
-    ast_wrapper->setTypeChecking(BPatch::bpatch->isTypeChecked());
-}
-
 BPatch_originalAddressExpr::BPatch_originalAddressExpr() {
     ast_wrapper = AddressAST::original();
 

--- a/dyninstAPI/src/hybridAnalysis.h
+++ b/dyninstAPI/src/hybridAnalysis.h
@@ -168,8 +168,7 @@ private:
     bool instrumentModule(BPatch_module *mod, bool useInsertionSet); 
     bool instrumentFunction(BPatch_function *func, 
                             bool useInsertionSet, 
-                            bool instrumentReturns=false,
-                            bool syncShadow = false);
+                            bool instrumentReturns=false);
     bool parseAfterCallAndInstrument(BPatch_point *callPoint, 
                         BPatch_function *calledFunc,
                         bool foundByRet) ;

--- a/dyninstAPI/src/hybridAnalysis.h
+++ b/dyninstAPI/src/hybridAnalysis.h
@@ -213,7 +213,6 @@ private:
               std::map<BPatch_point*,BPatchSnippetHandle*> *> * instrumentedFuncs;
     std::map< BPatch_point* , SynchHandle* > synchMap_pre_; // maps from prePt
     std::map< BPatch_point* , SynchHandle* > synchMap_post_; // maps from postPt
-    std::set< std::string > skipShadowFuncs_;
     std::map< BPatch_function *, BPatch_function *> replacedFuncs_;
     std::set< BPatch_point* > cachePoints_;
     BPatch_module *sharedlib_runtime;

--- a/dyninstAPI/src/hybridAnalysis.h
+++ b/dyninstAPI/src/hybridAnalysis.h
@@ -213,7 +213,6 @@ private:
               std::map<BPatch_point*,BPatchSnippetHandle*> *> * instrumentedFuncs;
     std::map< BPatch_point* , SynchHandle* > synchMap_pre_; // maps from prePt
     std::map< BPatch_point* , SynchHandle* > synchMap_post_; // maps from postPt
-    std::set< BPatch_function *> instShadowFuncs_;
     std::set< std::string > skipShadowFuncs_;
     std::map< BPatch_function *, BPatch_function *> replacedFuncs_;
     std::set< BPatch_point* > cachePoints_;

--- a/dyninstAPI/src/hybridInstrumentation.C
+++ b/dyninstAPI/src/hybridInstrumentation.C
@@ -267,8 +267,7 @@ bool HybridAnalysis::canUseCache(BPatch_point *pt)
 // unresolved, abruptEnds, and return instructions
 bool HybridAnalysis::instrumentFunction(BPatch_function *func, 
     bool useInsertionSet, 
-    bool instrumentReturns,
-    bool addShadowSync) 
+    bool instrumentReturns)
 {
     if (!instrumentReturns)
     {
@@ -289,10 +288,9 @@ bool HybridAnalysis::instrumentFunction(BPatch_function *func,
 
     Address funcAddr = (Address) func->getBaseAddr();
     int pointCount = 0;
-    mal_printf("instfunc at %lx; useInsertion %s, instrumentReturns %s, shadowSync %s\n", funcAddr,
+    mal_printf("instfunc at %lx; useInsertion %s, instrumentReturns %s\n", funcAddr,
         useInsertionSet ? "true" : "false",
-        instrumentReturns ? "true" : "false",
-        addShadowSync ? "true" : "false");
+        instrumentReturns ? "true" : "false");
     // first check to see if we've applied function replacement
     std::map<BPatch_function *,BPatch_function *>::iterator 
         rfIter = replacedFuncs_.find(func);
@@ -560,22 +558,6 @@ bool HybridAnalysis::instrumentFunction(BPatch_function *func,
             }
         }
 	}
-
-    // If we're copying original<->shadow do it here
-    if (addShadowSync) {
-        if (false)
-        {
-            malware_cerr << "Adding shadow sync instrumentation to function " << func->getName() << endl;
-            std::vector<BPatch_point *> *entryPoints = func->findPoint(BPatch_entry);
-            if (entryPoints) {
-                pointCount++;
-            }
-            std::vector<BPatch_point *> *exitPoints = func->findPoint(BPatch_exit);
-            if (exitPoints) {
-                pointCount++;
-            }
-        }
-    }
     
     // close insertion set
     if (pointCount) {
@@ -1191,7 +1173,7 @@ bool HybridAnalysis::processInterModuleEdge(BPatch_point *point,
             targFunc = proc()->findFunctionByEntry(target);
         }
         addIndirectEdgeIfNeeded(point, target);
-        instrumentFunction(targFunc, false, instReturns, true);
+        instrumentFunction(targFunc, false, instReturns);
         proc()->finalizeInsertionSet(false);
         doMoreProcessing = false;
     }

--- a/dyninstAPI/src/hybridInstrumentation.C
+++ b/dyninstAPI/src/hybridInstrumentation.C
@@ -89,11 +89,6 @@ static void signalHandlerExitCB_wrapper(BPatch_point *point, void *dontcare)
     dynamic_cast<BPatch_process*>(point->getFunction()->getProc())->
         getHybridAnalysis()->signalHandlerExitCB(point,dontcare); 
 }
-static void synchShadowOrigCB_wrapper(BPatch_point *point, void *toOrig) 
-{
-    dynamic_cast<BPatch_process*>(point->getFunction()->getProc())->
-        getHybridAnalysis()->synchShadowOrigCB(point, (bool) toOrig);
-}
 
 InternalSignalHandlerCallback HybridAnalysis::getSignalHandlerCB()
 { return signalHandlerCB_wrapper; }
@@ -574,14 +569,10 @@ bool HybridAnalysis::instrumentFunction(BPatch_function *func,
             std::vector<BPatch_point *> *entryPoints = func->findPoint(BPatch_entry);
             if (entryPoints) {
                 pointCount++;
-                proc()->insertSnippet(BPatch_shadowExpr(true, synchShadowOrigCB_wrapper, BPatch_constExpr(1)),
-                    *entryPoints, BPatch_firstSnippet);
             }
             std::vector<BPatch_point *> *exitPoints = func->findPoint(BPatch_exit);
             if (exitPoints) {
                 pointCount++;
-                proc()->insertSnippet(BPatch_shadowExpr(false, synchShadowOrigCB_wrapper, BPatch_constExpr(0)),
-                    *exitPoints, BPatch_lastSnippet);
             }
         }
     }

--- a/dyninstAPI/src/hybridInstrumentation.C
+++ b/dyninstAPI/src/hybridInstrumentation.C
@@ -568,7 +568,7 @@ bool HybridAnalysis::instrumentFunction(BPatch_function *func,
 
     // If we're copying original<->shadow do it here
     if (addShadowSync) {
-        if ((skipShadowFuncs_.find(func->getName()) == skipShadowFuncs_.end()))
+        if (false)
         {
             malware_cerr << "Adding shadow sync instrumentation to function " << func->getName() << endl;
             std::vector<BPatch_point *> *entryPoints = func->findPoint(BPatch_entry);

--- a/dyninstAPI/src/hybridInstrumentation.C
+++ b/dyninstAPI/src/hybridInstrumentation.C
@@ -568,8 +568,7 @@ bool HybridAnalysis::instrumentFunction(BPatch_function *func,
 
     // If we're copying original<->shadow do it here
     if (addShadowSync) {
-        if ((skipShadowFuncs_.find(func->getName()) == skipShadowFuncs_.end()) &&
-            (instShadowFuncs_.find(func) == instShadowFuncs_.end()))
+        if ((skipShadowFuncs_.find(func->getName()) == skipShadowFuncs_.end()))
         {
             malware_cerr << "Adding shadow sync instrumentation to function " << func->getName() << endl;
             std::vector<BPatch_point *> *entryPoints = func->findPoint(BPatch_entry);
@@ -584,7 +583,6 @@ bool HybridAnalysis::instrumentFunction(BPatch_function *func,
                 proc()->insertSnippet(BPatch_shadowExpr(false, synchShadowOrigCB_wrapper, BPatch_constExpr(0)),
                     *exitPoints, BPatch_lastSnippet);
             }
-            instShadowFuncs_.insert(func);
         }
     }
     


### PR DESCRIPTION
It generates a call to RThandleShadow which was disabled by 89919d982 in 2012 and removed by 0b9df83c9 in 2021.