### PR TITLE
Extract PowerPC decode tables out of decoder

### DIFF
--- a/instructionAPI/CMakeLists.txt
+++ b/instructionAPI/CMakeLists.txt
@@ -18,6 +18,7 @@ set(_sources
     src/InstructionDecoder.C
     src/InstructionDecoder-x86.C
     src/InstructionDecoder-power.C
+    src/power_opcode_tables.C
     src/InstructionDecoder-aarch64.C
     src/AMDGPU/gfx908/decodeOperands.C
     src/AMDGPU/gfx908/appendOperands.C
@@ -72,6 +73,7 @@ set(_private_headers
     src/InstructionDecoderImpl.h
     src/InstructionDecoder-power.h
     src/InstructionDecoder-x86.h
+    src/power_opcode_tables.h
     h/syscalls.h
     h/interrupts.h)
 
@@ -117,8 +119,8 @@ endif()
 
 if(NOT instructionDecoderPowerExtraFlags STREQUAL "")
   set_source_files_properties(
-    src/InstructionDecoder-power.C PROPERTIES COMPILE_FLAGS
-                                              "${instructionDecoderPowerExtraFlags}")
+    src/power_opcode_tables.C PROPERTIES COMPILE_FLAGS
+                                         "${instructionDecoderPowerExtraFlags}")
 endif()
 
 set(finalizeOperandsExtraFlags "")

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -32,6 +32,7 @@
 #include "registers/ppc32_regs.h"
 #include "registers/ppc64_regs.h"
 #include "unaligned_memory_access.h"
+#include "power_opcode_tables.h"
 
 #include <boost/assign/list_of.hpp>
 #include <mutex>
@@ -43,54 +44,6 @@ namespace Dyninst { namespace InstructionAPI {
   typedef std::map<unsigned int, power_entry> power_table;
   bool InstructionDecoder_power::foundDoubleHummerInsn = false;
   bool InstructionDecoder_power::foundQuadInsn = false;
-
-  struct power_entry {
-    power_entry(entryID o, const char* m, nextTableFunc next, operandSpec ops)
-        : op(o), mnemonic(m), next_table(next), operands(ops) {}
-
-    power_entry() : op(power_op_INVALID), mnemonic("INVALID"), next_table(NULL) {
-      operands.reserve(5);
-    }
-
-    power_entry(const power_entry& o)
-        : op(o.op), mnemonic(o.mnemonic), next_table(o.next_table), operands(o.operands) {}
-
-    const power_entry& operator=(const power_entry& rhs) {
-      operands.reserve(rhs.operands.size());
-      op = rhs.op;
-      mnemonic = rhs.mnemonic;
-      next_table = rhs.next_table;
-      operands = rhs.operands;
-      return *this;
-    }
-
-    entryID op;
-    const char* mnemonic;
-    nextTableFunc next_table;
-    operandSpec operands;
-    static void buildTables();
-    static std::vector<power_entry> main_opcode_table;
-    static power_table extended_op_0;
-    static power_table extended_op_4;
-    static power_table extended_op_4_1409;
-    static power_table extended_op_4_1538;
-    static power_table extended_op_4_1921;
-    static power_table extended_op_19;
-    static power_table extended_op_30;
-    static power_table extended_op_31;
-    static power_table extended_op_57;
-    static power_table extended_op_58;
-    static power_table extended_op_59;
-    static power_table extended_op_60;
-    static power_table extended_op_60_specials;
-    static power_table extended_op_60_347;
-    static power_table extended_op_60_475;
-    static power_table extended_op_61;
-    static power_table extended_op_63;
-    static power_table extended_op_63_583;
-    static power_table extended_op_63_804;
-    static power_table extended_op_63_836;
-  };
 
   InstructionDecoder_power::InstructionDecoder_power(Architecture a)
       : InstructionDecoderImpl(a), insn(0), isRAWritten(false), invertBranchCondition(false),
@@ -444,42 +397,6 @@ which are both 0).
       insn_in_progress->appendOperand(makeRegisterExpression(ppc32::xer), false, true);
       insn_in_progress->getOperation().mnemonic += "o";
     }
-  }
-
-  template <Result_Type size> void InstructionDecoder_power::L() {
-    insn_in_progress->appendOperand(makeMemRefNonIndex(size), true, false);
-  }
-
-  template <Result_Type size> void InstructionDecoder_power::ST() {
-    insn_in_progress->appendOperand(makeMemRefNonIndex(size), false, true);
-  }
-
-  template <Result_Type size> void InstructionDecoder_power::LX() {
-    insn_in_progress->appendOperand(makeMemRefIndex(size), true, false);
-  }
-
-  template <Result_Type size> void InstructionDecoder_power::STX() {
-    insn_in_progress->appendOperand(makeMemRefIndex(size), false, true);
-  }
-
-  template <Result_Type size> void InstructionDecoder_power::LU() {
-    L<size>();
-    insn_in_progress->appendOperand(makeRAExpr(), false, true, true);
-  }
-
-  template <Result_Type size> void InstructionDecoder_power::STU() {
-    ST<size>();
-    insn_in_progress->appendOperand(makeRAExpr(), false, true, true);
-  }
-
-  template <Result_Type size> void InstructionDecoder_power::LUX() {
-    LX<size>();
-    insn_in_progress->appendOperand(makeRAExpr(), false, true, true);
-  }
-
-  template <Result_Type size> void InstructionDecoder_power::STUX() {
-    STX<size>();
-    insn_in_progress->appendOperand(makeRAExpr(), false, true, true);
   }
 
   void InstructionDecoder_power::LK() {}
@@ -948,12 +865,6 @@ which are both 0).
                                                         unsigned int, unsigned int) {
     return MachRegister(base.val() + encoding);
   }
-
-#define fn(x) (&InstructionDecoder_power::x)
-
-  using namespace boost::assign;
-
-#include "power_opcode_tables.C"
 
   const power_entry& InstructionDecoder_power::extended_op_0() {
     unsigned int xo = field<26, 30>(insn);

--- a/instructionAPI/src/InstructionDecoder-power.h
+++ b/instructionAPI/src/InstructionDecoder-power.h
@@ -28,6 +28,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifndef DYNINST_INSTRUCTIONAPI_INSTRUCTIONDECODER_POWER_H
+#define DYNINST_INSTRUCTIONAPI_INSTRUCTIONDECODER_POWER_H
+
+#include "dyninst_visibility.h"
 #include "Immediate.h"
 #include "InstructionDecoderImpl.h"
 #include "registers/ppc32_regs.h"
@@ -39,7 +43,7 @@
 namespace Dyninst { namespace InstructionAPI {
   struct power_entry;
 
-  class InstructionDecoder_power : public InstructionDecoderImpl {
+  class DYNINST_EXPORT InstructionDecoder_power : public InstructionDecoderImpl {
     friend struct power_entry;
 
   public:
@@ -81,14 +85,42 @@ namespace Dyninst { namespace InstructionAPI {
     Expression::Ptr makeTOExpr();
     Expression::Ptr makeDSExpr();
     Expression::Ptr makeQFRAExpr();
-    template <Result_Type size> void L();
-    template <Result_Type size> void ST();
-    template <Result_Type size> void LX();
-    template <Result_Type size> void STX();
-    template <Result_Type size> void LU();
-    template <Result_Type size> void STU();
-    template <Result_Type size> void LUX();
-    template <Result_Type size> void STUX();
+
+    template <Result_Type size> void L() {
+       insn_in_progress->appendOperand(makeMemRefNonIndex(size), true, false);
+     }
+
+     template <Result_Type size> void ST() {
+       insn_in_progress->appendOperand(makeMemRefNonIndex(size), false, true);
+     }
+
+     template <Result_Type size> void LX() {
+       insn_in_progress->appendOperand(makeMemRefIndex(size), true, false);
+     }
+
+     template <Result_Type size> void STX() {
+       insn_in_progress->appendOperand(makeMemRefIndex(size), false, true);
+     }
+
+     template <Result_Type size> void LU() {
+       L<size>();
+       insn_in_progress->appendOperand(makeRAExpr(), false, true, true);
+     }
+
+     template <Result_Type size> void STU() {
+       ST<size>();
+       insn_in_progress->appendOperand(makeRAExpr(), false, true, true);
+     }
+
+     template <Result_Type size> void LUX() {
+       LX<size>();
+       insn_in_progress->appendOperand(makeRAExpr(), false, true, true);
+     }
+
+     template <Result_Type size> void STUX() {
+       STX<size>();
+       insn_in_progress->appendOperand(makeRAExpr(), false, true, true);
+     }
 
     void FC();
     void BHRBE();
@@ -304,3 +336,6 @@ namespace Dyninst { namespace InstructionAPI {
     bool findRAAndRS(const struct power_entry*);
   };
 }}
+
+#endif
+

--- a/instructionAPI/src/power_opcode_tables.C
+++ b/instructionAPI/src/power_opcode_tables.C
@@ -27,7 +27,19 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-std::once_flag built_tables;
+
+#include "power_opcode_tables.h"
+
+#include <boost/assign/list_of.hpp>
+#include <mutex>
+
+#define fn(x) (&InstructionDecoder_power::x)
+
+using namespace boost::assign;
+
+static std::once_flag built_tables;
+
+namespace Dyninst { namespace InstructionAPI {
 
 std::vector<power_entry> power_entry::main_opcode_table;
 power_table power_entry::extended_op_0;
@@ -1495,3 +1507,5 @@ extended_op_63_836[22] = power_entry(power_op_xscvdpqp, "xscvdpqp", NULL, list_o
 extended_op_63_836[25] = power_entry(power_op_xscvqpsdz, "xscvqpsdz", NULL, list_of(fn(VRT))(fn(VRB)));
     });
 }
+
+}}

--- a/instructionAPI/src/power_opcode_tables.h
+++ b/instructionAPI/src/power_opcode_tables.h
@@ -1,0 +1,98 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_INSTRUCTIONAPI_POWER_OPCODE_TABLES_H
+#define DYNINST_INSTRUCTIONAPI_POWER_OPCODE_TABLES_H
+
+#include "dyninst_visibility.h"
+#include "InstructionDecoder-power.h"
+
+#include <map>
+#include <vector>
+
+namespace Dyninst { namespace InstructionAPI {
+
+  typedef void (InstructionDecoder_power::*operandFactory)();
+  typedef std::vector<operandFactory> operandSpec;
+  typedef const power_entry &(InstructionDecoder_power::*nextTableFunc)();
+  typedef std::map<unsigned int, power_entry> power_table;
+
+  struct DYNINST_EXPORT power_entry {
+    power_entry(entryID o, const char *m, nextTableFunc next, operandSpec ops)
+        : op(o), mnemonic(m), next_table(next), operands(ops) {}
+
+    power_entry() : op(power_op_INVALID), mnemonic("INVALID"), next_table(NULL) {
+      operands.reserve(5);
+    }
+
+    power_entry(const power_entry &o)
+        : op(o.op), mnemonic(o.mnemonic), next_table(o.next_table), operands(o.operands) {}
+
+    const power_entry &operator=(const power_entry &rhs) {
+      operands.reserve(rhs.operands.size());
+      op = rhs.op;
+      mnemonic = rhs.mnemonic;
+      next_table = rhs.next_table;
+      operands = rhs.operands;
+      return *this;
+    }
+
+    entryID op;
+    const char *mnemonic;
+    nextTableFunc next_table;
+    operandSpec operands;
+    static void buildTables();
+    static std::vector<power_entry> main_opcode_table;
+    static power_table extended_op_0;
+    static power_table extended_op_4;
+    static power_table extended_op_4_1409;
+    static power_table extended_op_4_1538;
+    static power_table extended_op_4_1921;
+    static power_table extended_op_19;
+    static power_table extended_op_30;
+    static power_table extended_op_31;
+    static power_table extended_op_57;
+    static power_table extended_op_58;
+    static power_table extended_op_59;
+    static power_table extended_op_60;
+    static power_table extended_op_60_specials;
+    static power_table extended_op_60_347;
+    static power_table extended_op_60_475;
+    static power_table extended_op_61;
+    static power_table extended_op_63;
+    static power_table extended_op_63_583;
+    static power_table extended_op_63_804;
+    static power_table extended_op_63_836;
+  };
+
+  extern power_entry invalid_entry;
+}}
+
+#endif


### PR DESCRIPTION
They take much too long to compiler to make iterative changes to the decoder.