### PR TITLE
Remove disabledItem heap class

### DIFF
--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -381,7 +381,6 @@ void AddressSpace::initializeHeap() {
    // (re)initialize everything 
    heap_.heapActive.clear();
    heap_.heapFree.resize(0);
-   heap_.disabledList.resize(0);
    heap_.disabledListTotalMem = 0;
    heap_.freed = 0;
    heap_.totalFreeMemAvailable = 0;

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -381,7 +381,6 @@ void AddressSpace::initializeHeap() {
    // (re)initialize everything 
    heap_.heapActive.clear();
    heap_.heapFree.resize(0);
-   heap_.disabledListTotalMem = 0;
    heap_.freed = 0;
    heap_.totalFreeMemAvailable = 0;
 

--- a/dyninstAPI/src/infHeap.C
+++ b/dyninstAPI/src/infHeap.C
@@ -46,10 +46,6 @@ inferiorHeap::inferiorHeap(const inferiorHeap &src)
        heapActive[iter->first] = new heapItem(*(iter->second));
     }
 
-    for (unsigned u3 = 0; u3 < src.disabledList.size(); u3++) {
-      disabledList.push_back(src.disabledList[u3]);
-    }
-
     for (unsigned u4 = 0; u4 < src.bufferPool.size(); u4++) {
       bufferPool.push_back(new heapItem(src.bufferPool[u4]));
     }
@@ -68,10 +64,6 @@ inferiorHeap& inferiorHeap::operator=(const inferiorHeap &src)
 
     for (auto iter = src.heapActive.begin(); iter != src.heapActive.end(); ++iter) {
        heapActive[iter->first] = new heapItem(*(iter->second));
-    }
-
-    for (unsigned u3 = 0; u3 < src.disabledList.size(); u3++) {
-      disabledList.push_back(src.disabledList[u3]);
     }
 
     for (unsigned u4 = 0; u4 < src.bufferPool.size(); u4++) {
@@ -96,8 +88,6 @@ void inferiorHeap::clear() {
     for (unsigned i = 0; i < heapFree.size(); i++)
         delete heapFree[i];
     heapFree.clear();
-
-    disabledList.clear();
 
     disabledListTotalMem = 0;
     totalFreeMemAvailable = 0;

--- a/dyninstAPI/src/infHeap.C
+++ b/dyninstAPI/src/infHeap.C
@@ -50,7 +50,6 @@ inferiorHeap::inferiorHeap(const inferiorHeap &src)
       bufferPool.push_back(new heapItem(src.bufferPool[u4]));
     }
 
-    disabledListTotalMem = src.disabledListTotalMem;
     totalFreeMemAvailable = src.totalFreeMemAvailable;
     freed = 0;
 }
@@ -70,7 +69,6 @@ inferiorHeap& inferiorHeap::operator=(const inferiorHeap &src)
       bufferPool.push_back(new heapItem(src.bufferPool[u4]));
     }
 
-    disabledListTotalMem = src.disabledListTotalMem;
     totalFreeMemAvailable = src.totalFreeMemAvailable;
     freed = 0;
 
@@ -89,7 +87,6 @@ void inferiorHeap::clear() {
         delete heapFree[i];
     heapFree.clear();
 
-    disabledListTotalMem = 0;
     totalFreeMemAvailable = 0;
     freed = 0;
 

--- a/dyninstAPI/src/infHeap.h
+++ b/dyninstAPI/src/infHeap.h
@@ -128,14 +128,13 @@ class inferiorHeap {
     void clear();
     
   inferiorHeap() {
-      freed = 0; disabledListTotalMem = 0; totalFreeMemAvailable = 0;
+      freed = 0; totalFreeMemAvailable = 0;
   }
   inferiorHeap(const inferiorHeap &src);  // create a new heap that is a copy
                                           // of src (used on fork)
   inferiorHeap& operator=(const inferiorHeap &src);
   std::unordered_map<Dyninst::Address, heapItem*> heapActive; // active part of heap
   std::vector<heapItem*> heapFree;           // free block of data inferior heap 
-  int disabledListTotalMem;             // total size of item waiting to free
   int totalFreeMemAvailable;            // total free memory in the heap
   int freed;                            // total reclaimed (over time)
 

--- a/dyninstAPI/src/infHeap.h
+++ b/dyninstAPI/src/infHeap.h
@@ -97,38 +97,6 @@ class heapItem {
   void *buffer;
 };
 
-
-// disabledItem: an item on the heap that we are trying to free.
-// "pointsToCheck" corresponds to predecessor code blocks
-// (i.e. prior minitramp/basetramp code)
-class disabledItem {
- public:
-  disabledItem() noexcept : block() {}
-
-  disabledItem(heapItem *h, const std::vector<addrVecType> &preds) :
-    block(h), pointsToCheck(preds) {}
-  disabledItem(const disabledItem &src) :
-    block(src.block), pointsToCheck(src.pointsToCheck) {}
-
-  disabledItem &operator=(const disabledItem &src) {
-    if (&src == this) return *this; // check for x=x    
-    block = src.block;
-    pointsToCheck = src.pointsToCheck;
-    return *this;
-  }
-
-
- ~disabledItem() {}
-  
-  heapItem block;                    // inferior heap block
-  std::vector<addrVecType> pointsToCheck; // list of addresses to check against PCs
-
-  Dyninst::Address getPointer() const {return block.addr;}
-  inferiorHeapType getHeapType() const {return block.type;}
-  const std::vector<addrVecType> &getPointsToCheck() const {return pointsToCheck;}
-  std::vector<addrVecType> &getPointsToCheck() {return pointsToCheck;}
-};
-
 /* Dyninst heap class */
 /*
   This needs a better name. Contains a name, and address, and a size.
@@ -167,7 +135,6 @@ class inferiorHeap {
   inferiorHeap& operator=(const inferiorHeap &src);
   std::unordered_map<Dyninst::Address, heapItem*> heapActive; // active part of heap
   std::vector<heapItem*> heapFree;           // free block of data inferior heap 
-  std::vector<disabledItem> disabledList;    // items waiting to be freed.
   int disabledListTotalMem;             // total size of item waiting to free
   int totalFreeMemAvailable;            // total free memory in the heap
   int freed;                            // total reclaimed (over time)


### PR DESCRIPTION
It only exists in inferiorHeap::disabledList, but its usage was removed by 40607f1e2 in 2002.