### PR TITLE
[AMDGPU GFX908] [Emitter] Allow emitMoveRegToReg to move register blocks

### DIFF
--- a/dyninstAPI/src/ASTs/atomicOperationAST.C
+++ b/dyninstAPI/src/ASTs/atomicOperationAST.C
@@ -76,12 +76,7 @@ bool atomicOperationAST::generateCode_phase2(codeGen &gen, Address &retAddr,
   // TODO this needs to pick up the register from placeholderReg
   Dyninst::Register baseRegPair = Dyninst::Register(OperandRegId(94), RegKind::SCALAR, BlockSize(2));
 
-  // TODO: make movs work with blocks.
-  std::vector<Dyninst::Register> addrRegs = addrRegPair.getIndividualRegisters();
-  std::vector<Dyninst::Register> baseRegs = baseRegPair.getIndividualRegisters();
-
-  emitter->emitMoveRegToReg(baseRegs[0], addrRegs[0], gen);
-  emitter->emitMoveRegToReg(baseRegs[1], addrRegs[1], gen);
+  emitter->emitMoveRegToReg(baseRegPair, addrRegPair, gen);
   emitter->emitAddConstantToRegPair(addrRegPair, (Address)offset->getOValue(), gen);
 
   switch(opcode) {

--- a/dyninstAPI/src/emit-amdgpu.C
+++ b/dyninstAPI/src/emit-amdgpu.C
@@ -37,6 +37,8 @@
 #include "registerSpace.h"
 #include "arch-amdgpu.h"
 
+#include <cstdlib>
+
 using namespace Dyninst;
 using namespace AmdgpuGfx908;
 
@@ -435,10 +437,26 @@ void EmitterAmdgpuGfx908::emitStoreShared(Register /* source */, const image_var
 
 bool EmitterAmdgpuGfx908::emitMoveRegToReg(Register src, Register dest, codeGen &gen) {
   // TODO:
-  // 1. Allow this to move entire register blocks at the same time (using multiple instructions)
-  // 2. Make this work with VGPR-VGPR movs
-  assert(isValidSgpr(src) && isValidSgpr(dest) && "src and dest must be valid SGPRs");
-  emitSop1(S_MOV_B32, dest.getId(), src.getId(), /*hasLiteral=*/false, /*literal =*/0, gen);
+  // Make this work with VGPR-VGPR movs
+
+  bool bothSingleSgprs = isValidSgpr(src) && isValidSgpr(dest);
+  bool bothSgprBlocks = isValidSgprBlock(src) && isValidSgprBlock(dest);
+  bool bothHaveSameCount = src.getCount() == dest.getCount();
+
+  assert((bothSingleSgprs || bothSgprBlocks) && bothHaveSameCount &&
+         "src and dest must be valid sgprs or sgpr blocks of same size");
+
+  assert(std::abs(static_cast<int64_t>(src.getId() - dest.getId())) >= src.getCount() &&
+         "src and dest must not overlap");
+
+  std::vector<Register> srcRegisters = src.getIndividualRegisters();
+  std::vector<Register> destRegisters = dest.getIndividualRegisters();
+
+  assert(srcRegisters.size() == destRegisters.size());
+  for (size_t i = 0; i < srcRegisters.size(); ++i) {
+    emitSop1(S_MOV_B32, destRegisters[i].getId(), srcRegisters[i].getId(),
+             /*hasLiteral*/ false, /*literal*/ 0, gen);
+  }
 
   return false;
 }

--- a/tests/unit/dyninstAPI/emitter/amdgpu_gfx908.cpp
+++ b/tests/unit/dyninstAPI/emitter/amdgpu_gfx908.cpp
@@ -31,6 +31,15 @@ int main() {
     0x00,0x00,0x81,0xbe                      // s_mov_b32 s1, s0
   }});
 
+  // Move s[2:3] to s[4:5]
+  Register regBlock2To3 = Dyninst::Register::makeScalarRegister(Dyninst::OperandRegId(2), Dyninst::BlockSize(2));
+  Register regBlock4To5 = Dyninst::Register::makeScalarRegister(Dyninst::OperandRegId(4), Dyninst::BlockSize(2));
+  emitter->emitMoveRegToReg(regBlock2To3, regBlock4To5, gen);
+  failed |= !verify_emitter(gen, emitter_buffer_t<8>{{
+    0x02, 0x00, 0x84, 0xbe,                  // s_mov_b32 s4, s2
+    0x03, 0x00, 0x85, 0xbe                   // s_mov_b32 s5, s3
+  }});
+
   // Load 64-bit immediate into register pair s[0:1]
   // s0 contains lower 32 bits
   // s1 contains upper 32 bits
@@ -42,7 +51,6 @@ int main() {
   }});
 
   // Load a dword from s[2:3] into s4
-  Register regBlock2To3 = Dyninst::Register::makeScalarRegister(Dyninst::OperandRegId(2), Dyninst::BlockSize(2));
   emitter->emitLoadIndir(RegisterConstants::s4, regBlock2To3, 1, gen);
   failed |= !verify_emitter(gen, emitter_buffer_t<12>{{
     0x01,0x01,0x02,0xc0,0x00,0x00,0x00,0x00, // s_load_dword s4, s[2:3], 0x0
@@ -57,7 +65,6 @@ int main() {
   }});
 
   // Load 2 dwords from s[2:3] + 0x1234 into s[4:5]
-  Register regBlock4To5 = Dyninst::Register::makeScalarRegister(Dyninst::OperandRegId(4), Dyninst::BlockSize(2));
   emitter->emitLoadRelative(regBlock4To5, 0x1234, regBlock2To3, 2, gen);
   failed |= !verify_emitter(gen, emitter_buffer_t<12>{{
     0x01,0x01,0x06,0xc0,0x34,0x12,0x00,0x00, // s_load_dwordx2 s[4:5], s[2:3], 0x1234


### PR DESCRIPTION
So far, we supported moving single registers using the emitter API on AMDGPU. For register blocks, this required getting individual registers in the blocks and moving them separately.

This PR makes the emitter API handle this rather.