### PR TITLE
GitHubCI: update docker login action

### DIFF
--- a/.github/workflows/dev-containers.yaml
+++ b/.github/workflows/dev-containers.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.02
 
       - name: GHCR Login
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/refresh-containers.yaml
+++ b/.github/workflows/refresh-containers.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.02
 
       - name: GHCR Login
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -45,7 +45,7 @@ jobs:
           ref: ${{ needs.get-latest-release-version.outputs.value }}
 
       - name: GHCR Login
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
GitHub CI is moving not Node.js 24 in June which drops support for this version of the action.