### PR TITLE
Fix function_cache::contains implementation

### DIFF
--- a/dyninstAPI/src/function_cache.h
+++ b/dyninstAPI/src/function_cache.h
@@ -48,7 +48,7 @@ namespace Dyninst { namespace DyninstAPI {
         return c->addr() == f->addr() &&
                c->typedName() == f->typedName();
       };
-      return std::find_if(funcs.begin(), funcs.end(), cmp) == funcs.end();
+      return std::find_if(funcs.begin(), funcs.end(), cmp) != funcs.end();
     }
     void insert(func_instance *f) {
       funcs.push_back(f);


### PR DESCRIPTION
Previous logic implemented contains in reverse.
Fixes #2253 