### PR TITLE
[symtabAPI] Fix ELF boundary check in code segment selection

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2315,9 +2315,9 @@ void ObjectELF::find_code_and_data(Elf_X &elf,
         // txtaddr=0, so in this case we set these values by
         // identifying the segment that contains the entryAddress
         if (((phdr.p_vaddr() <= txtaddr) &&
-             (phdr.p_vaddr() + phdr.p_filesz() >= txtaddr)) ||
+             (phdr.p_vaddr() + phdr.p_filesz() > txtaddr)) ||
             (!txtaddr && ((phdr.p_vaddr() <= entryAddress_) &&
-                          (phdr.p_vaddr() + phdr.p_filesz() >= entryAddress_)))) {
+                          (phdr.p_vaddr() + phdr.p_filesz() > entryAddress_)))) {
 
             if (code_ptr_ == 0 && code_off_ == 0 && code_len_ == 0) {
                 code_ptr_ = (char *) (void *) &file_ptr[phdr.p_offset()];
@@ -2326,7 +2326,7 @@ void ObjectELF::find_code_and_data(Elf_X &elf,
             }
 
         } else if (((phdr.p_vaddr() <= dataddr) &&
-                    (phdr.p_vaddr() + phdr.p_filesz() >= dataddr)) ||
+                    (phdr.p_vaddr() + phdr.p_filesz() > dataddr)) ||
                    (!dataddr && (phdr.p_type() == PT_LOAD))) {
             if (data_ptr_ == 0 && data_off_ == 0 && data_len_ == 0) {
                 data_ptr_ = (char *) (void *) &file_ptr[phdr.p_offset()];


### PR DESCRIPTION
**Context**:

I am debugging a reported error with our `rocprof-sys-instrument` tool where a user was running a `rocm-examples` binary on an `oraclelinux 8.10` container. Upon execution, it would immediately fail with:

```
[rocprof-sys][exe] Fetched procedures from 149 modules: 4431 procedures found (0.869 sec, 39.728 MB)
[addressSpace.C:782] failed to find matching range for address 56535234e560
rocprof-sys-instrument: /__w/TheRock/TheRock/rocm-systems/projects/rocprofiler-systems/external/dyninst/dyninstAPI/src/addressSpace.C:783: virtual void* AddressSpace::getPtrToInstruction(Dyninst::Address) const: Assertion `0' failed.
```

I was able to reproduce the problem with dyninst HEAD using a custom walker. 

**Root Cause**: 

After investigation, I've found the problem to be within the `find_code_and_data` function https://github.com/dyninst/dyninst/blob/master/symtabAPI/src/Object-elf.C#L2302 

Specifically, it can choose the wrong `PT_LOAD` segment for the code range when `.text` starts exactly at the end address of the previous load segment.

**Evidence**:

Unfortunately, I am unable to provide a simple reproducer. However, if we look at the ELF program header output of the failing binary:

Note: Let `BIN` be the failing binary
```
# readelf -lW "$BIN"

Elf file type is DYN (Shared object file)
Entry point 0x11000
There are 11 program headers, starting at offset 64

Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
[...]
  LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x011000 0x011000 R   0x1000
  LOAD           0x011000 0x0000000000011000 0x0000000000011000 0x020640 0x020640 R E 0x1000
  LOAD           0x031640 0x0000000000032640 0x0000000000032640 0x000708 0x0009c0 RW  0x1000
[...]
```

We notice the `LOAD` segments are adjacent:
```
  LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x011000 0x011000 R   0x1000
  LOAD           0x011000 0x0000000000011000 0x0000000000011000 0x020640 0x020640 R E 0x1000
```

With `.text` being at virtual address `0x11000`:
```
 [15] .text             PROGBITS        0000000000011000 011000 01fe74 00  AX  0   0 16
```

In `find_code_and_data`, from what I gather, we are trying to find the load segment that contains `.text`. 

**The problem** is that the containment check currently treats `p_vaddr + p_filesz` as an **inclusive** upper bound:
 - https://github.com/dyninst/dyninst/blob/master/symtabAPI/src/Object-elf.C#L2318

`p_filesz` is the byte count, and not the last valid address. 
 - See https://refspecs.linuxbase.org/elf/gabi4+/ch5.pheader.html#:~:text=This%20member%20gives%20the%20number%20of%20bytes%20in%20the%20file%20image%20of%20the%20segment%3B%20it%20may%20be%20zero.

So when dyninst does the comparison:
```
# First LOAD
p_vaddr  = 0x0
p_filesz = 0x11000
range    = [0x0, 0x11000)

# Second LOAD
p_vaddr  = 0x11000
p_filesz = 0x20640
range    = [0x11000, 0x31640)

# Where txtaddr = 0x11000
```

The first load passes the check and is chosen (it appears first, and assignment is "first match wins"), which is incorrect.
As a consequence, dyninst records the wrong code range and is later unable to translate an instruction address into a pointer to the corresponding instruction bytes.

**The fix**:

The fix is to make `phdr.p_vaddr() + phdr.p_filesz() >= txtaddr` become `phdr.p_vaddr() + phdr.p_filesz() > txtaddr`, i.e. to not include the upper bound. 

I'll also apply it to the check against `entryAddress_` and `dataddr`, since they have the same containment logic:
 - https://github.com/dyninst/dyninst/blob/master/symtabAPI/src/Object-elf.C#L2320
 - https://github.com/dyninst/dyninst/blob/master/symtabAPI/src/Object-elf.C#L2329

**Fix Result**

With the fix, original CTests pass (from `rocm-examples`) and the original failure is no longer observed.