### PR TITLE
Fix iterator variable in IntervalMap copy ctor and assignment

### DIFF
--- a/dataflowAPI/rose/util/IntervalMap.h
+++ b/dataflowAPI/rose/util/IntervalMap.h
@@ -221,7 +221,7 @@ public:
     template<class Interval2, class T2, class Policy2>
     IntervalMap(const IntervalMap<Interval2, T2, Policy2> &other) {
         typedef typename IntervalMap<Interval2, T2, Policy2>::ConstNodeIterator OtherIterator;
-        for (OtherIterator otherIter=other.nodes().begin(); other!=other.nodes().end(); ++other)
+        for (OtherIterator otherIter=other.nodes().begin(); otherIter!=other.nodes().end(); ++otherIter)
             insert(Interval(otherIter->key()), Value(otherIter->value()));
     }
 
@@ -233,7 +233,7 @@ public:
     IntervalMap& operator=(const IntervalMap<Interval2, T2, Policy2> &other) {
         clear();
         typedef typename IntervalMap<Interval2, T2, Policy2>::ConstNodeIterator OtherIterator;
-        for (OtherIterator otherIter=other.nodes().begin(); other!=other.nodes().end(); ++other)
+        for (OtherIterator otherIter=other.nodes().begin(); otherIter!=other.nodes().end(); ++otherIter)
             insert(Interval(otherIter->key()), Value(otherIter->value()));
         return *this;
     }


### PR DESCRIPTION
The loops in the templated copy constructor and assignment operator used `other` (the container) instead of `otherIter` (the iterator) in the loop condition and increment, which would fail to compile if these templates were ever instantiated.