### PR TITLE
Reorganize dyninstAPI CMake structure

### DIFF
--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -140,8 +140,7 @@ if(DYNINST_CODEGEN_ARCH_I386 OR DYNINST_CODEGEN_ARCH_X86_64)
     src/codegen-x86.C
     src/IAPI_to_AST.C)
 elseif(DYNINST_CODEGEN_ARCH_PPC64LE)
-  list(APPEND _sources src/inst-power.C src/codegen-power.C src/RegisterConversion-ppc.C
-       src/trampolines/baseTramp-ppc.C)
+  list(APPEND _sources src/inst-power.C src/codegen-power.C src/RegisterConversion-ppc.C)
 elseif(DYNINST_CODEGEN_ARCH_AARCH64)
   list(APPEND _sources src/inst-aarch64.C src/emit-aarch64.C src/codegen-aarch64.C
        src/RegisterConversion-aarch64.C)

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -40,8 +40,10 @@ set(_public_headers
 add_subdirectory(src/ASTs)
 add_subdirectory(src/codegen)
 add_subdirectory(src/registerSpace)
+add_subdirectory(src/Relocation)
 
-set(_subprojects dyninstAPI_ASTs dyninstAPI_codegen dyninstAPI_registerSpace)
+set(_subprojects dyninstAPI_ASTs dyninstAPI_codegen dyninstAPI_registerSpace
+                 dyninstAPI_relocation)
 
 set(_private_headers
     src/addressSpace.h
@@ -171,32 +173,6 @@ set(_sources
     src/Parsing-arch.C
     src/Parsing.C
     src/Patching.C
-    src/Relocation/CFG/RelocBlock.C
-    src/Relocation/CFG/RelocEdge.C
-    src/Relocation/CFG/RelocGraph.C
-    src/Relocation/CFG/RelocTarget.C
-    src/Relocation/CodeBuffer.C
-    src/Relocation/CodeMover.C
-    src/Relocation/CodeTracker.C
-    src/Relocation/DynAddrSpace.C
-    src/Relocation/DynCFGMaker.C
-    src/Relocation/DynInstrumenter.C
-    src/Relocation/DynObject.C
-    src/Relocation/DynPointMaker.C
-    src/Relocation/Springboard.C
-    src/Relocation/Transformers/Instrumenter.C
-    src/Relocation/Transformers/Modification.C
-    src/Relocation/Transformers/Movement-adhoc.C
-    src/Relocation/Transformers/Movement-analysis.C
-    src/Relocation/Transformers/Transformer.C
-    src/Relocation/Widgets/CFWidget.C
-    src/Relocation/Widgets/CallbackWidget.C
-    src/Relocation/Widgets/InsnWidget.C
-    src/Relocation/Widgets/InstWidget.C
-    src/Relocation/Widgets/PCWidget.C
-    src/Relocation/Widgets/RelDataWidget.C
-    src/Relocation/Widgets/StackModWidget.C
-    src/Relocation/patchapi_debug.C
     src/trampolines/baseTramp.C)
 
 list(FIND DYNINST_PLATFORM_CAPABILITIES "-Dcap_stack_mods" cap_stack_mods_found)
@@ -226,8 +202,6 @@ if(DYNINST_CODEGEN_ARCH_I386 OR DYNINST_CODEGEN_ARCH_X86_64)
     APPEND
     _sources
     src/RegisterConversion-x86.C
-    src/Relocation/Widgets/CFWidget-x86.C
-    src/Relocation/Widgets/PCWidget-x86.C
     src/inst-x86.C
     src/emit-x86.C
     src/codegen-x86.C
@@ -240,8 +214,6 @@ elseif(DYNINST_CODEGEN_ARCH_PPC64LE)
     src/inst-power.C
     src/codegen-power.C
     src/RegisterConversion-ppc.C
-    src/Relocation/Widgets/CFWidget-ppc.C
-    src/Relocation/Widgets/PCWidget-ppc.C
     src/trampolines/baseTramp-ppc.C)
 elseif(DYNINST_CODEGEN_ARCH_AARCH64)
   list(
@@ -251,8 +223,6 @@ elseif(DYNINST_CODEGEN_ARCH_AARCH64)
     src/emit-aarch64.C
     src/codegen-aarch64.C
     src/RegisterConversion-aarch64.C
-    src/Relocation/Widgets/CFWidget-aarch64.C
-    src/Relocation/Widgets/PCWidget-aarch64.C
     src/trampolines/baseTramp-aarch64.C)
 elseif(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
   list(
@@ -262,8 +232,6 @@ elseif(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
     src/emit-amdgpu.C
     src/codegen-amdgpu.C
     src/RegisterConversion-amdgpu.C
-    src/Relocation/Widgets/CFWidget-amdgpu.C
-    src/Relocation/Widgets/PCWidget-amdgpu.C
     src/AmdgpuKernelDescriptor.C
     src/AmdgpuPointHandler.C
     src/amdgpu-gfx908-details.C)
@@ -291,12 +259,7 @@ elseif(DYNINST_OS_Windows)
     src/hybridOverwrites.C
     src/inst-winnt.C
     src/pdwinnt.C
-    src/syscall-nt.C
-    src/Relocation/DynAddrSpace.C
-    src/Relocation/DynCFGMaker.C
-    src/Relocation/DynInstrumenter.C
-    src/Relocation/DynObject.C
-    src/Relocation/DynPointMaker.C)
+    src/syscall-nt.C)
 endif()
 
 # cmake-format: off

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -39,8 +39,9 @@ set(_public_headers
 
 add_subdirectory(src/ASTs)
 add_subdirectory(src/codegen)
+add_subdirectory(src/registerSpace)
 
-set(_subprojects dyninstAPI_ASTs dyninstAPI_codegen)
+set(_subprojects dyninstAPI_ASTs dyninstAPI_codegen dyninstAPI_registerSpace)
 
 set(_private_headers
     src/addressSpace.h
@@ -109,9 +110,6 @@ set(_private_headers
     src/pdwinnt.h
     src/PointHandler.h
     src/RegisterConversion.h
-    src/registerSpace/registerSpace.h
-    src/registerSpace/RealRegister.h
-    src/registerSpace/registerSlot.h
     src/regTracker.h
     src/syscallNotification.h
     src/trapMappings.h
@@ -173,8 +171,6 @@ set(_sources
     src/Parsing-arch.C
     src/Parsing.C
     src/Patching.C
-    src/registerSpace/registerSpace.C
-    src/registerSpace/registerSlot.C
     src/Relocation/CFG/RelocBlock.C
     src/Relocation/CFG/RelocEdge.C
     src/Relocation/CFG/RelocGraph.C
@@ -230,7 +226,6 @@ if(DYNINST_CODEGEN_ARCH_I386 OR DYNINST_CODEGEN_ARCH_X86_64)
     APPEND
     _sources
     src/RegisterConversion-x86.C
-    src/registerSpace/registerSpace-x86.C
     src/Relocation/Widgets/CFWidget-x86.C
     src/Relocation/Widgets/PCWidget-x86.C
     src/inst-x86.C
@@ -244,7 +239,6 @@ elseif(DYNINST_CODEGEN_ARCH_PPC64LE)
     _sources
     src/inst-power.C
     src/codegen-power.C
-    src/registerSpace/registerSpace-ppc.C
     src/RegisterConversion-ppc.C
     src/Relocation/Widgets/CFWidget-ppc.C
     src/Relocation/Widgets/PCWidget-ppc.C
@@ -257,7 +251,6 @@ elseif(DYNINST_CODEGEN_ARCH_AARCH64)
     src/emit-aarch64.C
     src/codegen-aarch64.C
     src/RegisterConversion-aarch64.C
-    src/registerSpace/registerSpace-aarch64.C
     src/Relocation/Widgets/CFWidget-aarch64.C
     src/Relocation/Widgets/PCWidget-aarch64.C
     src/trampolines/baseTramp-aarch64.C)
@@ -268,7 +261,6 @@ elseif(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
     src/inst-amdgpu.C
     src/emit-amdgpu.C
     src/codegen-amdgpu.C
-    src/registerSpace/registerSpace-amdgpu.C
     src/RegisterConversion-amdgpu.C
     src/Relocation/Widgets/CFWidget-amdgpu.C
     src/Relocation/Widgets/PCWidget-amdgpu.C
@@ -328,7 +320,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   endif()
 endif()
 
-list(APPEND _inc_dirs "${CMAKE_CURRENT_SOURCE_DIR}/src/registerSpace")
 list(APPEND _inc_dirs "${CMAKE_CURRENT_SOURCE_DIR}/src/trampolines")
 list(APPEND _inc_dirs "${CMAKE_CURRENT_SOURCE_DIR}/src/BPatch")
 

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -8,44 +8,24 @@ endif()
 
 include(DyninstLibrary)
 
-set(_public_headers
-    h/BPatch_addressSpace.h
-    h/BPatch_basicBlock.h
-    h/BPatch_basicBlockLoop.h
-    h/BPatch_binaryEdit.h
-    h/BPatch_callbacks.h
-    h/BPatch_edge.h
-    h/BPatch_enums.h
-    h/BPatch_flowGraph.h
-    h/BPatch_frame.h
-    h/BPatch_function.h
-    h/BPatch.h
-    h/BPatch_image.h
-    h/BPatch_instruction.h
-    h/BPatch_loopTreeNode.h
-    h/BPatch_memoryAccess_NP.h
-    h/BPatch_module.h
-    h/BPatch_object.h
-    h/BPatch_point.h
-    h/BPatch_process.h
-    h/BPatch_snippet.h
-    h/BPatch_sourceBlock.h
-    h/BPatch_sourceObj.h
-    h/BPatch_statement.h
-    h/BPatch_thread.h
-    h/BPatch_type.h
-    h/BPatch_Vector.h
-    h/StackMod.h)
-
 add_subdirectory(src/ASTs)
+add_subdirectory(src/BPatch)
 add_subdirectory(src/codegen)
 add_subdirectory(src/registerSpace)
 add_subdirectory(src/Relocation)
 add_subdirectory(src/StackMod)
 add_subdirectory(src/trampolines)
 
-set(_subprojects dyninstAPI_ASTs dyninstAPI_codegen dyninstAPI_registerSpace
-                 dyninstAPI_relocation dyninstAPI_stackmod dyninstAPI_trampolines)
+set(_subprojects
+    dyninstAPI_ASTs
+    dyninstAPI_bpatch
+    dyninstAPI_codegen
+    dyninstAPI_registerSpace
+    dyninstAPI_relocation
+    dyninstAPI_stackmod
+    dyninstAPI_trampolines)
+
+set(_public_headers ${_BPatch_public_headers})
 
 set(_private_headers
     src/addressSpace.h
@@ -55,10 +35,6 @@ set(_private_headers
     ${PROJECT_SOURCE_DIR}/external/amdgpu/AMDGPUEFlags.h
     src/binaryEdit.h
     src/block.h
-    src/BPatch/BPatch_collections.h
-    src/BPatch/BPatch_libInfo.h
-    src/BPatch/BPatch_memoryAccessAdapter.h
-    src/BPatch/BPatch_private.h
     src/codegen-amdgpu.h
     src/codegen-aarch64.h
     src/codegen.h
@@ -142,30 +118,6 @@ set(_sources
     src/pcEventMuxer.C
     src/regTracker.C
     src/variable.C
-    src/BPatch/BPatch.C
-    src/BPatch/BPatch_addressSpace.C
-    src/BPatch/BPatch_basicBlock.C
-    src/BPatch/BPatch_basicBlockLoop.C
-    src/BPatch/BPatch_binaryEdit.C
-    src/BPatch/BPatch_collections.C
-    src/BPatch/BPatch_edge.C
-    src/BPatch/BPatch_flowGraph.C
-    src/BPatch/BPatch_frame.C
-    src/BPatch/BPatch_function.C
-    src/BPatch/BPatch_image.C
-    src/BPatch/BPatch_instruction.C
-    src/BPatch/BPatch_loopTreeNode.C
-    src/BPatch/BPatch_memoryAccess.C
-    src/BPatch/BPatch_memoryAccessAdapter.C
-    src/BPatch/BPatch_module.C
-    src/BPatch/BPatch_object.C
-    src/BPatch/BPatch_point.C
-    src/BPatch/BPatch_process.C
-    src/BPatch/BPatch_snippet.C
-    src/BPatch/BPatch_sourceBlock.C
-    src/BPatch/BPatch_statement.C
-    src/BPatch/BPatch_thread.C
-    src/BPatch/BPatch_type.C
     src/Parsing-arch.C
     src/Parsing.C
     src/Patching.C)
@@ -252,8 +204,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   endif()
 endif()
 
-list(APPEND _inc_dirs "${CMAKE_CURRENT_SOURCE_DIR}/src/BPatch")
-
 foreach(t ${dyninstAPI_TARGETS})
   if(DYNINST_OS_Windows)
     target_link_libraries(${t} PRIVATE dbghelp WS2_32 imagehlp)
@@ -268,9 +218,7 @@ foreach(t ${dyninstAPI_TARGETS})
   foreach(sp ${_subprojects})
     target_include_directories(
       ${t}
-      PUBLIC
-        "$<BUILD_INTERFACE:$<TARGET_PROPERTY:${sp},INTERFACE_INCLUDE_DIRECTORIES>;${_inc_dirs}>"
-      )
+      PUBLIC "$<BUILD_INTERFACE:$<TARGET_PROPERTY:${sp},INTERFACE_INCLUDE_DIRECTORIES>>")
   endforeach()
 
 endforeach()

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -37,34 +37,16 @@ set(_public_headers
     h/BPatch_Vector.h
     h/StackMod.h)
 
+add_subdirectory(src/ASTs)
+
+set(_subprojects dyninstAPI_ASTs)
+
 set(_private_headers
     src/addressSpace.h
     src/AmdgpuKernelDescriptor.h
     src/AmdgpuPointHandler.h
     ${PROJECT_SOURCE_DIR}/external/amdgpu/AMDHSAKernelDescriptor.h
     ${PROJECT_SOURCE_DIR}/external/amdgpu/AMDGPUEFlags.h
-    src/ast.h
-    src/ASTs/AmdgpuEpilogue.h
-    src/ASTs/AmdgpuPrologue.h
-    src/ASTs/ast_helpers.h
-    src/ASTs/addressAST.h
-    src/ASTs/memoryAccessAST.h
-    src/ASTs/nullAST.h
-    src/ASTs/stackAST.h
-    src/ASTs/operandAST.h
-    src/ASTs/operatorAST.h
-    src/ASTs/scrambleRegistersAST.h
-    src/ASTs/sequenceAST.h
-    src/ASTs/snippetAST.h
-    src/ASTs/stackInsertionAST.h
-    src/ASTs/genericStackAST.h
-    src/ASTs/stackRemovalAST.h
-    src/ASTs/atomicOperationAST.h
-    src/ASTs/codeGenAST.h
-    src/ASTs/functionCallAST.h
-    src/ASTs/jumpTargetAST.h
-    src/ASTs/variableAST.h
-    src/ASTs/OperandType.h
     src/trampolines/baseTramp.h
     src/trampolines/baseTramp-aarch64.h
     src/trampolines/baseTramp-amdgpu.h
@@ -139,24 +121,6 @@ set(_private_headers
 
 set(_sources
     src/addressSpace.C
-    src/ASTs/actualAddressAST.C
-    src/ASTs/memoryAccessAST.C
-    src/ASTs/nullAST.C
-    src/ASTs/operandAST.C
-    src/ASTs/operatorAST.C
-    src/ASTs/originalAddressAST.C
-    src/ASTs/scrambleRegistersAST.C
-    src/ASTs/sequenceAST.C
-    src/ASTs/snippetAST.C
-    src/ASTs/stackAST.C
-    src/ASTs/stackInsertionAST.C
-    src/ASTs/genericStackAST.C
-    src/ASTs/stackRemovalAST.C
-    src/ASTs/atomicOperationAST.C
-    src/ASTs/codeGenAST.C
-    src/ASTs/functionCallAST.C
-    src/ASTs/jumpTargetAST.C
-    src/ASTs/variableAST.C
     src/binaryEdit.C
     src/block.C
     src/codeRange.C
@@ -320,8 +284,6 @@ elseif(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
     src/Relocation/Widgets/PCWidget-amdgpu.C
     src/AmdgpuKernelDescriptor.C
     src/AmdgpuPointHandler.C
-    src/ASTs/AmdgpuPrologue.C
-    src/ASTs/AmdgpuEpilogue.C
     src/amdgpu-gfx908-details.C)
 endif()
 
@@ -361,7 +323,7 @@ dyninst_library(
   PUBLIC_HEADER_FILES ${_public_headers}
   SOURCE_FILES ${_sources}
   DYNINST_DEPS common instructionAPI stackwalk pcontrol patchAPI parseAPI symtabAPI
-  DYNINST_INTERNAL_DEPS dynDwarf dynElf
+  DYNINST_INTERNAL_DEPS dynDwarf dynElf ${_subprojects}
   PUBLIC_DEPS Dyninst::Boost_headers
   PRIVATE_DEPS Threads::Threads Dyninst::PeParse
 )
@@ -376,7 +338,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   endif()
 endif()
 
-list(APPEND _inc_dirs "${CMAKE_CURRENT_SOURCE_DIR}/src/ASTs")
 list(APPEND _inc_dirs "${CMAKE_CURRENT_SOURCE_DIR}/src/registerSpace")
 list(APPEND _inc_dirs "${CMAKE_CURRENT_SOURCE_DIR}/src/trampolines")
 list(APPEND _inc_dirs "${CMAKE_CURRENT_SOURCE_DIR}/src/BPatch")
@@ -392,7 +353,14 @@ foreach(t ${dyninstAPI_TARGETS})
       ${t} PRIVATE "DYNINST_COMPILER_SEARCH_DIRS=${DYNINST_COMPILER_SEARCH_DIRS}")
   endif()
 
-  target_include_directories(${t} PUBLIC "$<BUILD_INTERFACE:${_inc_dirs}>")
+  foreach(sp ${_subprojects})
+    target_include_directories(
+      ${t}
+      PUBLIC
+        "$<BUILD_INTERFACE:$<TARGET_PROPERTY:${sp},INTERFACE_INCLUDE_DIRECTORIES>;${_inc_dirs}>"
+      )
+  endforeach()
+  
 endforeach()
 
 unset(_inc_dirs)

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -38,8 +38,9 @@ set(_public_headers
     h/StackMod.h)
 
 add_subdirectory(src/ASTs)
+add_subdirectory(src/codegen)
 
-set(_subprojects dyninstAPI_ASTs)
+set(_subprojects dyninstAPI_ASTs dyninstAPI_codegen)
 
 set(_private_headers
     src/addressSpace.h
@@ -64,7 +65,6 @@ set(_private_headers
     src/codegen.h
     src/codegen-power.h
     src/codegen-x86.h
-    src/codegen/RegControl.h
     src/codeRange.h
     src/debug.h
     src/dynProcess.h
@@ -229,16 +229,6 @@ if(DYNINST_CODEGEN_ARCH_I386 OR DYNINST_CODEGEN_ARCH_X86_64)
   list(
     APPEND
     _sources
-    src/codegen/emitters/x86/IA32/EmitterIA32Dyn.C
-    src/codegen/emitters/x86/IA32/EmitterIA32Dyn.h
-    src/codegen/emitters/x86/IA32/EmitterIA32Stat.C
-    src/codegen/emitters/x86/IA32/EmitterIA32Stat.h
-    src/codegen/emitters/x86/IA32/EmitterIA32.C
-    src/codegen/emitters/x86/IA32/EmitterIA32.h
-    src/codegen/emitters/x86/Emitterx86.C
-    src/codegen/emitters/x86/Emitterx86.h
-    src/codegen/emitters/x86/generators.C
-    src/codegen/emitters/x86/generators.h
     src/RegisterConversion-x86.C
     src/registerSpace/registerSpace-x86.C
     src/Relocation/Widgets/CFWidget-x86.C
@@ -360,7 +350,7 @@ foreach(t ${dyninstAPI_TARGETS})
         "$<BUILD_INTERFACE:$<TARGET_PROPERTY:${sp},INTERFACE_INCLUDE_DIRECTORIES>;${_inc_dirs}>"
       )
   endforeach()
-  
+
 endforeach()
 
 unset(_inc_dirs)

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -41,9 +41,10 @@ add_subdirectory(src/ASTs)
 add_subdirectory(src/codegen)
 add_subdirectory(src/registerSpace)
 add_subdirectory(src/Relocation)
+add_subdirectory(src/StackMod)
 
 set(_subprojects dyninstAPI_ASTs dyninstAPI_codegen dyninstAPI_registerSpace
-                 dyninstAPI_relocation)
+                 dyninstAPI_relocation dyninstAPI_stackmod)
 
 set(_private_headers
     src/addressSpace.h
@@ -175,20 +176,6 @@ set(_sources
     src/Patching.C
     src/trampolines/baseTramp.C)
 
-list(FIND DYNINST_PLATFORM_CAPABILITIES "-Dcap_stack_mods" cap_stack_mods_found)
-if(cap_stack_mods_found GREATER -1)
-  list(
-    APPEND
-    _sources
-    src/StackMod/OffsetVector.C
-    src/StackMod/StackAccess.C
-    src/StackMod/StackLocation.C
-    src/StackMod/StackMod.C
-    src/StackMod/StackModExpr.C
-    src/StackMod/StackModChecker.C
-    src/StackMod/TMap.C)
-endif()
-
 if(DYNINST_HOST_ARCH_I386 OR DYNINST_HOST_ARCH_X86_64)
   list(APPEND _sources src/stackwalk-x86.C src/dynProcess-x86.C)
 elseif(DYNINST_HOST_ARCH_PPC64LE)
@@ -208,13 +195,8 @@ if(DYNINST_CODEGEN_ARCH_I386 OR DYNINST_CODEGEN_ARCH_X86_64)
     src/IAPI_to_AST.C
     src/trampolines/baseTramp-x86.C)
 elseif(DYNINST_CODEGEN_ARCH_PPC64LE)
-  list(
-    APPEND
-    _sources
-    src/inst-power.C
-    src/codegen-power.C
-    src/RegisterConversion-ppc.C
-    src/trampolines/baseTramp-ppc.C)
+  list(APPEND _sources src/inst-power.C src/codegen-power.C src/RegisterConversion-ppc.C
+       src/trampolines/baseTramp-ppc.C)
 elseif(DYNINST_CODEGEN_ARCH_AARCH64)
   list(
     APPEND

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -42,9 +42,10 @@ add_subdirectory(src/codegen)
 add_subdirectory(src/registerSpace)
 add_subdirectory(src/Relocation)
 add_subdirectory(src/StackMod)
+add_subdirectory(src/trampolines)
 
 set(_subprojects dyninstAPI_ASTs dyninstAPI_codegen dyninstAPI_registerSpace
-                 dyninstAPI_relocation dyninstAPI_stackmod)
+                 dyninstAPI_relocation dyninstAPI_stackmod dyninstAPI_trampolines)
 
 set(_private_headers
     src/addressSpace.h
@@ -52,12 +53,6 @@ set(_private_headers
     src/AmdgpuPointHandler.h
     ${PROJECT_SOURCE_DIR}/external/amdgpu/AMDHSAKernelDescriptor.h
     ${PROJECT_SOURCE_DIR}/external/amdgpu/AMDGPUEFlags.h
-    src/trampolines/baseTramp.h
-    src/trampolines/baseTramp-aarch64.h
-    src/trampolines/baseTramp-amdgpu.h
-    src/trampolines/baseTramp-ppc.h
-    src/trampolines/baseTramp-riscv64.h
-    src/trampolines/baseTramp-x86.h
     src/binaryEdit.h
     src/block.h
     src/BPatch/BPatch_collections.h
@@ -173,8 +168,7 @@ set(_sources
     src/BPatch/BPatch_type.C
     src/Parsing-arch.C
     src/Parsing.C
-    src/Patching.C
-    src/trampolines/baseTramp.C)
+    src/Patching.C)
 
 if(DYNINST_HOST_ARCH_I386 OR DYNINST_HOST_ARCH_X86_64)
   list(APPEND _sources src/stackwalk-x86.C src/dynProcess-x86.C)
@@ -192,20 +186,13 @@ if(DYNINST_CODEGEN_ARCH_I386 OR DYNINST_CODEGEN_ARCH_X86_64)
     src/inst-x86.C
     src/emit-x86.C
     src/codegen-x86.C
-    src/IAPI_to_AST.C
-    src/trampolines/baseTramp-x86.C)
+    src/IAPI_to_AST.C)
 elseif(DYNINST_CODEGEN_ARCH_PPC64LE)
   list(APPEND _sources src/inst-power.C src/codegen-power.C src/RegisterConversion-ppc.C
        src/trampolines/baseTramp-ppc.C)
 elseif(DYNINST_CODEGEN_ARCH_AARCH64)
-  list(
-    APPEND
-    _sources
-    src/inst-aarch64.C
-    src/emit-aarch64.C
-    src/codegen-aarch64.C
-    src/RegisterConversion-aarch64.C
-    src/trampolines/baseTramp-aarch64.C)
+  list(APPEND _sources src/inst-aarch64.C src/emit-aarch64.C src/codegen-aarch64.C
+       src/RegisterConversion-aarch64.C)
 elseif(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
   list(
     APPEND
@@ -265,7 +252,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   endif()
 endif()
 
-list(APPEND _inc_dirs "${CMAKE_CURRENT_SOURCE_DIR}/src/trampolines")
 list(APPEND _inc_dirs "${CMAKE_CURRENT_SOURCE_DIR}/src/BPatch")
 
 foreach(t ${dyninstAPI_TARGETS})

--- a/dyninstAPI/src/ASTs/CMakeLists.txt
+++ b/dyninstAPI/src/ASTs/CMakeLists.txt
@@ -1,0 +1,60 @@
+include_guard(GLOBAL)
+
+if(POLICY CMP0076)
+  # target_sources() converts relative paths to absolute
+  cmake_policy(SET CMP0076 NEW)
+endif()
+
+set(_headers
+    addressAST.h
+    ast.h
+    ast_helpers.h
+    atomicOperationAST.h
+    codeGenAST.h
+    functionCallAST.h
+    genericStackAST.h
+    jumpTargetAST.h
+    memoryAccessAST.h
+    nullAST.h
+    operandAST.h
+    OperandType.h
+    operatorAST.h
+    scrambleRegistersAST.h
+    sequenceAST.h
+    snippetAST.h
+    stackAST.h
+    stackInsertionAST.h
+    stackRemovalAST.h
+    variableAST.h)
+
+set(_sources
+    actualAddressAST.C
+    atomicOperationAST.C
+    codeGenAST.C
+    functionCallAST.C
+    genericStackAST.C
+    jumpTargetAST.C
+    memoryAccessAST.C
+    nullAST.C
+    operandAST.C
+    operatorAST.C
+    originalAddressAST.C
+    scrambleRegistersAST.C
+    sequenceAST.C
+    snippetAST.C
+    stackAST.C
+    stackInsertionAST.C
+    stackRemovalAST.C
+    variableAST.C)
+
+if(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
+  list(APPEND _headers AmdgpuEpilogue.h AmdgpuPrologue.h)
+  list(APPEND _sources AmdgpuEpilogue.C AmdgpuPrologue.C)
+endif()
+
+add_library(dyninstAPI_ASTs INTERFACE)
+target_sources(dyninstAPI_ASTs INTERFACE ${_headers} ${_sources})
+target_include_directories(dyninstAPI_ASTs INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+unset(_headers)
+unset(_sources)

--- a/dyninstAPI/src/BPatch/CMakeLists.txt
+++ b/dyninstAPI/src/BPatch/CMakeLists.txt
@@ -1,0 +1,72 @@
+include_guard(GLOBAL)
+
+if(POLICY CMP0076)
+  # target_sources() converts relative paths to absolute
+  cmake_policy(SET CMP0076 NEW)
+endif()
+
+set(_BPatch_public_headers
+    h/BPatch_addressSpace.h
+    h/BPatch_basicBlock.h
+    h/BPatch_basicBlockLoop.h
+    h/BPatch_binaryEdit.h
+    h/BPatch_callbacks.h
+    h/BPatch_edge.h
+    h/BPatch_enums.h
+    h/BPatch_flowGraph.h
+    h/BPatch_frame.h
+    h/BPatch_function.h
+    h/BPatch.h
+    h/BPatch_image.h
+    h/BPatch_instruction.h
+    h/BPatch_loopTreeNode.h
+    h/BPatch_memoryAccess_NP.h
+    h/BPatch_module.h
+    h/BPatch_object.h
+    h/BPatch_point.h
+    h/BPatch_process.h
+    h/BPatch_snippet.h
+    h/BPatch_sourceBlock.h
+    h/BPatch_sourceObj.h
+    h/BPatch_statement.h
+    h/BPatch_thread.h
+    h/BPatch_type.h
+    h/BPatch_Vector.h
+    h/StackMod.h
+    PARENT_SCOPE)
+
+set(_headers BPatch_collections.h BPatch_libInfo.h BPatch_memoryAccessAdapter.h
+             BPatch_private.h)
+
+set(_sources
+    BPatch.C
+    BPatch_addressSpace.C
+    BPatch_basicBlock.C
+    BPatch_basicBlockLoop.C
+    BPatch_binaryEdit.C
+    BPatch_collections.C
+    BPatch_edge.C
+    BPatch_flowGraph.C
+    BPatch_frame.C
+    BPatch_function.C
+    BPatch_image.C
+    BPatch_instruction.C
+    BPatch_loopTreeNode.C
+    BPatch_memoryAccess.C
+    BPatch_memoryAccessAdapter.C
+    BPatch_module.C
+    BPatch_object.C
+    BPatch_point.C
+    BPatch_process.C
+    BPatch_snippet.C
+    BPatch_sourceBlock.C
+    BPatch_statement.C
+    BPatch_thread.C
+    BPatch_type.C)
+
+add_library(dyninstAPI_bpatch INTERFACE)
+target_sources(dyninstAPI_bpatch INTERFACE ${_headers} ${_sources})
+target_include_directories(dyninstAPI_bpatch INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+unset(_headers)
+unset(_sources)

--- a/dyninstAPI/src/Relocation/CMakeLists.txt
+++ b/dyninstAPI/src/Relocation/CMakeLists.txt
@@ -1,0 +1,82 @@
+include_guard(GLOBAL)
+
+if(POLICY CMP0076)
+  # target_sources() converts relative paths to absolute
+  cmake_policy(SET CMP0076 NEW)
+endif()
+
+set(_headers
+    CFG/RelocBlock.h
+    CFG/RelocEdge.h
+    CFG/RelocGraph.h
+    CFG/RelocTarget.h
+    CodeBuffer.h
+    CodeMover.h
+    CodeTracker.h
+    DynAddrSpace.h
+    DynCommon.h
+    DynInstrumenter.h
+    DynObject.h
+    DynPointMaker.h
+    Relocation.h
+    Springboard.h
+    Transformers/Include.h
+    Transformers/Instrumenter.h
+    Transformers/Modification.h
+    Transformers/Movement-adhoc.h
+    Transformers/Movement-analysis.h
+    Transformers/Transformer.h
+    Widgets/CallbackWidget.h
+    Widgets/CFWidget.h
+    Widgets/Include.h
+    Widgets/InsnWidget.h
+    Widgets/InstWidget.h
+    Widgets/PCWidget.h
+    Widgets/RelDataWidget.h
+    Widgets/StackModWidget.h
+    Widgets/Widget.h)
+
+set(_sources
+    CFG/RelocBlock.C
+    CFG/RelocEdge.C
+    CFG/RelocGraph.C
+    CFG/RelocTarget.C
+    CodeBuffer.C
+    CodeMover.C
+    CodeTracker.C
+    DynAddrSpace.C
+    DynCFGMaker.C
+    DynInstrumenter.C
+    DynObject.C
+    DynPointMaker.C
+    Springboard.C
+    Transformers/Instrumenter.C
+    Transformers/Modification.C
+    Transformers/Movement-adhoc.C
+    Transformers/Movement-analysis.C
+    Transformers/Transformer.C
+    Widgets/CFWidget.C
+    Widgets/CallbackWidget.C
+    Widgets/InsnWidget.C
+    Widgets/InstWidget.C
+    Widgets/PCWidget.C
+    Widgets/RelDataWidget.C
+    Widgets/StackModWidget.C
+    patchapi_debug.C)
+
+if(DYNINST_CODEGEN_ARCH_I386 OR DYNINST_CODEGEN_ARCH_X86_64)
+  list(APPEND _sources Widgets/CFWidget-x86.C Widgets/PCWidget-x86.C)
+elseif(DYNINST_CODEGEN_ARCH_PPC64LE)
+  list(APPEND _sources Widgets/CFWidget-ppc.C Widgets/PCWidget-ppc.C)
+elseif(DYNINST_CODEGEN_ARCH_AARCH64)
+  list(APPEND _sources Widgets/CFWidget-aarch64.C Widgets/PCWidget-aarch64.C)
+elseif(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
+  list(APPEND _sources Widgets/CFWidget-amdgpu.C Widgets/PCWidget-amdgpu.C)
+endif()
+
+add_library(dyninstAPI_relocation INTERFACE)
+target_sources(dyninstAPI_relocation INTERFACE ${_headers} ${_sources})
+target_include_directories(dyninstAPI_relocation INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+unset(_headers)
+unset(_sources)

--- a/dyninstAPI/src/StackMod/CMakeLists.txt
+++ b/dyninstAPI/src/StackMod/CMakeLists.txt
@@ -1,0 +1,31 @@
+include_guard(GLOBAL)
+
+list(FIND DYNINST_PLATFORM_CAPABILITIES "-Dcap_stack_mods" cap_stack_mods_found)
+if(cap_stack_mods_found EQUAL -1)
+  add_library(dyninstAPI_stackmod INTERFACE)
+  return()
+endif()
+
+if(POLICY CMP0076)
+  # target_sources() converts relative paths to absolute
+  cmake_policy(SET CMP0076 NEW)
+endif()
+
+set(_headers OffsetVector.h StackAccess.h StackLocation.h StackModChecker.h
+             StackModExpr.h TMap.h)
+
+set(_sources
+    OffsetVector.C
+    StackAccess.C
+    StackLocation.C
+    StackMod.C
+    StackModExpr.C
+    StackModChecker.C
+    TMap.C)
+
+add_library(dyninstAPI_stackmod INTERFACE)
+target_sources(dyninstAPI_stackmod INTERFACE ${_headers} ${_sources})
+target_include_directories(dyninstAPI_stackmod INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+unset(_headers)
+unset(_sources)

--- a/dyninstAPI/src/codegen/CMakeLists.txt
+++ b/dyninstAPI/src/codegen/CMakeLists.txt
@@ -1,0 +1,35 @@
+include_guard(GLOBAL)
+
+if(POLICY CMP0076)
+  # target_sources() converts relative paths to absolute
+  cmake_policy(SET CMP0076 NEW)
+endif()
+
+set(_headers RegControl.h)
+
+if(DYNINST_CODEGEN_ARCH_I386 OR DYNINST_CODEGEN_ARCH_X86_64)
+  list(
+    APPEND
+    _headers
+    emitters/x86/Emitterx86.h
+    emitters/x86/generators.h
+    emitters/x86/IA32/EmitterIA32Dyn.h
+    emitters/x86/IA32/EmitterIA32.h
+    emitters/x86/IA32/EmitterIA32Stat.h)
+
+  list(
+    APPEND
+    _sources
+    emitters/x86/Emitterx86.C
+    emitters/x86/generators.C
+    emitters/x86/IA32/EmitterIA32.C
+    emitters/x86/IA32/EmitterIA32Dyn.C
+    emitters/x86/IA32/EmitterIA32Stat.C)
+endif()
+
+add_library(dyninstAPI_codegen INTERFACE)
+target_sources(dyninstAPI_codegen INTERFACE ${_headers} ${_sources})
+target_include_directories(dyninstAPI_codegen INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+unset(_headers)
+unset(_sources)

--- a/dyninstAPI/src/codegen/emitters/x86/Emitterx86.C
+++ b/dyninstAPI/src/codegen/emitters/x86/Emitterx86.C
@@ -4,6 +4,7 @@
 #include "Architecture.h"
 #include "binaryEdit.h"
 #include "BPatch_memoryAccess_NP.h"
+#include "codegen-x86.h"
 #include "codegen/emitters/x86/Emitterx86.h"
 #include "codegen/RegControl.h"
 #include "common/src/bitmath.h"

--- a/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32Stat.C
+++ b/dyninstAPI/src/codegen/emitters/x86/IA32/EmitterIA32Stat.C
@@ -1,5 +1,6 @@
 #include "arch-regs-x86.h"
 #include "EmitterIA32Stat.h"
+#include "encoding-x86.h"
 #include "function.h"
 #include "inst-x86.h"
 #include "registerSpace/RealRegister.h"

--- a/dyninstAPI/src/codegen/emitters/x86/generators.C
+++ b/dyninstAPI/src/codegen/emitters/x86/generators.C
@@ -1,5 +1,6 @@
 #include "arch-regs-x86.h"
 #include "codegen/emitters/x86/generators.h"
+#include "encoding-x86.h"
 #include "inst-x86.h"
 #include "registerSpace/registerSpace.h"
 #include "unaligned_memory_access.h"

--- a/dyninstAPI/src/registerSpace/CMakeLists.txt
+++ b/dyninstAPI/src/registerSpace/CMakeLists.txt
@@ -1,0 +1,27 @@
+include_guard(GLOBAL)
+
+if(POLICY CMP0076)
+  # target_sources() converts relative paths to absolute
+  cmake_policy(SET CMP0076 NEW)
+endif()
+
+set(_headers registerSpace.h RealRegister.h registerSlot.h)
+
+set(_sources registerSpace.C registerSlot.C)
+
+if(DYNINST_CODEGEN_ARCH_I386 OR DYNINST_CODEGEN_ARCH_X86_64)
+  list(APPEND _sources registerSpace-x86.C)
+elseif(DYNINST_CODEGEN_ARCH_PPC64LE)
+  list(APPEND _sources registerSpace-ppc.C)
+elseif(DYNINST_CODEGEN_ARCH_AARCH64)
+  list(APPEND _sources registerSpace-aarch64.C)
+elseif(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
+  list(APPEND _sources registerSpace-amdgpu.C)
+endif()
+
+add_library(dyninstAPI_registerSpace INTERFACE)
+target_sources(dyninstAPI_registerSpace INTERFACE ${_headers} ${_sources})
+target_include_directories(dyninstAPI_registerSpace INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+unset(_headers)
+unset(_sources)

--- a/dyninstAPI/src/trampolines/CMakeLists.txt
+++ b/dyninstAPI/src/trampolines/CMakeLists.txt
@@ -1,0 +1,26 @@
+include_guard(GLOBAL)
+
+if(POLICY CMP0076)
+  # target_sources() converts relative paths to absolute
+  cmake_policy(SET CMP0076 NEW)
+endif()
+
+set(_headers baseTramp.h baseTramp-aarch64.h baseTramp-amdgpu.h baseTramp-ppc.h
+             baseTramp-riscv64.h baseTramp-x86.h)
+
+set(_sources baseTramp.C)
+
+if(DYNINST_CODEGEN_ARCH_I386 OR DYNINST_CODEGEN_ARCH_X86_64)
+  list(APPEND _sources baseTramp-x86.C)
+elseif(DYNINST_CODEGEN_ARCH_PPC64LE)
+  list(APPEND _sources baseTramp-ppc.C)
+elseif(DYNINST_CODEGEN_ARCH_AARCH64)
+  list(APPEND _sources baseTramp-aarch64.C)
+endif()
+
+add_library(dyninstAPI_trampolines INTERFACE)
+target_sources(dyninstAPI_trampolines INTERFACE ${_headers} ${_sources})
+target_include_directories(dyninstAPI_trampolines INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+unset(_headers)
+unset(_sources)


### PR DESCRIPTION
This is purely cosmetic, but really needed because the number of files will continue to grow as codegen is made platform-independent.