### PR TITLE
[dyninstAPI] Use simple pointer equality in function_cache

### DIFF
--- a/dyninstAPI/src/function_cache.h
+++ b/dyninstAPI/src/function_cache.h
@@ -44,11 +44,7 @@ namespace Dyninst { namespace DyninstAPI {
       funcs.reserve(10);
     }
     bool contains(func_instance *f) const {
-      auto cmp = [f](func_instance *c) {
-        return c->addr() == f->addr() &&
-               c->typedName() == f->typedName();
-      };
-      return std::find_if(funcs.begin(), funcs.end(), cmp) != funcs.end();
+      return std::find(funcs.begin(), funcs.end(), f) != funcs.end();
     }
     void insert(func_instance *f) {
       funcs.push_back(f);


### PR DESCRIPTION
The current test doesn't seem to be correctly unique. This reverts back to the old pointer-based comparison.

I evidently just completely forgot to run the test battery on #2254 because it caused all sorts of regressions.