### PR TITLE
Fix type width in IndirectAnalyzer::ReadTable

### DIFF
--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -339,7 +339,7 @@ void IndirectControlFlowAnalyzer::ReadTable(AST::Ptr jumpTargetExpr,
             if (jtrv.readAddress > maxReadAddress) maxReadAddress = jtrv.readAddress;
             if (prevReadAddress > 0) indexStride = jtrv.readAddress - prevReadAddress;
             prevReadAddress = jtrv.readAddress;
-            parsing_printf("\t index %d, table address %lx, target address %lx\n", v, jtrv.readAddress, jtrv.targetAddress);
+            parsing_printf("\t index %ld, table address %lx, target address %lx\n", v, jtrv.readAddress, jtrv.targetAddress);
             jumpTargets.insert(jtrv.targetAddress);
             entries[jtrv.readAddress] = jtrv.targetAddress;
         } else {

--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -324,10 +324,10 @@ void IndirectControlFlowAnalyzer::ReadTable(AST::Ptr jumpTargetExpr,
                                             std::map<Address, Address>& entries) {
     CodeSource *cs = block->obj()->cs();
     set<Address> jumpTargets;
-    int start = 0;
+    int64_t start = 0;
     Address prevReadAddress = 0;
     if (indexBound.low > 0) start = indexBound.low = start;
-    for (int v = start; v <= indexBound.high; v += indexBound.stride) {
+    for (int64_t v = start; v <= indexBound.high; v += indexBound.stride) {
         JumpTableReadVisitor jtrv(index, v, cs, block->region(), isZeroExtend, memoryReadSize);
         jumpTargetExpr->accept(&jtrv);
        if (jtrv.valid && cs->isCode(jtrv.targetAddress)) {

--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -326,7 +326,7 @@ void IndirectControlFlowAnalyzer::ReadTable(AST::Ptr jumpTargetExpr,
     set<Address> jumpTargets;
     int64_t start = 0;
     Address prevReadAddress = 0;
-    if (indexBound.low > 0) start = indexBound.low = start;
+    if (indexBound.low > 0) start = indexBound.low;
     for (int64_t v = start; v <= indexBound.high; v += indexBound.stride) {
         JumpTableReadVisitor jtrv(index, v, cs, block->region(), isZeroExtend, memoryReadSize);
         jumpTargetExpr->accept(&jtrv);

--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -324,10 +324,9 @@ void IndirectControlFlowAnalyzer::ReadTable(AST::Ptr jumpTargetExpr,
                                             std::map<Address, Address>& entries) {
     CodeSource *cs = block->obj()->cs();
     set<Address> jumpTargets;
-    int64_t start = 0;
     Address prevReadAddress = 0;
-    if (indexBound.low > 0) start = indexBound.low;
-    for (int64_t v = start; v <= indexBound.high; v += indexBound.stride) {
+    auto start = std::max(indexBound.low,0L);
+    for (auto v = start; v <= indexBound.high; v += indexBound.stride) {
         JumpTableReadVisitor jtrv(index, v, cs, block->region(), isZeroExtend, memoryReadSize);
         jumpTargetExpr->accept(&jtrv);
        if (jtrv.valid && cs->isCode(jtrv.targetAddress)) {


### PR DESCRIPTION

indexBound.stride is 64 bit, v and start is 32 bit.
If v + indexBound.stride results in number with low 32 bit 0,
we get an infinite loop.

This PR changes v and start to be int64_t so the truncation 
no longer happens.

Also fix an logic error with respect to assignment of start, so
the lowerbound is actually used.

Fixes #2264 