### PR TITLE
Fix 64-bit shift count masking in ROSE x86-64 semantics

### DIFF
--- a/dataflowAPI/rose/x86_64InstructionSemantics.h
+++ b/dataflowAPI/rose/x86_64InstructionSemantics.h
@@ -1388,11 +1388,13 @@ struct X86_64InstructionSemantics {
                         break;
                     }
                     case 8: {
+                        // 64-bit shifts mask the count modulo 64, not 32
+                        Word(6) shiftCount64 = extract<0, 6>(read8(operands[1]));
                         Word(64) op = read64(operands[0]);
-                        Word(64) output = policy.shiftLeft(op, shiftCount);
+                        Word(64) output = policy.shiftLeft(op, shiftCount64);
                         Word(1) newCf = policy.ite(shiftCountZero,
                                                    policy.readFlag(x86_flag_cf),
-                                                   extract<63, 64>(policy.shiftLeft(op, policy.add(shiftCount, number<5>(63)))));
+                                                   extract<63, 64>(policy.shiftLeft(op, policy.add(shiftCount64, number<6>(63)))));
                         policy.writeFlag(x86_flag_cf, newCf);
                         policy.writeFlag(x86_flag_of, policy.ite(shiftCountZero,
                                                                  policy.readFlag(x86_flag_of),
@@ -1453,11 +1455,13 @@ struct X86_64InstructionSemantics {
                         break;
                     }
                     case 8: {
+                        // 64-bit shifts mask the count modulo 64, not 32
+                        Word(6) shiftCount64 = extract<0, 6>(read8(operands[1]));
                         Word(64) op = read64(operands[0]);
-                        Word(64) output = policy.shiftRight(op, shiftCount);
+                        Word(64) output = policy.shiftRight(op, shiftCount64);
                         Word(1) newCf = policy.ite(shiftCountZero,
                                                    policy.readFlag(x86_flag_cf),
-                                                   extract<0, 1>(policy.shiftRight(op, policy.add(shiftCount, number<5>(63)))));
+                                                   extract<0, 1>(policy.shiftRight(op, policy.add(shiftCount64, number<6>(63)))));
                         policy.writeFlag(x86_flag_cf, newCf);
                         policy.writeFlag(x86_flag_of, policy.ite(shiftCountZero,
                                                                  policy.readFlag(x86_flag_of),
@@ -1525,13 +1529,15 @@ struct X86_64InstructionSemantics {
                         break;
                     }
                     case 8: {
+                        // 64-bit shifts mask the count modulo 64, not 32
+                        Word(6) shiftCount64 = extract<0, 6>(read8(operands[1]));
                         Word(64) op = read64(operands[0]);
-                        Word(64) output = policy.shiftRightArithmetic(op, shiftCount);
+                        Word(64) output = policy.shiftRightArithmetic(op, shiftCount64);
                         Word(1) newCf = policy.ite(shiftCountZero,
                                                    policy.readFlag(x86_flag_cf),
-                                                   extract<0, 1>(policy.shiftRight(op, policy.add(shiftCount, number<5>(63)))));
+                                                   extract<0, 1>(policy.shiftRight(op, policy.add(shiftCount64, number<6>(63)))));
                         policy.writeFlag(x86_flag_cf, newCf);
-                        // No change with sc = 0, clear when sc = 1, undefined otherwise 
+                        // No change with sc = 0, clear when sc = 1, undefined otherwise
                         policy.writeFlag(x86_flag_of, policy.ite(shiftCountZero,
                                                                  policy.readFlag(x86_flag_of),
                                                                  policy.false_()));
@@ -1636,7 +1642,8 @@ struct X86_64InstructionSemantics {
                     }
                     case 8: {
                         Word(64) op = read64(operands[0]);
-                        Word(5) shiftCount = extract<0, 5>(read8(operands[1]));
+                        // 64-bit rotates mask the count modulo 64, not 32
+                        Word(6) shiftCount = extract<0, 6>(read8(operands[1]));
                         Word(64) output = policy.rotateRight(op, shiftCount);
                         policy.writeFlag(x86_flag_cf, policy.ite(policy.equalToZero(shiftCount),
                                                                  policy.readFlag(x86_flag_cf),

--- a/parseAPI/src/BoundFactData.C
+++ b/parseAPI/src/BoundFactData.C
@@ -230,16 +230,18 @@ void StridedInterval::Div(const StridedInterval &rhs) {
 }
 
 void StridedInterval::ShiftLeft(const StridedInterval &rhs) {
-    if (rhs.stride == 0) {
-        Mul(StridedInterval(1 << rhs.low));
+    // A shift amount of 64 or more is undefined at the machine level and
+    // would also overflow the 64-bit shift below; treat it as top.
+    if (rhs.stride == 0 && rhs.low >= 0 && rhs.low < 64) {
+        Mul(StridedInterval((int64_t)1 << rhs.low));
     } else {
         // In other case, we widen
 	*this = top;
     }
 }
 void StridedInterval::ShiftRight(const StridedInterval &rhs) {
-    if (rhs.stride == 0) {
-        Div(StridedInterval(1 << rhs.low));
+    if (rhs.stride == 0 && rhs.low >= 0 && rhs.low < 64) {
+        Div(StridedInterval((int64_t)1 << rhs.low));
     } else {
         // In other case, we widen
 	*this = top;


### PR DESCRIPTION
x86 masks shift/rotate counts modulo the operand size: mod 32 for 8/16/32-bit operands, but mod 64 for 64-bit operands. The ROSE semantics extracted the count as Word(5) (extract<0,5>, i.e. mod 32) for all sizes, so a 64-bit shift like `shrq $0x28` (count 40) was truncated to 40 & 0x1f = 8.

In jump-table index analysis this produced a bogus bound: an index computed as `(imm >> 40)` was evaluated as `imm >> 8`, scaling the StridedInterval by 2^32 and yielding strides/ranges like 2^32[0,10*2^32]. Combined with the 32-bit loop counter in ReadTable that became an infinite loop.

Fix the 64-bit (case 8) branches of shl/shr/sar/ror to mask the count mod 64 using Word(6)/extract<0,6>. The <=32-bit branches keep their correct mod-32 masking.

Also harden StridedInterval::ShiftLeft/ShiftRight: `1 << rhs.low` used a 32-bit int literal, which is undefined for counts >= 31. Use (int64_t)1 << rhs.low and bail to top for counts >= 64. Without this, the now-correct large shift counts would overflow.