### PR TITLE
Fix 64-bit jump target truncation in IA_riscv64::isMultiInsnJump

### DIFF
--- a/parseAPI/src/IA_riscv64.C
+++ b/parseAPI/src/IA_riscv64.C
@@ -462,7 +462,7 @@ bool IA_riscv64::isMultiInsnJump(Address *target, Function *context, Block *curr
             auto simplifiedAST = se.SimplifyAnAST(origAST, 0, false);
             if (simplifiedAST->getID() == AST::V_ConstantAST) {
                 DataflowAPI::ConstantAST::Ptr constAST = boost::static_pointer_cast<DataflowAPI::ConstantAST>(simplifiedAST);
-                uint32_t evalAddr = constAST->val().val;
+                Address evalAddr = constAST->val().val;
                 *target = evalAddr;
                 return true;
             }


### PR DESCRIPTION
The resolved multi-instruction jump target from ConstantAST::val().val (uint64_t) was funneled through a uint32_t local before being stored into *target (Address*). On riscv64 any indirect-branch target above 4 GiB lost its high 32 bits, causing parsing to follow a bogus address.

Widen the local to Address so the full 64-bit target is preserved.