### PR TITLE
Store ifTargetPatch target at full Address width

### DIFF
--- a/dyninstAPI/src/patch.h
+++ b/dyninstAPI/src/patch.h
@@ -96,10 +96,10 @@ public:
 class ifTargetPatch : public patchTarget
 {
  private:
-   signed int targetOffset;
+   Dyninst::Address targetOffset;
  public:
-   ifTargetPatch(signed int o) { targetOffset = o; }
-   virtual Dyninst::Address get_address() const { return (Dyninst::Address) targetOffset; }
+   ifTargetPatch(Dyninst::Address o) { targetOffset = o; }
+   virtual Dyninst::Address get_address() const { return targetOffset; }
    virtual unsigned get_size() const { return 0; }
    virtual std::string get_name() const { return std::string("ifTarget"); }
    virtual ~ifTargetPatch() { }


### PR DESCRIPTION
ifTargetPatch held its target in a signed int (32-bit), but it is constructed in operatorAST.C from an absolute code-buffer address (elseStartIndex/endIndex + gen.startAddr()). 

The 64-bit Address was truncated by the constructor. In relocPatch::applyPatch() the pcrel case computes get_address() - (startAddr() + offset): the minuend was truncated while the subtrahend kept full width, so they no longer cancel. 

When instrumentation is generated above 4 GiB (x86-64 ASLR / mmap'd trampolines) the resulting branch displacement is garbage.

Widen targetOffset to Dyninst::Address so the full target is preserved.