### PR TITLE
Old Fix failing to write instrumented shared library (#2081)

### DIFF
--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -1434,12 +1434,31 @@ void EmitterAMD64::emitRestoreFlagsFromStackSlot(codeGen &gen)
    emitSimpleInsn(0x9D, gen);
 }
 
+// SysV AMD64 caller-saved ("volatile") GPRs. A standard-ABI callee may clobber
+// these freely, and a caller normally does not keep them live across a call --
+// EXCEPT for GCC IPA-SRA local clones (.isra/.constprop), which co-allocate
+// scratch registers across the call between a clone and its callers. dyninst
+// cannot see that contract from the callee, so it must conservatively preserve
+// any of these that an inserted snippet clobbers (see #2081 follow-up: %r11
+// trashed by FEntryCoverage->printf inside an instrumented operator=.isra.0).
+static bool isCallerSavedGPR(int enc)
+{
+   switch (enc) {
+      case REGNUM_RAX: case REGNUM_RCX: case REGNUM_RDX:
+      case REGNUM_RSI: case REGNUM_RDI:
+      case REGNUM_R8:  case REGNUM_R9:  case REGNUM_R10: case REGNUM_R11:
+         return true;
+      default:               // RBX, RBP, R12-R15: callee-saved (preserved by the
+         return false;       // inserted call by ABI); RSP handled separately.
+   }
+}
+
 bool shouldSaveReg(registerSlot *reg, baseTramp *inst, bool saveFlags)
-{ 
+{
   if (reg->encoding() == REGNUM_RSP) {
     return false;
   }
-  
+
    if (inst->point()) {
       regalloc_printf("\t shouldSaveReg for BT %p, from 0x%lx\n", (void*)inst, inst->point()->insnAddr() );
    }
@@ -1447,8 +1466,21 @@ bool shouldSaveReg(registerSlot *reg, baseTramp *inst, bool saveFlags)
       regalloc_printf("\t shouldSaveReg for iRPC\n");
    }
    if (reg->liveState != registerSlot::live) {
-      regalloc_printf("\t Reg %u not live, concluding don't save\n", reg->number.getId());
-      return false;
+      // A register that is dead at this point normally need not be preserved.
+      // EXCEPTION: intra-procedural liveness cannot see a caller that keeps a
+      // caller-saved register (e.g. %r10/%r11) live across the call under a
+      // non-standard ABI (GCC IPA-SRA clones). If the inserted snippet clobbers
+      // such a register we must still save/restore it, or we silently corrupt
+      // the caller. (#2081 follow-up.)
+      bool clobbered = !(inst && inst->validOptimizationInfo())
+                       || inst->definedRegs[reg->encoding()];
+      if (!(clobbered && isCallerSavedGPR(reg->encoding()))) {
+         regalloc_printf("\t Reg %u not live, concluding don't save\n", reg->number.getId());
+         return false;
+      }
+      regalloc_printf("\t Reg %u dead but caller-saved & clobbered; saving "
+                      "conservatively for non-standard-ABI safety\n", reg->number.getId());
+      // fall through to save
    }
    if (saveFlags) {
       // Saving flags takes up EAX/RAX, and so if they're live they must

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -79,7 +79,7 @@ emitElf<ElfTypes>::emitElf(Elf_X *oldElfHandle_, bool isStripped_, ObjectELF *ob
         symTabData(NULL), dynsymData(NULL), dynData(NULL),
         phdrs_scn(NULL), verneednum(0), verdefnum(0),
         newSegmentStart(0), firstNewLoadSec(NULL),
-        dataSegEnd(0), dynSegOff(0), dynSegAddr(0),
+        dynSegOff(0), dynSegAddr(0),
         phdrSegOff(0), phdrSegAddr(0), dynSegSize(0),
         secNameIndex(0), currEndOffset(0), currEndAddress(0),
         linkedStaticData(NULL), loadSecTotalSize(0),
@@ -357,23 +357,51 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
     return true;
 }
 
-// Find the end of data/text segment
+// Find the start address of the last section that lies within the last
+// loadable (PT_LOAD) segment. This is the section after which dyninst appends
+// the newly created loadable sections.
+//
+// The old implementation (findSegmentEnds) assumed that some section ended
+// exactly on the boundary of the last loadable segment (p_vaddr + p_memsz).
+// That does not hold for all binaries: e.g. when the highest-addressed
+// loadable segment holds relocated read-only metadata (.gnu.hash/.dynstr) and
+// the segment's memsz is padded past the final section, no section ends on the
+// boundary. In that case the insertion point was never found,
+// createLoadableSections() was never called, and the rewritten file came out
+// without a .dynamic section / new code segment (see issue #2081).
+//
+// Instead, find the boundaries of the last loadable segment and return the
+// start address of the highest-addressed section contained within it.
 template<class ElfTypes>
-void emitElf<ElfTypes>::findSegmentEnds() {
+typename emitElf<ElfTypes>::Elf_Off emitElf<ElfTypes>::findLastLoadableSec() {
     Elf_Phdr *tmp = ElfTypes::elf_getphdr(oldElf);
-    // Find the offset of the start of the text & the data segment
-    // The first LOAD segment is the text & the second LOAD segment
-    // is the data
-    dataSegEnd = 0;
+    Elf_Off lastDataSegStart = 0, lastDataSegEnd = 0, lastLoadableSecStart = 0;
+
+    // Find the boundaries of the last (highest-addressed) loadable segment.
     for (unsigned i = 0; i < oldEhdr->e_phnum; i++) {
         if (tmp->p_type == PT_LOAD) {
-            if (dataSegEnd < tmp->p_vaddr + tmp->p_memsz)
-                dataSegEnd = tmp->p_vaddr + tmp->p_memsz;
+            if (tmp->p_vaddr + tmp->p_memsz > lastDataSegEnd) {
+                lastDataSegStart = tmp->p_vaddr;
+                lastDataSegEnd = tmp->p_vaddr + tmp->p_memsz;
+            }
         } else if (PT_TLS == tmp->p_type) {
             TLSExists = true;
         }
         tmp++;
     }
+
+    // Find the section with the highest start address that falls within the
+    // last loadable segment.
+    Elf_Scn *scn = NULL;
+    while ((scn = elf_nextscn(oldElf, scn))) {
+        Elf_Shdr *shdr = ElfTypes::elf_getshdr(scn);
+        Elf_Off secStart = shdr->sh_addr;
+        if (lastDataSegStart <= secStart && secStart < lastDataSegEnd &&
+            secStart > lastLoadableSecStart)
+            lastLoadableSecStart = secStart;
+    }
+
+    return lastLoadableSecStart;
 }
 
 // Rename an old section. Lengths of old and new names must match.
@@ -447,8 +475,8 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
 
     newEhdr->e_shnum += newSecs.size();
 
-    // Find the end of text and data segments
-    findSegmentEnds();
+    // Find the section after which new loadable sections will be appended
+    Elf_Off lastLoadableSecStart = findLastLoadableSec();
     unsigned insertPoint = oldEhdr->e_shnum;
     unsigned insertPointOffset = 0;
 
@@ -658,8 +686,9 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
                 sectionNumber, secLinkMapping[sectionNumber], secInfoMapping[sectionNumber],
                 changeMapping[sectionNumber]);
 
-        //Insert new loadable sections at the end of data segment
-        if (shdr->sh_addr + shdr->sh_size == dataSegEnd && !createdLoadableSections) {
+        //Insert new loadable sections after the last section of the last
+        //loadable segment
+        if (shdr->sh_addr == lastLoadableSecStart && !createdLoadableSections) {
             createdLoadableSections = true;
             insertPoint = scncount;
             if (SHT_NOBITS == shdr->sh_type) {
@@ -840,45 +869,31 @@ void emitElf<ElfTypes>::fixPhdrs() {
         newSeg.p_flags = PF_R + PF_W + PF_X;
         newSeg.p_align = pgSize;
 
-        // Search position to insert new segment
-        unsigned int position = -1;
+        // Search position to insert new segment.
+        //
+        // The ELF spec requires loadable segments to appear in the program
+        // header table sorted by ascending p_vaddr. PT_LOAD entries are NOT
+        // necessarily contiguous in the table -- other segment types (e.g.
+        // GNU_STACK) can appear between them -- so we cannot detect "the end
+        // of the loadable phdrs" by looking for the first LOAD->non-LOAD
+        // transition (issue #2081: libtorch_python.so has GNU_STACK as the
+        // second program header, right after the first LOAD).
+        //
+        // Insert the new segment immediately before the first PT_LOAD whose
+        // p_vaddr is greater than newSegmentStart; if there is none (the new
+        // segment has the highest address, which is the common case since it
+        // is appended past the end of the last loadable segment), append it at
+        // the end of the table. Non-loadable entries keep their relative
+        // order, and the PT_LOAD entries stay sorted by p_vaddr.
+        unsigned int position = segments.size();
         for( unsigned i = 0; i < segments.size(); i++ )
         {
-            if (i + 1 == segments.size()) {
-                // it's the last, so add after
-                position = i + 1;
-                break;
-            }
-            else if (segments[i].p_type == PT_LOAD && segments[i+1].p_type != PT_LOAD) {
-                // insert at end of loadable phdrs
-                position = i + 1;
-                break;
-            }
-            else if (segments[i].p_type != PT_LOAD &&
-                    segments[i+1].p_type == PT_LOAD &&
-                    newSegmentStart < segments[i+1].p_vaddr) {
-                // insert at beginning of loadable list (after the
-                // current phdr)
-                position = i + 1;
-                break;
-            }
-            else if (segments[i].p_type == PT_LOAD &&
-                    segments[i+1].p_type == PT_LOAD &&
-                    newSegmentStart >= segments[i].p_vaddr &&
-                    newSegmentStart < segments[i+1].p_vaddr) {
-                // insert in middle of loadable list, after current
-                position = i + 1;
-                break;
-            }
-            else if (i == 0 &&
-                    segments[i].p_type == PT_LOAD &&
-                    newSegmentStart < segments[i].p_vaddr) {
-                // insert BEFORE current phdr
+            if (segments[i].p_type == PT_LOAD &&
+                segments[i].p_vaddr > newSegmentStart) {
                 position = i;
                 break;
             }
         }
-        assert(position!=-1U);
 
         // Insert new Segment at position
         if( position == segments.size() )

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -216,8 +216,6 @@ namespace Dyninst {
             Elf_Off newSegmentStart;
             Elf_Shdr *firstNewLoadSec;// initialize to NULL
 
-            // data segment end
-            Elf_Off dataSegEnd;
             Elf_Off dynSegOff, dynSegAddr, phdrSegOff, phdrSegAddr;
             unsigned dynSegSize;
 
@@ -243,7 +241,10 @@ namespace Dyninst {
 
             bool createElfSymbol(Symbol *symbol, unsigned strIndex, vector<Elf_Sym *> &symbols,
                                  bool dynSymFlag = false);
-            void findSegmentEnds();
+            // Find the start address of the last section that falls within the
+            // last loadable (PT_LOAD) segment. This is where new loadable
+            // sections are appended. Also sets TLSExists as a side effect.
+            Elf_Off findLastLoadableSec();
             void renameSection(const std::string &oldStr, const std::string &newStr, bool renameAll=true);
             void fixPhdrs();
 


### PR DESCRIPTION
Rewriting some shared libraries (e.g. libtorch_python.so) produced a broken or unloadable output. Two assumptions in the ELF emitter break on binaries whose program/section layout is unusual; both must be fixed.

1. Insertion point for new loadable sections. findSegmentEnds() computed dataSegEnd as max(p_vaddr + p_memsz) over all PT_LOAD segments, and driver() only appended the new instrumentation sections when some section satisfied sh_addr + sh_size == dataSegEnd. When the highest-addressed loadable segment holds relocated read-only metadata (.gnu.hash/.dynstr) and is padded past its last section, no section ends on that boundary, so createLoadableSections() was never called and the result came out with a zero-sized .dynamic ("object file has no dynamic section"). Replace findSegmentEnds() with findLastLoadableSec(), which returns the start address of the highest-addressed section contained in the last loadable segment; the trigger becomes shdr->sh_addr == lastLoadableSecStart. This is equivalent to the previous behavior for ordinary binaries (still triggers on .bss).

2. Program-header insertion order. fixPhdrs() located the slot for the new PT_LOAD by scanning for the first LOAD -> non-LOAD transition, assuming PT_LOAD entries are contiguous in the program header table. libtorch_python.so has GNU_STACK as the second program header (right after the first LOAD), so the new highest-vaddr segment was inserted at index 1, leaving the PT_LOAD entries unsorted by p_vaddr. glibc's _dl_map_segments relies on ascending p_vaddr order and crashes. Insert the new segment before the first PT_LOAD whose p_vaddr is greater than newSegmentStart (else append at the end), keeping PT_LOAD entries sorted regardless of interspersed non-loadable entries.

With both fixes, the rewritten library has a valid .dynamic, a correctly ordered new loadable segment, and loads under the dynamic linker the same way the original does; instrumenting and running ordinary binaries is unaffected.