### PR TITLE
Symtab: don't abort in findRegion on duplicate same-(addr,size) sections

### DIFF
--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -548,11 +548,14 @@ bool Symtab::findRegion(Region *&ret, const Offset addr, const unsigned long siz
    for(unsigned index=0;index<regions_.size();index++) {
       if(regions_[index]->getMemOffset() == addr && regions_[index]->getMemSize() == size) {
          if (ret) {
-	   assert((addr == 0) ||
-		  (ret->getRegionType() == Region::RT_BSS) ||
-		  (regions_[index]->getRegionType() == Region::RT_BSS));
-
-	    // Probably don't want bss
+	    // More than one region has this (addr,size). This is legitimate for a
+	    // NOBITS .bss aliasing a PROGBITS section's address, and for zero-size
+	    // marker sections placed at the same address (e.g. the empty
+	    // .gnu.offload_funcs/.gnu.offload_vars GCC emits in offload builds).
+	    // Ambiguous but not fatal: prefer a non-BSS match, report
+	    // Multiple_Region_Matches, and let the caller disambiguate (e.g. by
+	    // section name). Do NOT abort -- findRegion is library code reachable
+	    // from ordinary third-party binaries (was: assert that one match is BSS).
 	    if (ret->getRegionType() == Region::RT_BSS) {
 	      ret = regions_[index];
 	    }


### PR DESCRIPTION
Symtab::findRegion(ret, addr, size) asserted that if two regions share an identical (memOffset, memSize), at least one must be RT_BSS (or addr==0). That assumption does not hold: GCC offload builds emit empty marker sections such as .gnu.offload_funcs and .gnu.offload_vars at the *same* address with size 0, both PROGBITS. On such a binary (observed on a CPU PyTorch libtorch_python.so) the assertion aborts a debug-built dyninst during writeFile.

The abort is also unnecessary: the multiple-match case already reports Multiple_Region_Matches and returns false, and callers handle that -- e.g. emitElf's section loop falls back to findRegion-by-name, which is unambiguous. In release builds the assert is compiled out and this already works; the fix just makes debug builds behave the same.

Remove the assert and keep the existing graceful path (prefer a non-BSS match, set Multiple_Region_Matches, return false). findRegion is library code reachable from ordinary third-party binaries and should not abort() on valid input.