### PR TITLE
Preserve caller-saved GPRs clobbered by an inserted instrumentation call

### DIFF
--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -1460,12 +1460,21 @@ static bool isCallerSavedGPR(int enc)
 // which a caller keeps a caller-saved register live across a call, so the
 // conservative save below is restricted to them -- ordinary functions keep the
 // normal liveness-based pruning. Uses SymtabAPI's clone predicate so the
-// detection lives in one place (Symbol::isClone: mangled name contains '.').
+// detection lives in one place (Symbol::isClone: name carries a clone suffix).
+//
+// A function can have several symbol-table names (aliases), so check all of
+// them rather than just the primary symTabName(); treat the function as a clone
+// if any name is a clone name.
 static bool isCloneFunc(baseTramp *inst)
 {
    if (!inst || !inst->point() || !inst->point()->func())
       return false;
-   return Dyninst::SymtabAPI::Symbol::isClone(inst->point()->func()->symTabName());
+   func_instance *f = inst->point()->func();
+   for (auto it = f->symtab_names_begin(); it != f->symtab_names_end(); ++it) {
+      if (Dyninst::SymtabAPI::Symbol::isClone(*it))
+         return true;
+   }
+   return false;
 }
 
 bool shouldSaveReg(registerSlot *reg, baseTramp *inst, bool saveFlags)

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -40,6 +40,7 @@
 #include "compiler_annotations.h"
 #include "dyninstAPI/src/codegen.h"
 #include "patching/function.h"
+#include "Symbol.h"
 #include "dyninstAPI/src/emit-x86.h"
 #include "dyninstAPI/src/inst-x86.h"
 #include "dyninstAPI/src/debug.h"
@@ -1434,12 +1435,45 @@ void EmitterAMD64::emitRestoreFlagsFromStackSlot(codeGen &gen)
    emitSimpleInsn(0x9D, gen);
 }
 
+// SysV AMD64 caller-saved ("volatile") GPRs. A standard-ABI callee may clobber
+// these freely, and a caller normally does not keep them live across a call --
+// EXCEPT for GCC IPA-SRA local clones (.isra/.constprop), which co-allocate
+// scratch registers across the call between a clone and its callers. dyninst
+// cannot see that contract from the callee, so it must conservatively preserve
+// any of these that an inserted snippet clobbers (e.g. %r11 trashed by an
+// instrumentation reporter's printf inside an instrumented
+// std::string::operator=.isra.0 clone whose caller kept %r11 live across it).
+static bool isCallerSavedGPR(int enc)
+{
+   switch (enc) {
+      case REGNUM_RAX: case REGNUM_RCX: case REGNUM_RDX:
+      case REGNUM_RSI: case REGNUM_RDI:
+      case REGNUM_R8:  case REGNUM_R9:  case REGNUM_R10: case REGNUM_R11:
+         return true;
+      default:               // RBX, RBP, R12-R15: callee-saved (preserved by the
+         return false;       // inserted call by ABI); RSP handled separately.
+   }
+}
+
+// True if the instrumented function is a GCC local clone (.isra/.constprop/
+// .part/.cold). Only such clones can carry a non-standard calling convention in
+// which a caller keeps a caller-saved register live across a call, so the
+// conservative save below is restricted to them -- ordinary functions keep the
+// normal liveness-based pruning. Uses SymtabAPI's clone predicate so the
+// detection lives in one place (Symbol::isClone: mangled name contains '.').
+static bool isCloneFunc(baseTramp *inst)
+{
+   if (!inst || !inst->point() || !inst->point()->func())
+      return false;
+   return Dyninst::SymtabAPI::Symbol::isClone(inst->point()->func()->symTabName());
+}
+
 bool shouldSaveReg(registerSlot *reg, baseTramp *inst, bool saveFlags)
-{ 
+{
   if (reg->encoding() == REGNUM_RSP) {
     return false;
   }
-  
+
    if (inst->point()) {
       regalloc_printf("\t shouldSaveReg for BT %p, from 0x%lx\n", (void*)inst, inst->point()->insnAddr() );
    }
@@ -1447,8 +1481,26 @@ bool shouldSaveReg(registerSlot *reg, baseTramp *inst, bool saveFlags)
       regalloc_printf("\t shouldSaveReg for iRPC\n");
    }
    if (reg->liveState != registerSlot::live) {
-      regalloc_printf("\t Reg %u not live, concluding don't save\n", reg->number.getId());
-      return false;
+      // A register that is dead at this point normally need not be preserved.
+      // EXCEPTION: intra-procedural liveness cannot see a caller that keeps a
+      // caller-saved register (e.g. %r10/%r11) live across the call under a
+      // non-standard ABI -- only GCC local clones (.isra/.constprop/...) have
+      // such an ABI. For a clone callee, preserve any caller-saved register the
+      // inserted snippet clobbers even when dead here, or we silently corrupt
+      // the caller. isCloneFunc() is checked first: it is false for almost every
+      // function, so non-clones take the normal "dead -> don't save" path
+      // immediately (and we avoid the per-register clobbered/caller-saved work).
+      bool needSave = isCloneFunc(inst)
+                      && isCallerSavedGPR(reg->encoding())
+                      && (!(inst && inst->validOptimizationInfo())
+                          || inst->definedRegs[reg->encoding()]);
+      if (!needSave) {
+         regalloc_printf("\t Reg %u not live, concluding don't save\n", reg->number.getId());
+         return false;
+      }
+      regalloc_printf("\t Reg %u dead but caller-saved & clobbered on a clone; "
+                      "saving conservatively for non-standard-ABI safety\n", reg->number.getId());
+      // fall through to save
    }
    if (saveFlags) {
       // Saving flags takes up EAX/RAX, and so if they're live they must


### PR DESCRIPTION
The base trampoline's register guard decided which registers to save using intra-procedural liveness (shouldSaveReg in emit-x86.C). A caller-saved GPR marked "dead" at the instrumentation point was skipped -- correct for a standard-ABI function, since a caller never keeps a caller-saved scratch register live across a call.

That assumption is wrong for GCC local clones (.isra/.constprop/...), which co-allocate scratch registers across the call between a clone and its callers: the caller legitimately keeps e.g. %r11 live across the call because the clone promises not to touch it. That contract is invisible from the callee, so dyninst skipped saving %r11 -- and the inserted snippet's call (here a coverage reporter that calls printf) then clobbered it, corrupting the caller's value.

Observed on an instrumented PyTorch libtorch_python.so: pybind11::detail::string_caster<std::string,false>::load keeps &local in %r11 across a call to std::string::operator=.isra.0; the instrumented operator='s guard saved only {rsi,rdi}, printf clobbered %r11, and the following _M_dispose dereferenced 0xffffffff -> SIGSEGV during `import torch`.

Fix: in shouldSaveReg, when the instrumented function is a clone (SymtabAPI Symbol::isClone -- mangled name carries a GCC clone suffix), a caller-saved GPR that the inserted snippet clobbers is saved even when intra-procedural liveness marks it dead. The check is gated on isClone (and checked first, as it is false for almost all functions) so ordinary functions keep the liveness optimization -- they cannot have a caller holding a caller-saved register live across the call. Callee-saved registers are unaffected (the inserted call preserves them by ABI). No restore-side change is needed: markSavedRegister() marks the reg spilled, the restore loop pops every spilled reg, and the num_to_save counting loop uses the same predicate, so saves/pops stay balanced.

Verified on x86-64: the operator=.isra.0 guard now pushes the full caller-saved set {rax,r10,r11,r8,r9,rcx,rdx,rsi,rdi}, and instrumented `import torch` exits 0 with results identical to the uninstrumented baseline. (Note: writing an instrumented libtorch_python.so also requires the separate insertion-point / program-header emit fix; the run above used a build that included it.) AArch64/PPC base tramps may need the analogous change.