### PR TITLE
parseAPI: make speculative getGapRange O(log F) via funcsByRange

### DIFF
--- a/parseAPI/src/Parser-speculative.C
+++ b/parseAPI/src/Parser-speculative.C
@@ -347,15 +347,12 @@ void Parser::parse_gap_heuristic(CodeRegion * cr)
     finalize();
 }
 
-bool Parser::getGapRange(CodeRegion* cr, Address curAddr, Address& gapStart, Address& gapEnd) {
-    std::set< std::pair<Address, Address> > func_range;
-    for (auto fit = sorted_funcs.begin(); fit != sorted_funcs.end(); ++fit) {
-        Function * f = *fit;
-	for (auto eit = f->extents().begin(); eit != f->extents().end(); ++eit) {
-	    FuncExtent *fe = *eit;
-	    func_range.insert(make_pair(fe->start(), fe->end()));
-	}
-    }
+bool Parser::getGapRange(CodeRegion* cr, Address curAddr, Address& gapStart, Address& gapEnd,
+                         const std::set<std::pair<Address, Address> >& func_range) {
+    // func_range -- a start-ordered set of every parsed function's extents -- is built
+    // and maintained by the caller (probabilistic_gap_parsing) rather than rebuilt from
+    // sorted_funcs on every call; that per-call O(F) rebuild was the speculative pass's
+    // O(gaps x F) hot spot. The logic below is otherwise unchanged.
     auto iter = func_range.upper_bound(make_pair(curAddr, std::numeric_limits<Address>::max() ));
     if (iter == func_range.end()) {
         gapEnd = cr->offset() + cr->length();
@@ -382,6 +379,11 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
     if (_parse_state < COMPLETE)
         parse();
     finalize();
+    // Drain pending finalized functions into funcsByRange now (single-threaded), so
+    // funcs_to_ranges starts empty and the in-loop fold below only sees gap-discovered
+    // functions.
+    if (!funcs_to_ranges.empty())
+        finalize_ranges();
 
     string model_spec;
     if (obj().cs()->getAddressWidth() == 8) 
@@ -391,6 +393,15 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
 
     // Load the pre-trained idiom model:
     hd::ProbabilityCalculator pc(cr, obj().cs(), this, model_spec);
+
+    // Start-ordered index of every parsed extent (start,end). Built once; maintained
+    // incrementally below. getGapRange queries this instead of rebuilding it from
+    // sorted_funcs on every call (the old O(gaps x F) hot spot). See getGapRange.
+    std::set<std::pair<Address, Address> > func_range;
+    for (auto fit = sorted_funcs.begin(); fit != sorted_funcs.end(); ++fit)
+        for (auto eit = (*fit)->extents().begin(); eit != (*fit)->extents().end(); ++eit)
+            func_range.insert(std::make_pair((*eit)->start(), (*eit)->end()));
+
     Address gapStart;
     Address gapEnd;
     Address curAddr = cr->offset();
@@ -402,7 +413,7 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
     const Address regBeg = cr->offset();
     const Address regEnd = cr->offset() + cr->length();
     gap_progress_report("starting speculative gap parsing", regBeg, regBeg, regEnd);
-    while (getGapRange(cr, curAddr, gapStart, gapEnd)) {
+    while (getGapRange(cr, curAddr, gapStart, gapEnd, func_range)) {
         parsing_printf("[%s] scanning for FEP in [%lx,%lx)\n",
             FILE__,gapStart,gapEnd);
         for(curAddr=gapStart; curAddr < gapEnd; ++curAddr) {
@@ -417,6 +428,14 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
             }
         }
         finalize();
+        // Fold gap-discovered functions into the index, then drain funcs_to_ranges
+        // into funcsByRange (keeping other consumers current and the fold incremental
+        // -- next iteration only sees newly-finalized functions).
+        for (Function* f : funcs_to_ranges)
+            for (auto eit = f->extents().begin(); eit != f->extents().end(); ++eit)
+                func_range.insert(std::make_pair((*eit)->start(), (*eit)->end()));
+        if (!funcs_to_ranges.empty())
+            finalize_ranges();
     }
     gap_progress_report("speculative gap parsing done", regEnd, regBeg, regEnd);
 }

--- a/parseAPI/src/Parser-speculative.C
+++ b/parseAPI/src/Parser-speculative.C
@@ -398,9 +398,9 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
     // incrementally below. getGapRange queries this instead of rebuilding it from
     // sorted_funcs on every call (the old O(gaps x F) hot spot). See getGapRange.
     std::set<std::pair<Address, Address> > func_range;
-    for (auto fit = sorted_funcs.begin(); fit != sorted_funcs.end(); ++fit)
-        for (auto eit = (*fit)->extents().begin(); eit != (*fit)->extents().end(); ++eit)
-            func_range.insert(std::make_pair((*eit)->start(), (*eit)->end()));
+    for (Function *f : sorted_funcs)
+        for (FuncExtent *ext : f->extents())
+            func_range.insert(std::make_pair(ext->start(), ext->end()));
 
     Address gapStart;
     Address gapEnd;
@@ -431,9 +431,9 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
         // Fold gap-discovered functions into the index, then drain funcs_to_ranges
         // into funcsByRange (keeping other consumers current and the fold incremental
         // -- next iteration only sees newly-finalized functions).
-        for (Function* f : funcs_to_ranges)
-            for (auto eit = f->extents().begin(); eit != f->extents().end(); ++eit)
-                func_range.insert(std::make_pair((*eit)->start(), (*eit)->end()));
+        for (Function *f : funcs_to_ranges)
+            for (FuncExtent *ext : f->extents())
+                func_range.insert(std::make_pair(ext->start(), ext->end()));
         if (!funcs_to_ranges.empty())
             finalize_ranges();
     }

--- a/parseAPI/src/Parser-speculative.C
+++ b/parseAPI/src/Parser-speculative.C
@@ -348,25 +348,25 @@ void Parser::parse_gap_heuristic(CodeRegion * cr)
 }
 
 bool Parser::getGapRange(CodeRegion* cr, Address curAddr, Address& gapStart, Address& gapEnd,
-                         const std::set<std::pair<Address, Address> >& func_range) {
-    // func_range -- a start-ordered set of every parsed function's extents -- is built
+                         const std::set<std::pair<Address, Address> >& known_extents) {
+    // known_extents -- a start-ordered set of every parsed function's extents -- is built
     // and maintained by the caller (probabilistic_gap_parsing) rather than rebuilt from
     // sorted_funcs on every call; that per-call O(F) rebuild was the speculative pass's
     // O(gaps x F) hot spot. The logic below is otherwise unchanged.
-    auto iter = func_range.upper_bound(make_pair(curAddr, std::numeric_limits<Address>::max() ));
-    if (iter == func_range.end()) {
+    auto iter = known_extents.upper_bound(make_pair(curAddr, std::numeric_limits<Address>::max() ));
+    if (iter == known_extents.end()) {
         gapEnd = cr->offset() + cr->length();
     } else {
         gapEnd = iter->first;
     }
-    if (iter == func_range.begin()) {
+    if (iter == known_extents.begin()) {
         gapStart = curAddr;
     } else {
-	--iter;
+        --iter;
         if (iter->second > curAddr) {
-	    gapStart = iter->second;
+            gapStart = iter->second;
         } else {
-	    gapStart = curAddr;
+            gapStart = curAddr;
         }
     }
     return gapStart < gapEnd;
@@ -397,10 +397,10 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
     // Start-ordered index of every parsed extent (start,end). Built once; maintained
     // incrementally below. getGapRange queries this instead of rebuilding it from
     // sorted_funcs on every call (the old O(gaps x F) hot spot). See getGapRange.
-    std::set<std::pair<Address, Address> > func_range;
-    for (Function *f : sorted_funcs)
-        for (FuncExtent *ext : f->extents())
-            func_range.insert(std::make_pair(ext->start(), ext->end()));
+    std::set<std::pair<Address, Address> > known_extents;
+    for (auto f : sorted_funcs)
+        for (auto ext : f->extents())
+            known_extents.insert(std::make_pair(ext->start(), ext->end()));
 
     Address gapStart;
     Address gapEnd;
@@ -413,7 +413,7 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
     const Address regBeg = cr->offset();
     const Address regEnd = cr->offset() + cr->length();
     gap_progress_report("starting speculative gap parsing", regBeg, regBeg, regEnd);
-    while (getGapRange(cr, curAddr, gapStart, gapEnd, func_range)) {
+    while (getGapRange(cr, curAddr, gapStart, gapEnd, known_extents)) {
         parsing_printf("[%s] scanning for FEP in [%lx,%lx)\n",
             FILE__,gapStart,gapEnd);
         for(curAddr=gapStart; curAddr < gapEnd; ++curAddr) {
@@ -431,9 +431,9 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
         // Fold gap-discovered functions into the index, then drain funcs_to_ranges
         // into funcsByRange (keeping other consumers current and the fold incremental
         // -- next iteration only sees newly-finalized functions).
-        for (Function *f : funcs_to_ranges)
-            for (FuncExtent *ext : f->extents())
-                func_range.insert(std::make_pair(ext->start(), ext->end()));
+        for (auto f : funcs_to_ranges)
+            for (auto ext : f->extents())
+                known_extents.insert(std::make_pair(ext->start(), ext->end()));
         if (!funcs_to_ranges.empty())
             finalize_ranges();
     }

--- a/parseAPI/src/Parser.h
+++ b/parseAPI/src/Parser.h
@@ -186,7 +186,7 @@ namespace Dyninst {
             void parse_gap_heuristic(CodeRegion *cr);
 
             bool getGapRange(CodeRegion*, Address, Address&, Address&,
-                             const std::set<std::pair<Address, Address> >&);
+                             const std::set<std::pair<Address, Address> >& known_extents);
             void probabilistic_gap_parsing(CodeRegion *cr);
 
             ParseFrame::Status frame_status(CodeRegion *cr, Address addr);

--- a/parseAPI/src/Parser.h
+++ b/parseAPI/src/Parser.h
@@ -185,7 +185,8 @@ namespace Dyninst {
             void cleanup_frames();
             void parse_gap_heuristic(CodeRegion *cr);
 
-            bool getGapRange(CodeRegion*, Address, Address&, Address&);
+            bool getGapRange(CodeRegion*, Address, Address&, Address&,
+                             const std::set<std::pair<Address, Address> >&);
             void probabilistic_gap_parsing(CodeRegion *cr);
 
             ParseFrame::Status frame_status(CodeRegion *cr, Address addr);


### PR DESCRIPTION
parseAPI: speed up speculative getGapRange without changing its result
Parser::getGapRange located the gap around curAddr by rebuilding a start-ordered
set of *every* parsed function's extents on every call. It runs once per gap
found during speculative parsing, so the pass was ~O(gaps x functions); on a
large, symbol-rich library (e.g. a ~400 MB shared object with ~250k functions)
that per-call rebuild dominated rewrite time -- the speculative pass ran for
hours while the recursive-descent parse before it finished in seconds.

Build the start-ordered extent index ONCE in probabilistic_gap_parsing and pass
it to getGapRange, which keeps the original upper_bound logic verbatim (so the
gaps scanned are byte-for-byte identical). After each gap-discovered function is
finalized, fold its extents into the index incrementally; funcs_to_ranges is
drained into funcsByRange up front and after each discovery to keep that tree
current for other consumers. The pass drops from O(gaps x F) to
O(F + gaps x log F) -- hours to ~seconds on the large-library case -- with no
change to results.

