### PR TITLE
dyninstAPI: parallel liveness pre-warm before code generation

### DIFF
--- a/dataflowAPI/h/liveness.h
+++ b/dataflowAPI/h/liveness.h
@@ -88,6 +88,11 @@ public:
 	void clean(ParseAPI::Function *func);
 	void clean();
 
+	// Merge another analyzer's per-function results into this one (used to fold
+	// per-thread parallel-prewarm analyzers into the shared analyzer). Existing
+	// entries are kept; coincident keys (e.g. shared blocks) carry equal values.
+	void absorb(LivenessAnalyzer &other);
+
 	int getIndex(MachRegister machReg);
 	ABI* getABI() { return abi;}
 

--- a/dataflowAPI/src/liveness.C
+++ b/dataflowAPI/src/liveness.C
@@ -584,6 +584,16 @@ void LivenessAnalyzer::clean(){
 	cachedLivenessInfo.clean();
 }
 
+void LivenessAnalyzer::absorb(LivenessAnalyzer &other){
+	// std::map::insert(range) keeps any existing entry on a duplicate key. Block-
+	// level liveness is a property of the block + its (block-global) intraprocedural
+	// successors, so a block computed by two threads carries the same value -- keep
+	// either. Used to fold per-thread parallel-prewarm analyzers into the shared one.
+	blockLiveInfo.insert(other.blockLiveInfo.begin(), other.blockLiveInfo.end());
+	liveFuncCalculated.insert(other.liveFuncCalculated.begin(), other.liveFuncCalculated.end());
+	funcRegsDefined.insert(other.funcRegsDefined.begin(), other.funcRegsDefined.end());
+}
+
 void LivenessAnalyzer::clean(Function *func){
 
 	if (liveFuncCalculated.find(func) != liveFuncCalculated.end()){		

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -134,7 +134,7 @@ dyninst_library(
   DYNINST_DEPS common instructionAPI stackwalk pcontrol patchAPI parseAPI symtabAPI
   DYNINST_INTERNAL_DEPS dynDwarf dynElf ${_subprojects}
   PUBLIC_DEPS Dyninst::Boost_headers
-  PRIVATE_DEPS Threads::Threads Dyninst::PeParse
+  PRIVATE_DEPS Threads::Threads Dyninst::PeParse OpenMP::OpenMP_CXX
 )
 # cmake-format: on
 

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -37,6 +37,8 @@
 
 #include "patching/instPoint.h"
 #include "debug.h"
+#include "liveness.h"   // LivenessAnalyzer, for the parallel liveness pre-warm
+#include "BPatch.h"     // BPatch::bpatch->livenessAnalysisOn()
 
 // Two-level codeRange structure
 #include "mapped_object.h"
@@ -1666,6 +1668,39 @@ bool AddressSpace::relocateInt(FuncSet::const_iterator begin, FuncSet::const_ite
 
   relocation_cerr << "Debugging CodeMover" << endl;
   relocation_cerr << cm->format() << endl;
+
+  // Parallel liveness pre-warm. With liveness analysis on, register liveness is
+  // otherwise computed lazily and serially at code-generation time -- by both the
+  // coverage trampolines AND the relocation widgets (e.g. RelDataPatch for
+  // PC-relative fixups, which are created during relocation) -- each via analyze(F)
+  // on the shared liveness analyzer. That per-function analysis dominates rewrite
+  // time on a large binary. Liveness is per-function and intraprocedural, so analyze
+  // every function in parallel here, each thread using its own analyzer (no shared
+  // analyzer state during analysis), then merge the per-function results into the
+  // shared analyzer that instPoint::liveRegisters() reads. Code generation then
+  // finds analyze(F) already cached for every liveness query -- coverage and
+  // relocation alike. Purely a cache warm-up: results are identical to the serial
+  // path, and anything not warmed is still computed on demand there.
+  if (BPatch::bpatch && BPatch::bpatch->livenessAnalysisOn() && begin != end) {
+    std::vector<func_instance *> funcs(begin, end);
+    int width = funcs[0]->ifunc()->region()->getAddressWidth();
+    LivenessAnalyzer *shared = instPoint::livenessAnalyzer(width);
+    // Warm the shared ABI singleton serially (it is lazily created the first time a
+    // LivenessAnalyzer is constructed; concurrent first-creation would race).
+    { LivenessAnalyzer abiWarm(width); (void)abiWarm; }
+    long n = (long) funcs.size();
+#pragma omp parallel
+    {
+      // Per-thread analyzer: analyze() writes only to this thread's caches.
+      LivenessAnalyzer local(width);
+#pragma omp for schedule(dynamic, 64)
+      for (long i = 0; i < n; ++i)
+        local.analyze(funcs[i]->ifunc());
+      // Fold this thread's per-function results into the shared analyzer.
+#pragma omp critical
+      shared->absorb(local);
+    }
+  }
 
   relocation_cerr << "  Entering code generation loop" << endl;
   Address baseAddr = generateCode(cm, nearTo);

--- a/dyninstAPI/src/patching/instPoint.C
+++ b/dyninstAPI/src/patching/instPoint.C
@@ -471,14 +471,26 @@ void instPoint::markModified() {
    }
 }
          
-bitArray instPoint::liveRegisters(){
+LivenessAnalyzer *instPoint::livenessAnalyzer(int addressWidth){
 	static LivenessAnalyzer live1(4);
 	static LivenessAnalyzer live2(8);
-	LivenessAnalyzer *live;
-	if (func()->function()->region()->getAddressWidth() == 4) live = &live1; else live = &live2;
+	return (addressWidth == 4) ? &live1 : &live2;
+}
+
+bitArray instPoint::liveRegisters(){
+	fillLiveRegisters(livenessAnalyzer(func()->function()->region()->getAddressWidth()));
+	return liveRegs_;
+}
+
+// Compute liveRegs_ using a caller-provided analyzer. Idempotent: if liveRegs_ is
+// already populated (cached from a prior call or a parallel pre-warm), returns
+// immediately. Splitting this out of liveRegisters() lets a pre-warm pass fill
+// liveRegs_ with a thread-local analyzer; the serial code-gen path then just hits
+// the cached value.
+void instPoint::fillLiveRegisters(LivenessAnalyzer *live){
 	if (liveRegs_.size() && liveRegs_.size() == live->getABI()->getAllRegs().size()){
-		return liveRegs_;
-	}	
+		return;
+	}
 	switch(type()) {
 		case FuncEntry:
 			if (!live->query(ParseAPI::Location(EntrySite(func()->function(), func()->function()->entry())), LivenessAnalyzer::Before, liveRegs_)) assert(0);
@@ -508,8 +520,6 @@ bitArray instPoint::liveRegisters(){
 		        if (!live->query(ParseAPI::Location(func()->function(), InsnLoc(block()->block(), insnAddr() - func()->obj()->codeBase(), insn())), LivenessAnalyzer::After, liveRegs_)) assert(0);
 			break;
 		default:
-			assert(0);  
+			assert(0);
 	}
-	return liveRegs_;
-
 }

--- a/dyninstAPI/src/patching/instPoint.h
+++ b/dyninstAPI/src/patching/instPoint.h
@@ -52,6 +52,7 @@ class block_instance;
 class func_instance;
 class edge_instance;
 class baseTramp;
+class LivenessAnalyzer;
 
 class instPoint;
 
@@ -135,6 +136,15 @@ class instPoint : public Dyninst::PatchAPI::Point {
     Address addr_compat() const;
 
     bitArray liveRegisters();
+    // Compute liveRegs_ using a caller-supplied analyzer (lets a parallel pre-warm
+    // populate it with a thread-local analyzer, off the serial code-gen path).
+    // Idempotent; the no-arg liveRegisters() delegates here with a shared analyzer.
+    void fillLiveRegisters(LivenessAnalyzer *live);
+    // The process-global liveness analyzer used at code-gen time (one per address
+    // width). Exposed so a pre-warm pass can populate the *same* instance that
+    // liveRegisters() reads, so analyze(F) is cached for every code-gen liveness
+    // query -- coverage trampolines and relocation widgets alike.
+    static LivenessAnalyzer *livenessAnalyzer(int addressWidth);
 
     std::string format() const;
 


### PR DESCRIPTION
With liveness analysis on, register liveness is otherwise computed lazily and serially at code-generation time -- by both the coverage trampolines and the relocation widgets (e.g. RelDataPatch for PC-relative fixups, created during relocation) -- each via LivenessAnalyzer::analyze(F) on the shared analyzer. 

Liveness is per-function and intraprocedural (call sites use ABI conventions, no callee recursion), so analyze every function in parallel before generateCode() and warm the *shared* analyzer that instPoint::liveRegisters() reads:

  - instPoint::livenessAnalyzer(width): expose the process-global per-width analyzers (was a function-local static), so the pre-warm populates the same instance code generation reads.
  - LivenessAnalyzer::absorb(): merge another analyzer's per-function caches (blockLiveInfo/liveFuncCalculated/funcRegsDefined). Shared blocks carry equal values, so keep-either is correct.
  - AddressSpace::relocateInt: before generateCode(), each thread analyzes a slice of the functions into its own analyzer (no shared analyzer state during analysis; CFG reads are block-locked, ABI singleton warmed serially first), then merges into the shared analyzer under a critical section.
  - instPoint::fillLiveRegisters(LivenessAnalyzer*): split out of liveRegisters() (idempotent via the liveRegs_ cache).
  - CMakeLists: add OpenMP::OpenMP_CXX to dyninstAPI (as symtabAPI/parseAPI do).

Pure cache warm-up: results match the serial path, and any function not warmed is still analyzed on demand at code-gen time. Code generation then finds analyze(F) cached for every liveness query -- coverage and relocation alike.

On the example libtorch_cpu.so with 250k functions, shorten liveness time from 36 minutes to 4 minutes.