### PR TITLE
dataflowAPI: restore register/memory abslocs in convertAll

### DIFF
--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -60,8 +60,24 @@ void AbsRegionConverter::convertAll(InstructionAPI::Expression::Ptr expr,
 				    ParseAPI::Function *func,
                                     ParseAPI::Block *block,
 				    std::vector<AbsRegion> &regions) {
-  for(auto reg : getUsedRegisters(expr)) {
-    regions.push_back(convert(reg, addr, func, block));
+  // If this is a memory dereference, classify the location it accesses by
+  // converting the *whole* address subexpression (registers + immediate
+  // offsets) with the expression-aware overload. That is what resolves a
+  // stack slot, frame slot, or absolute/heap memory location -- it must see
+  // the full address expression, not just the leaf registers.
+  if (auto deref = boost::dynamic_pointer_cast<Dereference>(expr)) {
+    for (auto c : deref->getSubexpressions()) {
+      regions.push_back(convert(c, addr, func, block));
+    }
+  }
+
+  // Add the registers the expression reads as plain register abslocs. For a
+  // dereference these are the address-computation registers; otherwise this
+  // is the operand's register(s) themselves. Use the register-preserving
+  // overload -- routing a bare register through the expression-aware overload
+  // collapses any non-SP/FP/PC register to Absloc::Heap.
+  for (auto reg : getUsedRegisters(expr)) {
+    regions.push_back(convert(reg));
   }
 }
 


### PR DESCRIPTION
Commit 84d95d0 ("Deprecate Expression::getUses") rewrote AbsRegionConverter::convertAll(Expression, ...) to route every used register through the expression-aware 4-arg convert() overload. That overload evaluates an expression as a memory address and only binds SP/FP/PC; any other register is treated as an undefined address and collapses to Absloc::Heap. It also dropped the Dereference branch that classified the accessed memory location.

This regressed AMDGPU indirect control flow: the SGPR pair feeding S_SETPC_B64 / S_SWAPPC_B64 (and the SGPRs defined by the address arithmetic that produces it) became Heap abslocs instead of register abslocs, so the def/use chains no longer connected and the indirect target could not be resolved. It also dropped the immediate offset from stack/frame memory operands on other architectures.

Restore the pre-84d95d0 two-path behavior while keeping the modern getUsedRegisters() API instead of the deprecated getUses():
  - classify a memory dereference via the 4-arg overload on the whole address subexpression (offsets preserved -> correct stack/frame/mem)
  - add the registers the expression reads as plain register abslocs via the register-preserving 1-arg convert() overload