### PR TITLE
parseAPI: avoid duplicate edges on delayed indirect jumps

### DIFF
--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -1853,7 +1853,13 @@ Parser::parse_frame_one_iteration(ParseFrame &frame, bool recursive) {
                     // Create a work element to represent that
                     // we will resolve the jump table later
                     end_block(cur,ahPtr);
-                    set_edge_parsing_status(frame,cur->last(), cur);
+                    // If another block already owns the edge ending at this
+                    // address, this block has been split to fall through into
+                    // that canonical block. The owning block is responsible for
+                    // resolving the indirect jump, so pushing another work
+                    // element here would add a duplicate edge to the same block
+                    // when it is later resolved.
+                    if (!set_edge_parsing_status(frame,cur->last(), cur)) break;
                     frame.pushWork( frame.mkWork( work->bundle(), cur, ahPtr));
                 } else {
                     end_block(cur,ahPtr);


### PR DESCRIPTION
When a block ends in an indirect jump (e.g. AMDGPU s_setpc_b64), the parser defers jump-table resolution by pushing a resolve_jump_table work element. Unlike the direct-CFT path, the indirect path ignored the return value of set_edge_parsing_status().

When several overlapping blocks end at the same indirect-jump address, only the first claims the edge; the rest are split to fall through into that canonical block. But each colliding block still pushed its own resolve work, and ProcessCFInsn always re-attaches the resolved edge to the canonical block (cur = a->second.b). The result was one duplicate sink edge per collision (e.g. s_setpc_b64 repeated 5 times at 0x14c70 in test_binaries/2-90a.gpubin).

Respect set_edge_parsing_status() in the indirect path, matching the direct path: only the block that owns the edge pushes the resolve work.