### PR TITLE
[parseAPI] Treat AMDGPU s_trap 0x02 (llvm.trap) as a block terminator

### DIFF
--- a/parseAPI/src/IA_amdgpu.C
+++ b/parseAPI/src/IA_amdgpu.C
@@ -140,3 +140,37 @@ bool IA_amdgpu::isNopJump() const
 {
     return false;
 }
+
+bool IA_amdgpu::isSoftwareException() const
+{
+    Instruction ci = curInsn();
+    auto id = ci.getOperation().getID();
+    if(id != amdgpu_gfx908_op_S_TRAP &&
+       id != amdgpu_gfx90a_op_S_TRAP &&
+       id != amdgpu_gfx940_op_S_TRAP)
+        return IA_IAPI::isSoftwareException();
+
+    // s_trap takes a 16-bit immediate whose low 8 bits are the trap ID.
+    //
+    // The per-trap-ID behavior is defined by the AMDGPU trap handler ABI in the
+    // LLVM AMDGPU backend documentation:
+    //   https://llvm.org/docs/AMDGPUUsage.html#trap-handler-abi
+    // (see the "AMDGPU Trap Handler for AMDHSA OS Code Object V3 / V4 and Above"
+    // tables). Summarizing the relevant trap IDs:
+    //   - 0x01 (debugger breakpoint): the wave is halted and the debugger
+    //     resumes it, re-executing the overwritten instruction. Execution
+    //     continues, so the fall-through must be preserved.
+    //   - 0x02 (llvm.trap): the wave is halted and its queue is put into the
+    //     error state, terminating the dispatch's waves. It does not return,
+    //     so this is the only s_trap that ends the block with no fall-through.
+    //   - 0x03 (llvm.debugtrap): a no-op when no debugger is attached, otherwise
+    //     reported to the debugger which resumes the wave. Either way execution
+    //     continues, so the fall-through must be preserved.
+    // All other trap IDs are reserved and are left to fall through.
+    Immediate::Ptr imm =
+        boost::dynamic_pointer_cast<Immediate>(ci.getOperand(0).getValue());
+    if(!imm)
+        return false;
+    Result trapId = imm->eval();
+    return trapId.defined && ((trapId.val.s16val & 0xff) == 0x02);
+}

--- a/parseAPI/src/IA_amdgpu.h
+++ b/parseAPI/src/IA_amdgpu.h
@@ -65,6 +65,7 @@ class IA_amdgpu : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+	virtual bool isSoftwareException() const;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };


### PR DESCRIPTION
s_trap was decoded as an ordinary scalar instruction with no control-flow category, so parseAPI gave it an implicit fall-through and kept parsing the bytes after it. For non-returning traps (s_trap 0x02, the lowering of llvm.trap) the following bytes are padding/garbage, leading to mis-parses.

Override IA_amdgpu::isSoftwareException() to recognize s_trap and inspect its trap ID (low 8 bits of the SIMM16 immediate). Only trap ID 0x02 terminates the wavefront, so only it is reported as a software exception, which makes the parser end the block with no fall-through edge. Trap IDs 0x01 (debugger breakpoint) and 0x03 (llvm.debugtrap) resume execution, so they keep their fall-through; all other (reserved) trap IDs are left unchanged.

The trap-ID semantics follow the LLVM AMDGPU trap handler ABI: https://llvm.org/docs/AMDGPUUsage.html#trap-handler-abi

The distinction depends on the immediate operand, so it cannot be expressed in the opcode-only entryToCategory()/allowsFallThrough() paths and is handled in the AMDGPU parse adapter instead.