### PR TITLE
Add DYNINST_REPORT_PROGRESS rewrite-progress reporting

### DIFF
--- a/common/src/debug_common.C
+++ b/common/src/debug_common.C
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <time.h>     // progress timestamps (progress_printf_int)
 
 #include "common/src/debug_common.h"
 
@@ -38,6 +39,7 @@ int common_debug_dwarf = 0;
 int common_debug_addrtranslate = 0;
 int common_debug_lineinfo = 0;
 int common_debug_parsing = 0;
+int common_debug_progress = 0;
 int common_debug_initialized = 0;
 
 bool init_debug_common() {
@@ -59,6 +61,15 @@ bool init_debug_common() {
     
     if(getenv("COMMON_DEBUG_PARSING")){
         common_debug_parsing = 1;  
+    }
+
+    // Match the dyninstAPI check_env_value() truthiness (set and non-zero) so the
+    // single DYNINST_DEBUG_PROGRESS knob behaves identically across both layers.
+    {
+        const char *v = getenv("DYNINST_DEBUG_PROGRESS");
+        if (v && atoi(v) != 0) {
+            common_debug_progress = 1;
+        }
     }
 
     return true;
@@ -112,6 +123,32 @@ int common_parsing_printf_int(const char *format, ...)
    init_debug_common();
   if (!common_debug_parsing) return 0;
   if (NULL == format) return -1;
+
+  va_list va;
+  va_start(va, format);
+  int ret = vfprintf(stderr, format, va);
+  va_end(va);
+
+  return ret;
+}
+
+int progress_printf_int(const char *format, ...)
+{
+   init_debug_common();
+  if (!common_debug_progress) return 0;
+  if (NULL == format) return -1;
+
+  // Unlike the other debug channels, prefix each progress line with a wall-clock
+  // timestamp so phase timing is visible during long rewrites/parses.
+  time_t now = time(NULL);
+  struct tm tmv;
+  char ts[40];
+#if defined(os_windows)
+  if (localtime_s(&tmv, &now) == 0 && strftime(ts, sizeof(ts), "[%Y-%m-%d %H:%M:%S] ", &tmv))
+#else
+  if (localtime_r(&now, &tmv) && strftime(ts, sizeof(ts), "[%Y-%m-%d %H:%M:%S] ", &tmv))
+#endif
+    fputs(ts, stderr);
 
   va_list va;
   va_start(va, format);

--- a/common/src/debug_common.C
+++ b/common/src/debug_common.C
@@ -143,16 +143,16 @@ int progress_printf_int(const char *format, ...)
   time_t now = time(NULL);
   struct tm tmv;
   char ts[40];
-#if defined(os_windows)
-  if (localtime_s(&tmv, &now) == 0 && strftime(ts, sizeof(ts), "[%Y-%m-%d %H:%M:%S] ", &tmv))
-#else
-  if (localtime_r(&now, &tmv) && strftime(ts, sizeof(ts), "[%Y-%m-%d %H:%M:%S] ", &tmv))
-#endif
-    fputs(ts, stderr);
 
   va_list va;
   va_start(va, format);
+  // Hold the stream lock across the timestamp and the message so concurrent
+  // writers cannot interleave output between the two.
+  flockfile(stderr);
+  if (localtime_r(&now, &tmv) && strftime(ts, sizeof(ts), "[%Y-%m-%d %H:%M:%S] ", &tmv))
+    fputs(ts, stderr);
   int ret = vfprintf(stderr, format, va);
+  funlockfile(stderr);
   va_end(va);
 
   return ret;

--- a/common/src/debug_common.h
+++ b/common/src/debug_common.h
@@ -39,6 +39,7 @@ DYNINST_EXPORT extern int common_debug_dwarf;
 DYNINST_EXPORT extern int common_debug_addrtranslate;
 DYNINST_EXPORT extern int common_debug_lineinfo;
 DYNINST_EXPORT extern int common_debug_parsing;
+DYNINST_EXPORT extern int common_debug_progress;  // coarse rewrite/parse-progress reporting (DYNINST_DEBUG_PROGRESS)
 DYNINST_EXPORT extern int common_debug_initialized;
 
 #define common_debug_printf(debug_sys_var, debug_sys_printf, ...) \
@@ -62,6 +63,16 @@ DYNINST_EXPORT int lineinfo_printf_int(const char *format, ...)
         DYNINST_PRINTF_ANNOTATION(1, 2);
 DYNINST_EXPORT int common_parsing_printf_int(const char *format, ...)
         DYNINST_PRINTF_ANNOTATION(1, 2);
+
+// Coarse, opt-in progress channel (DYNINST_DEBUG_PROGRESS), shared by dyninstAPI
+// and parseAPI. Each line is prefixed with a wall-clock timestamp so phases can
+// be timed directly from the log. progress_printf_int() is self-gating: it
+// initializes the common debug state and checks common_debug_progress before
+// printing, so it is safe -- and a no-op -- to call when the env var is unset.
+DYNINST_EXPORT int progress_printf_int(const char *format, ...)
+        DYNINST_PRINTF_ANNOTATION(1, 2);
+
+#define progress_printf(...) progress_printf_int(__VA_ARGS__)
 
 // And initialization
 DYNINST_EXPORT bool init_debug_common();

--- a/dyninstAPI/src/BPatch/BPatch_binaryEdit.C
+++ b/dyninstAPI/src/BPatch/BPatch_binaryEdit.C
@@ -199,17 +199,17 @@ bool BPatch_binaryEdit::writeFile(const char * outFile)
     getAS(as);
     bool ret = true;
 
-    // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). Committing pending
+    // Rewrite-progress reporting (DYNINST_DEBUG_PROGRESS). Committing pending
     // instrumentation and then writing each output file are otherwise silent and
     // dominate wall time on a large rewrite.
-    progress_printf("[dyninst] write: committing pending instrumentation to %s\n", outFile);
+    progress_printf("write: committing pending instrumentation to %s\n", outFile);
 
     /* PatchAPI stuffs */
     if (as.size() > 0) {
       ret = AddressSpace::patch(as[0]);
     }
     /* end of PatchAPI stuffs */
-    progress_printf("[dyninst] write: instrumentation committed\n");
+    progress_printf("write: instrumentation committed\n");
 
 
    // Now that we've instrumented we can see if we need to replace the
@@ -223,7 +223,7 @@ bool BPatch_binaryEdit::writeFile(const char * outFile)
    }
 
 
-   progress_printf("[dyninst] write: writing primary output file %s\n", outFile);
+   progress_printf("write: writing primary output file %s\n", outFile);
    if( !origBinEdit->writeFile(outFile) ) return false;
 #if defined(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
    std::string inputFileName = this->getImage()->getProgramFileName();
@@ -242,10 +242,10 @@ bool BPatch_binaryEdit::writeFile(const char * outFile)
        continue;
 
      std::string newname = bin->getMappedObject()->fileName();
-     progress_printf("[dyninst] write: writing dependent library %s\n", newname.c_str());
+     progress_printf("write: writing dependent library %s\n", newname.c_str());
      if( !bin->writeFile(newname) ) return false;
    }
-   progress_printf("[dyninst] write: writeFile complete\n");
+   progress_printf("write: writeFile complete\n");
    return ret;
 }
 

--- a/dyninstAPI/src/BPatch/BPatch_binaryEdit.C
+++ b/dyninstAPI/src/BPatch/BPatch_binaryEdit.C
@@ -199,11 +199,17 @@ bool BPatch_binaryEdit::writeFile(const char * outFile)
     getAS(as);
     bool ret = true;
 
+    // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). Committing pending
+    // instrumentation and then writing each output file are otherwise silent and
+    // dominate wall time on a large rewrite.
+    progress_printf("[dyninst] write: committing pending instrumentation to %s\n", outFile);
+
     /* PatchAPI stuffs */
     if (as.size() > 0) {
       ret = AddressSpace::patch(as[0]);
     }
     /* end of PatchAPI stuffs */
+    progress_printf("[dyninst] write: instrumentation committed\n");
 
 
    // Now that we've instrumented we can see if we need to replace the
@@ -217,6 +223,7 @@ bool BPatch_binaryEdit::writeFile(const char * outFile)
    }
 
 
+   progress_printf("[dyninst] write: writing primary output file %s\n", outFile);
    if( !origBinEdit->writeFile(outFile) ) return false;
 #if defined(DYNINST_CODEGEN_ARCH_AMDGPU_GFX908)
    std::string inputFileName = this->getImage()->getProgramFileName();
@@ -235,8 +242,10 @@ bool BPatch_binaryEdit::writeFile(const char * outFile)
        continue;
 
      std::string newname = bin->getMappedObject()->fileName();
+     progress_printf("[dyninst] write: writing dependent library %s\n", newname.c_str());
      if( !bin->writeFile(newname) ) return false;
    }
+   progress_printf("[dyninst] write: writeFile complete\n");
    return ret;
 }
 

--- a/dyninstAPI/src/Relocation/CodeBuffer.C
+++ b/dyninstAPI/src/Relocation/CodeBuffer.C
@@ -258,14 +258,12 @@ bool CodeBuffer::generate(Address baseAddr) {
       gen_.allocate(size_);
       totalPadding = 0;
 
-      // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). This do/while is a
+      // Rewrite-progress reporting (DYNINST_DEBUG_PROGRESS). This do/while is a
       // fixpoint: a branch whose displacement grew forces a full re-emit, so on a
       // large rewrite (millions of buffer elements) this can take many silent
-      // passes. Report each pass and periodic progress within it.
-      const size_t progTotal = dyn_debug_progress ? buffers_.size() : 0;
-      progress_printf("[dyninst] relocate: emit codebuffer pass %d over %zu buffer elements\n",
-                      curIteration_, progTotal);
-      size_t progN = 0;
+      // passes. Report each pass.
+      progress_printf("relocate: emit codebuffer pass %d over %zu buffer elements\n",
+                      curIteration_, buffers_.size());
       for (Buffers::iterator iter = buffers_.begin();
            iter != buffers_.end(); ++iter) {
 	bool regenerate = false;
@@ -273,13 +271,10 @@ bool CodeBuffer::generate(Address baseAddr) {
             return false;
          }
          doOver |= regenerate;
-         if ((++progN % 500000) == 0)
-            progress_printf("[dyninst] relocate: emit pass %d, %zu/%zu buffer elements\n",
-                            curIteration_, progN, progTotal);
       }
 
    } while (doOver);
-   progress_printf("[dyninst] relocate: emit codebuffer converged after %d pass(es), %u bytes\n",
+   progress_printf("relocate: emit codebuffer converged after %d pass(es), %u bytes\n",
                    curIteration_, gen_.used());
 
    shift_ = 0;

--- a/dyninstAPI/src/Relocation/CodeBuffer.C
+++ b/dyninstAPI/src/Relocation/CodeBuffer.C
@@ -258,6 +258,14 @@ bool CodeBuffer::generate(Address baseAddr) {
       gen_.allocate(size_);
       totalPadding = 0;
 
+      // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). This do/while is a
+      // fixpoint: a branch whose displacement grew forces a full re-emit, so on a
+      // large rewrite (millions of buffer elements) this can take many silent
+      // passes. Report each pass and periodic progress within it.
+      const size_t progTotal = dyn_debug_progress ? buffers_.size() : 0;
+      progress_printf("[dyninst] relocate: emit codebuffer pass %d over %zu buffer elements\n",
+                      curIteration_, progTotal);
+      size_t progN = 0;
       for (Buffers::iterator iter = buffers_.begin();
            iter != buffers_.end(); ++iter) {
 	bool regenerate = false;
@@ -265,9 +273,14 @@ bool CodeBuffer::generate(Address baseAddr) {
             return false;
          }
          doOver |= regenerate;
+         if ((++progN % 500000) == 0)
+            progress_printf("[dyninst] relocate: emit pass %d, %zu/%zu buffer elements\n",
+                            curIteration_, progN, progTotal);
       }
-      
+
    } while (doOver);
+   progress_printf("[dyninst] relocate: emit codebuffer converged after %d pass(es), %u bytes\n",
+                   curIteration_, gen_.used());
 
    shift_ = 0;
    size_ = gen_.used();

--- a/dyninstAPI/src/Relocation/CodeMover.C
+++ b/dyninstAPI/src/Relocation/CodeMover.C
@@ -72,17 +72,14 @@ CodeMover::~CodeMover() {
 
 bool CodeMover::addFunctions(FuncSet::const_iterator begin, 
 			     FuncSet::const_iterator end) {
-   // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). The per-function build
+   // Rewrite-progress reporting (DYNINST_DEBUG_PROGRESS). The per-function build
    // loop and the per-block codegen loop are otherwise silent, so a large binary
    // rewrite (e.g. a multi-hundred-MB shared library) can look hung for a long time.
-   const size_t progTotal = dyn_debug_progress ? (size_t)std::distance(begin, end) : 0;
-   size_t progN = 0;
-   progress_printf("[dyninst] relocate: building reloc blocks for %zu functions\n", progTotal);
+   progress_printf("relocate: building reloc blocks for %zu functions\n",
+                   (size_t)std::distance(begin, end));
    // A vector of Functions is just an extended vector of basic blocks...
    for (; begin != end; ++begin) {
       func_instance *func = *begin;
-      if ((++progN % 2000) == 0)
-         progress_printf("[dyninst] relocate: scanned %zu/%zu functions\n", progN, progTotal);
       if (!func->isInstrumentable()) {
 	relocation_cerr << "\tFunction " << func->symTabName() << " is non-instrumentable, skipping" << endl;
          continue;
@@ -158,7 +155,6 @@ bool CodeMover::initialize(const codeGen &templ) {
       finalizeRelocBlocks();
    
    // Tell all the blocks to do their generation thang...
-   size_t progN = 0;
    for (RelocBlock *iter = cfg_->begin(); iter != cfg_->end(); iter = iter->next()) {
       if (!iter->finalizeCF()) return false;
 
@@ -166,10 +162,8 @@ bool CodeMover::initialize(const codeGen &templ) {
          cerr << "ERROR: failed to generate RelocBlock!" << endl;
          return false; // Catastrophic failure
       }
-      if ((++progN % 20000) == 0)
-         progress_printf("[dyninst] relocate: generated %zu reloc blocks\n", progN);
    }
-   progress_printf("[dyninst] relocate: generated %zu reloc blocks (codegen done)\n", progN);
+   progress_printf("relocate: reloc block code generation done\n");
    return true;
 }
 

--- a/dyninstAPI/src/Relocation/CodeMover.C
+++ b/dyninstAPI/src/Relocation/CodeMover.C
@@ -42,6 +42,8 @@
 #include "CodeTracker.h"
 #include "CFG/RelocGraph.h"
 
+#include <iterator>  // std::distance (rewrite-progress reporting)
+
 using namespace std;
 using namespace Dyninst;
 using namespace InstructionAPI;
@@ -70,9 +72,17 @@ CodeMover::~CodeMover() {
 
 bool CodeMover::addFunctions(FuncSet::const_iterator begin, 
 			     FuncSet::const_iterator end) {
+   // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). The per-function build
+   // loop and the per-block codegen loop are otherwise silent, so a large binary
+   // rewrite (e.g. a multi-hundred-MB shared library) can look hung for a long time.
+   const size_t progTotal = dyn_debug_progress ? (size_t)std::distance(begin, end) : 0;
+   size_t progN = 0;
+   progress_printf("[dyninst] relocate: building reloc blocks for %zu functions\n", progTotal);
    // A vector of Functions is just an extended vector of basic blocks...
    for (; begin != end; ++begin) {
       func_instance *func = *begin;
+      if ((++progN % 2000) == 0)
+         progress_printf("[dyninst] relocate: scanned %zu/%zu functions\n", progN, progTotal);
       if (!func->isInstrumentable()) {
 	relocation_cerr << "\tFunction " << func->symTabName() << " is non-instrumentable, skipping" << endl;
          continue;
@@ -148,14 +158,18 @@ bool CodeMover::initialize(const codeGen &templ) {
       finalizeRelocBlocks();
    
    // Tell all the blocks to do their generation thang...
+   size_t progN = 0;
    for (RelocBlock *iter = cfg_->begin(); iter != cfg_->end(); iter = iter->next()) {
       if (!iter->finalizeCF()) return false;
-      
+
       if (!iter->generate(templ, buffer_)) {
          cerr << "ERROR: failed to generate RelocBlock!" << endl;
          return false; // Catastrophic failure
       }
+      if ((++progN % 20000) == 0)
+         progress_printf("[dyninst] relocate: generated %zu reloc blocks\n", progN);
    }
+   progress_printf("[dyninst] relocate: generated %zu reloc blocks (codegen done)\n", progN);
    return true;
 }
 

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -1662,13 +1662,13 @@ bool AddressSpace::relocateInt(FuncSet::const_iterator begin, FuncSet::const_ite
 
   relocation_cerr << "Debugging CodeMover (pre-transform)" << endl;
   relocation_cerr << cm->format() << endl;
-  progress_printf("[dyninst] relocate: applying instrumentation transforms\n");
+  progress_printf("relocate: applying instrumentation transforms\n");
   transform(cm);
 
   relocation_cerr << "Debugging CodeMover" << endl;
   relocation_cerr << cm->format() << endl;
 
-  progress_printf("[dyninst] relocate: generating code\n");
+  progress_printf("relocate: generating code\n");
   relocation_cerr << "  Entering code generation loop" << endl;
   Address baseAddr = generateCode(cm, nearTo);
   if (!baseAddr) {
@@ -1690,7 +1690,7 @@ bool AddressSpace::relocateInt(FuncSet::const_iterator begin, FuncSet::const_ite
     return false;
 
   // Now handle patching; AKA linking
-  progress_printf("[dyninst] relocate: patching jumps/springboards\n");
+  progress_printf("relocate: patching jumps/springboards\n");
   relocation_cerr << "  Patching in jumps to generated code" << endl;
 
   if (!patchCode(cm, spb)) {
@@ -1825,12 +1825,12 @@ Address AddressSpace::generateCode(CodeMover::Ptr cm, Address nearTo) {
     return 0;
   }
 
-  // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). The loop below is an
+  // Rewrite-progress reporting (DYNINST_DEBUG_PROGRESS). The loop below is an
   // address-fixpoint: emit all relocated code, and if it does not fit the
   // allocated space, free and retry. On a large rewrite each pass re-emits
   // millions of blocks, so report each attempt.
   unsigned emitAttempt = 0;
-  progress_printf("[dyninst] relocate: emitting relocated code (address fixpoint)\n");
+  progress_printf("relocate: emitting relocated code (address fixpoint)\n");
   while (1) {
      relocation_cerr << "   Attempting to allocate " << cm->size() << "bytes" << endl;
     unsigned size = cm->size();
@@ -1841,7 +1841,7 @@ Address AddressSpace::generateCode(CodeMover::Ptr cm, Address nearTo) {
         size = 1;
     }
     baseAddr = inferiorMalloc(size, anyHeap, nearTo);
-    progress_printf("[dyninst] relocate: emit attempt %u (base=0x%lx, size=%u bytes)\n",
+    progress_printf("relocate: emit attempt %u (base=0x%lx, size=%u bytes)\n",
                     ++emitAttempt, (unsigned long)baseAddr, size);
 
     relocation_cerr << "   Calling CodeMover::relocate" << endl;

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -1662,11 +1662,13 @@ bool AddressSpace::relocateInt(FuncSet::const_iterator begin, FuncSet::const_ite
 
   relocation_cerr << "Debugging CodeMover (pre-transform)" << endl;
   relocation_cerr << cm->format() << endl;
+  progress_printf("[dyninst] relocate: applying instrumentation transforms\n");
   transform(cm);
 
   relocation_cerr << "Debugging CodeMover" << endl;
   relocation_cerr << cm->format() << endl;
 
+  progress_printf("[dyninst] relocate: generating code\n");
   relocation_cerr << "  Entering code generation loop" << endl;
   Address baseAddr = generateCode(cm, nearTo);
   if (!baseAddr) {
@@ -1688,6 +1690,7 @@ bool AddressSpace::relocateInt(FuncSet::const_iterator begin, FuncSet::const_ite
     return false;
 
   // Now handle patching; AKA linking
+  progress_printf("[dyninst] relocate: patching jumps/springboards\n");
   relocation_cerr << "  Patching in jumps to generated code" << endl;
 
   if (!patchCode(cm, spb)) {
@@ -1822,6 +1825,12 @@ Address AddressSpace::generateCode(CodeMover::Ptr cm, Address nearTo) {
     return 0;
   }
 
+  // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). The loop below is an
+  // address-fixpoint: emit all relocated code, and if it does not fit the
+  // allocated space, free and retry. On a large rewrite each pass re-emits
+  // millions of blocks, so report each attempt.
+  unsigned emitAttempt = 0;
+  progress_printf("[dyninst] relocate: emitting relocated code (address fixpoint)\n");
   while (1) {
      relocation_cerr << "   Attempting to allocate " << cm->size() << "bytes" << endl;
     unsigned size = cm->size();
@@ -1832,15 +1841,16 @@ Address AddressSpace::generateCode(CodeMover::Ptr cm, Address nearTo) {
         size = 1;
     }
     baseAddr = inferiorMalloc(size, anyHeap, nearTo);
-    
-    
+    progress_printf("[dyninst] relocate: emit attempt %u (base=0x%lx, size=%u bytes)\n",
+                    ++emitAttempt, (unsigned long)baseAddr, size);
+
     relocation_cerr << "   Calling CodeMover::relocate" << endl;
     if (!cm->relocate(baseAddr)) {
        // Whoa
        relocation_cerr << "   ERROR: CodeMover failed relocation!" << endl;
        return 0;
     }
-    
+
     // Either attempt to expand or shrink...
     relocation_cerr << "   Calling inferiorRealloc to fit new size " << cm->size() 
 		    << ", current base addr is " 

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -479,13 +479,13 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
          }
       }
 
-      // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). relocate() emits its
+      // Rewrite-progress reporting (DYNINST_DEBUG_PROGRESS). relocate() emits its
       // own per-phase markers, but the rest of writeFile -- assembling the in-memory
       // output image and emitting it to disk -- is otherwise silent and dominates
       // wall time on a large binary, so bracket each phase below.
-      progress_printf("[dyninst] write: relocating instrumented code (in memory)\n");
+      progress_printf("write: relocating instrumented code (in memory)\n");
       relocate();
-      progress_printf("[dyninst] write: relocation done; assembling output image\n");
+      progress_printf("write: relocation done; assembling output image\n");
 
       vector<Region*> oldSegs;
       symObj->getAllRegions(oldSegs);
@@ -519,12 +519,11 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       std::vector<codeRange *> writes;
       memoryTracker_.elements(writes);
 
-      // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). This copies every
+      // Rewrite-progress reporting (DYNINST_DEBUG_PROGRESS). This copies every
       // tracked region into the output buffer; on a large rewrite there are millions
-      // of them, so report the total up front and periodic progress within the loop.
-      progress_printf("[dyninst] write: copying %zu tracked regions into output buffer\n",
+      // of them, so bracket the loop with start/done markers.
+      progress_printf("write: copying %zu tracked regions into output buffer\n",
                       (size_t)writes.size());
-      size_t progCopied = 0;
       for (unsigned i = 0; i < writes.size(); i++) {
          assert(newSectionPtr);
          memoryTracker *tracker = dynamic_cast<memoryTracker *>(writes[i]);
@@ -537,11 +536,8 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
          assert((offset + tracker->get_size()) < highWaterMark_);
          void *ptr = (void *)(offset + (Address)newSectionPtr);
          memcpy(ptr, tracker->get_local_ptr(), tracker->get_size());
-         if (dyn_debug_progress && (++progCopied % 100000) == 0)
-            progress_printf("[dyninst] write: copied %zu/%zu regions\n",
-                            progCopied, (size_t)writes.size());
       }
-      progress_printf("[dyninst] write: copied %zu regions into output buffer\n", progCopied);
+      progress_printf("write: copied tracked regions into output buffer\n");
             
       // Righto. Now, that includes the old binary - by design - 
       // so skip it and see what we're talking about size-wise. Which should
@@ -594,7 +590,7 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
 	  symObj->getObject()->addModule(mod);
       }
       buildDyninstSymbols(newSyms, newSec, mod);
-      progress_printf("[dyninst] write: adding %zu instrumentation symbols to symbol table\n",
+      progress_printf("write: adding %zu instrumentation symbols to symbol table\n",
                       (size_t)newSyms.size());
       for (unsigned i = 0; i < newSyms.size(); i++) {
          symObj->addSymbol(newSyms[i]);
@@ -614,14 +610,14 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       
       
       // And now we generate the new binary
-      progress_printf("[dyninst] write: emitting output file %s (final on-disk write; can take a while for large binaries)\n",
+      progress_printf("write: emitting output file %s (final on-disk write; can take a while for large binaries)\n",
                       newFileName.c_str());
       if (!symObj->emit(newFileName.c_str())) {
          SymtabError lastError = Symtab::getLastSymtabError();
          showErrorCallback(109, Symtab::printError(lastError));
          return false;
       }
-      progress_printf("[dyninst] write: wrote output file %s\n", newFileName.c_str());
+      progress_printf("write: wrote output file %s\n", newFileName.c_str());
    return true;
 }
 

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -479,8 +479,14 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
          }
       }
 
+      // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). relocate() emits its
+      // own per-phase markers, but the rest of writeFile -- assembling the in-memory
+      // output image and emitting it to disk -- is otherwise silent and dominates
+      // wall time on a large binary, so bracket each phase below.
+      progress_printf("[dyninst] write: relocating instrumented code (in memory)\n");
       relocate();
-      
+      progress_printf("[dyninst] write: relocation done; assembling output image\n");
+
       vector<Region*> oldSegs;
       symObj->getAllRegions(oldSegs);
 
@@ -513,6 +519,12 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       std::vector<codeRange *> writes;
       memoryTracker_.elements(writes);
 
+      // Rewrite-progress reporting (DYNINST_REPORT_PROGRESS). This copies every
+      // tracked region into the output buffer; on a large rewrite there are millions
+      // of them, so report the total up front and periodic progress within the loop.
+      progress_printf("[dyninst] write: copying %zu tracked regions into output buffer\n",
+                      (size_t)writes.size());
+      size_t progCopied = 0;
       for (unsigned i = 0; i < writes.size(); i++) {
          assert(newSectionPtr);
          memoryTracker *tracker = dynamic_cast<memoryTracker *>(writes[i]);
@@ -525,7 +537,11 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
          assert((offset + tracker->get_size()) < highWaterMark_);
          void *ptr = (void *)(offset + (Address)newSectionPtr);
          memcpy(ptr, tracker->get_local_ptr(), tracker->get_size());
+         if (dyn_debug_progress && (++progCopied % 100000) == 0)
+            progress_printf("[dyninst] write: copied %zu/%zu regions\n",
+                            progCopied, (size_t)writes.size());
       }
+      progress_printf("[dyninst] write: copied %zu regions into output buffer\n", progCopied);
             
       // Righto. Now, that includes the old binary - by design - 
       // so skip it and see what we're talking about size-wise. Which should
@@ -578,6 +594,8 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
 	  symObj->getObject()->addModule(mod);
       }
       buildDyninstSymbols(newSyms, newSec, mod);
+      progress_printf("[dyninst] write: adding %zu instrumentation symbols to symbol table\n",
+                      (size_t)newSyms.size());
       for (unsigned i = 0; i < newSyms.size(); i++) {
          symObj->addSymbol(newSyms[i]);
       }
@@ -596,11 +614,14 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       
       
       // And now we generate the new binary
+      progress_printf("[dyninst] write: emitting output file %s (final on-disk write; can take a while for large binaries)\n",
+                      newFileName.c_str());
       if (!symObj->emit(newFileName.c_str())) {
          SymtabError lastError = Symtab::getLastSymtabError();
          showErrorCallback(109, Symtab::printError(lastError));
          return false;
       }
+      progress_printf("[dyninst] write: wrote output file %s\n", newFileName.c_str());
    return true;
 }
 

--- a/dyninstAPI/src/debug.C
+++ b/dyninstAPI/src/debug.C
@@ -33,7 +33,6 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <assert.h>
-#include <time.h>     // progress timestamps (progress_printf_int)
 #include <string>
 #include "BPatch.h"
 #include "dyninstAPI/src/debug.h"
@@ -222,7 +221,6 @@ int dyn_debug_proccontrol = 0;
 int dyn_debug_stackwalk = 0;
 int dyn_debug_inst = 0;
 int dyn_debug_reloc = 0;
-int dyn_debug_progress = 0;
 int dyn_debug_springboard = 0;
 int dyn_debug_sensitivity = 0;
 int dyn_debug_dyn_unw = 0;
@@ -267,10 +265,6 @@ bool init_debug() {
   if (check_env_value("DYNINST_DEBUG_SPRINGBOARD")) {
     fprintf(stderr, "Enabling DyninstAPI springboard debug\n");
     dyn_debug_springboard = 1;
-  }
-  if (check_env_value("DYNINST_REPORT_PROGRESS")) {
-    fprintf(stderr, "Enabling DyninstAPI rewrite-progress reporting\n");
-    dyn_debug_progress = 1;
   }
   if (check_env_value("DYNINST_DEBUG_STARTUP")) {
     fprintf(stderr, "Enabling DyninstAPI startup debug\n");
@@ -543,31 +537,6 @@ int reloc_printf_int(const char *format, ...)
   debugPrintLock->lock();
 
   fprintf(stderr, "[%lu]", getExecThreadID());
-  va_list va;
-  va_start(va, format);
-  int ret = vfprintf(stderr, format, va);
-  va_end(va);
-
-  debugPrintLock->unlock();
-
-  return ret;
-}
-
-int progress_printf_int(const char *format, ...)
-{
-  if (!dyn_debug_progress) return 0;
-  if (NULL == format) return -1;
-
-  debugPrintLock->lock();
-
-  // Unlike the other debug channels, prefix each progress line with a wall-clock
-  // timestamp so phase timing is visible during long rewrites.
-  time_t now = time(NULL);
-  struct tm tmv;
-  char ts[32];
-  if (localtime_r(&now, &tmv) && strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tmv))
-    fprintf(stderr, "[%s] ", ts);
-
   va_list va;
   va_start(va, format);
   int ret = vfprintf(stderr, format, va);

--- a/dyninstAPI/src/debug.C
+++ b/dyninstAPI/src/debug.C
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <assert.h>
+#include <time.h>     // progress timestamps (progress_printf_int)
 #include <string>
 #include "BPatch.h"
 #include "dyninstAPI/src/debug.h"
@@ -221,6 +222,7 @@ int dyn_debug_proccontrol = 0;
 int dyn_debug_stackwalk = 0;
 int dyn_debug_inst = 0;
 int dyn_debug_reloc = 0;
+int dyn_debug_progress = 0;
 int dyn_debug_springboard = 0;
 int dyn_debug_sensitivity = 0;
 int dyn_debug_dyn_unw = 0;
@@ -265,6 +267,10 @@ bool init_debug() {
   if (check_env_value("DYNINST_DEBUG_SPRINGBOARD")) {
     fprintf(stderr, "Enabling DyninstAPI springboard debug\n");
     dyn_debug_springboard = 1;
+  }
+  if (check_env_value("DYNINST_REPORT_PROGRESS")) {
+    fprintf(stderr, "Enabling DyninstAPI rewrite-progress reporting\n");
+    dyn_debug_progress = 1;
   }
   if (check_env_value("DYNINST_DEBUG_STARTUP")) {
     fprintf(stderr, "Enabling DyninstAPI startup debug\n");
@@ -537,6 +543,31 @@ int reloc_printf_int(const char *format, ...)
   debugPrintLock->lock();
 
   fprintf(stderr, "[%lu]", getExecThreadID());
+  va_list va;
+  va_start(va, format);
+  int ret = vfprintf(stderr, format, va);
+  va_end(va);
+
+  debugPrintLock->unlock();
+
+  return ret;
+}
+
+int progress_printf_int(const char *format, ...)
+{
+  if (!dyn_debug_progress) return 0;
+  if (NULL == format) return -1;
+
+  debugPrintLock->lock();
+
+  // Unlike the other debug channels, prefix each progress line with a wall-clock
+  // timestamp so phase timing is visible during long rewrites.
+  time_t now = time(NULL);
+  struct tm tmv;
+  char ts[32];
+  if (localtime_r(&now, &tmv) && strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tmv))
+    fprintf(stderr, "[%s] ", ts);
+
   va_list va;
   va_start(va, format);
   int ret = vfprintf(stderr, format, va);

--- a/dyninstAPI/src/debug.h
+++ b/dyninstAPI/src/debug.h
@@ -63,6 +63,7 @@ extern int dyn_debug_proccontrol;
 extern int dyn_debug_stackwalk;
 extern int dyn_debug_inst;
 extern int dyn_debug_reloc;
+extern int dyn_debug_progress;  // coarse rewrite-progress reporting (DYNINST_REPORT_PROGRESS)
 extern int dyn_debug_springboard;
 extern int dyn_debug_sensitivity;
 extern int dyn_debug_dyn_unw;
@@ -112,6 +113,7 @@ extern const std::string CODEGEN_LIVENESS_TIMER;
 #define proccontrol_cerr  debug_sys_cerr(proccontrol)
 #define stackwalk_cerr    debug_sys_cerr(stackwalk)
 #define relocation_cerr   debug_sys_cerr(reloc)
+#define progress_cerr     debug_sys_cerr(progress)
 #define springboard_cerr  debug_sys_cerr(springboard)
 #define malware_cerr      debug_sys_cerr(malware)
 #define trap_cerr         debug_sys_cerr(trap)
@@ -133,6 +135,7 @@ DECLARE_PRINTF_FUNC(proccontrol_printf_int);
 DECLARE_PRINTF_FUNC(stackwalk_printf_int);
 DECLARE_PRINTF_FUNC(inst_printf_int);
 DECLARE_PRINTF_FUNC(reloc_printf_int);
+DECLARE_PRINTF_FUNC(progress_printf_int);
 DECLARE_PRINTF_FUNC(dyn_unw_printf_int);
 DECLARE_PRINTF_FUNC(mutex_printf_int);
 DECLARE_PRINTF_FUNC(thread_printf_int);
@@ -153,6 +156,7 @@ DECLARE_PRINTF_FUNC(stackmods_printf_int);
 #define stackwalk_printf(...)   debug_sys_printf(stackwalk, __VA_ARGS__)
 #define inst_printf(...)        debug_sys_printf(inst, __VA_ARGS__)
 #define reloc_printf(...)       debug_sys_printf(reloc, __VA_ARGS__)
+#define progress_printf(...)    debug_sys_printf(progress, __VA_ARGS__)
 #define dyn_unw_printf(...)     debug_sys_printf(dyn_unw, __VA_ARGS__)
 #define mutex_printf(...)       debug_sys_printf(mutex, __VA_ARGS__)
 #define thread_printf(...)      debug_sys_printf(thread, __VA_ARGS__)

--- a/dyninstAPI/src/debug.h
+++ b/dyninstAPI/src/debug.h
@@ -33,6 +33,7 @@
 
 #include <string>
 #include "compiler_annotations.h"
+#include "common/src/debug_common.h"  // shared progress channel (progress_printf / DYNINST_DEBUG_PROGRESS)
 
 #define BPFATAL(x) bpfatal_lf(__FILE__, __LINE__, x)
 extern void logLine(const char *line);
@@ -63,7 +64,6 @@ extern int dyn_debug_proccontrol;
 extern int dyn_debug_stackwalk;
 extern int dyn_debug_inst;
 extern int dyn_debug_reloc;
-extern int dyn_debug_progress;  // coarse rewrite-progress reporting (DYNINST_REPORT_PROGRESS)
 extern int dyn_debug_springboard;
 extern int dyn_debug_sensitivity;
 extern int dyn_debug_dyn_unw;
@@ -113,7 +113,6 @@ extern const std::string CODEGEN_LIVENESS_TIMER;
 #define proccontrol_cerr  debug_sys_cerr(proccontrol)
 #define stackwalk_cerr    debug_sys_cerr(stackwalk)
 #define relocation_cerr   debug_sys_cerr(reloc)
-#define progress_cerr     debug_sys_cerr(progress)
 #define springboard_cerr  debug_sys_cerr(springboard)
 #define malware_cerr      debug_sys_cerr(malware)
 #define trap_cerr         debug_sys_cerr(trap)
@@ -135,7 +134,6 @@ DECLARE_PRINTF_FUNC(proccontrol_printf_int);
 DECLARE_PRINTF_FUNC(stackwalk_printf_int);
 DECLARE_PRINTF_FUNC(inst_printf_int);
 DECLARE_PRINTF_FUNC(reloc_printf_int);
-DECLARE_PRINTF_FUNC(progress_printf_int);
 DECLARE_PRINTF_FUNC(dyn_unw_printf_int);
 DECLARE_PRINTF_FUNC(mutex_printf_int);
 DECLARE_PRINTF_FUNC(thread_printf_int);
@@ -156,7 +154,6 @@ DECLARE_PRINTF_FUNC(stackmods_printf_int);
 #define stackwalk_printf(...)   debug_sys_printf(stackwalk, __VA_ARGS__)
 #define inst_printf(...)        debug_sys_printf(inst, __VA_ARGS__)
 #define reloc_printf(...)       debug_sys_printf(reloc, __VA_ARGS__)
-#define progress_printf(...)    debug_sys_printf(progress, __VA_ARGS__)
 #define dyn_unw_printf(...)     debug_sys_printf(dyn_unw, __VA_ARGS__)
 #define mutex_printf(...)       debug_sys_printf(mutex, __VA_ARGS__)
 #define thread_printf(...)      debug_sys_printf(thread, __VA_ARGS__)

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -1291,12 +1291,12 @@ void image::analyzeImage() {
        {
         SymtabCodeRegion * scr = static_cast<SymtabCodeRegion*>(*rit);
         if(parseGaps_ && scr->symRegion()->isText()) {
-            progress_printf("[dyninst] parse: speculative gap parsing region [%lx,%lx) (%lu KB) -- this is single-threaded and can be very slow on large binaries\n",
+            progress_printf("parse: speculative gap parsing region [%lx,%lx) (%lu KB) -- this is single-threaded and can be very slow on large binaries\n",
                             (unsigned long)scr->offset(),
                             (unsigned long)(scr->offset() + scr->length()),
                             (unsigned long)(scr->length() / 1024));
             obj_->parseGaps(scr);
-            progress_printf("[dyninst] parse: gap parsing done for region [%lx,%lx)\n",
+            progress_printf("parse: gap parsing done for region [%lx,%lx)\n",
                             (unsigned long)scr->offset(),
                             (unsigned long)(scr->offset() + scr->length()));
         }

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -1291,7 +1291,14 @@ void image::analyzeImage() {
        {
         SymtabCodeRegion * scr = static_cast<SymtabCodeRegion*>(*rit);
         if(parseGaps_ && scr->symRegion()->isText()) {
+            progress_printf("[dyninst] parse: speculative gap parsing region [%lx,%lx) (%lu KB) -- this is single-threaded and can be very slow on large binaries\n",
+                            (unsigned long)scr->offset(),
+                            (unsigned long)(scr->offset() + scr->length()),
+                            (unsigned long)(scr->length() / 1024));
             obj_->parseGaps(scr);
+            progress_printf("[dyninst] parse: gap parsing done for region [%lx,%lx)\n",
+                            (unsigned long)scr->offset(),
+                            (unsigned long)(scr->offset() + scr->length()));
         }
        } 
    }

--- a/parseAPI/src/Parser-speculative.C
+++ b/parseAPI/src/Parser-speculative.C
@@ -42,10 +42,7 @@
 
 #include "Parser.h"
 #include "debug_parse.h"
-
-#include <cstdio>   // self-contained DYNINST_REPORT_PROGRESS reporting for gap parsing
-#include <cstdlib>
-#include <ctime>
+#include "common/src/debug_common.h"   // shared progress channel (progress_printf / DYNINST_DEBUG_PROGRESS)
 
 using namespace std;
 using namespace Dyninst;
@@ -53,23 +50,17 @@ using namespace Dyninst::ParseAPI;
 
 #if defined(cap_stripped_binaries)
 
-// Timestamped one-line progress report for the speculative gap-parsing phase,
-// gated by DYNINST_REPORT_PROGRESS (checked by the caller). Format matches the
-// dyninstAPI progress channel ("[YYYY-MM-DD HH:MM:SS] ...") so tool output and
-// dyninst progress line up on one timeline.
+// One-line progress report for the speculative gap-parsing phase, routed through
+// the shared progress channel (progress_printf / DYNINST_DEBUG_PROGRESS, implemented
+// in common). progress_printf adds the wall-clock timestamp and self-gates on the
+// env var, so dyninstAPI and parseAPI progress line up on one timeline.
 static void gap_progress_report(const char *what, Dyninst::Address at,
                                 Dyninst::Address regBeg, Dyninst::Address regEnd) {
-    char ts[32];
-    time_t now = time(NULL);
-    struct tm tmv;
-    if (!(localtime_r(&now, &tmv) && strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tmv)))
-        ts[0] = '\0';
     unsigned long span = (regEnd > regBeg) ? (unsigned long)(regEnd - regBeg) : 0;
     unsigned long done = (at > regBeg && at <= regEnd) ? (unsigned long)(at - regBeg) : 0;
     double pct = span ? (100.0 * (double)done / (double)span) : 0.0;
-    fprintf(stderr, "[%s] [dyninst] gap-parse: %s at %lx (~%.1f%% of region [%lx,%lx))\n",
-            ts, what, (unsigned long)at, pct, (unsigned long)regBeg, (unsigned long)regEnd);
-    fflush(stderr);
+    progress_printf("gap-parse: %s at %lx (~%.1f%% of region [%lx,%lx))\n",
+            what, (unsigned long)at, pct, (unsigned long)regBeg, (unsigned long)regEnd);
 }
 
 static bool isStackFramePrecheck_msvs( const unsigned char *buffer );
@@ -403,24 +394,17 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
     Address gapStart;
     Address gapEnd;
     Address curAddr = cr->offset();
-    // Self-contained rewrite-progress reporting (DYNINST_REPORT_PROGRESS). parseAPI
-    // sits below dyninstAPI, so it cannot use that layer's progress_printf channel;
-    // gate a lightweight timestamped stderr report on the env var directly. Match the
-    // dyninstAPI check_env_value() truthiness (set and non-zero) so the single knob
-    // behaves identically across both layers. This gap-parsing loop is the dominant
-    // cost on large binaries and is otherwise silent.
-    const char *progEnv = getenv("DYNINST_REPORT_PROGRESS");
-    const bool progReport = (progEnv != NULL && atoi(progEnv) != 0);
+    // Rewrite/parse-progress reporting via the shared progress channel
+    // (progress_printf / DYNINST_DEBUG_PROGRESS, implemented in common). This
+    // gap-parsing loop is the dominant cost on large binaries and is otherwise
+    // silent; progress_printf self-gates on the env var, so these calls are no-ops
+    // unless DYNINST_DEBUG_PROGRESS is set.
     const Address regBeg = cr->offset();
     const Address regEnd = cr->offset() + cr->length();
-    unsigned long gapCount = 0;
-    if (progReport)
-        gap_progress_report("starting speculative gap parsing", regBeg, regBeg, regEnd);
+    gap_progress_report("starting speculative gap parsing", regBeg, regBeg, regEnd);
     while (getGapRange(cr, curAddr, gapStart, gapEnd)) {
         parsing_printf("[%s] scanning for FEP in [%lx,%lx)\n",
             FILE__,gapStart,gapEnd);
-        if (progReport && (++gapCount % 5000) == 0)
-            gap_progress_report("gap parsing in progress", gapStart, gapStart, regEnd);
         for(curAddr=gapStart; curAddr < gapEnd; ++curAddr) {
             if(cr->isCode(curAddr)) {
 	        pc.calcProbByMatchingIdioms(curAddr);
@@ -434,8 +418,7 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
         }
         finalize();
     }
-    if (progReport)
-        gap_progress_report("speculative gap parsing done", regEnd, regBeg, regEnd);
+    gap_progress_report("speculative gap parsing done", regEnd, regBeg, regEnd);
 }
 
 bool isStackFramePrecheck_gcc( const unsigned char *buffer )

--- a/parseAPI/src/Parser-speculative.C
+++ b/parseAPI/src/Parser-speculative.C
@@ -43,11 +43,34 @@
 #include "Parser.h"
 #include "debug_parse.h"
 
+#include <cstdio>   // self-contained DYNINST_REPORT_PROGRESS reporting for gap parsing
+#include <cstdlib>
+#include <ctime>
+
 using namespace std;
 using namespace Dyninst;
 using namespace Dyninst::ParseAPI;
 
 #if defined(cap_stripped_binaries)
+
+// Timestamped one-line progress report for the speculative gap-parsing phase,
+// gated by DYNINST_REPORT_PROGRESS (checked by the caller). Format matches the
+// dyninstAPI progress channel ("[YYYY-MM-DD HH:MM:SS] ...") so tool output and
+// dyninst progress line up on one timeline.
+static void gap_progress_report(const char *what, Dyninst::Address at,
+                                Dyninst::Address regBeg, Dyninst::Address regEnd) {
+    char ts[32];
+    time_t now = time(NULL);
+    struct tm tmv;
+    if (!(localtime_r(&now, &tmv) && strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tmv)))
+        ts[0] = '\0';
+    unsigned long span = (regEnd > regBeg) ? (unsigned long)(regEnd - regBeg) : 0;
+    unsigned long done = (at > regBeg && at <= regEnd) ? (unsigned long)(at - regBeg) : 0;
+    double pct = span ? (100.0 * (double)done / (double)span) : 0.0;
+    fprintf(stderr, "[%s] [dyninst] gap-parse: %s at %lx (~%.1f%% of region [%lx,%lx))\n",
+            ts, what, (unsigned long)at, pct, (unsigned long)regBeg, (unsigned long)regEnd);
+    fflush(stderr);
+}
 
 static bool isStackFramePrecheck_msvs( const unsigned char *buffer );
 static bool isStackFramePrecheck_gcc( const unsigned char *buffer );
@@ -380,9 +403,24 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
     Address gapStart;
     Address gapEnd;
     Address curAddr = cr->offset();
+    // Self-contained rewrite-progress reporting (DYNINST_REPORT_PROGRESS). parseAPI
+    // sits below dyninstAPI, so it cannot use that layer's progress_printf channel;
+    // gate a lightweight timestamped stderr report on the env var directly. Match the
+    // dyninstAPI check_env_value() truthiness (set and non-zero) so the single knob
+    // behaves identically across both layers. This gap-parsing loop is the dominant
+    // cost on large binaries and is otherwise silent.
+    const char *progEnv = getenv("DYNINST_REPORT_PROGRESS");
+    const bool progReport = (progEnv != NULL && atoi(progEnv) != 0);
+    const Address regBeg = cr->offset();
+    const Address regEnd = cr->offset() + cr->length();
+    unsigned long gapCount = 0;
+    if (progReport)
+        gap_progress_report("starting speculative gap parsing", regBeg, regBeg, regEnd);
     while (getGapRange(cr, curAddr, gapStart, gapEnd)) {
         parsing_printf("[%s] scanning for FEP in [%lx,%lx)\n",
             FILE__,gapStart,gapEnd);
+        if (progReport && (++gapCount % 5000) == 0)
+            gap_progress_report("gap parsing in progress", gapStart, gapStart, regEnd);
         for(curAddr=gapStart; curAddr < gapEnd; ++curAddr) {
             if(cr->isCode(curAddr)) {
 	        pc.calcProbByMatchingIdioms(curAddr);
@@ -396,6 +434,8 @@ void Parser::probabilistic_gap_parsing(CodeRegion *cr) {
         }
         finalize();
     }
+    if (progReport)
+        gap_progress_report("speculative gap parsing done", regEnd, regBeg, regEnd);
 }
 
 bool isStackFramePrecheck_gcc( const unsigned char *buffer )


### PR DESCRIPTION
Rewriting a very large binary (e.g. a multi-hundred-MB shared library) spends long stretches in silent loops -- building reloc blocks, applying transforms, code generation, the emit address-fixpoint, speculative gap parsing, and assembling/emitting the output file -- so the tool can look hung for many minutes with no output.

Add a coarse, opt-in progress channel gated on the DYNINST_REPORT_PROGRESS environment variable (and the dyn_debug_progress flag), following the existing debug-channel convention in debug.{h,C}. Each progress line is prefixed with a wall-clock timestamp so phases can be timed directly from the log.

Instrumented phases:
  - CodeMover: per-function reloc-block build loop and per-RelocBlock codegen loop (periodic counts + "codegen done").
  - addressSpace::relocateInt/generateCode: phase markers (transforms, code generation, emit address-fixpoint attempts, patching).
  - CodeBuffer::generate: per-pass / periodic progress over the buffer elements in the do/while regeneration fixpoint.
  - image::analyzeImage: brackets around the (single-threaded) speculative gap-parse phase per text region.
  - BinaryEdit::writeFile / BPatch_binaryEdit::writeFile: committing instrumentation, in-memory relocation, copying tracked regions into the output buffer (periodic), building the symbol table, the final symtab emit (the on-disk write), and per-dependent-library writes -- the span from "patching jumps/springboards" through the end of writeFile.
  - Parser-speculative probabilistic_gap_parsing: self-contained, DYNINST_REPORT_PROGRESS-gated timestamped progress (parseAPI sits below dyninstAPI and cannot use its progress channel directly). The env-var check matches dyninstAPI's check_env_value() truthiness (set and non-zero) so the single knob behaves identically across both layers.

No behavior change when the env var is unset.