### PR TITLE
Do not link tbbmalloc_proxy

### DIFF
--- a/cmake/tpls/DyninstTBB.cmake
+++ b/cmake/tpls/DyninstTBB.cmake
@@ -28,7 +28,7 @@ endif()
 
 find_package(
   TBB ${_min_version}
-  COMPONENTS tbb tbbmalloc tbbmalloc_proxy
+  COMPONENTS tbb tbbmalloc
   REQUIRED ${_find_path_args})
 
 # Don't let TBB variables seep through
@@ -36,13 +36,11 @@ mark_as_advanced(TBB_DIR)
 
 if(NOT TARGET Dyninst::TBB)
   add_library(Dyninst::TBB INTERFACE IMPORTED)
-  target_link_libraries(Dyninst::TBB INTERFACE TBB::tbb TBB::tbbmalloc
-                                               TBB::tbbmalloc_proxy)
+  target_link_libraries(Dyninst::TBB INTERFACE TBB::tbb TBB::tbbmalloc)
   target_include_directories(
     Dyninst::TBB SYSTEM
     INTERFACE $<TARGET_PROPERTY:TBB::tbb,INTERFACE_INCLUDE_DIRECTORIES>
-              $<TARGET_PROPERTY:TBB::tbbmalloc,INTERFACE_INCLUDE_DIRECTORIES>
-              $<TARGET_PROPERTY:TBB::tbbmalloc_proxy,INTERFACE_INCLUDE_DIRECTORIES>)
+              $<TARGET_PROPERTY:TBB::tbbmalloc,INTERFACE_INCLUDE_DIRECTORIES>)
 endif()
 
 message(STATUS "Found TBB ${TBB_VERSION}")


### PR DESCRIPTION
`tbbmalloc_proxy` is a `malloc` replacement library that calls TBB's `scalable_malloc` equivalents. It was at one time recommended for Dyninst users since it improved performance, although [it's not clear whether these benefits apply to modern Glibc](https://github.com/dyninst/dyninst/issues/916). Unfortunately replacing `malloc` is tricky business and `tbbmalloc` is known to do things that are [explicitly documented as unsafe like `dlopen`/`dlsym`](https://sourceware.org/glibc/manual/latest/html_node/Replacing-malloc.html). As of TBB `2023.0.0` we have finally observed it crashing when combined with ParseAPI (for details see https://gitlab.com/hpctoolkit/hpctoolkit/-/work_items/998#note_3475868658). 

This PR drops Dyninst's dependency on `tbbmalloc_proxy`, making it the users' prerogative to link it if they so desire. This is more correct anyway, `malloc` replacements need to be linked to the _main executable_ (or `LD_PRELOAD`'d) to ensure proper symbol resolution, but Dyninst is a library and not in (enough) control of the user's executable link line to make this happen.