### PR TITLE
Fix capstone 6 riscv mode constant name

### DIFF
--- a/instructionAPI/src/decoder/riscv/decoder.C
+++ b/instructionAPI/src/decoder/riscv/decoder.C
@@ -31,6 +31,11 @@
 #include "arch-riscv64.h"
 #include "capstone/capstone.h"
 #include "capstone/riscv.h"
+
+#ifndef CS_MODE_RISCV_C
+#define CS_MODE_RISCV_C CS_MODE_RISCVC
+#endif
+
 #include "categories.h"
 #include "debug.h"
 #include "decoder/riscv/decoder.h"
@@ -74,7 +79,7 @@ InstructionDecoder_riscv64::InstructionDecoder_riscv64(Dyninst::Architecture a)
     : InstructionDecoderImpl(a) {
 
   // Currently we only support RV64
-  mode = (cs_mode)(CS_MODE_RISCV64 | CS_MODE_RISCVC);
+  mode = (cs_mode)(CS_MODE_RISCV64 | CS_MODE_RISCV_C);
 
   cs_open(CS_ARCH_RISCV, this->mode, &disassembler.handle);
   cs_option(disassembler.handle, CS_OPT_DETAIL, CS_OPT_ON);
@@ -881,9 +886,3 @@ bool is_compressed(di::Instruction &insn) {
 }
 
 } // namespace
-
-// Forward compatibility with future capstone versions that may rename
-// CS_MODE_RISCVC to CS_MODE_RISCV_C
-#ifndef CS_MODE_RISCV_C
-#define CS_MODE_RISCV_C CS_MODE_RISCVC
-#endif

--- a/instructionAPI/src/decoder/riscv/decoder.C
+++ b/instructionAPI/src/decoder/riscv/decoder.C
@@ -881,3 +881,9 @@ bool is_compressed(di::Instruction &insn) {
 }
 
 } // namespace
+
+// Forward compatibility with future capstone versions that may rename
+// CS_MODE_RISCVC to CS_MODE_RISCV_C
+#ifndef CS_MODE_RISCV_C
+#define CS_MODE_RISCV_C CS_MODE_RISCVC
+#endif


### PR DESCRIPTION
Capstone 6 renamed CS_MODE_RISCVC -> CS_MODE_RISCV_C. Since Dyninst's CMakeLists
already requires capstone >= 6.0.0-Alpha5, this is a straightforward rename of
the affected constant in the riscv decoder.
