### PR TITLE
Use CMake CTest module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ add_subdirectory(parseThat)
 add_subdirectory(dyninstAPI_RT)
 
 if(DYNINST_ENABLE_TESTS)
-  enable_testing()
+  include(CTest)
   message(STATUS "Enabling tests")
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
This is needed to upload ctest results to CDash.

This is part of my work on the DoE PESO project.