### PR TITLE
Define _REENTRANT when OpenMP is enabled to fix Clang thread-safety

### DIFF
--- a/dataflowAPI/rose/util/Sawyer.h
+++ b/dataflowAPI/rose/util/Sawyer.h
@@ -8,6 +8,22 @@
 #ifndef Sawyer_H
 #define Sawyer_H
 
+// Dyninst: define _REENTRANT before any system header so Sawyer selects its
+// thread-safe path (the SAWYER_MULTI_THREADED / SAWYER_THREAD_LOCAL block
+// below keys on _REENTRANT). Dyninst runs its parser in parallel (OpenMP), so
+// Sawyer's pool allocator, shared-pointer reference counting, and per-thread
+// PRNG (fastRandomIndex) must be thread-safe. The compiler only defines
+// _REENTRANT when invoked with -pthread, and Dyninst cannot rely on that:
+// CMake's Threads::Threads adds -pthread as a *compile* flag only when
+// THREADS_HAVE_PTHREAD_ARG is true, which is false whenever pthread lives in
+// libc (glibc >= 2.34), leaving Threads::Threads an empty target. When
+// _REENTRANT is undefined these classes compile with no-op locks and shared
+// "thread-local" state, which crashed the parallel parser under clang.
+// Guarded so it is a no-op where -pthread already defined it.
+#ifndef _REENTRANT
+#define _REENTRANT 1
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
 #include <vector>


### PR DESCRIPTION
Dyninst's bundled Sawyer/ROSE only compiles its pool allocator and shared-pointer reference counting as thread-safe when _REENTRANT is defined (dataflowAPI/rose/util/Sawyer.h). GCC's -fopenmp defines _REENTRANT implicitly, but Clang's -fopenmp/-fopenmp=libomp does not, so Clang builds ran the OpenMP-parallel parser with no-op allocator locks. This corrupted the pool free list and SValue reference counts, causing assertion failures and segfaults during parallel jump-table symbolic evaluation (only reproducible with >1 OpenMP thread).

Define _REENTRANT globally when USE_OpenMP is set, matching GCC's behavior and keeping the setting consistent across all translation units to avoid ODR mismatches in Sawyer's shared-object layout.

Required for #2298.