### PR TITLE
Compile parseAPI with -pthread to fix Clang thread-safety

### DIFF
--- a/cmake/tpls/DyninstThreads.cmake
+++ b/cmake/tpls/DyninstThreads.cmake
@@ -4,6 +4,14 @@ if(DYNINST_OS_UNIX)
   set(_required REQUIRED)
 endif()
 
+# Prefer the compiler's -pthread flag over a bare -lpthread. On GCC and Clang,
+# -pthread also defines _REENTRANT, which Dyninst's bundled Sawyer/ROSE relies
+# on to compile its pool allocator and shared-pointer reference counting as
+# thread-safe (see dataflowAPI/rose/util/Sawyer.h). GCC's -fopenmp defines
+# _REENTRANT implicitly, but Clang's -fopenmp=libomp does not; using -pthread
+# makes the thread-safe path explicit and compiler-independent.
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
 find_package(Threads ${_required})
 
 if(NOT Threads_FOUND)

--- a/parseAPI/CMakeLists.txt
+++ b/parseAPI/CMakeLists.txt
@@ -94,6 +94,13 @@ dyninst_library(
   DYNINST_DEPS common instructionAPI ${SYMREADER}
   PUBLIC_DEPS Dyninst::Boost_headers
   PRIVATE_DEPS OpenMP::OpenMP_CXX
+               # -pthread (via Threads::Threads) defines _REENTRANT so the
+               # bundled Sawyer/ROSE sources compiled into parseAPI use their
+               # thread-safe pool allocator and refcounting. Linked
+               # unconditionally so these classes are thread-safe even in
+               # non-OpenMP builds where the application drives them in
+               # parallel.
+               Threads::Threads
 )
 # cmake-format: on
 

--- a/parseAPI/CMakeLists.txt
+++ b/parseAPI/CMakeLists.txt
@@ -95,11 +95,7 @@ dyninst_library(
   PUBLIC_DEPS Dyninst::Boost_headers
   PRIVATE_DEPS OpenMP::OpenMP_CXX
                # -pthread (via Threads::Threads) defines _REENTRANT so the
-               # bundled Sawyer/ROSE sources compiled into parseAPI use their
-               # thread-safe pool allocator and refcounting. Linked
-               # unconditionally so these classes are thread-safe even in
-               # non-OpenMP builds where the application drives them in
-               # parallel.
+               # Sawyer/ROSE pool allocator is thread safe
                Threads::Threads
 )
 # cmake-format: on


### PR DESCRIPTION
Dyninst's bundled Sawyer/ROSE only compiles its pool allocator and shared-pointer reference counting as thread-safe when _REENTRANT is defined (dataflowAPI/rose/util/Sawyer.h). GCC's -fopenmp defines _REENTRANT implicitly, but Clang's -fopenmp=libomp does not, so Clang builds ran the OpenMP-parallel parser with no-op allocator locks. This corrupted the pool free list and SValue reference counts, causing assertion failures and segfaults during parallel jump-table symbolic evaluation (only reproducible with >1 OpenMP thread).

Rather than defining the deprecated _REENTRANT macro directly, set THREADS_PREFER_PTHREAD_FLAG and link parseAPI against Threads::Threads when USE_OpenMP is enabled. On GCC/Clang, -pthread defines _REENTRANT as a documented side effect (see feature_test_macros(7)), so this is the standard, compiler-independent way to compile threaded code. All Sawyer/ROSE sources compile into the single parseAPI target and none of the affected types are exposed in public headers, so scoping the flag to parseAPI keeps the shared-object layout consistent (no ODR mismatch) without touching the vendored Sawyer header.

This is an alternative to the global add_compile_definitions(_REENTRANT) approach in PR #2310, offered for reviewer comparison.