### PR TITLE
Make C++ exceptions catchable through relocated / instrumented code (#1437)

### DIFF
--- a/dwarf/h/dwarfFrameParser.h
+++ b/dwarf/h/dwarfFrameParser.h
@@ -98,6 +98,30 @@ public:
             std::vector<VariableLocation> &locs,
             FrameErrors_t &err_result);
 
+    // the classified CFI rule for one register over
+    // [range.first, range.second), one entry per CFI row. Says where the
+    // caller's value of `reg` lives at each PC sub-range; used to re-emit
+    // unwind info for relocated code. Rules that cannot be expressed as one
+    // of the simple kinds (DWARF expressions, val_offset) report Undefined.
+    struct FrameRegRule {
+        Address lowPC, hiPC;
+        enum Kind { SameValue = 0, AtCFAOffset = 1, InRegister = 2,
+                    Undefined = 3 } kind;
+        long offset;      // AtCFAOffset: value is stored at CFA+offset
+        unsigned regnum;  // InRegister: DWARF number of the holding register
+    };
+    bool getRegRulesForFunction(
+            std::pair<Address, Address> range,
+            MachRegister reg,
+            std::vector<FrameRegRule> &rules,
+            FrameErrors_t &err_result);
+    // As above but keyed on a raw DWARF register number, so a CFI column with
+    // no Dyninst MachRegister (e.g. ppc64 return address, DWARF 65) is reachable.
+    bool getRegRulesForDwarf(
+            std::pair<Address, Address> range,
+            int dwarf_reg,
+            std::vector<FrameRegRule> &rules,
+            FrameErrors_t &err_result);
 
 private:
 

--- a/dwarf/src/dwarfFrameParser.C
+++ b/dwarf/src/dwarfFrameParser.C
@@ -218,28 +218,136 @@ bool DwarfFrameParser::getRegsForFunction(
         {
             Dwarf_Frame * frame = NULL;
             int result = dwarf_cfi_addrframe(cfi_data[i], next_pc, &frame);
-            if(result==-1) break;
+            // No FDE covers next_pc: a padding gap between functions. When the
+            // caller's range legitimately spans more than one function (e.g.
+            // sampling a hot/cold-split function whose partitions bracket other
+            // functions), such gaps must be skipped, not treated as the end of
+            // the range -- otherwise rows past the first gap are lost. Advancing
+            // one byte is fine: inter-function padding is tiny.
+            if(result==-1) { next_pc++; continue; }
 
             Dwarf_Addr start_pc, end_pc;
             dwarf_frame_info(frame, &start_pc, &end_pc, NULL);
+            Dwarf_Addr row_next = (end_pc > next_pc) ? end_pc : next_pc + 1;
 
             Dwarf_Op * ops;
             size_t nops;
             result = dwarf_frame_cfa(frame, &ops, &nops);
-            if (result != 0) break;
-
-            VariableLocation loc2;
-            DwarfDyninst::SymbolicDwarfResult cons(loc2, arch);
-            if (!DwarfDyninst::decodeDwarfExpression(ops, nops, NULL, cons, arch)) break;
-            loc2.lowPC = next_pc;
-            loc2.hiPC = end_pc;
-
-            locs.push_back(cons.val());
-            next_pc = end_pc;
+            if (result == 0) {
+                VariableLocation loc2;
+                DwarfDyninst::SymbolicDwarfResult cons(loc2, arch);
+                // A row we cannot decode (e.g. an expression CFA in a foreign
+                // function within a spanning range) is skipped, not fatal.
+                if (DwarfDyninst::decodeDwarfExpression(ops, nops, NULL, cons, arch)) {
+                    loc2.lowPC = next_pc;
+                    loc2.hiPC = end_pc;
+                    locs.push_back(cons.val());
+                }
+            }
+            free(frame);   // dwarf_cfi_addrframe allocates; free every row (the
+                           // gap-skipping walk visits many) as getRegRulesForFunction does
+            next_pc = row_next;
         }
     }
 
     return !locs.empty();
+}
+
+// convenience wrapper -- map the MachRegister to its DWARF number.
+// Callers that need a CFI column with no Dyninst MachRegister (notably ppc64's
+// link register, DWARF 65, which Dyninst's register map assigns to 108) must
+// use getRegRulesForDwarf directly.
+bool DwarfFrameParser::getRegRulesForFunction(
+        std::pair<Address, Address> range,
+        Dyninst::MachRegister reg,
+        std::vector<FrameRegRule> &rules,
+        FrameErrors_t &err_result)
+{
+    return getRegRulesForDwarf(range, DwarfDyninst::register_to_dwarf(reg), rules, err_result);
+}
+
+// classify dwarf_frame_register's location description for the DWARF
+// column `dwarf_reg` across `range`. Same row-walk as getRegsForFunction, but
+// keyed on a raw DWARF register number so any column (e.g. a return-address
+// register that has no MachRegister) is reachable.
+bool DwarfFrameParser::getRegRulesForDwarf(
+        std::pair<Address, Address> range,
+        int dwarf_reg,
+        std::vector<FrameRegRule> &rules,
+        FrameErrors_t &err_result)
+{
+    rules.clear();
+    dwarf_printf("Entry to getRegRulesForDwarf at 0x%lx, range end 0x%lx, dwarf_reg %d\n",
+                 range.first, range.second, dwarf_reg);
+    err_result = FE_No_Error;
+
+    setupCFIData();
+    if (!cfi_data.size()) {
+        err_result = FE_Bad_Frame_Data;
+        return false;
+    }
+
+    boost::unique_lock<dyn_mutex> l(cfi_lock);
+    for (size_t i = 0; i < cfi_data.size(); i++)
+    {
+        auto next_pc = range.first;
+        while (next_pc < range.second)
+        {
+            Dwarf_Frame *frame = NULL;
+            // Skip padding gaps between functions (no FDE) rather than ending
+            // the walk, so a range spanning a hot/cold-split function's
+            // partitions still yields the rows past the gap.
+            if (dwarf_cfi_addrframe(cfi_data[i], next_pc, &frame) == -1) { next_pc++; continue; }
+
+            Dwarf_Addr start_pc, end_pc;
+            dwarf_frame_info(frame, &start_pc, &end_pc, NULL);
+            Dwarf_Addr row_next = (end_pc > next_pc) ? end_pc : next_pc + 1;
+
+            Dwarf_Op ops_mem[3];
+            Dwarf_Op *ops = NULL;
+            size_t nops = 0;
+            int result = dwarf_frame_register(frame, dwarf_reg, ops_mem, &ops, &nops);
+            if (result != 0) { free(frame); next_pc = row_next; continue; }
+
+            FrameRegRule r;
+            r.lowPC = next_pc;
+            r.hiPC = end_pc;
+            r.offset = 0;
+            r.regnum = 0;
+            if (nops == 0) {
+                // libdw: *ops == ops_mem means "undefined"; *ops == NULL means
+                // "same_value" (this frame does not modify the register).
+                r.kind = (ops == ops_mem) ? FrameRegRule::Undefined
+                                          : FrameRegRule::SameValue;
+            }
+            else if (ops[0].atom == DW_OP_call_frame_cfa &&
+                     ops[nops-1].atom != DW_OP_stack_value &&
+                     (nops == 1 ||
+                      (nops == 2 && ops[1].atom == DW_OP_plus_uconst))) {
+                r.kind = FrameRegRule::AtCFAOffset;
+                r.offset = (nops == 2) ? (long)(int64_t)ops[1].number : 0;
+            }
+            else if (nops == 1 && ops[0].atom >= DW_OP_reg0 &&
+                     ops[0].atom <= DW_OP_reg31) {
+                r.kind = FrameRegRule::InRegister;
+                r.regnum = (unsigned)(ops[0].atom - DW_OP_reg0);
+            }
+            else if (nops == 1 && ops[0].atom == DW_OP_regx) {
+                r.kind = FrameRegRule::InRegister;
+                r.regnum = (unsigned)ops[0].number;
+            }
+            else {
+                // DWARF expression / val_offset rules are not representable in
+                // the simple re-emission; report Undefined so callers stay safe.
+                r.kind = FrameRegRule::Undefined;
+            }
+            rules.push_back(r);
+            free(frame);
+            next_pc = row_next;
+        }
+    }
+
+    return !rules.empty();
 }
 
 bool DwarfFrameParser::getRegAtFrame(

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -71,6 +71,8 @@ set(_sources
     src/addressSpace.C
     src/binaryEdit.C
     src/codeRange.C
+    src/eh_frame_arch.C
+    src/eh_frame_gen.C
     src/debug.C
     src/hybridCallbacks.C
     src/hybridInstrumentation.C

--- a/dyninstAPI/src/BPatch/BPatch_process.C
+++ b/dyninstAPI/src/BPatch/BPatch_process.C
@@ -754,6 +754,13 @@ bool BPatch_process::finalizeInsertionSet(bool, bool *)
   bool ret = AddressSpace::patch(llproc);
   /* End of PatchAPI stuffs */
 
+  // Relocation just installed new code into the live process. Hand libgcc the
+  // synthesized .eh_frame for it (staged in the target + registered via iRPC)
+  // so C++ exceptions can unwind through and be caught in the relocated frames.
+  // Must run here, while the process is stopped, before it is resumed.
+  if (ret)
+    llproc->registerRelocatedExceptionFrames();
+
   llproc->trapMapping.flush();
 
   if (shouldContinue)

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget-aarch64.C
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget-aarch64.C
@@ -81,6 +81,9 @@ bool CFWidget::generateIndirectCall(CodeBuffer &buffer,
     return true;
 }
 
+// No architecture-specific fixup is needed after a non-returning call on aarch64.
+void CFWidget::emitArchNonReturningCallFixup(CodeBuffer & /*buffer*/, const RelocBlock * /*trace*/) {}
+
 bool CFPatch::apply(codeGen &gen, CodeBuffer *buf) {
     if (isPLT(gen)) {
         relocation_cerr << "\t\t\t isPLT..." << endl;

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget-amdgpu.C
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget-amdgpu.C
@@ -54,6 +54,9 @@ bool CFWidget::generateIndirectCall(CodeBuffer & /* buffer */, Register /*reg*/,
   return true;
 }
 
+// No architecture-specific fixup is needed after a non-returning call on AMDGPU.
+void CFWidget::emitArchNonReturningCallFixup(CodeBuffer & /*buffer*/, const RelocBlock * /*trace*/) {}
+
 bool CFPatch::apply(codeGen &gen, CodeBuffer *buf) {
   int targetLabel = target->label(buf);
 

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget-ppc.C
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget-ppc.C
@@ -29,6 +29,8 @@
  */
 // ppc-specific methods for generating control flow
 
+#include <cstring>
+
 #include "CFWidget.h"
 #include "Widget.h"
 #include "../CFG/RelocTarget.h"
@@ -84,6 +86,33 @@ bool CFWidget::generateIndirectCall(CodeBuffer &buffer,
    buffer.addPIC(gen, tracker(trace));
 
    return true;
+}
+
+// ppc64le ELFv2 keeps a TOC-restore `ld r2,24(r1)` at the instruction after a
+// cross-module call. After a non-returning call (e.g. `bl __cxa_throw`) that
+// instruction never executes on the (absent) return path, so the CFG has no
+// edge to it and relocation drops it as unreachable. It is not dead: libgcc's
+// unwinder (frob_update_context in config/rs6000/linux-unwind.h) pattern-matches
+// this exact instruction at a frame's return address to recover the caller's
+// TOC (r2) while unwinding an exception through the frame. Dropped, a C++ catch
+// handler reached through relocated code runs with a stale TOC and crashes.
+// Re-emit it verbatim when the original had one; a local non-returning call gets
+// a `nop` there instead, which we leave alone.
+void CFWidget::emitArchNonReturningCallFixup(CodeBuffer &buffer, const RelocBlock *trace) {
+  static const unsigned char ld_r2_24_r1[4] = {0x18, 0x00, 0x41, 0xe8};
+  block_instance *b = trace->block();
+  if (!b || !b->obj()) return;
+  Address postAddr = addr_ + insn_.size();
+  const unsigned char *post = static_cast<const unsigned char *>(
+      b->obj()->getPtrToInstruction(postAddr));
+  if (!post || memcmp(post, ld_r2_24_r1, sizeof(ld_r2_24_r1)) != 0) return;
+  // Attribute the re-emitted instruction to its true original address (the
+  // call's return point, where the original `ld r2,24(r1)` lived), not to the
+  // call itself. That keeps the orig->reloc map's entry for the call site clean;
+  // otherwise the synthesized .gcc_except_table maps the throw call-site region
+  // onto this inserted instruction (call+4), leaving the throw's return IP
+  // uncovered and breaking the phase-1 handler search.
+  buffer.addPIC(ld_r2_24_r1, sizeof(ld_r2_24_r1), addrTracker(postAddr, trace));
 }
 
 bool CFPatch::apply(codeGen &gen, CodeBuffer *buf) {

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget-x86.C
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget-x86.C
@@ -153,6 +153,9 @@ bool CFWidget::generateIndirectCall(CodeBuffer &buffer,
    return true;
 }
 
+// No architecture-specific fixup is needed after a non-returning call on x86/x86-64.
+void CFWidget::emitArchNonReturningCallFixup(CodeBuffer & /*buffer*/, const RelocBlock * /*trace*/) {}
+
 bool CFPatch::apply(codeGen &gen, CodeBuffer *buf) {
    // Question 1: are we doing an inter-module static control transfer?
    // If so, things get... complicated

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget.C
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget.C
@@ -236,7 +236,7 @@ bool CFWidget::generate(const codeGen &,
          if (destMap_.find(Fallthrough) != destMap_.end()) {
             TargetInt *ft = destMap_[Fallthrough];
             if (ft->necessary()) {
-               if (!generateBranch(buffer, 
+               if (!generateBranch(buffer,
                                    ft,
                                    insn_,
                                    trace,
@@ -244,6 +244,13 @@ bool CFWidget::generate(const codeGen &,
                   return false;
                }
             }
+         }
+         else if (isCall_) {
+            // A call with no fallthrough edge does not return (e.g. __cxa_throw,
+            // abort). Some architectures place an instruction after such a call
+            // that the CFG treats as unreachable and drops, but that the
+            // unwinder still relies on; let the target arch re-emit it.
+            emitArchNonReturningCallFixup(buffer, trace);
          }
          break;
       }

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget.h
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget.h
@@ -194,6 +194,13 @@ class CFWidget : public Widget {
 							InstructionAPI::Instruction insn,
 							const RelocBlock *trace,
 							Address origAddr);
+
+  // Per-architecture hook (defined in CFWidget-<arch>.C) invoked after a
+  // relocated call that does not return. On most architectures this is a no-op;
+  // ppc64le uses it to re-emit the ELFv2 TOC-restore (`ld r2,24(r1)`) that the
+  // CFG dropped as unreachable but that libgcc's unwinder needs at the call's
+  // return address.
+  void emitArchNonReturningCallFixup(CodeBuffer &gens, const RelocBlock *trace);
 };
 
 struct CFPatch : public Patch {

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -33,6 +33,7 @@
 #include "Architecture.h"
 #include "binaryEdit.h"
 #include "common/src/headers.h"
+#include "common/src/debug_common.h"
 #include "mapped_object.h"
 #include "mapped_module.h"
 #include "debug.h"
@@ -45,10 +46,15 @@
 #include "image.h"
 #include "Symbol.h"
 #include "Archive.h"
+// synthesize .eh_frame for relocated code (machinery in eh_frame_gen.{h,C})
+#include "eh_frame_arch.h"   // per-arch CFI parameters, ehFrameArchFor()
+#include "eh_frame_gen.h"    // synthesizeRelocatedEHFrame()
+#include "Relocation/CodeTracker.h"
 
 #include <cstdio>
 #include <iostream>
 #include <map>
+#include <algorithm>
 #include <tuple>
 
 using namespace Dyninst::SymtabAPI;
@@ -568,7 +574,17 @@ bool BinaryEdit::writeFile(const std::string &newFileName)
       symObj->findRegion(newSec, ".dyninstInst");
       assert(newSec);
 
-      
+      // Synthesize .eh_frame (+ .gcc_except_table) for the relocated code and
+      // register it at load, so C++ exceptions can be unwound through and caught
+      // in relocated frames. All the CIE/FDE/LSDA machinery lives in
+      // synthesizeRelocatedEHFrame(); the per-arch CFI parameters come from
+      // ehFrameArchFor() (nullptr => unsupported arch, skipped). Dynamic
+      // rewriting only -- the static RT does not register the region (see
+      // RTcommon.c), so generating it there would be dead weight.
+      const EHFrameArch* ehArch = ehFrameArchFor(getArch());
+      if (!symObj->isStaticBinary() && ehArch)
+        synthesizeRelocatedEHFrame(symObj, relocatedCode_, *ehArch, highWaterMark_);
+
       if (mobj == getAOut()) {
          // Add dynamic symbol relocations
          for (unsigned i=0; i < dependentRelocations.size(); i++) {

--- a/dyninstAPI/src/debug.C
+++ b/dyninstAPI/src/debug.C
@@ -221,6 +221,7 @@ int dyn_debug_proccontrol = 0;
 int dyn_debug_stackwalk = 0;
 int dyn_debug_inst = 0;
 int dyn_debug_reloc = 0;
+int dyn_debug_eh = 0;
 int dyn_debug_springboard = 0;
 int dyn_debug_sensitivity = 0;
 int dyn_debug_dyn_unw = 0;
@@ -265,6 +266,10 @@ bool init_debug() {
   if (check_env_value("DYNINST_DEBUG_SPRINGBOARD")) {
     fprintf(stderr, "Enabling DyninstAPI springboard debug\n");
     dyn_debug_springboard = 1;
+  }
+  if (check_env_value("DYNINST_DEBUG_EH")) {
+    fprintf(stderr, "Enabling DyninstAPI exception-handling (.eh_frame synthesis) debug\n");
+    dyn_debug_eh = 1;
   }
   if (check_env_value("DYNINST_DEBUG_STARTUP")) {
     fprintf(stderr, "Enabling DyninstAPI startup debug\n");
@@ -532,6 +537,24 @@ int inst_printf_int(const char *format, ...)
 int reloc_printf_int(const char *format, ...)
 {
   if (!dyn_debug_reloc) return 0;
+  if (NULL == format) return -1;
+
+  debugPrintLock->lock();
+
+  fprintf(stderr, "[%lu]", getExecThreadID());
+  va_list va;
+  va_start(va, format);
+  int ret = vfprintf(stderr, format, va);
+  va_end(va);
+
+  debugPrintLock->unlock();
+
+  return ret;
+}
+
+int eh_printf_int(const char *format, ...)
+{
+  if (!dyn_debug_eh) return 0;
   if (NULL == format) return -1;
 
   debugPrintLock->lock();

--- a/dyninstAPI/src/debug.h
+++ b/dyninstAPI/src/debug.h
@@ -64,6 +64,7 @@ extern int dyn_debug_proccontrol;
 extern int dyn_debug_stackwalk;
 extern int dyn_debug_inst;
 extern int dyn_debug_reloc;
+extern int dyn_debug_eh;   // .eh_frame / .gcc_except_table synthesis (DYNINST_DEBUG_EH)
 extern int dyn_debug_springboard;
 extern int dyn_debug_sensitivity;
 extern int dyn_debug_dyn_unw;
@@ -134,6 +135,7 @@ DECLARE_PRINTF_FUNC(proccontrol_printf_int);
 DECLARE_PRINTF_FUNC(stackwalk_printf_int);
 DECLARE_PRINTF_FUNC(inst_printf_int);
 DECLARE_PRINTF_FUNC(reloc_printf_int);
+DECLARE_PRINTF_FUNC(eh_printf_int);
 DECLARE_PRINTF_FUNC(dyn_unw_printf_int);
 DECLARE_PRINTF_FUNC(mutex_printf_int);
 DECLARE_PRINTF_FUNC(thread_printf_int);
@@ -154,6 +156,7 @@ DECLARE_PRINTF_FUNC(stackmods_printf_int);
 #define stackwalk_printf(...)   debug_sys_printf(stackwalk, __VA_ARGS__)
 #define inst_printf(...)        debug_sys_printf(inst, __VA_ARGS__)
 #define reloc_printf(...)       debug_sys_printf(reloc, __VA_ARGS__)
+#define eh_printf(...)          debug_sys_printf(eh, __VA_ARGS__)
 #define dyn_unw_printf(...)     debug_sys_printf(dyn_unw, __VA_ARGS__)
 #define mutex_printf(...)       debug_sys_printf(mutex, __VA_ARGS__)
 #define thread_printf(...)      debug_sys_printf(thread, __VA_ARGS__)

--- a/dyninstAPI/src/dynproc/dynProcess.C
+++ b/dyninstAPI/src/dynproc/dynProcess.C
@@ -42,6 +42,8 @@
 #include "registerSpace/registerSpace.h"
 #include "mapped_object.h"
 #include "image.h"
+#include "eh_frame_arch.h"   // ehFrameArchFor()
+#include "eh_frame_gen.h"    // buildRelocatedEHFrame()
 #include "common/src/headers.h"
 #include "common/src/dyninst_filesystem.h"
 
@@ -1611,6 +1613,114 @@ void alignUp(int &val, int align) {
     if (val % align != 0) {
         val = ((val / align) + 1) * align;
     }
+}
+
+// Dynamic (live-process) delivery of synthesized .eh_frame for relocated code.
+// The rewriter bakes the blob into the output ELF behind a DT tag; a running
+// process has neither, so once relocation has installed the new code (process
+// stopped, called from BPatch_process::finalizeInsertionSet) we build the
+// .eh_frame/.gcc_except_table for the in-process relocated code, stage it in the
+// target, and inferior-RPC the RT's DYNINSTregisterEHFrame with its live address
+// so libgcc can unwind through and catch in relocated frames. This is what lets
+// C++ exceptions survive dynamic instrumentation.
+//
+// Only the main executable's Symtab is used to sample the original CFI, so
+// relocated code originating in a shared library is not yet covered.
+void PCProcess::registerRelocatedExceptionFrames() {
+   const Dyninst::EHFrameArch *arch = Dyninst::ehFrameArchFor(getArch());
+   if (!arch) return;                          // architecture not supported
+   if (relocatedCode_.empty()) return;
+
+   mapped_object *ao = getAOut();
+   if (!ao || !ao->parse_img()) return;
+   Dyninst::SymtabAPI::Symtab *symObj = ao->parse_img()->getObject();
+   if (!symObj) return;
+
+   // Restrict synthesis to the mutatee's own code. Dynamic instrumentation can
+   // relocate foreign libc helpers (fork/vfork, pulled in by the iRPC/runtime
+   // machinery) into relocatedCode_; we have no CFI for those, so a synthesized
+   // FDE would be a fabricated CIE-default descriptor that corrupts the whole
+   // __register_frame batch (observed: a stack-realigning catch then escaping
+   // to std::terminate). Pass the a.out's runtime code range as the filter.
+   Address ownLo = ao->codeAbs();
+   Address ownHi = ownLo + ao->imageSize();
+
+   // Pass 1: size the blobs (their byte lengths do not depend on placement).
+   std::vector<unsigned char> eh, ex;
+   Address ehV = 0, exV = 0;
+   unsigned nfde = Dyninst::buildRelocatedEHFrame(symObj, relocatedCode_, *arch,
+                                                  0 /*placeholder base*/, eh, ex, ehV, exV,
+                                                  ownLo, ownHi);
+   if (!nfde) return;                          // nothing exception-bearing was relocated
+
+   // The RT entrypoint must be present (it lives in the injected RT library).
+   if (!findOnlyOneFunction("DYNINSTregisterEHFrame")) return;
+
+   // Allocate one target-process region for the page-aligned layout that
+   // buildRelocatedEHFrame produces (exVaddr page-aligned, then eh after ex).
+   unsigned long exPad = (ex.size() + 0xfffUL) & ~0xfffUL;
+   unsigned long ehPad = (eh.size() + 0xfffUL) & ~0xfffUL;
+   Address base = inferiorMalloc((unsigned)(0x1000 + exPad + ehPad));
+   if (!base) return;
+
+   // inferiorMalloc'd memory is uninitialized. A file-delivered .eh_frame sits
+   // in a zero-filled region, so libgcc reading a byte past our data still reads
+   // zero; in-process it would read heap garbage (flaky catches). Zero the whole
+   // region first so the padding beyond the blobs is deterministic.
+   {
+      std::vector<unsigned char> zeros((size_t)(0x1000 + exPad + ehPad), 0);
+      writeDataSpace((void *)base, (u_int)zeros.size(), zeros.data());
+   }
+
+   // Pass 2: rebuild at the real base and write the bytes into the target.
+   eh.clear(); ex.clear(); ehV = exV = 0;
+   Dyninst::buildRelocatedEHFrame(symObj, relocatedCode_, *arch, base, eh, ex, ehV, exV,
+                                  ownLo, ownHi);
+   if (!ex.empty())
+      writeDataSpace((void *)exV, (u_int)ex.size(), ex.data());
+   writeDataSpace((void *)ehV, (u_int)eh.size(), eh.data());
+
+   eh_printf("EHREG: pid=%d base=0x%lx exV=0x%lx ehV=0x%lx ex.sz=%lu eh.sz=%lu nfde=%u\n",
+             getPid(), (unsigned long)base, (unsigned long)exV, (unsigned long)ehV,
+             (unsigned long)ex.size(), (unsigned long)eh.size(), nfde);
+   // Gate the /proc/maps dump (real I/O) on the debug flag.
+   if (dyn_debug_eh) {
+      char pth[64]; snprintf(pth, sizeof pth, "/proc/%d/maps", getPid());
+      FILE *mf = fopen(pth, "r");
+      if (mf) {
+         char ln[512];
+         while (fgets(ln, sizeof ln, mf)) {
+            unsigned long a = 0, b = 0;
+            if (sscanf(ln, "%lx-%lx", &a, &b) == 2 &&
+                ((ehV >= a && ehV < b) || (exV >= a && exV < b) ||
+                 (base >= a && base < b) || strstr(ln, "r-xp")))
+               eh_printf("MAP %s", ln);
+         }
+         fclose(mf);
+      }
+   }
+
+   // libgcc must hold only the current FDEs. Dynamic instrumentation commits
+   // incrementally: each round re-relocates the affected functions and lands
+   // here again, so drop the previous registration (a now-superseded relocation
+   // of the same code) before adding this one -- otherwise stale FDEs pile up
+   // and the unwinder may pick one.
+   if (lastRelocatedEHFrame_) {
+      std::vector<codeGenASTPtr> dargs(1);
+      dargs[0] = operandAST::Constant((void *)lastRelocatedEHFrame_);
+      codeGenASTPtr dcode = functionCallAST::namedCall("DYNINSTderegisterEHFrame", dargs);
+      void *dres = 0;
+      postIRPC(dcode, NULL, false, NULL, true, &dres, false);
+   }
+
+   // Register with libgcc in the target: iRPC DYNINSTregisterEHFrame(ehV).
+   std::vector<codeGenASTPtr> args(1);
+   args[0] = operandAST::Constant((void *)ehV);
+   codeGenASTPtr code = functionCallAST::namedCall("DYNINSTregisterEHFrame", args);
+   void *result = 0;
+   postIRPC(code, NULL, /*runProcessWhenDone=*/false, /*thread=*/NULL,
+            /*synchronous=*/true, &result, /*userRPC=*/false);
+   lastRelocatedEHFrame_ = ehV;
 }
 
 bool PCProcess::inferiorMallocDynamic(int size, Address lo, Address hi) {

--- a/dyninstAPI/src/dynproc/dynProcess.C
+++ b/dyninstAPI/src/dynproc/dynProcess.C
@@ -1644,13 +1644,17 @@ void PCProcess::registerRelocatedExceptionFrames() {
    // to std::terminate). Pass the a.out's runtime code range as the filter.
    Address ownLo = ao->codeAbs();
    Address ownHi = ownLo + ao->imageSize();
+   // The trackers carry RUNTIME original addresses; the a.out's DWARF CFI and
+   // LSDA are read at LINK-time addresses. codeBase() is the load bias (0 for a
+   // non-PIE ET_EXEC, the mapped base for a PIE), so runtime = link + codeBase().
+   Address loadBias = ao->codeBase();
 
    // Pass 1: size the blobs (their byte lengths do not depend on placement).
    std::vector<unsigned char> eh, ex;
    Address ehV = 0, exV = 0;
    unsigned nfde = Dyninst::buildRelocatedEHFrame(symObj, relocatedCode_, *arch,
                                                   0 /*placeholder base*/, eh, ex, ehV, exV,
-                                                  ownLo, ownHi);
+                                                  ownLo, ownHi, loadBias);
    if (!nfde) return;                          // nothing exception-bearing was relocated
 
    // The RT entrypoint must be present (it lives in the injected RT library).
@@ -1675,7 +1679,7 @@ void PCProcess::registerRelocatedExceptionFrames() {
    // Pass 2: rebuild at the real base and write the bytes into the target.
    eh.clear(); ex.clear(); ehV = exV = 0;
    Dyninst::buildRelocatedEHFrame(symObj, relocatedCode_, *arch, base, eh, ex, ehV, exV,
-                                  ownLo, ownHi);
+                                  ownLo, ownHi, loadBias);
    if (!ex.empty())
       writeDataSpace((void *)exV, (u_int)ex.size(), ex.data());
    writeDataSpace((void *)ehV, (u_int)eh.size(), eh.data());

--- a/dyninstAPI/src/dynproc/dynProcess.h
+++ b/dyninstAPI/src/dynproc/dynProcess.h
@@ -200,9 +200,18 @@ public:
 		PCThread* thread, 
 		bool synchronous, 
 		void** result, 
-		bool userRPC, 
-		bool isMemAlloc = false, 
+		bool userRPC,
+		bool isMemAlloc = false,
 		Address addr = 0);
+
+    // Synthesize and register (via iRPC) .eh_frame for code just relocated into
+    // this live process, so C++ exceptions can unwind through/catch in it.
+    // Called from BPatch_process::finalizeInsertionSet while the process is
+    // stopped, after the relocated code has been installed.
+    void registerRelocatedExceptionFrames();
+    // Live address of the .eh_frame currently registered with libgcc for
+    // relocated code, or 0 if none; deregistered before each re-registration.
+    Address lastRelocatedEHFrame_ = 0;
 private:
         bool postIRPC_internal(void *buffer,
                                unsigned size,

--- a/dyninstAPI/src/eh_frame_arch.C
+++ b/dyninstAPI/src/eh_frame_arch.C
@@ -31,6 +31,7 @@
 #include "eh_frame_arch.h"
 
 #include "registers/x86_64_regs.h"
+#include "registers/aarch64_regs.h"
 
 namespace Dyninst {
 
@@ -46,8 +47,20 @@ const EHFrameArch* ehFrameArchFor(Architecture arch) {
     /* stackPtrDwarf       */ 7,
   };
 
+  // aarch64: link-register architecture. lr(x30) is sampled like any other
+  // callee-saved register. Initial CFI: def_cfa sp(31),0.
+  static const EHFrameArch k_aarch64 = {
+    /* returnAddrReg       */ 30,
+    /* cieInitialCFI       */ { 0x0c, 31, 0 },
+    /* calleeSavedDwarfRegs*/ { 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 },  // x19-x28, fp, lr
+    /* framePtr            */ aarch64::x29,
+    /* framePtrDwarf       */ 29,
+    /* stackPtrDwarf       */ 31,
+  };
+
   switch (arch) {
     case Arch_x86_64:  return &k_x86_64;
+    case Arch_aarch64: return &k_aarch64;
     default:           return nullptr;
   }
 }

--- a/dyninstAPI/src/eh_frame_arch.C
+++ b/dyninstAPI/src/eh_frame_arch.C
@@ -1,0 +1,55 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "eh_frame_arch.h"
+
+#include "registers/x86_64_regs.h"
+
+namespace Dyninst {
+
+const EHFrameArch* ehFrameArchFor(Architecture arch) {
+  // x86-64: the return address is kept on the stack at CFA-8 via a constant
+  // rule, so it is not sampled. Initial CFI: def_cfa rsp(7),8 ; ra(16) @ cfa-8.
+  static const EHFrameArch k_x86_64 = {
+    /* returnAddrReg       */ 16,
+    /* cieInitialCFI       */ { 0x0c, 7, 8, 0x90, 1 },
+    /* calleeSavedDwarfRegs*/ { 3, 6, 12, 13, 14, 15 },   // rbx, rbp, r12-r15
+    /* framePtr            */ x86_64::rbp,
+    /* framePtrDwarf       */ 6,
+    /* stackPtrDwarf       */ 7,
+  };
+
+  switch (arch) {
+    case Arch_x86_64:  return &k_x86_64;
+    default:           return nullptr;
+  }
+}
+
+}  // namespace Dyninst

--- a/dyninstAPI/src/eh_frame_arch.C
+++ b/dyninstAPI/src/eh_frame_arch.C
@@ -32,6 +32,7 @@
 
 #include "registers/x86_64_regs.h"
 #include "registers/aarch64_regs.h"
+#include "registers/ppc64_regs.h"
 
 namespace Dyninst {
 
@@ -58,9 +59,23 @@ const EHFrameArch* ehFrameArchFor(Architecture arch) {
     /* stackPtrDwarf       */ 31,
   };
 
+  // ppc64le (ELFv2): link-register architecture. The link register is DWARF
+  // number 65 and is sampled like a callee-saved register. Initial CFI:
+  // def_cfa r1(sp),0.
+  static const EHFrameArch k_ppc64 = {
+    /* returnAddrReg       */ 65,
+    /* cieInitialCFI       */ { 0x0c, 1, 0 },
+    /* calleeSavedDwarfRegs*/ { 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                                24, 25, 26, 27, 28, 29, 30, 31, 65 },  // r14-r31, lr(65)
+    /* framePtr            */ ppc64::r31,
+    /* framePtrDwarf       */ 31,
+    /* stackPtrDwarf       */ 1,
+  };
+
   switch (arch) {
     case Arch_x86_64:  return &k_x86_64;
     case Arch_aarch64: return &k_aarch64;
+    case Arch_ppc64:   return &k_ppc64;
     default:           return nullptr;
   }
 }

--- a/dyninstAPI/src/eh_frame_arch.h
+++ b/dyninstAPI/src/eh_frame_arch.h
@@ -1,0 +1,90 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_EH_FRAME_ARCH_H
+#define DYNINST_EH_FRAME_ARCH_H
+
+#include <vector>
+
+#include "Architecture.h"
+#include "registers/MachRegister.h"
+
+namespace Dyninst {
+
+// Per-architecture parameters for synthesizing DWARF CFI (.eh_frame) for
+// relocated code.
+//
+// The synthesis itself -- sampling the original frame rules via libdw, laying
+// out CIEs/FDEs, and regenerating the .gcc_except_table -- is architecture
+// neutral. Only three things differ per architecture:
+//   * the CIE return_address_register,
+//   * the CIE's initial CFI (the CFA definition and, on architectures that
+//     keep the return address on the stack at a fixed offset, the constant
+//     rule that recovers it), and
+//   * the set of callee-saved registers whose rules are sampled per PC.
+//
+// On link-register architectures (aarch64, ppc64le) the return address is held
+// in a register that is spilled like any other callee-saved register, so it is
+// sampled per PC and appears in `calleeSavedDwarfRegs`. x86-64 instead recovers
+// the return address from a constant rule baked into `cieInitialCFI` and does
+// not sample it.
+struct EHFrameArch {
+  // CIE return_address_register (DWARF number).
+  unsigned returnAddrReg;
+
+  // CIE initial instructions: the CFA definition, plus (x86-64 only) the
+  // constant rule recovering the return address from the stack.
+  std::vector<unsigned char> cieInitialCFI;
+
+  // Callee-saved registers to sample and restore, by DWARF number. On
+  // link-register architectures this includes the return-address register.
+  std::vector<unsigned> calleeSavedDwarfRegs;
+
+  // This architecture's frame pointer and the DWARF numbers used to express a
+  // CFA that is anchored to either the frame or the stack pointer.
+  MachRegister framePtr;
+  unsigned framePtrDwarf;
+  unsigned stackPtrDwarf;
+
+  // DWARF number for a CFA anchored at the frame pointer (if `r` is the frame
+  // pointer) or otherwise at the stack pointer.
+  unsigned dwarfForFrameOrStack(MachRegister r) const {
+    return (r == framePtr) ? framePtrDwarf : stackPtrDwarf;
+  }
+};
+
+// Returns the parameters for `arch`, or nullptr if synthesizing .eh_frame for
+// relocated code is not supported on it (e.g. RISC-V, AMDGPU). Callers must
+// skip synthesis when this returns nullptr.
+const EHFrameArch* ehFrameArchFor(Architecture arch);
+
+}  // namespace Dyninst
+
+#endif  // DYNINST_EH_FRAME_ARCH_H

--- a/dyninstAPI/src/eh_frame_gen.C
+++ b/dyninstAPI/src/eh_frame_gen.C
@@ -1,0 +1,744 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+// Synthesizes .eh_frame and, for functions with a C++ LSDA, .gcc_except_table
+// for relocated code: all the CIE/FDE/LSDA machinery that lets a C++ exception
+// unwind through, and be caught in, code dyninst has relocated.
+
+#include "eh_frame_gen.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>   // malloc
+#include <cstring>   // memcpy, memset
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "Relocation/CodeTracker.h"          // Relocation::CodeTracker
+#include "symtabAPI/h/Symtab.h"              // Symtab, EHFunctionInfo, FrameRegRule
+#include "Region.h"                          // Region
+#include "VariableLocation.h"
+#include "debug.h"                            // eh_printf (DYNINST_DEBUG_EH)
+#include "dyninstAPI_RT/h/dyninstAPI_RT.h"   // DT_DYNINST_EH_FRAME
+
+using namespace Dyninst;
+using namespace Dyninst::SymtabAPI;
+
+// Build the .eh_frame / .gcc_except_table blobs for the relocated code, placed
+// at addresses derived from `regionBase` (the low end of where the blobs will
+// live -- a link-time vaddr for a rewriter, a live inferiorMalloc address for a
+// process). Pure: no delivery, no side effects on symObj beyond reads, so it is
+// safe to call twice (once with a placeholder base to learn the sizes, once
+// with the real base once the region has been allocated). Returns the number of
+// FDEs emitted; the bytes and their chosen placement addresses come back through
+// the out-parameters.
+unsigned Dyninst::buildRelocatedEHFrame(Symtab *symObj,
+                                        std::list<Relocation::CodeTracker *> &relocatedCode,
+                                        const EHFrameArch &arch,
+                                        Address regionBase,
+                                        std::vector<unsigned char> &ehOut,
+                                        std::vector<unsigned char> &exOut,
+                                        Address &ehVaddrOut,
+                                        Address &exVaddrOut,
+                                        Address ownLo, Address ownHi) {
+  typedef std::list<Relocation::CodeTracker *> CodeTrackers;
+
+  // ---- byte emitters (buffer-parameterized) ----
+  typedef std::vector<unsigned char> Bytes;
+  auto pU8  = [](Bytes&b, unsigned char v){ b.push_back(v); };
+  auto pU32 = [](Bytes&b, uint32_t v){ for(int i=0;i<4;i++) b.push_back((unsigned char)((v>>(8*i))&0xff)); };
+  auto pS32 = [&](Bytes&b, int32_t v){ pU32(b,(uint32_t)v); };
+  auto pUleb= [](Bytes&b, uint64_t v){ do{ unsigned char c=v&0x7f; v>>=7; if(v)c|=0x80; b.push_back(c);}while(v); };
+  auto pSleb= [](Bytes&b, int64_t v){ bool more=true; while(more){ unsigned char c=v&0x7f; v>>=7;
+                 if((v==0&&!(c&0x40))||(v==-1&&(c&0x40))) more=false; else c|=0x80; b.push_back(c);} };
+  auto dwreg= [&](Dyninst::MachRegister r)->unsigned {
+                 return arch.dwarfForFrameOrStack(r); };
+  auto rdSleb=[](const Bytes&b, size_t p, int64_t*out)->size_t {
+                 int64_t r=0; int sh=0; size_t n=0; unsigned char c;
+                 do{ if(p+n>=b.size()){*out=0;return n?n:1;} c=b[p+n]; r|=(int64_t)(c&0x7f)<<sh; sh+=7; n++; }while(c&0x80);
+                 if(sh<64 && (c&0x40)) r|=-((int64_t)1<<sh);
+                 *out=r; return n; };
+
+  // ---- Pass 1: gather trackers -> per-func original trackers, global
+  //      orig->reloc map, and the overall relocated span. ----
+  struct OrigTracker { Address relocAddr, origAddr; unsigned size; };
+  struct TrackerMapEnt { Address origAddr, relocAddr; unsigned size; bool isOrig; };
+  struct FuncRec { void* fp; Address relocStart, relocEnd, origLo, origHi;
+                   std::vector<OrigTracker> origTrackers; std::vector<EHFunctionInfo*> eh;
+                   // origRuns: maximal runs of this function's ORIGINAL bytes not
+                   //   interrupted by another function's code -- the units to
+                   //   sample CFA/reg rules over. A hot/cold-split function has
+                   //   two; sampling the whole [origLo,origHi] hull instead would
+                   //   leak a bracketed foreign function's entry rule.
+                   // relocRuns: maximal runs of this function's RELOCATED code --
+                   //   one FDE per run, so no FDE over-claims an interleaved
+                   //   neighbor.
+                   std::vector<std::pair<Address,Address>> origRuns, relocRuns; };
+  std::map<void*, FuncRec> byFunc;
+  std::vector<TrackerMapEnt> origRelocMap;
+  std::vector<std::pair<std::pair<Address,Address>,void*>> allOrig, allReloc;
+  Address relocHi = 0;
+  for (CodeTrackers::iterator ci = relocatedCode.begin(); ci != relocatedCode.end(); ++ci) {
+    for (Relocation::CodeTracker::TrackerList::const_iterator ti = (*ci)->trackers().begin();
+         ti != (*ci)->trackers().end(); ++ti) {
+      Relocation::TrackerElement *te = *ti;
+      Address relocAddr = te->reloc(); unsigned size = te->size();
+      if (!relocAddr || !size) continue;
+      if (relocAddr + size > relocHi) relocHi = relocAddr + size;
+      bool isOrig = (te->type() == Relocation::TrackerElement::original);
+      origRelocMap.push_back({ te->orig(), relocAddr, size, isOrig });
+      if (te->func())
+        allReloc.push_back({ { relocAddr, relocAddr+size }, (void*)te->func() });   // ALL trackers: reloc extent
+      if (isOrig && te->func()) {
+        void* fp = (void*)te->func();
+        FuncRec &rec = byFunc[fp];
+        if (rec.origTrackers.empty()) { rec.fp=fp; rec.relocStart=relocAddr; rec.origLo=te->orig(); rec.origHi=te->orig()+size; }
+        if (relocAddr < rec.relocStart) rec.relocStart = relocAddr;
+        if (te->orig() < rec.origLo) rec.origLo = te->orig();
+        if (te->orig()+size > rec.origHi) rec.origHi = te->orig()+size;
+        rec.origTrackers.push_back({ relocAddr, te->orig(), size });
+        allOrig.push_back({ { te->orig(), te->orig()+size }, fp });    // original-only: orig extent
+      }
+    }
+  }
+  std::sort(origRelocMap.begin(), origRelocMap.end(), [](const TrackerMapEnt&a,const TrackerMapEnt&b){
+    if (a.origAddr != b.origAddr) return a.origAddr < b.origAddr;
+    // A single original instruction can be tracked twice at one origAddr: the
+    // verbatim copy (isOrig) and an inserted instrumentation snippet emulated
+    // alongside it. origToReloc resolves the LAST entry with origAddr <= a, so
+    // the verbatim tracker must sort last -- it yields the precise per-instruction
+    // reloc PC (relocAddr + (a-origAddr)). Resolving to the snippet returns its
+    // start for every interior PC, collapsing a function's CFA-rule PCs onto one
+    // address; the FDE then loses its advance_loc boundaries and flattens to its
+    // last def_cfa rule. For a stack-realigning function that drops the rbp-based
+    // rule, and the unwinder reads a garbage return address off the realigned
+    // rsp -> std::terminate.
+    return a.isOrig < b.isOrig;
+  });
+  // origRelocMap is the ground truth for every address this generator emits;
+  // dump it under DYNINST_DEBUG_EH to diagnose a mis-mapping.
+  for (auto &e : origRelocMap)
+    eh_printf("OMAP os=0x%lx rs=0x%lx sz=%u orig=%d\n",
+              (unsigned long)e.origAddr, (unsigned long)e.relocAddr, e.size, (int)e.isOrig);
+  // Group globally-ordered trackers into per-function runs, breaking a run
+  // wherever another function's code falls between two of this function's
+  // trackers. allOrig->origRuns (sampling units); allReloc->relocRuns (FDE units).
+  auto buildRuns = [](std::vector<std::pair<std::pair<Address,Address>,void*>> &all,
+                      std::map<void*,FuncRec> &bf,
+                      std::vector<std::pair<Address,Address>> FuncRec::*dst) {
+    std::sort(all.begin(), all.end(),
+              [](const std::pair<std::pair<Address,Address>,void*>&a,
+                 const std::pair<std::pair<Address,Address>,void*>&b){ return a.first < b.first; });
+    for (size_t i=0;i<all.size();) {
+      void* fp = all[i].second;
+      Address lo = all[i].first.first, hiR = all[i].first.second;
+      size_t j=i+1;
+      for (; j<all.size() && all[j].second==fp; ++j) hiR = std::max(hiR, all[j].first.second);
+      (bf[fp].*dst).push_back({ lo, hiR });
+      i=j;
+    }
+  };
+  buildRuns(allOrig, byFunc, &FuncRec::origRuns);
+  buildRuns(allReloc, byFunc, &FuncRec::relocRuns);
+  // A function's relocated footprint can BEGIN with an emulated tracker -- e.g. a
+  // rewritten call at the very start of a hot/cold .cold fragment -- which sits
+  // below its first verbatim instruction. relocRuns (built from ALL trackers)
+  // carry the true low bound; without lowering relocStart to it, that leading
+  // call falls below relocStart, its call-site region is dropped as unmappable,
+  // and a throw through it escapes to std::terminate. Only ever lower the bound.
+  for (auto &kv : byFunc)
+    if (!kv.second.relocRuns.empty() &&
+        kv.second.relocRuns.front().first < kv.second.relocStart)
+      kv.second.relocStart = kv.second.relocRuns.front().first;
+  // orig -> reloc (exact within a verbatim tracker; start-of-tracker otherwise).
+  auto origToReloc = [&](Address a)->Address {
+    if (origRelocMap.empty()) return 0;
+    size_t loIdx=0, hiIdx=origRelocMap.size(); // first ent with origAddr > a
+    while (loIdx<hiIdx){ size_t m=(loIdx+hiIdx)/2; if(origRelocMap[m].origAddr<=a) loIdx=m+1; else hiIdx=m; }
+    if (loIdx==0) return 0;
+    const TrackerMapEnt&e = origRelocMap[loIdx-1];
+    if (e.isOrig && a < e.origAddr + e.size) return e.relocAddr + (a - e.origAddr);
+    return e.relocAddr;
+  };
+  // Map the one-past-end of an original range to the one-past-end of its
+  // relocated code via the range's LAST byte. (Mapping the end ADDRESS through
+  // origToReloc is wrong twice over: that address belongs to the NEXT block, and
+  // an emulated tracker's interior bytes all fall back to the tracker start,
+  // collapsing the range.)
+  auto origToRelocEnd = [&](Address end)->Address {
+    if (origRelocMap.empty() || end == 0) return 0;
+    Address a = end - 1;
+    size_t loIdx=0, hiIdx=origRelocMap.size();
+    while (loIdx<hiIdx){ size_t m=(loIdx+hiIdx)/2; if(origRelocMap[m].origAddr<=a) loIdx=m+1; else hiIdx=m; }
+    if (loIdx==0) return 0;
+    // One original instruction can expand into several relocated trackers at this
+    // origAddr (an inserted snippet PLUS the copied instruction), disjoint in
+    // reloc space and emitted in either order -- the one that sorts last may have
+    // the SMALLER reloc end. Take the MAXIMUM over every tracker at this origAddr;
+    // otherwise a call whose snippet sorts last is left just OUTSIDE its call-site
+    // region, the throw PC falls into a call-site-table gap, and the personality
+    // treats it as a nothrow region and calls std::terminate.
+    Address origAddr = origRelocMap[loIdx-1].origAddr, best = 0;
+    for (size_t k = loIdx; k-- > 0 && origRelocMap[k].origAddr == origAddr; ) {
+      const TrackerMapEnt &e = origRelocMap[k];
+      Address r = (e.isOrig && a < e.origAddr + e.size) ? e.relocAddr + (a - e.origAddr) + 1
+                                                        : e.relocAddr + e.size;
+      if (r > best) best = r;
+    }
+    return best;
+  };
+
+  // sorted function list; relocEnd = next func's start (contiguous, disjoint FDEs).
+  std::vector<FuncRec*> funcs;
+  for (auto &kv : byFunc) {
+    if (kv.second.origTrackers.empty()) continue;   // skip pseudo-entries (emulated-only, from allReloc)
+    // Restrict to the instrumented application's own code. Dynamic
+    // instrumentation can relocate foreign helpers (e.g. libc fork/vfork pulled
+    // in by the iRPC/runtime machinery) into relocatedCode_; we hold no source
+    // CFI for them, so any FDE we synthesized would carry only CIE default rules
+    // -- a fabricated descriptor that corrupts the whole __register_frame batch
+    // and defeats the application's own correct FDEs.
+    if (ownHi > ownLo &&
+        (kv.second.origLo < ownLo || kv.second.origLo >= ownHi)) {
+      eh_printf("EH: skipping foreign relocated func orig[0x%lx,0x%lx] "
+                "(outside app range [0x%lx,0x%lx))\n",
+                (unsigned long)kv.second.origLo, (unsigned long)kv.second.origHi,
+                (unsigned long)ownLo, (unsigned long)ownHi);
+      continue;
+    }
+    funcs.push_back(&kv.second);
+  }
+  std::sort(funcs.begin(), funcs.end(),
+            [](const FuncRec*a,const FuncRec*b){ return a->relocStart < b->relocStart; });
+  for (size_t i=0;i<funcs.size();i++)
+    funcs[i]->relocEnd = (i+1<funcs.size()) ? funcs[i+1]->relocStart : relocHi;
+
+  // ---- Extract + assign original LSDA info to relocated functions. ----
+  std::vector<EHFunctionInfo> ehInfos;
+  symObj->getEHFrameInfo(ehInfos);
+  // Type-table entry encoding, from the first LSDA that has a type table (PIE:
+  // indirect|pcrel|sdata4 = 0x9b). Personality is looked up per-function at
+  // CIE-emit time (funcPers), not tracked globally.
+  unsigned char ttype_format = 0x9b;
+  bool ttypeSet = false;
+  for (auto &info : ehInfos) {
+    // Attach each original LSDA to the relocated function whose ORIGINAL code it
+    // describes, scored by OVERLAP against that function's origRuns rather than
+    // by simple "func_low_pc in [origLo,origHi)" containment. A hot/cold-split
+    // function has two FDEs (hot body + .cold fragment) that both must land on
+    // the one relocated FuncRec that merged them, and containment fails two ways:
+    //   1. a .cold FDE's func_low_pc can sit a few bytes BELOW origLo (the first
+    //      byte dyninst actually relocated), so containment drops the fragment --
+    //      and with it the throw's call-site region -> a terminate trap.
+    //   2. a split function's [origLo,origHi) hull SUBSUMES an interleaved
+    //      neighbor (cold blocks pool in .text.unlikely), so containment is
+    //      ambiguous between functions.
+    // origRuns exclude the interleaved foreign code; score with the FDE's full
+    // extent (func_low_pc .. end-of-last-call-site), not just its entry pc.
+    Address fdeLo = info.func_low_pc, fdeHi = info.func_low_pc + 1;
+    for (auto &cs : info.callsites) {
+      Address e = cs.region_start + (cs.region_size ? cs.region_size : 1);
+      if (cs.region_start < fdeLo) fdeLo = cs.region_start;
+      if (e > fdeHi) fdeHi = e;
+    }
+    FuncRec* best = nullptr; Address bestOv = 0;
+    for (auto f : funcs) {
+      Address ov = 0;
+      for (auto &r : f->origRuns) {
+        Address lo = std::max(fdeLo, r.first), hiO = std::min(fdeHi, r.second);
+        if (hiO > lo) ov += hiO - lo;
+      }
+      if (ov > bestOv) { bestOv = ov; best = f; }
+    }
+    if (best) {
+      best->eh.push_back(&info);
+      eh_printf("LSDA: assign FDE[0x%lx..0x%lx] -> func reloc 0x%lx "
+                "(origRun overlap=%lu, %zu callsites)\n",
+                (unsigned long)fdeLo, (unsigned long)fdeHi,
+                (unsigned long)best->relocStart, (unsigned long)bestOv,
+                info.callsites.size());
+      if (!ttypeSet && info.ttype_format != 0xff) {
+        ttype_format = info.ttype_format;
+        ttypeSet = true;
+      }
+    } else {
+      eh_printf("LSDA: FDE[0x%lx..0x%lx] matched no relocated function "
+                "(dropped)\n", (unsigned long)fdeLo, (unsigned long)fdeHi);
+    }
+  }
+  // Byte width of a DW_EH_PE_* value, and whether it is pcrel. PIE uses
+  // pcrel/indirect encodings, non-PIE absolute (udata4); honor whichever the
+  // original .eh_frame used or the personality reads a bogus pointer.
+  auto encSize = [](unsigned char enc)->int {
+    switch (enc & 0x0f) {
+      case 0x02: case 0x0a: return 2;   // [s]data2
+      case 0x03: case 0x0b: return 4;   // [s]data4
+      case 0x04: case 0x0c: return 8;   // [s]data8
+      case 0x00: return 8;              // absptr (x86-64)
+      default: return 4;
+    }
+  };
+  auto isPcrel = [](unsigned char enc)->bool { return (enc & 0x70) == 0x10; };
+
+  // ---- Pass 2: decode each LSDA-bearing function's call sites, action chain,
+  //      and type table into a per-function LsdaData. Not emitted here: pass 3
+  //      emits a SEPARATE LSDA per relocated run (per FDE), since call-site and
+  //      landing-pad offsets are relative to each FDE's own start (per the ELF
+  //      LSDA format), so one function-wide table can't be shared across a split
+  //      function's multiple FDEs. ----
+  Address exVaddr = (regionBase + 0xfffUL) & ~((Address)0xfffUL);
+  Bytes ex;
+  // Call-site record in ABSOLUTE relocated addresses (made FDE-relative at emit
+  // time in pass 3). filters: original action-chain values (>0 catch, 0 cleanup,
+  // <0 spec).
+  struct CallSiteRec { Address rstart, rend, lp; std::vector<int64_t> filters; };
+  struct LsdaData { std::vector<CallSiteRec> callSites; std::vector<unsigned> csAction;
+                    Bytes action; std::map<unsigned,Address> filterType;
+                    unsigned maxFilter=0; };
+  std::map<FuncRec*, LsdaData> lsdaData;
+
+  // The synthesized tables can be delivered far from the mutatee's typeinfo /
+  // personality GOT slots -- a live-process inferiorMalloc region may land >2GB
+  // away, overflowing a 4-byte pcrel offset (wrong type pointer -> the catch
+  // type-match fails -> the exception escapes). Widen the cross-reference
+  // encodings (personality, TType) from pcrel|sdata4 (the usual PIE encoding) to
+  // pcrel|sdata8: still position-independent, unlimited range, and libgcc reads
+  // the widened encoding byte we emit. References to our own adjacent regions
+  // (the FDE initial_location, the LSDA pointer) stay sdata4.
+  auto widenPcrel = [&](unsigned char enc)->unsigned char {
+    return (isPcrel(enc) && (enc & 0x0f) == 0x0b) ? (unsigned char)((enc & 0xf0) | 0x0c) : enc;
+  };
+  ttype_format = widenPcrel(ttype_format);
+
+  const int ttypeEntrySize = encSize(ttype_format);   // type-table entry width
+  for (auto f : funcs) {
+    if (f->eh.empty()) continue;
+    // Preserve the ORIGINAL filter numbering: relocated landing pads are copied
+    // verbatim and still switch on the original selector constants the
+    // personality passes them, so a regenerated `filter K` must resolve to the
+    // same typeinfo the original `type_targets[K-1]` did. filterType maps a
+    // positive filter to its typeinfo (0 == catch-all sentinel); maxFilter sizes
+    // the type table.
+    std::map<unsigned, Address> filterType;
+    unsigned maxFilter = 0;
+    std::vector<CallSiteRec> callSites;
+    for (auto info : f->eh) {
+      for (auto &cs : info->callsites) {
+        CallSiteRec site; site.rstart=origToReloc(cs.region_start);
+        site.rend = cs.region_size
+                 ? origToRelocEnd(cs.region_start + cs.region_size)
+                 : site.rstart;
+        site.lp = cs.landing_pad ? origToReloc(cs.landing_pad) : 0;
+        if (cs.action != 0) {           // walk the original action chain
+          uint64_t a=cs.action; int guard=0;
+          while (a && guard++<64) {
+            size_t p=a-1; if (p>=info->action_table.size()) break;
+            int64_t filter; size_t fs=rdSleb(info->action_table,p,&filter);
+            int64_t next;   size_t np=p+fs; rdSleb(info->action_table,np,&next);
+            // Keep every record (0 cleanup / >0 catch / <0 spec) so the chain --
+            // e.g. a cleanup ahead of a catch -- stays intact.
+            site.filters.push_back(filter);
+            if (filter > 0) {
+              Address tgt = ((size_t)filter <= info->type_targets.size())
+                            ? info->type_targets[filter-1] : 0;
+              filterType[(unsigned)filter] = tgt;   // 0 => catch-all
+              if ((unsigned)filter > maxFilter) maxFilter = (unsigned)filter;
+            } else if (filter < 0) {
+              eh_printf("LSDA: exception-spec filter %ld not reconstructed "
+                        "(func reloc 0x%lx)\n", (long)filter,
+                        (unsigned long)f->relocStart);
+            }
+            if (next==0) break;
+            long npos=(long)np+next; if (npos<0) break; a=(uint64_t)npos+1;
+          }
+        }
+        // Keep zero-landing-pad rows: a PC MISSING from the call-site table
+        // means "call std::terminate" to the personality, while a row with lp=0
+        // means "unwind through, nothing to run here". Dropping them turns every
+        // may-throw region without a handler -- e.g. the __cxa_throw call in a
+        // function whose LSDA has only cleanups -- into a terminate trap.
+        //
+        // But only rows that MAP into this function's relocated span may be
+        // emitted: origToReloc returns 0 / a foreign block for regions whose
+        // code was not relocated with this function, and an out-of-range start
+        // underflows the FDE-relative uleb, corrupting the table.
+        if (!site.rstart || site.rstart < f->relocStart || site.rstart >= f->relocEnd) {
+          if (site.lp || !site.filters.empty())
+            eh_printf("LSDA: dropping unmappable call-site region 0x%lx+%lu (lp=0x%lx)\n",
+                      (unsigned long)cs.region_start, (unsigned long)cs.region_size,
+                      (unsigned long)site.lp);
+          continue;
+        }
+        if (site.rend <= site.rstart) site.rend = site.rstart + 1;
+        if (site.rend > f->relocEnd) site.rend = f->relocEnd;
+        if (site.lp && (site.lp < f->relocStart || site.lp >= f->relocEnd)) {
+          eh_printf("LSDA: landing pad 0x%lx maps outside function, clearing\n",
+                    (unsigned long)site.lp);
+          site.lp = 0; site.filters.clear();
+        }
+        callSites.push_back(site);
+      }
+    }
+    if (callSites.empty()) { f->eh.clear(); continue; }  // treat as non-LSDA
+    // The personality scans the call-site table linearly and stops at the first
+    // entry starting past the PC, so entries must be sorted by relocated start
+    // (block reordering can permute the originals).
+    std::sort(callSites.begin(), callSites.end(),
+              [](const CallSiteRec&a, const CallSiteRec&b){ return a.rstart < b.rstart; });
+    // action table + per-call-site action index (shared across this function's
+    // per-run LSDAs; filter values index the type table).
+    LsdaData &lsda = lsdaData[f];
+    lsda.filterType = std::move(filterType);
+    lsda.maxFilter = maxFilter;
+    lsda.csAction.assign(callSites.size(), 0);
+    for (size_t i=0;i<callSites.size();i++) {
+      if (callSites[i].filters.empty()) { lsda.csAction[i]=0; continue; }  // cleanup: action 0
+      lsda.csAction[i] = (unsigned)(lsda.action.size()+1);
+      for (size_t k=0;k<callSites[i].filters.size();k++) {
+        pSleb(lsda.action,(int64_t)callSites[i].filters[k]);
+        pSleb(lsda.action, (k+1<callSites[i].filters.size()) ? 1 : 0);
+      }
+    }
+    lsda.callSites = std::move(callSites);
+  }
+
+  // ---- Pass 3a: emit ONE LSDA PER RELOCATED RUN into the .gcc_except_table
+  //      blob, and record per-run descriptors. A function split across
+  //      non-contiguous relocated runs gets one FDE per run, and each FDE needs
+  //      its OWN LSDA whose call-site/landing-pad offsets are relative to that
+  //      run's start (= the FDE's initial_location, which is what the omitted
+  //      LPStart defaults to). Sharing one function-wide table across the runs
+  //      mis-resolves every offset in the runs that don't start at relocStart. ----
+  auto emitRunLSDA = [&](Address runLo, Address runHi, LsdaData &lsda) -> size_t {
+    Bytes csrec;
+    for (size_t i=0;i<lsda.callSites.size();i++) {
+      CallSiteRec &site = lsda.callSites[i];
+      if (site.rstart < runLo || site.rstart >= runHi) continue;   // not in this run
+      Address rend = (site.rend > site.rstart) ? site.rend : site.rstart+1;
+      if (rend > runHi) rend = runHi;
+      // Landing-pad offset is relative to runLo (the FDE start); a pad in ANOTHER
+      // run at a LOWER address can't be encoded as an unsigned uleb, so drop the
+      // action there (unwind continues) rather than emit a bogus pad. In-run and
+      // forward pads encode fine.
+      unsigned act = lsda.csAction[i];
+      Address lpoff = 0;
+      if (site.lp) { if (site.lp >= runLo) lpoff = site.lp - runLo; else act = 0; }
+      pUleb(csrec, site.rstart - runLo);
+      pUleb(csrec, rend - site.rstart);
+      pUleb(csrec, lpoff);
+      pUleb(csrec, act);
+    }
+    Bytes body; pU8(body,0x01); pUleb(body,csrec.size());   // 0x01 = call-site table enc DW_EH_PE_uleb128
+    body.insert(body.end(), csrec.begin(), csrec.end());
+    body.insert(body.end(), lsda.action.begin(), lsda.action.end());
+    size_t nTypeSlots = lsda.maxFilter;                     // type table has slots 1..nTypeSlots
+    size_t bdSize = body.size() + nTypeSlots*ttypeEntrySize;  // == TType base offset
+    size_t off = ex.size();
+    pU8(ex, 0xff);                            // LPStart: omit -> FDE initial_location (=runLo)
+    pU8(ex, nTypeSlots ? ttype_format : 0xff);// TType encoding
+    if (nTypeSlots) pUleb(ex, bdSize);        // TType base offset
+    ex.insert(ex.end(), body.begin(), body.end());
+    for (long fk=(long)nTypeSlots; fk>=1; fk--) {  // type table: slots nTypeSlots..1 (downward)
+      auto it = lsda.filterType.find((unsigned)fk);
+      Address tgt = (it != lsda.filterType.end()) ? it->second : 0;  // absent/catch-all => 0
+      size_t eoff = ex.size();
+      // Emit exactly ttypeEntrySize bytes little-endian (the width the TType
+      // encoding declares) -- pcrel offset, absolute target, or zero for a
+      // catch-all. Must match the encoding width for the same reason the
+      // personality pointer must (ppc64le = 8 bytes).
+      int64_t v = (tgt == 0) ? 0
+                  : (isPcrel(ttype_format) ? ((int64_t)tgt - (int64_t)(exVaddr + eoff))
+                                           : (int64_t)tgt);
+      for (int b=0;b<ttypeEntrySize;b++) ex.push_back((unsigned char)((v>>(8*b))&0xff));
+    }
+    return off;
+  };
+  struct RunDesc { Address lo, hi; size_t lsda; };   // lsda==(size_t)-1: CFA-only run
+  std::map<FuncRec*, std::vector<RunDesc>> runDescs;
+  for (auto f : funcs) {
+    auto ldIt = lsdaData.find(f);
+    std::vector<RunDesc> descs;
+    for (auto &rrun : f->relocRuns) {
+      RunDesc d{ rrun.first, rrun.second, (size_t)-1 };
+      if (ldIt != lsdaData.end()) {
+        bool has=false;
+        for (auto &site : ldIt->second.callSites)
+          if (site.rstart >= rrun.first && site.rstart < rrun.second) { has=true; break; }
+        if (has) d.lsda = emitRunLSDA(rrun.first, rrun.second, ldIt->second);
+      }
+      descs.push_back(d);
+    }
+    runDescs[f] = std::move(descs);
+  }
+
+  // ---- Pass 3: build .eh_frame (CIEs + FDEs, one per relocated run). ----
+  Address ehVaddr = exVaddr + ((ex.size()+0xfffUL) & ~((Address)0xfffUL));
+  if (ex.empty()) ehVaddr = exVaddr;   // no LSDAs -> reuse the page
+  Bytes eh;
+  // Per-arch CFI parameters (eh_frame_arch.h); the rule sampling (libdw) and the
+  // .gcc_except_table are arch-neutral. calleeSavedRegs holds the DWARF register
+  // NUMBERS to sample/restore, sampled by number (getFrameRegRulesByDwarf) so a
+  // column with no Dyninst MachRegister -- ppc64 LR = 65 -- is reachable. On
+  // link-register arches (aarch64, ppc64le) the return-address register is itself
+  // in this set and sampled per-PC; x86-64 keeps the RA on the stack at cfa-8 via
+  // a constant rule baked into cieInitialCFI and does not sample it.
+  const unsigned raReg = arch.returnAddrReg;
+  const Bytes& cieInitCFI = arch.cieInitialCFI;
+  const std::vector<unsigned>& calleeSavedRegs = arch.calleeSavedDwarfRegs;
+  // CIE #0: "zR" (FDE ptr enc pcrel|sdata8), for functions without an LSDA.
+  size_t cieZR = eh.size();
+  { size_t lp=eh.size(); pU32(eh,0); size_t b=eh.size();
+    pU32(eh,0); pU8(eh,1); pU8(eh,0x7a); pU8(eh,0x52); pU8(eh,0);   // "zR"
+    pUleb(eh,1); pU8(eh,0x78); pUleb(eh,raReg);                     // caf=1 daf=-8 ra=<arch>
+    pUleb(eh,1); pU8(eh,0x1c);                                     // aug data: R=pcrel|sdata8 (wide: reloc code may be far)
+    eh.insert(eh.end(), cieInitCFI.begin(), cieInitCFI.end());     // arch initial CFI
+    while ((eh.size()-b)&3) eh.push_back(0);
+    uint32_t l=(uint32_t)(eh.size()-b); memcpy(&eh[lp],&l,4); }
+  // One "zPLR" CIE (personality + LSDA) per DISTINCT PERSONALITY. A mixed C/C++
+  // binary references both __gxx_personality_v0 (C++ -- does catch/type matching)
+  // and __gcc_personality_v0 (C -- cleanup only, never matches a catch). A single
+  // global personality unwinds every C++ frame under whichever comes first; under
+  // the C personality a C++ catch silently never fires and the exception escapes
+  // to std::terminate. Emit a CIE per (personality target, encoding) actually
+  // used, and point each function's FDE at the CIE matching ITS OWN personality.
+  auto emitZPLR = [&](Address ptarget, unsigned char pformat) -> size_t {
+    pformat = widenPcrel(pformat);   // avoid 4-byte pcrel overflow to a far personality
+    size_t cie = eh.size();
+    size_t lp=eh.size(); pU32(eh,0); size_t b=eh.size();
+    pU32(eh,0); pU8(eh,1);
+    pU8(eh,0x7a); pU8(eh,0x50); pU8(eh,0x4c); pU8(eh,0x52); pU8(eh,0); // "zPLR"
+    pUleb(eh,1); pU8(eh,0x78); pUleb(eh,raReg);                     // caf=1 daf=-8 (0x78=sleb -8) ra=<arch>
+    // aug data = [P_enc][P_val][L_enc][R_enc]; P_val width follows P_enc, and the
+    // original personality encoding (pcrel PIE / absolute non-PIE) is preserved.
+    int psz = encSize(pformat);
+    pUleb(eh, (uint64_t)(1 + psz + 1 + 1));
+    pU8(eh, pformat);                                // P enc (as in original)
+    { size_t pf=eh.size();
+      // Emit exactly encSize(pformat) bytes little-endian: pcrel offset or
+      // absolute target. Width MUST match the encoding -- ppc64le udata8 (8),
+      // x86-64/aarch64 sdata4 (4) -- or the aug data is short and libgcc's
+      // read_encoded_value_with_base crashes on the personality pointer.
+      int64_t v = isPcrel(pformat)
+                  ? ((int64_t)ptarget - (int64_t)(ehVaddr+pf))
+                  : (int64_t)ptarget;
+      for (int b2=0;b2<psz;b2++) eh.push_back((unsigned char)((v>>(8*b2))&0xff)); }
+    pU8(eh, 0x1b);                                   // L enc: pcrel|sdata4 (LSDA is in our adjacent region)
+    pU8(eh, 0x1c);                                   // R enc: pcrel|sdata8 (wide: reloc code may be far)
+    eh.insert(eh.end(), cieInitCFI.begin(), cieInitCFI.end());     // arch initial CFI
+    while ((eh.size()-b)&3) eh.push_back(0);
+    uint32_t l=(uint32_t)(eh.size()-b); memcpy(&eh[lp],&l,4);
+    return cie;
+  };
+  // A function's personality: the first of its original FDEs that carried one
+  // (a function's hot and .cold fragments share it).
+  auto funcPers = [](FuncRec *f, Address &pt, unsigned char &pf)->bool {
+    for (auto info : f->eh)
+      if (info->personality_target) {
+        pt = info->personality_target; pf = info->personality_format; return true;
+      }
+    return false;
+  };
+  std::map<std::pair<Address,unsigned>, size_t> cieForPers;
+  if (!ex.empty()) {
+    for (auto f : funcs) {
+      if (lsdaData.find(f) == lsdaData.end()) continue;
+      Address pt=0; unsigned char pf=0;
+      if (!funcPers(f, pt, pf)) continue;
+      auto key = std::make_pair(pt,(unsigned)pf);
+      if (cieForPers.find(key)==cieForPers.end())
+        cieForPers[key] = emitZPLR(pt, pf);
+    }
+  }
+  unsigned nfde=0, nlsda=0;
+  // A sampled CFA-or-register rule at a relocated PC. regColumn -1 marks a CFA
+  // rule; otherwise it is an index into calleeSavedRegs.
+  struct RuleEvent { Address rpc; int regColumn; int kind; unsigned reg; int64_t val; };
+  for (auto f : funcs) {
+    // Sample the CFA and callee-saved rules per ORIGINAL run of THIS function
+    // only (never across the foreign functions between a hot/cold split, which
+    // would leak a foreign entry rule). +1 catches a transition row that begins
+    // exactly at a run boundary. Rules map via origToReloc to this function's own
+    // relocated runs; the per-run FDE filter below selects each run's rules.
+    std::vector<RuleEvent> ruleEvents;
+    for (auto &orun : f->origRuns) {
+      std::vector<VariableLocation> cfa;
+      if (symObj->getCFALocations(orun.first, orun.second+1, cfa))
+        for (auto &L : cfa) {
+          Address r = origToReloc(L.lowPC);
+          if (!r) continue;
+          ruleEvents.push_back({ r, -1, 0, dwreg(L.mr_reg), (int64_t)L.frameOffset });
+        }
+      for (size_t k = 0; k < calleeSavedRegs.size(); ++k) {
+        std::vector<Symtab::FrameRegRule> rr;
+        if (!symObj->getFrameRegRulesByDwarf(orun.first, orun.second+1, calleeSavedRegs[k], rr)) continue;
+        for (auto &R : rr) {
+          Address r = origToReloc(R.lowPC);
+          if (!r) continue;
+          int64_t v = (R.kind == Symtab::FrameRegRule::InRegister)
+                      ? (int64_t)R.regnum : (int64_t)R.offset;
+          ruleEvents.push_back({ r, (int)k, (int)R.kind, calleeSavedRegs[k], v });
+        }
+      }
+    }
+    std::sort(ruleEvents.begin(), ruleEvents.end(), [](const RuleEvent&a,const RuleEvent&b){
+        return a.rpc < b.rpc || (a.rpc == b.rpc && a.regColumn < b.regColumn); });
+
+    // One FDE per relocated run, bounded to the run (never next-func-start, which
+    // over-claims an interleaved neighbor). A run carrying an LSDA (lsda != -1)
+    // uses a "zPLR" CIE, else the CFA-only "zR" CIE.
+    auto emitFDE = [&](Address pStart, Address pEnd, size_t cie, size_t lsda) {
+      size_t fdeLenPos=eh.size(); pU32(eh,0);
+      size_t fdeBody=eh.size();
+      pU32(eh,(uint32_t)(fdeBody - cie));                       // CIE pointer
+      { int64_t v=(int64_t)pStart-(int64_t)(ehVaddr+eh.size());           // initial_location (sdata8: reloc code may be far)
+        for(int i=0;i<8;i++) eh.push_back((unsigned char)((v>>(8*i))&0xff)); }
+      { uint64_t r=(uint64_t)(pEnd - pStart);                            // address_range (8 bytes, matching R enc width)
+        for(int i=0;i<8;i++) eh.push_back((unsigned char)((r>>(8*i))&0xff)); }
+      if (lsda != (size_t)-1) { pUleb(eh,4);
+        size_t lf=eh.size();
+        pS32(eh,(int32_t)((int64_t)(exVaddr+lsda) - (int64_t)(ehVaddr+lf))); // LSDA ptr
+        nlsda++;
+      } else pUleb(eh,0);
+      Address cur=pStart;
+      unsigned lastCfaReg=0xffffffffu; int64_t lastCfaOff=0x7fffffffLL;
+      std::vector<int> lastKind(calleeSavedRegs.size(), (int)Symtab::FrameRegRule::SameValue);
+      std::vector<int64_t> lastVal(calleeSavedRegs.size(), 0);
+      auto advanceTo = [&](Address at){
+        if (at <= cur) return;
+        Address d=at-cur;
+        // DW_CFA_advance_loc (0x40|delta) / advance_loc1 (0x02) / advance_loc4 (0x04)
+        if (d<0x40) eh.push_back((unsigned char)(0x40|d));
+        else if (d<0x100){ eh.push_back(0x02); eh.push_back((unsigned char)d); }
+        else { eh.push_back(0x04); pU32(eh,(uint32_t)d); }
+        cur=at;
+      };
+      for (auto &e : ruleEvents) {
+        if (e.rpc < pStart || e.rpc >= pEnd) continue;   // only this run's rules
+        Address at = e.rpc;
+        if (e.regColumn < 0) {                    // CFA rule
+          if (e.reg==lastCfaReg && e.val==lastCfaOff) continue;
+          advanceTo(at);
+          pU8(eh,0x0c); pUleb(eh,e.reg); pUleb(eh,(uint64_t)e.val);  // DW_CFA_def_cfa
+          lastCfaReg=e.reg; lastCfaOff=e.val;
+        } else {                                  // callee-saved register rule
+          int k = e.regColumn;
+          if (e.kind==lastKind[k] && e.val==lastVal[k]) continue;
+          if (e.kind == (int)Symtab::FrameRegRule::AtCFAOffset &&
+              (e.val % 8) != 0) continue;                 // not factorable with daf=-8
+          advanceTo(at);
+          switch (e.kind) {
+            case (int)Symtab::FrameRegRule::AtCFAOffset: {
+              int64_t foff = e.val / -8;                             // factored (daf=-8)
+              if (e.reg < 64 && foff >= 0) {
+                pU8(eh,(unsigned char)(0x80 | e.reg));               // DW_CFA_offset (reg<64, >=0)
+                pUleb(eh,(uint64_t)foff);
+              } else {
+                // reg>=64 (ppc64 LR=65) or a positive CFA offset (ppc64 LR at
+                // cfa+16) needs the extended, signed-factored form.
+                pU8(eh,0x11); pUleb(eh,e.reg); pSleb(eh,foff);       // DW_CFA_offset_extended_sf
+              }
+              break;
+            }
+            case (int)Symtab::FrameRegRule::InRegister:
+              pU8(eh,0x09); pUleb(eh,e.reg); pUleb(eh,(uint64_t)e.val); // DW_CFA_register
+              break;
+            case (int)Symtab::FrameRegRule::Undefined:
+              pU8(eh,0x07); pUleb(eh,e.reg);                         // DW_CFA_undefined
+              break;
+            default:
+              pU8(eh,0x08); pUleb(eh,e.reg);                         // DW_CFA_same_value
+              break;
+          }
+          lastKind[k]=e.kind; lastVal[k]=e.val;
+        }
+      }
+      while ((eh.size()-fdeBody)&3) eh.push_back(0);
+      uint32_t l=(uint32_t)(eh.size()-fdeBody); memcpy(&eh[fdeLenPos],&l,4);
+      nfde++;
+    };
+    Address fpt=0; unsigned char fpf=0;
+    size_t fcie = (size_t)-1;
+    if (funcPers(f, fpt, fpf)) {
+      auto it = cieForPers.find(std::make_pair(fpt,(unsigned)fpf));
+      if (it != cieForPers.end()) fcie = it->second;
+    }
+    for (auto &d : runDescs[f]) {
+      bool useLSDA = (d.lsda != (size_t)-1) && fcie != (size_t)-1;
+      eh_printf("FDE origFunc[0x%lx,0x%lx] relocStart=0x%lx -> reloc[0x%lx,0x%lx) lsda=%s\n",
+                (unsigned long)f->origLo, (unsigned long)f->origHi,
+                (unsigned long)f->relocStart, (unsigned long)d.lo, (unsigned long)d.hi,
+                useLSDA ? "y" : "-");
+      emitFDE(d.lo, d.hi, useLSDA ? fcie : cieZR, useLSDA ? d.lsda : (size_t)-1);
+    }
+  }
+  pU32(eh,0);   // terminator
+
+  eh_printf(".eh_frame: %u FDEs (%u w/LSDA), %zu bytes @0x%lx; "
+            ".gcc_except_table %zu bytes @0x%lx\n",
+            nfde, nlsda, eh.size(), (unsigned long)ehVaddr, ex.size(), (unsigned long)exVaddr);
+
+  // Hand the blobs and their chosen placement back to the caller, which decides
+  // how to deliver them: an output-file region + DT_DYNINST_EH_FRAME tag for a
+  // rewriter (synthesizeRelocatedEHFrame, below), or an in-process region +
+  // __register_frame iRPC for a live process (PCProcess).
+  exVaddrOut = exVaddr;
+  ehVaddrOut = ehVaddr;
+  exOut.swap(ex);
+  ehOut.swap(eh);
+  return nfde;
+}
+
+// Rewriter delivery: place the synthesized blobs as loadable regions in the
+// output object above `regionHighWaterMark`, and point a DT_DYNINST_EH_FRAME
+// dynamic tag at the .eh_frame so the runtime registers it at load (RTlinux.c).
+// The tag reuses the DT_DYNINST channel to avoid regenerating the object's
+// dynamic metadata.
+void Dyninst::synthesizeRelocatedEHFrame(Symtab *symObj,
+                                         std::list<Relocation::CodeTracker *> &relocatedCode,
+                                         const EHFrameArch &arch,
+                                         Address regionHighWaterMark,
+                                         Address ownLo, Address ownHi) {
+  std::vector<unsigned char> eh, ex;
+  Address ehVaddr = 0, exVaddr = 0;
+  unsigned nfde = buildRelocatedEHFrame(symObj, relocatedCode, arch,
+                                        regionHighWaterMark, eh, ex, ehVaddr, exVaddr,
+                                        ownLo, ownHi);
+  if (!nfde) return;
+  if (!ex.empty()) {
+    void *exCopy = malloc(ex.size()); memcpy(exCopy, ex.data(), ex.size());
+    symObj->addRegion(exVaddr, exCopy, ex.size(), ".dyninst_gcc_except",
+                      Region::RT_DATA, true);
+  }
+  void *ehCopy = malloc(eh.size()); memcpy(ehCopy, eh.data(), eh.size());
+  symObj->addRegion(ehVaddr, ehCopy, eh.size(), ".dyninst_ehframe",
+                    Region::RT_DATA, true);
+  symObj->addSysVDynamic(DT_DYNINST_EH_FRAME, ehVaddr);
+}

--- a/dyninstAPI/src/eh_frame_gen.C
+++ b/dyninstAPI/src/eh_frame_gen.C
@@ -68,7 +68,8 @@ unsigned Dyninst::buildRelocatedEHFrame(Symtab *symObj,
                                         std::vector<unsigned char> &exOut,
                                         Address &ehVaddrOut,
                                         Address &exVaddrOut,
-                                        Address ownLo, Address ownHi) {
+                                        Address ownLo, Address ownHi,
+                                        Address loadBias) {
   typedef std::list<Relocation::CodeTracker *> CodeTrackers;
 
   // ---- byte emitters (buffer-parameterized) ----
@@ -244,6 +245,23 @@ unsigned Dyninst::buildRelocatedEHFrame(Symtab *symObj,
   // ---- Extract + assign original LSDA info to relocated functions. ----
   std::vector<EHFunctionInfo> ehInfos;
   symObj->getEHFrameInfo(ehInfos);
+  // getEHFrameInfo reports LINK-time addresses; the CodeTrackers (origRuns,
+  // origToReloc, the ownership range) are in RUNTIME space. Rebase the LSDA by
+  // the load bias so overlap-assignment and origToReloc resolve in one space.
+  // Code addresses (func_low_pc, call-site region/pad) and the mutatee's own GOT
+  // slots (personality/type targets, via indirect encodings) all shift by the
+  // same bias. Bias 0 for non-PIE / the static rewriter.
+  if (loadBias) {
+    for (auto &info : ehInfos) {
+      info.func_low_pc += loadBias;
+      if (info.personality_target) info.personality_target += loadBias;
+      for (auto &cs : info.callsites) {
+        cs.region_start += loadBias;
+        if (cs.landing_pad) cs.landing_pad += loadBias;
+      }
+      for (auto &t : info.type_targets) if (t) t += loadBias;
+    }
+  }
   // Type-table entry encoding, from the first LSDA that has a type table (PIE:
   // indirect|pcrel|sdata4 = 0x9b). Personality is looked up per-function at
   // CIE-emit time (funcPers), not tracked globally.
@@ -589,18 +607,21 @@ unsigned Dyninst::buildRelocatedEHFrame(Symtab *symObj,
     // relocated runs; the per-run FDE filter below selects each run's rules.
     std::vector<RuleEvent> ruleEvents;
     for (auto &orun : f->origRuns) {
+      // origRuns are RUNTIME addresses; the DWARF frame parser reads LINK-time
+      // PCs. Query in link space (-loadBias) and map each result PC back to
+      // runtime (+loadBias) before origToReloc. No-op for non-PIE (bias 0).
       std::vector<VariableLocation> cfa;
-      if (symObj->getCFALocations(orun.first, orun.second+1, cfa))
+      if (symObj->getCFALocations(orun.first - loadBias, orun.second+1 - loadBias, cfa))
         for (auto &L : cfa) {
-          Address r = origToReloc(L.lowPC);
+          Address r = origToReloc(L.lowPC + loadBias);
           if (!r) continue;
           ruleEvents.push_back({ r, -1, 0, dwreg(L.mr_reg), (int64_t)L.frameOffset });
         }
       for (size_t k = 0; k < calleeSavedRegs.size(); ++k) {
         std::vector<Symtab::FrameRegRule> rr;
-        if (!symObj->getFrameRegRulesByDwarf(orun.first, orun.second+1, calleeSavedRegs[k], rr)) continue;
+        if (!symObj->getFrameRegRulesByDwarf(orun.first - loadBias, orun.second+1 - loadBias, calleeSavedRegs[k], rr)) continue;
         for (auto &R : rr) {
-          Address r = origToReloc(R.lowPC);
+          Address r = origToReloc(R.lowPC + loadBias);
           if (!r) continue;
           int64_t v = (R.kind == Symtab::FrameRegRule::InRegister)
                       ? (int64_t)R.regnum : (int64_t)R.offset;
@@ -725,12 +746,13 @@ void Dyninst::synthesizeRelocatedEHFrame(Symtab *symObj,
                                          std::list<Relocation::CodeTracker *> &relocatedCode,
                                          const EHFrameArch &arch,
                                          Address regionHighWaterMark,
-                                         Address ownLo, Address ownHi) {
+                                         Address ownLo, Address ownHi,
+                                         Address loadBias) {
   std::vector<unsigned char> eh, ex;
   Address ehVaddr = 0, exVaddr = 0;
   unsigned nfde = buildRelocatedEHFrame(symObj, relocatedCode, arch,
                                         regionHighWaterMark, eh, ex, ehVaddr, exVaddr,
-                                        ownLo, ownHi);
+                                        ownLo, ownHi, loadBias);
   if (!nfde) return;
   if (!ex.empty()) {
     void *exCopy = malloc(ex.size()); memcpy(exCopy, ex.data(), ex.size());

--- a/dyninstAPI/src/eh_frame_gen.h
+++ b/dyninstAPI/src/eh_frame_gen.h
@@ -57,7 +57,8 @@ void synthesizeRelocatedEHFrame(SymtabAPI::Symtab *symObj,
                                 std::list<Relocation::CodeTracker *> &relocatedCode,
                                 const EHFrameArch &arch,
                                 Address regionHighWaterMark,
-                                Address ownLo = 0, Address ownHi = 0);
+                                Address ownLo = 0, Address ownHi = 0,
+                                Address loadBias = 0);
 
 // Build the .eh_frame / .gcc_except_table bytes for the relocated code, placed
 // at addresses derived from `regionBase`, WITHOUT delivering them. Pure and
@@ -83,7 +84,14 @@ unsigned buildRelocatedEHFrame(SymtabAPI::Symtab *symObj,
                                std::vector<unsigned char> &exOut,
                                Address &ehVaddrOut,
                                Address &exVaddrOut,
-                               Address ownLo = 0, Address ownHi = 0);
+                               Address ownLo = 0, Address ownHi = 0,
+                               // Load bias (mapped_object::codeBase()): runtime = link + loadBias.
+                               // The CodeTrackers carry RUNTIME original addresses, but the DWARF
+                               // CFI (getCFALocations) and LSDA (getEHFrameInfo) are read at
+                               // LINK-time addresses. For a PIE they differ; without the bias every
+                               // CFA lookup and LSDA assignment misses (0 rules, 0 landing pads) and
+                               // exceptions escape. 0 for non-PIE / the static rewriter.
+                               Address loadBias = 0);
 
 }  // namespace Dyninst
 

--- a/dyninstAPI/src/eh_frame_gen.h
+++ b/dyninstAPI/src/eh_frame_gen.h
@@ -1,0 +1,90 @@
+/*
+ * See the dyninst/COPYRIGHT file for copyright information.
+ *
+ * We provide the Paradyn Tools (below described as "Paradyn")
+ * on an AS IS basis, and do not warrant its validity or performance.
+ * We reserve the right to update, modify, or discontinue this
+ * software at any time.  We shall have no obligation to supply such
+ * updates or modifications or any other form of support to you.
+ *
+ * By your use of Paradyn, you understand and agree that we (or any
+ * other person or entity with proprietary rights in Paradyn) are
+ * under no obligation to provide either maintenance services,
+ * update services, notices of latent defects, or correction of
+ * defects for Paradyn.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DYNINST_EH_FRAME_GEN_H
+#define DYNINST_EH_FRAME_GEN_H
+
+#include <list>
+#include <vector>
+
+#include "dyntypes.h"        // Dyninst::Address
+#include "eh_frame_arch.h"   // Dyninst::EHFrameArch
+
+namespace Dyninst {
+
+namespace SymtabAPI { class Symtab; }
+namespace Relocation { class CodeTracker; }
+
+// Synthesize .eh_frame (and, for functions with a C++ LSDA, .gcc_except_table)
+// for the relocated code described by `relocatedCode`, and install them into
+// `symObj` as loadable regions plus a DT_DYNINST_EH_FRAME dynamic tag that the
+// runtime library reads and hands to __register_frame. This is what lets a C++
+// exception be unwound through, and caught in, relocated code.
+//
+// `arch` supplies the per-architecture CFI parameters (see EHFrameArch);
+// `regionHighWaterMark` is the end of the relocated-code section, used to place
+// the new regions above it. Intended for dynamic rewriting only (a static
+// binary links the runtime at emit time and would mis-relocate its reference to
+// the region), and the caller is responsible for that gating.
+void synthesizeRelocatedEHFrame(SymtabAPI::Symtab *symObj,
+                                std::list<Relocation::CodeTracker *> &relocatedCode,
+                                const EHFrameArch &arch,
+                                Address regionHighWaterMark,
+                                Address ownLo = 0, Address ownHi = 0);
+
+// Build the .eh_frame / .gcc_except_table bytes for the relocated code, placed
+// at addresses derived from `regionBase`, WITHOUT delivering them. Pure and
+// re-runnable: the byte lengths are independent of the placement addresses, so
+// a caller that must allocate the region first can call once with a placeholder
+// base to learn the sizes, allocate, then call again with the real base. Returns
+// the number of FDEs emitted; the two blobs and the placement addresses chosen
+// for them come back through the out-parameters. Used by both the rewriter
+// (synthesizeRelocatedEHFrame) and the live-process delivery (PCProcess).
+// `ownLo`/`ownHi`, when non-empty (ownHi > ownLo), restrict synthesis to code
+// whose ORIGINAL address lies in [ownLo, ownHi) -- the instrumented
+// application's own range. Foreign functions that dynamic instrumentation
+// incidentally relocated (e.g. libc helpers pulled in by the iRPC/runtime
+// machinery) are skipped: we have no source CFI for them, so an emitted FDE
+// would carry only the CIE default rules -- a fabricated, wrong descriptor that
+// can corrupt the whole __register_frame batch and defeat the application's own
+// (correct) FDEs. Pass runtime addresses so the filter is PIE-safe.
+unsigned buildRelocatedEHFrame(SymtabAPI::Symtab *symObj,
+                               std::list<Relocation::CodeTracker *> &relocatedCode,
+                               const EHFrameArch &arch,
+                               Address regionBase,
+                               std::vector<unsigned char> &ehOut,
+                               std::vector<unsigned char> &exOut,
+                               Address &ehVaddrOut,
+                               Address &exVaddrOut,
+                               Address ownLo = 0, Address ownHi = 0);
+
+}  // namespace Dyninst
+
+#endif  // DYNINST_EH_FRAME_GEN_H

--- a/dyninstAPI_RT/h/dyninstAPI_RT.h
+++ b/dyninstAPI_RT/h/dyninstAPI_RT.h
@@ -166,6 +166,10 @@ typedef struct {
 
 #define TRAP_HEADER_SIG 0x759191D6
 #define DT_DYNINST 0x6D191957
+/* dynamic tag carrying the link-time vaddr of the synthesized
+ * .dyninst_ehframe region; the RT adds the object's load base (the loader does
+ * not relocate unknown OS-specific tags -- same convention as DT_DYNINST). */
+#define DT_DYNINST_EH_FRAME 0x6D191958
 
 // Suppress warning about flexible array members not valid in C++
 // FIXME: invalid flexible array member, traps[], in structure below

--- a/dyninstAPI_RT/src/RTcommon.c
+++ b/dyninstAPI_RT/src/RTcommon.c
@@ -169,6 +169,12 @@ void DYNINSTBaseInit(void)
 #if defined(cap_mutatee_traps)
    DYNINSTinitializeTrapHandler();
 #endif
+#if !defined(DYNINST_RT_STATIC_LIB) && defined(os_linux)
+   /* register every rewritten object's synthesized .eh_frame,
+    * delivered via a DT_DYNINST_EH_FRAME dynamic tag (rationale and the
+    * static-RT exclusion are explained at the definition in RTlinux.c). */
+   DYNINSTregisterEHFrames();
+#endif
    DYNINST_unlock_tramp_guard();
    DYNINSThasInitialized = 1;
 }

--- a/dyninstAPI_RT/src/RTcommon.h
+++ b/dyninstAPI_RT/src/RTcommon.h
@@ -45,6 +45,9 @@ void DYNINSTinit(void);
 int DYNINSTreturnZero(void);
 
 int DYNINSTinitializeTrapHandler(void);
+/* (linux, dynamic RT only): register synthesized .eh_frame
+ * regions found via DT_DYNINST_EH_FRAME dynamic tags (see RTlinux.c). */
+void DYNINSTregisterEHFrames(void);
 void* dyninstTrapTranslate(void *source, 
                            volatile unsigned long *table_used,
                            volatile unsigned long *table_version,

--- a/dyninstAPI_RT/src/RTlinux.c
+++ b/dyninstAPI_RT/src/RTlinux.c
@@ -130,6 +130,39 @@ void DYNINSTregisterEHFrames(void)
    else if (getenv("DYNINST_DEBUG_EH"))
       fprintf(stderr, "[dyninst-eh] RT register: __register_frame absent, skipping\n");
 }
+
+/* Dynamic-instrumentation delivery. Unlike the rewriter, a live process has no
+ * output ELF / DT tag: dyninstAPI synthesizes the .eh_frame for the in-process
+ * relocated code, writes it into the target, and inferior-RPCs this function
+ * with the region's live address so libgcc's unwinder can unwind through and
+ * catch in the relocated frames. No load base to add -- the address is already
+ * the runtime one. */
+void DYNINSTregisterEHFrame(void *frames)
+{
+   if (__register_frame) {
+      __register_frame(frames);
+      if (getenv("DYNINST_DEBUG_EH"))
+         fprintf(stderr, "[dyninst-eh] RT register (dynamic): eh_frame=%p\n", frames);
+   } else if (getenv("DYNINST_DEBUG_EH")) {
+      fprintf(stderr, "[dyninst-eh] RT register (dynamic): __register_frame absent\n");
+   }
+}
+
+/* Drop a previously-registered dynamic .eh_frame. Each round of dynamic
+ * instrumentation re-relocates the affected functions and synthesizes a fresh
+ * .eh_frame for them; without removing the superseded one, libgcc would keep
+ * stale FDEs covering the same code and could unwind with them. dyninstAPI
+ * deregisters the prior region before registering the new one. */
+extern void __deregister_frame(void *) __attribute__((weak));
+
+void DYNINSTderegisterEHFrame(void *frames)
+{
+   if (__deregister_frame) {
+      __deregister_frame(frames);
+      if (getenv("DYNINST_DEBUG_EH"))
+         fprintf(stderr, "[dyninst-eh] RT deregister (dynamic): eh_frame=%p\n", frames);
+   }
+}
 #endif /* !DYNINST_RT_STATIC_LIB */
 
 /************************************************************************

--- a/dyninstAPI_RT/src/RTlinux.c
+++ b/dyninstAPI_RT/src/RTlinux.c
@@ -51,6 +51,7 @@
 #include <sys/types.h>
 #include <sys/syscall.h>
 #include <string.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <signal.h>
 #include <sys/mman.h>
@@ -79,6 +80,57 @@ static struct trap_mapping_header *getStaticTrapMap(unsigned long addr);
 unsigned long DYNINSTlinkSave;
 unsigned long DYNINSTtocSave;
 #endif
+
+/* register every rewritten object's synthesized .eh_frame so
+ * libgcc can unwind through instrumented frames (C++ exceptions). binaryEdit
+ * stores the region's link-time vaddr in a DT_DYNINST_EH_FRAME dynamic tag
+ * (the same channel DT_DYNINST uses for the trap table); the loader does not
+ * relocate unknown OS-specific tags, so the load base is added here.
+ * __register_frame lives in libgcc; the ref is weak so uninstrumented /
+ * pure-C binaries link and run unchanged.
+ *
+ * DYNAMIC rewriting only: compiled out of the static RT. The static rewriter
+ * relocates any new global-data reference in the relocated DYNINSTBaseInit to
+ * a bad address (it links the RT at emit, after computing such references),
+ * so static-binary exception support needs a rewriter-aware delivery and is
+ * not attempted here. */
+#if !defined(DYNINST_RT_STATIC_LIB)
+extern void __register_frame(void *) __attribute__((weak));
+
+static int registerEHFrameCB(struct dl_phdr_info *info, size_t size, void *data)
+{
+   ElfW(Half) i;
+   (void)size; (void)data;
+   for (i = 0; i < info->dlpi_phnum; i++) {
+      const ElfW(Dyn) *dyn;
+      if (info->dlpi_phdr[i].p_type != PT_DYNAMIC)
+         continue;
+      dyn = (const ElfW(Dyn) *) (info->dlpi_phdr[i].p_vaddr + info->dlpi_addr);
+      for (; dyn->d_tag != DT_NULL; dyn++) {
+         if (dyn->d_tag == DT_DYNINST_EH_FRAME) {
+            void *frames = (void *) (dyn->d_un.d_ptr + info->dlpi_addr);
+            __register_frame(frames);
+            /* RT lib is libc-only (injected into the mutatee); it cannot call
+             * dyninstAPI's C++ eh_printf, so it gates on the same env var directly. */
+            if (getenv("DYNINST_DEBUG_EH"))
+               fprintf(stderr, "[dyninst-eh] RT register: %s eh_frame=%p\n",
+                       info->dlpi_name && info->dlpi_name[0] ? info->dlpi_name : "(exe)",
+                       frames);
+         }
+      }
+      break;
+   }
+   return 0;
+}
+
+void DYNINSTregisterEHFrames(void)
+{
+   if (__register_frame)
+      dl_iterate_phdr(registerEHFrameCB, NULL);
+   else if (getenv("DYNINST_DEBUG_EH"))
+      fprintf(stderr, "[dyninst-eh] RT register: __register_frame absent, skipping\n");
+}
+#endif /* !DYNINST_RT_STATIC_LIB */
 
 /************************************************************************
  * void DYNINSTbreakPoint(void)

--- a/symtabAPI/h/Symtab.h
+++ b/symtabAPI/h/Symtab.h
@@ -51,6 +51,7 @@
 #include "relocationEntry.h"
 #include "ExceptionBlock.h"
 #include "dyninstversion.h"
+#include "VariableLocation.h"
 
 #include "boost/shared_ptr.hpp"
 
@@ -73,6 +74,27 @@ class Type;
 struct symtab_impl;
 
 typedef Dyninst::ProcessReader MemRegReader;
+
+// decoded C++ exception-handling info for one function, extracted
+// from .eh_frame (FDE->LSDA linkage) + .gcc_except_table. Used to regenerate a
+// valid LSDA for relocated/instrumented code. All addresses are in the input
+// binary's (original) vaddr space.
+struct EHCallSite {
+   Dyninst::Offset region_start;  // absolute; the try region [start, start+size)
+   Dyninst::Offset region_size;
+   Dyninst::Offset landing_pad;   // absolute; 0 = no landing pad
+   uint64_t        action;        // 1-based byte index into action_table (0 = none)
+};
+struct EHFunctionInfo {
+   Dyninst::Offset func_low_pc{0};        // FDE initial_location
+   Dyninst::Offset lpstart{0};            // landing-pad base (== low_pc if LPStart omitted)
+   unsigned char   ttype_format{0xff};    // DW_EH_PE_* encoding of type-table entries
+   unsigned char   personality_format{0xff};
+   Dyninst::Offset personality_target{0}; // absolute target the CIE 'P' aug resolves to
+   std::vector<EHCallSite>       callsites;
+   std::vector<unsigned char>    action_table;  // raw bytes, verbatim
+   std::vector<Dyninst::Offset>  type_targets;  // abs targets; index 0 == filter value 1
+};
 
 class DYNINST_EXPORT Symtab : public LookupInterface,
                public AnnotatableSparse
@@ -539,6 +561,34 @@ class DYNINST_EXPORT Symtab : public LookupInterface,
  public:
    Object *getObject();
    const Object *getObject() const;
+   // CFA (canonical frame address) rules over [low,high) from the
+   // binary's .eh_frame, used to synthesize unwind info for relocated code.
+   DYNINST_EXPORT bool getCFALocations(Offset low, Offset high,
+                                       std::vector<VariableLocation> &locs);
+   // the classified CFI rule for one register over [low,high),
+   // one entry per CFI row: where the caller's value of `reg` lives at each
+   // PC sub-range (unchanged, saved at CFA+offset, moved to another register,
+   // or undefined). Rules that cannot be expressed as one of these kinds
+   // (DWARF expressions, val_offset) are reported Undefined. Used with
+   // getCFALocations to synthesize unwind info for relocated code.
+   struct FrameRegRule {
+      Offset lowPC, hiPC;
+      enum Kind { SameValue = 0, AtCFAOffset = 1, InRegister = 2,
+                  Undefined = 3 } kind;
+      long offset;      // AtCFAOffset: value is stored at CFA+offset
+      unsigned regnum;  // InRegister: DWARF number of the holding register
+   };
+   DYNINST_EXPORT bool getFrameRegRules(Offset low, Offset high,
+                                        Dyninst::MachRegister reg,
+                                        std::vector<FrameRegRule> &rules);
+   // As above, keyed on a raw DWARF register number (reaches columns with no
+   // Dyninst MachRegister, e.g. ppc64 return address = DWARF 65).
+   DYNINST_EXPORT bool getFrameRegRulesByDwarf(Offset low, Offset high,
+                                               unsigned dwarfReg,
+                                               std::vector<FrameRegRule> &rules);
+   // decoded LSDA/eh info per function (see EHFunctionInfo), used to
+   // regenerate exception tables for relocated code.
+   DYNINST_EXPORT bool getEHFrameInfo(std::vector<EHFunctionInfo> &out);
    void dumpModRanges();
    void dumpFuncRanges();
 

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3297,7 +3297,7 @@ bool ObjectELF::getEHFrameInfo(std::vector<EHFunctionInfo> &out)
         unsigned char personality_encoding = DW_EH_PE_omit;
         unsigned char range_encoding = DW_EH_PE_absptr;
         Address personality_target = 0;
-        unsigned char *cur_augdata = const_cast<unsigned char *>(thisCIE.cie.augmentation_data);
+        const unsigned char *cur_augdata = thisCIE.cie.augmentation_data;
         for (unsigned j = 0; j < augmentor_len; j++) {
             if (augmentor[j] == 'L') { lsda_encoding = *cur_augdata++; }
             else if (augmentor[j] == 'P') {
@@ -3327,7 +3327,7 @@ bool ObjectELF::getEHFrameInfo(std::vector<EHFunctionInfo> &out)
         mi.pc = fde_addr + (unsigned long)(aug_length_start - fde_bytes);
         int aug_length_size = read_val_of_type(DW_EH_PE_uleb128, &aug_length_value, aug_length_start, mi);
 
-        unsigned char *fde_aug = (unsigned char *) aug_length_start + aug_length_size;
+        const unsigned char *fde_aug = aug_length_start + aug_length_size;
         unsigned char *lsda_ptr = NULL;
         cur_augdata = fde_aug;
         for (unsigned j = 0; j < augmentor_len; j++) {

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -1599,6 +1599,9 @@ void ObjectELF::load_object(bool alloc_syms) {
             find_catch_blocks(eh_frame_scnp, gcc_except,
                               txtaddr, dataddr, catch_addrs_);
         }
+        // retain the sections so getEHFrameInfo() can re-walk them.
+        eh_frame_scn_saved_ = eh_frame_scnp;
+        gcc_except_scn_saved_ = gcc_except;
 
 #endif
         if (interp_scnp) {
@@ -2668,7 +2671,11 @@ static unsigned long read_uleb128(const unsigned char *data, unsigned *bytes_rea
     unsigned shift = 0;
     *bytes_read = 0;
     while (1) {
-        result |= (data[*bytes_read] & 0x7f) << shift;
+        // Cast to unsigned long so the shift runs at 64-bit width. The byte
+        // integer-promotes to int, and int << shift is undefined once shift
+        // reaches 32; for a value wider than 32 bits the payload bits would
+        // otherwise be lost. (read_sleb128 casts for the same reason.)
+        result |= ((unsigned long)(data[*bytes_read] & 0x7f)) << shift;
         if ((data[(*bytes_read)++] & 0x80) == 0)
             break;
         shift += 7;
@@ -2681,17 +2688,22 @@ static signed long read_sleb128(const unsigned char *data, unsigned *bytes_read)
     unsigned shift = 0;
     *bytes_read = 0;
     while (1) {
-        result |= (data[*bytes_read] & 0x7f) << shift;
+        result |= ((unsigned long)(data[*bytes_read] & 0x7f)) << shift;
         shift += 7;
         if ((data[*bytes_read] & 0x80) == 0)
             break;
         (*bytes_read)++;
     }
-    if (shift < sizeof(int) && (data[*bytes_read] & 0x40))
-        result |= -(1 << shift);
+    // shift is a BIT count; the sign bit lives in the last byte's 0x40. The old
+    // guard compared shift (bits) against sizeof(int) (== 4 bytes), so after the
+    // first byte (shift==7) it was never taken and every negative SLEB128 -- e.g.
+    // the negative self-relative "next" links in a .gcc_except_table action chain
+    // -- read back as a large positive value.
+    if (shift < 8 * sizeof(result) && (data[*bytes_read] & 0x40))
+        result |= -((unsigned long)1 << shift);
     (*bytes_read)++;
 
-    return result;
+    return (signed long)result;
 }
 
 #define DW_EH_PE_absptr      0x00
@@ -3180,6 +3192,247 @@ bool ObjectELF::find_catch_blocks(Elf_X_Shdr *eh_frame,
     sort(catch_addrs.begin(),catch_addrs.end(),exception_compare());
 
     return result;
+}
+
+/**
+ * like read_except_table_gcc3, but instead of only the
+ * try/catch *addresses* it captures everything needed to *regenerate* a valid
+ * LSDA for relocated code: per-FDE landing-pad base, full call-site table
+ * (region + landing pad + action), the raw action table, the resolved type-table
+ * targets, and the personality target. Emits one EHFunctionInfo per FDE that
+ * carries a non-null LSDA. All addresses are in the input binary's vaddr space.
+ */
+bool ObjectELF::getEHFrameInfo(std::vector<EHFunctionInfo> &out)
+{
+    Elf_X_Shdr *eh_frame = eh_frame_scn_saved_;
+    Elf_X_Shdr *except_scn = gcc_except_scn_saved_;
+    if (!eh_frame || !except_scn) return false;
+
+    mach_relative_info mi;
+    mi.text = 0; mi.data = 0; mi.pc = 0; mi.func = 0;
+    mi.word_size = eh_frame->wordSize();
+    mi.big_input = elfHdr->e_endian();
+    Elf_X *elfHdrDbg = dwarf->debugLinkFile();
+    auto e_ident = (!eh_frame->isFromDebugFile()) ? elfHdr->e_ident() : elfHdrDbg->e_ident();
+
+    Elf_Data *eh_frame_data = eh_frame->get_data().elf_data();
+    Elf_X_Data except_data = except_scn->get_data();
+    if (!except_data.isValid()) return false;
+    const unsigned char *datap = (const unsigned char *) except_data.get_string();
+    unsigned long except_size = except_data.d_size();
+    Address except_addr = except_scn->sh_addr();
+
+    // Resolve an encoded pointer to its absolute *target*. Unlike
+    // read_val_of_type this does NOT zero indirect entries (we want the slot
+    // address so we can re-encode a pcrel offset to it), and it sign-extends.
+    auto entrySize = [&](unsigned char enc)->int {
+        switch (enc & 0x0f) {
+            case DW_EH_PE_sdata2: case DW_EH_PE_udata2: return 2;
+            case DW_EH_PE_sdata4: case DW_EH_PE_udata4: return 4;
+            case DW_EH_PE_sdata8: case DW_EH_PE_udata8: return 8;
+            case DW_EH_PE_absptr: return (int)mi.word_size;
+            default: return 4;
+        }
+    };
+    auto resolveEnc = [&](unsigned char enc, const unsigned char *p,
+                          Address field_vaddr)->Address {
+        if (enc == DW_EH_PE_omit) return 0;
+        long v = 0;
+        switch (enc & 0x0f) {
+            case DW_EH_PE_sdata4: v = (int32_t) Dyninst::read_memory_as<uint32_t>(p); break;
+            case DW_EH_PE_udata4: v = (uint32_t) Dyninst::read_memory_as<uint32_t>(p); break;
+            case DW_EH_PE_sdata8:
+            case DW_EH_PE_udata8: v = (long) Dyninst::read_memory_as<uint64_t>(p); break;
+            case DW_EH_PE_absptr:
+                v = (mi.word_size == 8) ? (long) Dyninst::read_memory_as<uint64_t>(p)
+                                        : (long) Dyninst::read_memory_as<uint32_t>(p);
+                break;
+            default: return 0;
+        }
+        // A zero-valued type-table slot is the catch-all (catch(...)) sentinel:
+        // it must resolve to 0, not to base+0 (which for pcrel would be the
+        // slot's own address and read as a bogus real type downstream).
+        if (v == 0) return 0;
+        Address base = 0;
+        switch (enc & 0x70) {
+            case DW_EH_PE_pcrel:   base = field_vaddr; break;
+            case DW_EH_PE_textrel: base = mi.text; break;
+            case DW_EH_PE_datarel: base = mi.data; break;
+            case DW_EH_PE_funcrel: base = mi.func; break;
+            default: base = 0;
+        }
+        return base + (Address) v;
+    };
+
+    Dwarf_Off offset = 0, next_offset, saved_cur_offset;
+    int res = 0;
+    do {
+        Dwarf_CFI_Entry entry;
+        res = dwarf_next_cfi(e_ident, eh_frame_data, true, offset, &next_offset, &entry);
+        saved_cur_offset = offset;
+        offset = next_offset;
+        if (res == 1 && next_offset == (Dwarf_Off)-1) break;
+        if (res == -1) {
+            if (offset != saved_cur_offset) continue;
+            return false;
+        }
+        if (dwarf_cfi_cie_p(&entry)) continue;   // only FDEs
+
+        Dwarf_Off fde_offset = saved_cur_offset;
+        unsigned char *fde_bytes = (unsigned char *) eh_frame->get_data().d_buf() + fde_offset;
+        unsigned char *cie_bytes = (unsigned char *) eh_frame->get_data().d_buf() + entry.fde.CIE_pointer;
+        Dwarf_CFI_Entry thisCIE; Dwarf_Off unused;
+        dwarf_next_cfi(e_ident, eh_frame_data, true, entry.fde.CIE_pointer, &unused, &thisCIE);
+        if (!dwarf_cfi_cie_p(&thisCIE)) continue;
+        const char *augmentor = thisCIE.cie.augmentation;
+        unsigned long augmentor_len = augmentor ? strlen(augmentor) : 0;
+        bool has_L = false;
+        for (unsigned j = 0; j < augmentor_len; j++) if (augmentor[j] == 'L') { has_L = true; break; }
+        if (!has_L) continue;
+
+        Address fde_addr = eh_frame->sh_addr() + fde_offset;
+        Address cie_addr = eh_frame->sh_addr() + entry.fde.CIE_pointer;
+
+        unsigned char lsda_encoding = DW_EH_PE_omit;
+        unsigned char personality_encoding = DW_EH_PE_omit;
+        unsigned char range_encoding = DW_EH_PE_absptr;
+        Address personality_target = 0;
+        unsigned char *cur_augdata = const_cast<unsigned char *>(thisCIE.cie.augmentation_data);
+        for (unsigned j = 0; j < augmentor_len; j++) {
+            if (augmentor[j] == 'L') { lsda_encoding = *cur_augdata++; }
+            else if (augmentor[j] == 'P') {
+                personality_encoding = *cur_augdata++;
+                Address pfield = cie_addr + (unsigned long)(cur_augdata - cie_bytes);
+                personality_target = resolveEnc(personality_encoding, cur_augdata, pfield);
+                cur_augdata += entrySize(personality_encoding);
+            }
+            else if (augmentor[j] == 'R') { range_encoding = *cur_augdata++; }
+            else if (augmentor[j] == 'z') { /* nothing */ }
+            else break;
+        }
+        if (lsda_encoding == DW_EH_PE_omit) continue;
+
+        // FDE header -> low_pc + LSDA pointer
+        const unsigned char *pc_begin_start = fde_bytes + 4 +
+            (Dyninst::read_memory_as<uint32_t>(fde_bytes) == 0xffffffff ? LONG_FDE_HLEN : SHORT_FDE_HLEN);
+        unsigned long pc_begin_val;
+        mi.pc = fde_addr + (unsigned long)(pc_begin_start - fde_bytes);
+        int pc_begin_size = read_val_of_type(range_encoding, &pc_begin_val, pc_begin_start, mi);
+        const unsigned char *pc_range_start = pc_begin_start + pc_begin_size;
+        unsigned long pc_range_val;
+        mi.pc = fde_addr + (unsigned long)(pc_range_start - fde_bytes);
+        int pc_range_size = read_val_of_type(range_encoding, &pc_range_val, pc_range_start, mi);
+        const unsigned char *aug_length_start = pc_range_start + pc_range_size;
+        unsigned long aug_length_value;
+        mi.pc = fde_addr + (unsigned long)(aug_length_start - fde_bytes);
+        int aug_length_size = read_val_of_type(DW_EH_PE_uleb128, &aug_length_value, aug_length_start, mi);
+
+        unsigned char *fde_aug = (unsigned char *) aug_length_start + aug_length_size;
+        unsigned char *lsda_ptr = NULL;
+        cur_augdata = fde_aug;
+        for (unsigned j = 0; j < augmentor_len; j++) {
+            if (augmentor[j] == 'L') {
+                unsigned long lsda_val;
+                mi.pc = fde_addr + (unsigned long)(cur_augdata - fde_bytes);
+                int ps = read_val_of_type(lsda_encoding, &lsda_val, cur_augdata, mi);
+                if (ps == -1) break;
+                lsda_ptr = (unsigned char *) lsda_val;
+                cur_augdata += ps;
+            }
+        }
+        if (!lsda_ptr) continue;
+        unsigned long eoff = (unsigned long)((Address) lsda_ptr - except_addr);
+        if (eoff >= except_size) continue;
+
+        // --- LSDA header ---
+        EHFunctionInfo info;
+        info.func_low_pc = pc_begin_val;
+        info.personality_format = personality_encoding;
+        info.personality_target = personality_target;
+
+        unsigned char lpstart_format = datap[eoff++];
+        Address landingpad_base;
+        if (lpstart_format != DW_EH_PE_omit) {
+            unsigned long v; eoff += read_val_of_type(DW_EH_PE_uleb128, &v, datap + eoff, mi);
+            landingpad_base = v;
+        } else {
+            landingpad_base = pc_begin_val;
+        }
+        info.lpstart = landingpad_base;
+
+        unsigned char ttype_format = datap[eoff++];
+        info.ttype_format = ttype_format;
+        unsigned long ttype_base_val = 0, ttype_base_off = 0;
+        if (ttype_format != DW_EH_PE_omit) {
+            eoff += read_val_of_type(DW_EH_PE_uleb128, &ttype_base_val, datap + eoff, mi);
+            ttype_base_off = eoff;
+        }
+        unsigned long ttype_base_section_off = ttype_base_off + ttype_base_val;
+
+        unsigned char cs_format = datap[eoff++];
+        unsigned long cs_table_len = 0;
+        eoff += read_val_of_type(DW_EH_PE_uleb128, &cs_table_len, datap + eoff, mi);
+        unsigned long cs_table_end = eoff + cs_table_len;
+        while (eoff < cs_table_end && eoff < except_size) {
+            unsigned long rs, rl, lp, act;
+            mi.pc = except_addr + eoff; eoff += read_val_of_type(cs_format, &rs, datap + eoff, mi);
+            mi.pc = except_addr + eoff; eoff += read_val_of_type(cs_format, &rl, datap + eoff, mi);
+            mi.pc = except_addr + eoff; eoff += read_val_of_type(cs_format, &lp, datap + eoff, mi);
+            eoff += read_val_of_type(DW_EH_PE_uleb128, &act, datap + eoff, mi);
+            EHCallSite cs;
+            cs.region_start = landingpad_base + rs;
+            cs.region_size = rl;
+            cs.landing_pad = lp ? (landingpad_base + lp) : 0;
+            cs.action = act;
+            info.callsites.push_back(cs);
+        }
+        unsigned long action_table_off = cs_table_end;
+
+        // Walk action chains from every call-site to find the highest type
+        // filter -> that is the number of entries in the type table.
+        long max_filter = 0;
+        for (size_t c = 0; c < info.callsites.size(); c++) {
+            uint64_t a = info.callsites[c].action;
+            int guard = 0;
+            while (a != 0 && guard++ < 256) {
+                unsigned long p = action_table_off + (a - 1);
+                if (p >= except_size) break;
+                unsigned fs = 0, ns = 0;
+                long filter = read_sleb128(datap + p, &fs);
+                unsigned long np = p + fs;
+                long nextrel = read_sleb128(datap + np, &ns);
+                long af = filter < 0 ? -filter : filter;
+                if (af > max_filter) max_filter = af;
+                if (nextrel == 0) break;
+                long nextpos = (long) np + nextrel;
+                if (nextpos < (long) action_table_off) break;
+                a = (uint64_t)(nextpos - action_table_off) + 1;
+            }
+        }
+
+        if (ttype_format != DW_EH_PE_omit && max_filter > 0) {
+            int esize = entrySize(ttype_format);
+            unsigned long num_types = (unsigned long) max_filter;
+            unsigned long type_table_start = ttype_base_section_off - num_types * esize;
+            for (unsigned long o = action_table_off; o < type_table_start && o < except_size; o++)
+                info.action_table.push_back(datap[o]);
+            for (unsigned long k = 1; k <= num_types; k++) {
+                unsigned long entry_off = ttype_base_section_off - k * esize;
+                Address tgt = resolveEnc(ttype_format, datap + entry_off, except_addr + entry_off);
+                info.type_targets.push_back(tgt);   // index 0 == filter value 1
+            }
+        } else {
+            // Cleanup-only (or omitted type table): copy whatever action bytes
+            // sit between the call-site table and the type-table base.
+            unsigned long end = (ttype_format != DW_EH_PE_omit) ? ttype_base_section_off : action_table_off;
+            for (unsigned long o = action_table_off; o < end && o < except_size; o++)
+                info.action_table.push_back(datap[o]);
+        }
+
+        out.push_back(info);
+    } while (true);
+
+    return true;
 }
 
 #endif

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -440,6 +440,10 @@ public:
 
   public:
   Dyninst::DwarfDyninst::DwarfHandle::ptr dwarf;
+  // retained so getEHFrameInfo() can re-walk them after load.
+  Elf_X_Shdr *eh_frame_scn_saved_{nullptr};
+  Elf_X_Shdr *gcc_except_scn_saved_{nullptr};
+  bool getEHFrameInfo(std::vector<EHFunctionInfo> &out);
   private:
 
   enum class ObjectType {

--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -52,6 +52,10 @@
 #include "debug.h"
 
 #include "symtabAPI/src/Object.h"
+// CFA query for relocated-code unwind-info synthesis
+#include "symtabAPI/src/Object-elf.h"
+#include "dwarfFrameParser.h"
+#include "registers/abstract_regs.h"
 #include "symtab_impl.hpp"
 
 
@@ -2005,6 +2009,105 @@ Object *Symtab::getObject()
 const Object *Symtab::getObject() const
 {
     return obj_private;
+}
+
+// return the CFA (canonical frame address) rules over [low,high)
+// from this binary's .eh_frame. Each returned VariableLocation gives, for a
+// PC sub-range, the base register (mr_reg) and offset (frameOffset) such that
+// CFA = mr_reg + frameOffset. Used to synthesize FDEs for relocated code.
+bool Symtab::getCFALocations(Offset low, Offset high,
+                             std::vector<VariableLocation> &locs)
+{
+    using namespace Dyninst::DwarfDyninst;
+    ObjectELF *obj_elf = dynamic_cast<ObjectELF *>(getObject());
+    if (!obj_elf || !obj_elf->dwarf)
+        return false;
+    DwarfFrameParser::Ptr fp = DwarfFrameParser::create(
+        *obj_elf->dwarf->frame_dbg(), obj_elf->dwarf->origFile()->e_elfp(),
+        obj_elf->getArch());
+    if (!fp)
+        return false;
+    FrameErrors_t err;
+    return fp->getRegsForFunction(std::make_pair(low, high), Dyninst::CFA,
+                                  locs, err);
+}
+
+// classified per-row CFI rule for one register over [low,high);
+// see the declaration. Companion of getCFALocations for synthesizing complete
+// unwind info (CFA + callee-saved register rules) for relocated code.
+bool Symtab::getFrameRegRules(Offset low, Offset high,
+                              Dyninst::MachRegister reg,
+                              std::vector<FrameRegRule> &rules)
+{
+    using namespace Dyninst::DwarfDyninst;
+    rules.clear();
+    ObjectELF *obj_elf = dynamic_cast<ObjectELF *>(getObject());
+    if (!obj_elf || !obj_elf->dwarf)
+        return false;
+    DwarfFrameParser::Ptr fp = DwarfFrameParser::create(
+        *obj_elf->dwarf->frame_dbg(), obj_elf->dwarf->origFile()->e_elfp(),
+        obj_elf->getArch());
+    if (!fp)
+        return false;
+    FrameErrors_t err;
+    std::vector<DwarfFrameParser::FrameRegRule> raw;
+    // The parser maps the MachRegister to its DWARF number internally (where
+    // register_to_dwarf is in scope).
+    if (!fp->getRegRulesForFunction(std::make_pair(low, high), reg, raw, err))
+        return false;
+    for (auto &r : raw) {
+        FrameRegRule out;
+        out.lowPC = r.lowPC;
+        out.hiPC = r.hiPC;
+        out.kind = (FrameRegRule::Kind) (int) r.kind;
+        out.offset = r.offset;
+        out.regnum = r.regnum;
+        rules.push_back(out);
+    }
+    return true;
+}
+
+// as getFrameRegRules but keyed on a raw DWARF register number, so a
+// CFI column with no Dyninst MachRegister (ppc64 return address = DWARF 65) is
+// reachable for the synthesized unwind info.
+bool Symtab::getFrameRegRulesByDwarf(Offset low, Offset high,
+                                     unsigned dwarfReg,
+                                     std::vector<FrameRegRule> &rules)
+{
+    using namespace Dyninst::DwarfDyninst;
+    rules.clear();
+    ObjectELF *obj_elf = dynamic_cast<ObjectELF *>(getObject());
+    if (!obj_elf || !obj_elf->dwarf)
+        return false;
+    DwarfFrameParser::Ptr fp = DwarfFrameParser::create(
+        *obj_elf->dwarf->frame_dbg(), obj_elf->dwarf->origFile()->e_elfp(),
+        obj_elf->getArch());
+    if (!fp)
+        return false;
+    FrameErrors_t err;
+    std::vector<DwarfFrameParser::FrameRegRule> raw;
+    if (!fp->getRegRulesForDwarf(std::make_pair(low, high), (int)dwarfReg, raw, err))
+        return false;
+    for (auto &r : raw) {
+        FrameRegRule out;
+        out.lowPC = r.lowPC;
+        out.hiPC = r.hiPC;
+        out.kind = (FrameRegRule::Kind) (int) r.kind;
+        out.offset = r.offset;
+        out.regnum = r.regnum;
+        rules.push_back(out);
+    }
+    return true;
+}
+
+// decoded per-function LSDA info (see EHFunctionInfo), used to
+// regenerate exception tables for relocated code.
+bool Symtab::getEHFrameInfo(std::vector<EHFunctionInfo> &out)
+{
+    ObjectELF *obj_elf = dynamic_cast<ObjectELF *>(getObject());
+    if (!obj_elf)
+        return false;
+    return obj_elf->getEHFrameInfo(out);
 }
 
 void Symtab::parseTypesNow()

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -2350,6 +2350,7 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
             case DT_INIT:
             case DT_FINI:
             case DT_DYNINST:
+            case DT_DYNINST_EH_FRAME:  // points at the shifted .dyninst_ehframe
                 adjust = library_adjust;
                 break;
             default:

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -9,3 +9,6 @@ add_subdirectory(InstructionAPI/decoder/x86)
 if(DYNINST_ENABLE_CAPSTONE)
   add_subdirectory(InstructionAPI/decoder/riscv)
 endif()
+
+# C++ exception handling through relocated code (issue #1437)
+add_subdirectory(dyninstAPI/exceptions)

--- a/tests/integration/dyninstAPI/exceptions/CMakeLists.txt
+++ b/tests/integration/dyninstAPI/exceptions/CMakeLists.txt
@@ -29,6 +29,29 @@ target_link_libraries(eh_rewrite_driver PRIVATE dyninstAPI)
 add_executable(eh_dynamic_driver eh_dynamic_driver.cpp)
 target_link_libraries(eh_dynamic_driver PRIVATE dyninstAPI)
 
+# The dynamic (live-process) EH-delivery path is x86-64 only for now; the static
+# rewriter path works on all three supported arches (incl. PIE). Skip the dynamic
+# (eh_dyncatch) tests where dynamic delivery is unavailable rather than record
+# spurious failures -- each for a DIFFERENT reason:
+#   * aarch64: dynamic instrumentation itself is unimplemented (dyninst#449) --
+#     BPatch::processCreate aborts in the stackwalker during bootstrap, before any
+#     EH code runs.
+#   * ppc64le: a pre-existing ppc64le DYNAMIC-RELOCATION bug, not EH. The frames
+#     synthesize and register fine, but the relocated code SIGSEGVs BEFORE any
+#     exception is thrown: a relocated external/PLT call runs with a wrong TOC
+#     (r2), so a TOC-relative indirect call (bctrl) loads a garbage pointer and
+#     jumps into ld.so. (Confirmed: the crash NIP is a fixed offset in ld64.so.2
+#     across runs; _Unwind_Find_FDE never sees a relocated PC, so the synthesized
+#     FDEs are never consulted. Neither #2336 ifunc-exclusion nor #2338 isel
+#     changes it.) This is the dynamic analogue of the static TOC-restore fix
+#     (the "preserve the TOC-restore after a non-returning call" commit) and is a
+#     separate relocation-correctness fix from the EH work. The identical
+#     synthesized bytes unwind correctly via static delivery (32/32 above).
+set(_eh_dynamic_supported TRUE)
+if(DYNINST_HOST_ARCH_AARCH64 OR DYNINST_HOST_ARCH_PPC64LE)
+  set(_eh_dynamic_supported FALSE)
+endif()
+
 # --- mutatees: self-checking C++ programs that throw and catch ---
 set(_eh_mutatees
     eh_single    # single class-type try/catch
@@ -50,49 +73,104 @@ set(_eh_env
     "DYNINSTAPI_RT_LIB=${_rt_lib}"
     "LD_LIBRARY_PATH=${_ld_path}:$ENV{LD_LIBRARY_PATH}")
 
-foreach(m ${_eh_mutatees})
-  add_executable(${m} ${m}.cpp)
-  set_target_properties(${m} PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
-  # -O2 so the compiler hot/cold-splits and stack-realigns (eh_align relies on it).
-  target_compile_options(${m} PRIVATE -O2)
+# Build each mutatee BOTH position-independent (PIE, ET_DYN -- the default on
+# modern distros) and not (ET_EXEC), and run each variant through both the static
+# rewriter and dynamic instrumentation. The EH delivery genuinely differs by
+# type: a PIE loads at a runtime bias, so the dynamic path must rebase the
+# DWARF/LSDA addresses (link -> runtime) and the static path must shift the
+# DT_DYNINST_EH_FRAME tag by library_adjust (the PIE "PHDR in the first page"
+# workaround). Testing only one type hides an entire class of bug -- the PIE gap
+# was invisible for exactly this reason: every earlier mutatee was ET_EXEC. The
+# -pie / -no-pie flags force the type explicitly so the matrix is identical on a
+# PIE-default and a non-PIE-default toolchain (i.e. reproducible across machines).
+#
+# Pass/fail contract (all eh_catch_/eh_dyncatch_ tests): each mutatee prints
+# "CAUGHT-<n>" only on full success (right handler + cleanups run); a wrong
+# handler prints "WRONG-...", a skipped cleanup "NO-CLEANUP-<n>", an escaped
+# exception "MISSED-<n>", and a bad unwind terminates before printing anything.
+# So matching the success sentinel alone suffices -- any failure simply fails to
+# print it. No FAIL_REGULAR_EXPRESSION (it takes precedence, so an incidental
+# substring in e.what() could fail a passing run). The "-[0-9]" anchor is load-
+# bearing: a bare "CAUGHT" is a substring of "MISSED-<n>"'s historical spelling.
+# eh_register_mutatee(<target> <source> <opt> <nopie|pie>): build one mutatee
+# variant (its binary under mutatees/) and register its test chain --
+# eh_prep_<t> (clean the artifact dir) -> eh_rewrite_<t> -> eh_catch_<t> (static),
+# and eh_dyncatch_<t> (dynamic, where supported). Reads _eh_env and
+# _eh_dynamic_supported from the enclosing scope.
+function(eh_register_mutatee t src opt variant)
+  add_executable(${t} ${src})
+  set_target_properties(${t} PROPERTIES
+      CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mutatees")
+  target_compile_options(${t} PRIVATE ${opt})
+  if(variant STREQUAL "pie")
+    set_target_properties(${t} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    target_compile_options(${t} PRIVATE -fPIE)
+    target_link_options(${t} PRIVATE -pie)
+  else()
+    set_target_properties(${t} PROPERTIES POSITION_INDEPENDENT_CODE OFF)
+    target_compile_options(${t} PRIVATE -fno-pie)
+    target_link_options(${t} PRIVATE -no-pie)
+  endif()
 
-  set(_rw "${CMAKE_CURRENT_BINARY_DIR}/${m}_rewritten")
+  # Each test's rewritten binary (and any future per-test debug output) lives in
+  # its own artifacts/<t>/ directory, kept after the run for inspection.
+  set(_adir "${CMAKE_CURRENT_BINARY_DIR}/artifacts/${t}")
+  set(_rw "${_adir}/${t}_rewritten")
+
+  # Phase 0 (setup): clean+create the artifact dir so a failed/partial rewrite
+  # can't leave a stale binary for the catch phase to false-pass on. Unlabeled --
+  # fixture plumbing, kept out of the -L exceptions count but still run
+  # automatically whenever a test requiring eh_fx_${t} runs.
+  add_test(NAME eh_prep_${t}
+           COMMAND ${CMAKE_COMMAND} -DDIR=${_adir}
+                   -P "${CMAKE_CURRENT_SOURCE_DIR}/eh_clean_dir.cmake")
+  set_tests_properties(eh_prep_${t} PROPERTIES FIXTURES_SETUP eh_fx_${t})
 
   # Phase 1: rewrite the mutatee (relocate all functions -> regenerate EH info).
-  add_test(NAME eh_rewrite_${m}
-           COMMAND eh_rewrite_driver "$<TARGET_FILE:${m}>" "${_rw}")
-  set_tests_properties(eh_rewrite_${m} PROPERTIES
+  add_test(NAME eh_rewrite_${t}
+           COMMAND eh_rewrite_driver "$<TARGET_FILE:${t}>" "${_rw}")
+  set_tests_properties(eh_rewrite_${t} PROPERTIES
       LABELS "integration;exceptions"
-      FIXTURES_SETUP eh_fx_${m}
+      FIXTURES_SETUP eh_fx_${t}
+      DEPENDS eh_prep_${t}
       ENVIRONMENT "${_eh_env}")
 
-  # Phase 2: run the rewritten mutatee; it must still CATCH the RIGHT exception
-  # and run its cleanups, which each mutatee reports by printing "CAUGHT-<n>"
-  # only on full success (a wrong handler prints "WRONG-...", a skipped cleanup
-  # "NO-CLEANUP-<n>", an escaped exception "MISSED-<n>", and a bad unwind
-  # terminates before printing anything). Matching the success sentinel alone is
-  # therefore sufficient: any failure -- wrong catch, crash, terminate, timeout
-  # -- simply fails to print it. No FAIL_REGULAR_EXPRESSION is needed, and using
-  # one would be a hazard (it takes precedence, so an incidental substring in
-  # e.what() could fail a genuinely-passing run). The "-[0-9]" anchor is load-
-  # bearing: a bare "CAUGHT" is a substring of the "MISSED-<n>" sentinel's
-  # historical spelling, so keep success sentinels disjoint from failure ones.
-  add_test(NAME eh_catch_${m} COMMAND "${_rw}")
-  set_tests_properties(eh_catch_${m} PROPERTIES
+  # Phase 2 (static): run the rewritten mutatee; it must still CATCH.
+  add_test(NAME eh_catch_${t} COMMAND "${_rw}")
+  set_tests_properties(eh_catch_${t} PROPERTIES
       LABELS "integration;exceptions"
-      FIXTURES_REQUIRED eh_fx_${m}
+      FIXTURES_REQUIRED eh_fx_${t}
       PASS_REGULAR_EXPRESSION "CAUGHT-[0-9]"
       ENVIRONMENT "${_eh_env}")
 
-  # Dynamic-instrumentation path: create the mutatee live, instrument every basic
-  # block (forcing relocation), and run it. Same pass/fail contract as eh_catch;
-  # the driver create+instrument+runs in one shot (no fixture). Like any Dyninst
-  # mutator it needs the RT at load time (DYNINSTAPI_RT_LIB).
-  add_test(NAME eh_dyncatch_${m}
-           COMMAND eh_dynamic_driver "$<TARGET_FILE:${m}>")
-  set_tests_properties(eh_dyncatch_${m} PROPERTIES
-      LABELS "integration;exceptions"
-      PASS_REGULAR_EXPRESSION "CAUGHT-[0-9]"
-      TIMEOUT 180
-      ENVIRONMENT "${_eh_env}")
+  # Dynamic path: create the mutatee live, instrument every basic block (forcing
+  # relocation), and run it -- the issue reproducer's path. Skipped where dynamic
+  # delivery is unavailable (aarch64 #449; ppc64le unported -- see above).
+  if(_eh_dynamic_supported)
+    add_test(NAME eh_dyncatch_${t}
+             COMMAND eh_dynamic_driver "$<TARGET_FILE:${t}>")
+    set_tests_properties(eh_dyncatch_${t} PROPERTIES
+        LABELS "integration;exceptions"
+        PASS_REGULAR_EXPRESSION "CAUGHT-[0-9]"
+        TIMEOUT 180
+        ENVIRONMENT "${_eh_env}")
+  endif()
+endfunction()
+
+# The standard mutatees at -O2 (enough for their hot/cold + stack-realign shapes),
+# each built PIE and non-PIE.
+foreach(m ${_eh_mutatees})
+  foreach(variant nopie pie)
+    eh_register_mutatee("${m}_${variant}" "${m}.cpp" "-O2" "${variant}")
+  endforeach()
+endforeach()
+
+# Hot/cold split exercised at BOTH -O2 and -O3: the block-partitioning heuristics
+# -- and thus which fragment the throwing call-site vs. the landing pad end up in
+# -- differ between the two levels, so each is worth its own coverage.
+foreach(opt O2 O3)
+  foreach(variant nopie pie)
+    eh_register_mutatee("eh_hotcold_${opt}_${variant}" "eh_hotcold.cpp" "-${opt}" "${variant}")
+  endforeach()
 endforeach()

--- a/tests/integration/dyninstAPI/exceptions/CMakeLists.txt
+++ b/tests/integration/dyninstAPI/exceptions/CMakeLists.txt
@@ -4,16 +4,22 @@ include_guard(GLOBAL)
 # regeneration and the DT_DYNINST_EH_FRAME + __register_frame delivery, which
 # are ELF- and glibc/libgcc-specific. The unwind-info synthesis is implemented
 # for x86-64, aarch64, and ppc64le; on any other architecture BinaryEdit does
-# not synthesize it (ehFrameArchFor() returns null), so the feature is
-# unsupported there and the tests do not apply. Gate on the supported set to
-# avoid spurious failures on e.g. RISC-V or AMDGPU.
+# not synthesize it (ehFrameArchFor() returns null).
+#
+# These tests build native mutatees and then rewrite AND execute them, so the
+# code generator must target the host architecture. A cross-architecture codegen
+# build (the CI "codegen cross-build" matrix retargets the generator -- i386,
+# aarch64, ppc64le, ... -- while the mutatees stay native to the x86-64 host)
+# cannot rewrite the native mutatees at all: a 32-bit generator has no 64-bit
+# register space, and a foreign generator aborts mid-rewrite. Require codegen
+# arch == host arch, restricted to the arches whose EH-info synthesis exists.
 if(NOT UNIX)
   return()
 endif()
 if(NOT
-   (DYNINST_HOST_ARCH_X86_64
-    OR DYNINST_HOST_ARCH_AARCH64
-    OR DYNINST_HOST_ARCH_PPC64LE))
+   ((DYNINST_CODEGEN_ARCH_X86_64 AND DYNINST_HOST_ARCH_X86_64)
+    OR (DYNINST_CODEGEN_ARCH_AARCH64 AND DYNINST_HOST_ARCH_AARCH64)
+    OR (DYNINST_CODEGEN_ARCH_PPC64LE AND DYNINST_HOST_ARCH_PPC64LE)))
   return()
 endif()
 if(NOT (TARGET dyninstAPI AND TARGET dyninstAPI_RT))

--- a/tests/integration/dyninstAPI/exceptions/CMakeLists.txt
+++ b/tests/integration/dyninstAPI/exceptions/CMakeLists.txt
@@ -10,7 +10,10 @@ include_guard(GLOBAL)
 if(NOT UNIX)
   return()
 endif()
-if(NOT (DYNINST_HOST_ARCH_X86_64 OR DYNINST_HOST_ARCH_AARCH64 OR DYNINST_HOST_ARCH_PPC64LE))
+if(NOT
+   (DYNINST_HOST_ARCH_X86_64
+    OR DYNINST_HOST_ARCH_AARCH64
+    OR DYNINST_HOST_ARCH_PPC64LE))
   return()
 endif()
 if(NOT (TARGET dyninstAPI AND TARGET dyninstAPI_RT))
@@ -54,14 +57,14 @@ endif()
 
 # --- mutatees: self-checking C++ programs that throw and catch ---
 set(_eh_mutatees
-    eh_single    # single class-type try/catch
-    eh_multi     # multiple catch clauses; matching (non-first) one fires
-    eh_nested    # nested try/catch, type discrimination
-    eh_rethrow   # catch + re-throw caught by an outer frame
-    eh_cleanup   # destructor runs during unwind before the handler
+    eh_single # single class-type try/catch
+    eh_multi # multiple catch clauses; matching (non-first) one fires
+    eh_nested # nested try/catch, type discrimination
+    eh_rethrow # catch + re-throw caught by an outer frame
+    eh_cleanup # destructor runs during unwind before the handler
     eh_basecatch # throw derived, catch by base reference
-    eh_deep      # deep (9-frame) non-tail-call unwind
-    eh_align)    # alignas(64) -> stack realign + hot/cold split (SPEC omnetpp shape)
+    eh_deep # deep (9-frame) non-tail-call unwind
+    eh_align) # alignas(64) -> stack realign + hot/cold split (SPEC omnetpp shape)
 
 # Runtime environment shared by both phases: the rewrite driver must know which
 # RT to bind into the output (DYNINSTAPI_RT_LIB), and the rewritten mutatee must
@@ -69,9 +72,8 @@ set(_eh_mutatees
 # tree via generator expressions.
 set(_rt_lib "$<TARGET_FILE:dyninstAPI_RT>")
 set(_ld_path "$<TARGET_FILE_DIR:dyninstAPI_RT>:$<TARGET_FILE_DIR:dyninstAPI>")
-set(_eh_env
-    "DYNINSTAPI_RT_LIB=${_rt_lib}"
-    "LD_LIBRARY_PATH=${_ld_path}:$ENV{LD_LIBRARY_PATH}")
+set(_eh_env "DYNINSTAPI_RT_LIB=${_rt_lib}"
+            "LD_LIBRARY_PATH=${_ld_path}:$ENV{LD_LIBRARY_PATH}")
 
 # Build each mutatee BOTH position-independent (PIE, ET_DYN -- the default on
 # modern distros) and not (ET_EXEC), and run each variant through both the static
@@ -99,9 +101,11 @@ set(_eh_env
 # _eh_dynamic_supported from the enclosing scope.
 function(eh_register_mutatee t src opt variant)
   add_executable(${t} ${src})
-  set_target_properties(${t} PROPERTIES
-      CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON
-      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mutatees")
+  set_target_properties(
+    ${t}
+    PROPERTIES CXX_STANDARD 11
+               CXX_STANDARD_REQUIRED ON
+               RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mutatees")
   target_compile_options(${t} PRIVATE ${opt})
   if(variant STREQUAL "pie")
     set_target_properties(${t} PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -122,39 +126,51 @@ function(eh_register_mutatee t src opt variant)
   # can't leave a stale binary for the catch phase to false-pass on. Unlabeled --
   # fixture plumbing, kept out of the -L exceptions count but still run
   # automatically whenever a test requiring eh_fx_${t} runs.
-  add_test(NAME eh_prep_${t}
-           COMMAND ${CMAKE_COMMAND} -DDIR=${_adir}
-                   -P "${CMAKE_CURRENT_SOURCE_DIR}/eh_clean_dir.cmake")
+  add_test(NAME eh_prep_${t} COMMAND ${CMAKE_COMMAND} -DDIR=${_adir} -P
+                                     "${CMAKE_CURRENT_SOURCE_DIR}/eh_clean_dir.cmake")
   set_tests_properties(eh_prep_${t} PROPERTIES FIXTURES_SETUP eh_fx_${t})
 
   # Phase 1: rewrite the mutatee (relocate all functions -> regenerate EH info).
-  add_test(NAME eh_rewrite_${t}
-           COMMAND eh_rewrite_driver "$<TARGET_FILE:${t}>" "${_rw}")
-  set_tests_properties(eh_rewrite_${t} PROPERTIES
-      LABELS "integration;exceptions"
-      FIXTURES_SETUP eh_fx_${t}
-      DEPENDS eh_prep_${t}
-      ENVIRONMENT "${_eh_env}")
+  add_test(NAME eh_rewrite_${t} COMMAND eh_rewrite_driver "$<TARGET_FILE:${t}>" "${_rw}")
+  set_tests_properties(
+    eh_rewrite_${t}
+    PROPERTIES LABELS
+               "integration;exceptions"
+               FIXTURES_SETUP
+               eh_fx_${t}
+               DEPENDS
+               eh_prep_${t}
+               ENVIRONMENT
+               "${_eh_env}")
 
   # Phase 2 (static): run the rewritten mutatee; it must still CATCH.
   add_test(NAME eh_catch_${t} COMMAND "${_rw}")
-  set_tests_properties(eh_catch_${t} PROPERTIES
-      LABELS "integration;exceptions"
-      FIXTURES_REQUIRED eh_fx_${t}
-      PASS_REGULAR_EXPRESSION "CAUGHT-[0-9]"
-      ENVIRONMENT "${_eh_env}")
+  set_tests_properties(
+    eh_catch_${t}
+    PROPERTIES LABELS
+               "integration;exceptions"
+               FIXTURES_REQUIRED
+               eh_fx_${t}
+               PASS_REGULAR_EXPRESSION
+               "CAUGHT-[0-9]"
+               ENVIRONMENT
+               "${_eh_env}")
 
   # Dynamic path: create the mutatee live, instrument every basic block (forcing
   # relocation), and run it -- the issue reproducer's path. Skipped where dynamic
   # delivery is unavailable (aarch64 #449; ppc64le unported -- see above).
   if(_eh_dynamic_supported)
-    add_test(NAME eh_dyncatch_${t}
-             COMMAND eh_dynamic_driver "$<TARGET_FILE:${t}>")
-    set_tests_properties(eh_dyncatch_${t} PROPERTIES
-        LABELS "integration;exceptions"
-        PASS_REGULAR_EXPRESSION "CAUGHT-[0-9]"
-        TIMEOUT 180
-        ENVIRONMENT "${_eh_env}")
+    add_test(NAME eh_dyncatch_${t} COMMAND eh_dynamic_driver "$<TARGET_FILE:${t}>")
+    set_tests_properties(
+      eh_dyncatch_${t}
+      PROPERTIES LABELS
+                 "integration;exceptions"
+                 PASS_REGULAR_EXPRESSION
+                 "CAUGHT-[0-9]"
+                 TIMEOUT
+                 180
+                 ENVIRONMENT
+                 "${_eh_env}")
   endif()
 endfunction()
 
@@ -171,6 +187,7 @@ endforeach()
 # -- differ between the two levels, so each is worth its own coverage.
 foreach(opt O2 O3)
   foreach(variant nopie pie)
-    eh_register_mutatee("eh_hotcold_${opt}_${variant}" "eh_hotcold.cpp" "-${opt}" "${variant}")
+    eh_register_mutatee("eh_hotcold_${opt}_${variant}" "eh_hotcold.cpp" "-${opt}"
+                        "${variant}")
   endforeach()
 endforeach()

--- a/tests/integration/dyninstAPI/exceptions/CMakeLists.txt
+++ b/tests/integration/dyninstAPI/exceptions/CMakeLists.txt
@@ -23,6 +23,12 @@ message(STATUS "Enabling dyninstAPI exception-handling integration tests")
 add_executable(eh_rewrite_driver eh_rewrite_driver.cpp)
 target_link_libraries(eh_rewrite_driver PRIVATE dyninstAPI)
 
+# --- dynamic driver: create the mutatee as a live process and instrument every
+#     basic block, forcing relocation in-process (the original issue reproducer's
+#     path) rather than via the static rewriter ---
+add_executable(eh_dynamic_driver eh_dynamic_driver.cpp)
+target_link_libraries(eh_dynamic_driver PRIVATE dyninstAPI)
+
 # --- mutatees: self-checking C++ programs that throw and catch ---
 set(_eh_mutatees
     eh_single    # single class-type try/catch
@@ -60,14 +66,33 @@ foreach(m ${_eh_mutatees})
       FIXTURES_SETUP eh_fx_${m}
       ENVIRONMENT "${_eh_env}")
 
-  # Phase 2: run the rewritten mutatee; it must still CATCH (print "CAUGHT").
-  # If the synthesized unwind info is wrong the exception escapes and the
-  # process terminates before printing, so the regex fails -> test fails.
+  # Phase 2: run the rewritten mutatee; it must still CATCH the RIGHT exception
+  # and run its cleanups, which each mutatee reports by printing "CAUGHT-<n>"
+  # only on full success (a wrong handler prints "WRONG-...", a skipped cleanup
+  # "NO-CLEANUP-<n>", an escaped exception "MISSED-<n>", and a bad unwind
+  # terminates before printing anything). Matching the success sentinel alone is
+  # therefore sufficient: any failure -- wrong catch, crash, terminate, timeout
+  # -- simply fails to print it. No FAIL_REGULAR_EXPRESSION is needed, and using
+  # one would be a hazard (it takes precedence, so an incidental substring in
+  # e.what() could fail a genuinely-passing run). The "-[0-9]" anchor is load-
+  # bearing: a bare "CAUGHT" is a substring of the "MISSED-<n>" sentinel's
+  # historical spelling, so keep success sentinels disjoint from failure ones.
   add_test(NAME eh_catch_${m} COMMAND "${_rw}")
   set_tests_properties(eh_catch_${m} PROPERTIES
       LABELS "integration;exceptions"
       FIXTURES_REQUIRED eh_fx_${m}
-      PASS_REGULAR_EXPRESSION "CAUGHT"
-      FAIL_REGULAR_EXPRESSION "NOT-CAUGHT|terminate called|WRONG-|NO-CLEANUP"
+      PASS_REGULAR_EXPRESSION "CAUGHT-[0-9]"
+      ENVIRONMENT "${_eh_env}")
+
+  # Dynamic-instrumentation path: create the mutatee live, instrument every basic
+  # block (forcing relocation), and run it. Same pass/fail contract as eh_catch;
+  # the driver create+instrument+runs in one shot (no fixture). Like any Dyninst
+  # mutator it needs the RT at load time (DYNINSTAPI_RT_LIB).
+  add_test(NAME eh_dyncatch_${m}
+           COMMAND eh_dynamic_driver "$<TARGET_FILE:${m}>")
+  set_tests_properties(eh_dyncatch_${m} PROPERTIES
+      LABELS "integration;exceptions"
+      PASS_REGULAR_EXPRESSION "CAUGHT-[0-9]"
+      TIMEOUT 180
       ENVIRONMENT "${_eh_env}")
 endforeach()

--- a/tests/integration/dyninstAPI/exceptions/CMakeLists.txt
+++ b/tests/integration/dyninstAPI/exceptions/CMakeLists.txt
@@ -1,0 +1,73 @@
+include_guard(GLOBAL)
+
+# These are ELF/Linux tests: they depend on .eh_frame / .gcc_except_table
+# regeneration and the DT_DYNINST_EH_FRAME + __register_frame delivery, which
+# are ELF- and glibc/libgcc-specific. The unwind-info synthesis is implemented
+# for x86-64, aarch64, and ppc64le; on any other architecture BinaryEdit does
+# not synthesize it (ehFrameArchFor() returns null), so the feature is
+# unsupported there and the tests do not apply. Gate on the supported set to
+# avoid spurious failures on e.g. RISC-V or AMDGPU.
+if(NOT UNIX)
+  return()
+endif()
+if(NOT (DYNINST_HOST_ARCH_X86_64 OR DYNINST_HOST_ARCH_AARCH64 OR DYNINST_HOST_ARCH_PPC64LE))
+  return()
+endif()
+if(NOT (TARGET dyninstAPI AND TARGET dyninstAPI_RT))
+  return()
+endif()
+
+message(STATUS "Enabling dyninstAPI exception-handling integration tests")
+
+# --- rewriter driver: relocate every function, forcing EH-info synthesis ---
+add_executable(eh_rewrite_driver eh_rewrite_driver.cpp)
+target_link_libraries(eh_rewrite_driver PRIVATE dyninstAPI)
+
+# --- mutatees: self-checking C++ programs that throw and catch ---
+set(_eh_mutatees
+    eh_single    # single class-type try/catch
+    eh_multi     # multiple catch clauses; matching (non-first) one fires
+    eh_nested    # nested try/catch, type discrimination
+    eh_rethrow   # catch + re-throw caught by an outer frame
+    eh_cleanup   # destructor runs during unwind before the handler
+    eh_basecatch # throw derived, catch by base reference
+    eh_deep      # deep (9-frame) non-tail-call unwind
+    eh_align)    # alignas(64) -> stack realign + hot/cold split (SPEC omnetpp shape)
+
+# Runtime environment shared by both phases: the rewrite driver must know which
+# RT to bind into the output (DYNINSTAPI_RT_LIB), and the rewritten mutatee must
+# find that RT at load time (LD_LIBRARY_PATH). All paths come from the build
+# tree via generator expressions.
+set(_rt_lib "$<TARGET_FILE:dyninstAPI_RT>")
+set(_ld_path "$<TARGET_FILE_DIR:dyninstAPI_RT>:$<TARGET_FILE_DIR:dyninstAPI>")
+set(_eh_env
+    "DYNINSTAPI_RT_LIB=${_rt_lib}"
+    "LD_LIBRARY_PATH=${_ld_path}:$ENV{LD_LIBRARY_PATH}")
+
+foreach(m ${_eh_mutatees})
+  add_executable(${m} ${m}.cpp)
+  set_target_properties(${m} PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
+  # -O2 so the compiler hot/cold-splits and stack-realigns (eh_align relies on it).
+  target_compile_options(${m} PRIVATE -O2)
+
+  set(_rw "${CMAKE_CURRENT_BINARY_DIR}/${m}_rewritten")
+
+  # Phase 1: rewrite the mutatee (relocate all functions -> regenerate EH info).
+  add_test(NAME eh_rewrite_${m}
+           COMMAND eh_rewrite_driver "$<TARGET_FILE:${m}>" "${_rw}")
+  set_tests_properties(eh_rewrite_${m} PROPERTIES
+      LABELS "integration;exceptions"
+      FIXTURES_SETUP eh_fx_${m}
+      ENVIRONMENT "${_eh_env}")
+
+  # Phase 2: run the rewritten mutatee; it must still CATCH (print "CAUGHT").
+  # If the synthesized unwind info is wrong the exception escapes and the
+  # process terminates before printing, so the regex fails -> test fails.
+  add_test(NAME eh_catch_${m} COMMAND "${_rw}")
+  set_tests_properties(eh_catch_${m} PROPERTIES
+      LABELS "integration;exceptions"
+      FIXTURES_REQUIRED eh_fx_${m}
+      PASS_REGULAR_EXPRESSION "CAUGHT"
+      FAIL_REGULAR_EXPRESSION "NOT-CAUGHT|terminate called|WRONG-|NO-CLEANUP"
+      ENVIRONMENT "${_eh_env}")
+endforeach()

--- a/tests/integration/dyninstAPI/exceptions/eh_align.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_align.cpp
@@ -25,6 +25,6 @@ int main() {
     std::printf("CAUGHT-9 %s\n", e.what());
     return 0;
   }
-  std::printf("NOT-CAUGHT-9\n");
+  std::printf("MISSED-9\n");
   return 2;
 }

--- a/tests/integration/dyninstAPI/exceptions/eh_align.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_align.cpp
@@ -1,0 +1,30 @@
+// EH mutatee: the hardest case. alignas(64) stack buffers force the compiler
+// to realign the stack (and, at -O2, to hot/cold-split the throwing and
+// catching functions). The throw then unwinds through frames whose relocated
+// FDE/LSDA must be assembled per-run and whose personality must be the C++
+// one -- the combination that regressed on SPEC 620.omnetpp_s.
+#include <cstdio>
+#include <stdexcept>
+__attribute__((noinline)) static void sink(char* p) { p[0] = 1; asm volatile("" ::: "memory"); }
+__attribute__((noinline)) static void thrower() {
+  alignas(64) char buf[64];
+  sink(buf);
+  throw std::runtime_error("align");
+}
+__attribute__((noinline)) static void middle() {
+  alignas(64) char buf[128];
+  sink(buf);
+  thrower();
+}
+int main() {
+  alignas(64) char buf[64];
+  sink(buf);
+  try {
+    middle();
+  } catch (const std::exception& e) {
+    std::printf("CAUGHT-9 %s\n", e.what());
+    return 0;
+  }
+  std::printf("NOT-CAUGHT-9\n");
+  return 2;
+}

--- a/tests/integration/dyninstAPI/exceptions/eh_basecatch.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_basecatch.cpp
@@ -11,6 +11,6 @@ int main() {
     std::printf("CAUGHT-7 %s\n", b.tag());
     return 0;
   }
-  std::printf("NOT-CAUGHT-7\n");
+  std::printf("MISSED-7\n");
   return 2;
 }

--- a/tests/integration/dyninstAPI/exceptions/eh_basecatch.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_basecatch.cpp
@@ -1,0 +1,16 @@
+// EH mutatee: throw a derived type, catch by base reference (polymorphic
+// match through the type table, not an exact-type match).
+#include <cstdio>
+struct Base { virtual ~Base() {} virtual const char* tag() const { return "base"; } };
+struct Derived : Base { const char* tag() const override { return "term"; } };
+__attribute__((noinline)) static void thrower() { throw Derived{}; }
+int main() {
+  try {
+    thrower();
+  } catch (const Base& b) {
+    std::printf("CAUGHT-7 %s\n", b.tag());
+    return 0;
+  }
+  std::printf("NOT-CAUGHT-7\n");
+  return 2;
+}

--- a/tests/integration/dyninstAPI/exceptions/eh_clean_dir.cmake
+++ b/tests/integration/dyninstAPI/exceptions/eh_clean_dir.cmake
@@ -1,0 +1,13 @@
+# Clean + (re)create a single directory, passed as -DDIR=<path>.
+#
+# Used as a ctest FIXTURES_SETUP step so each exception test starts from an empty
+# artifact directory: a rewrite that fails or partially writes can then never
+# leave a stale binary behind for the catch phase to run (a false pass). Cleaning
+# at SETUP (rather than a FIXTURES_CLEANUP that deletes afterward) means the
+# artifacts survive the run and are available for post-mortem debugging until the
+# next run re-cleans them.
+if(NOT DEFINED DIR)
+  message(FATAL_ERROR "eh_clean_dir.cmake requires -DDIR=<path>")
+endif()
+file(REMOVE_RECURSE "${DIR}")
+file(MAKE_DIRECTORY "${DIR}")

--- a/tests/integration/dyninstAPI/exceptions/eh_cleanup.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_cleanup.cpp
@@ -17,6 +17,6 @@ int main() {
     std::printf("CAUGHT-5 %s\n", e.what());
     return 0;
   }
-  std::printf("NOT-CAUGHT-5\n");
+  std::printf("MISSED-5\n");
   return 2;
 }

--- a/tests/integration/dyninstAPI/exceptions/eh_cleanup.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_cleanup.cpp
@@ -1,0 +1,22 @@
+// EH mutatee: a stack object's destructor must run during unwinding (cleanup
+// landing pad) before the handler catches -- exercises cleanup call-sites.
+#include <cstdio>
+#include <stdexcept>
+static bool cleaned = false;
+struct Guard { ~Guard() { cleaned = true; } };
+__attribute__((noinline)) static void thrower() { throw std::runtime_error("unwind"); }
+__attribute__((noinline)) static void middle() {
+  Guard g;          // must be destroyed as the exception unwinds through here
+  thrower();
+}
+int main() {
+  try {
+    middle();
+  } catch (const std::exception& e) {
+    if (!cleaned) { std::printf("NO-CLEANUP-5\n"); return 2; }
+    std::printf("CAUGHT-5 %s\n", e.what());
+    return 0;
+  }
+  std::printf("NOT-CAUGHT-5\n");
+  return 2;
+}

--- a/tests/integration/dyninstAPI/exceptions/eh_deep.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_deep.cpp
@@ -23,6 +23,6 @@ int main() {
     std::printf("CAUGHT-8 %s\n", e.what());
     return 0;
   }
-  std::printf("NOT-CAUGHT-8\n");
+  std::printf("MISSED-8\n");
   return 2;
 }

--- a/tests/integration/dyninstAPI/exceptions/eh_deep.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_deep.cpp
@@ -1,0 +1,28 @@
+// EH mutatee: a deep (9-frame) non-tail-call stack; the exception must unwind
+// through every intermediate frame's synthesized CFI to reach the handler.
+#include <cstdio>
+#include <stdexcept>
+static void sink(volatile int* p) { *p = *p + 1; }
+#define FRAME(n, next)                                                       \
+  __attribute__((noinline)) static void frame##n() {                        \
+    volatile int local = n; sink(&local); next(); sink(&local);             \
+  }
+__attribute__((noinline)) static void bottom() { throw std::runtime_error("deep8"); }
+FRAME(1, bottom)
+FRAME(2, frame1)
+FRAME(3, frame2)
+FRAME(4, frame3)
+FRAME(5, frame4)
+FRAME(6, frame5)
+FRAME(7, frame6)
+FRAME(8, frame7)
+int main() {
+  try {
+    frame8();
+  } catch (const std::exception& e) {
+    std::printf("CAUGHT-8 %s\n", e.what());
+    return 0;
+  }
+  std::printf("NOT-CAUGHT-8\n");
+  return 2;
+}

--- a/tests/integration/dyninstAPI/exceptions/eh_dynamic_driver.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_dynamic_driver.cpp
@@ -1,0 +1,102 @@
+/*
+ * Exception-handling integration test driver (dynamic instrumentation).
+ *
+ * processCreate()s the mutatee, then instruments the entry of every basic block
+ * of every function in the mutatee's own image with a counter increment. That
+ * forces Dyninst to relocate those functions in the live process (the same
+ * thing the original issue reproducer does), which is what triggers .eh_frame /
+ * .gcc_except_table synthesis for the relocated code. The mutatee then throws
+ * and catches; if the synthesized unwind info is missing or wrong, the mutatee
+ * terminates instead of catching.
+ *
+ * Companion of eh_rewrite_driver: same mutatees, but the dynamic-instrumentation
+ * path (BPatch_process) instead of the static rewriter (BPatch_binaryEdit). Pass
+ * iff the mutatee exits normally with code 0 (it prints CAUGHT); a non-zero exit
+ * or a termination by signal (std::terminate -> abort) is a failure.
+ */
+#include "BPatch.h"
+#include "BPatch_process.h"
+#include "BPatch_image.h"
+#include "BPatch_function.h"
+#include "BPatch_flowGraph.h"
+#include "BPatch_basicBlock.h"
+#include "BPatch_point.h"
+#include "BPatch_snippet.h"
+#include "BPatch_module.h"
+#include "BPatch_object.h"
+
+#include <cstdio>
+#include <set>
+#include <string>
+#include <vector>
+
+static BPatch bpatch;
+
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
+    std::fprintf(stderr, "usage: %s <mutatee>\n", argv[0]);
+    return 2;
+  }
+  const char* path = argv[1];
+  const char* args[] = { path, nullptr };
+
+  BPatch_process* proc = bpatch.processCreate(path, args);
+  if (!proc) {
+    std::fprintf(stderr, "eh_dynamic_driver: processCreate(%s) failed\n", path);
+    return 2;
+  }
+
+  BPatch_image* image = proc->getImage();
+  std::vector<BPatch_function*>* funcs = image->getProcedures();
+  if (!funcs || funcs->empty()) {
+    std::fprintf(stderr, "eh_dynamic_driver: no procedures in %s\n", path);
+    return 2;
+  }
+
+  // A scratch counter; storing to it is just a pretext to force relocation.
+  BPatch_variableExpr* counter = proc->malloc(sizeof(long));
+  if (!counter) {
+    std::fprintf(stderr, "eh_dynamic_driver: malloc failed\n");
+    return 2;
+  }
+
+  // Instrument the entry of every basic block of every function in the
+  // mutatee's own image (skip shared libraries / the runtime), forcing those
+  // functions to be relocated in the live process.
+  proc->beginInsertionSet();
+  unsigned instrumented = 0;
+  for (BPatch_function* f : *funcs) {
+    if (!f) continue;
+    BPatch_module* m = f->getModule();
+    if (!m || m->isSharedLib()) continue;   // mutatee code only
+    BPatch_flowGraph* cfg = f->getCFG();
+    if (!cfg) continue;
+    std::set<BPatch_basicBlock*> blocks;
+    cfg->getAllBasicBlocks(blocks);
+    for (BPatch_basicBlock* bb : blocks) {
+      BPatch_point* pt = bb->findEntryPoint();
+      if (!pt) continue;
+      BPatch_arithExpr bump(BPatch_assign, *counter,
+                            BPatch_arithExpr(BPatch_plus, *counter, BPatch_constExpr(1)));
+      if (proc->insertSnippet(bump, *pt, BPatch_callBefore)) instrumented++;
+    }
+  }
+  proc->finalizeInsertionSet(false, nullptr);
+  std::fprintf(stderr, "eh_dynamic_driver: instrumented %u basic-block entries\n", instrumented);
+
+  // Run to completion.
+  proc->continueExecution();
+  while (!proc->isTerminated()) {
+    bpatch.waitForStatusChange();
+    if (proc->isStopped()) proc->continueExecution();
+  }
+
+  if (proc->terminationStatus() == ExitedViaSignal) {
+    std::fprintf(stderr, "MUTATEE_SIGNALED=%d (exception not caught -> terminate)\n",
+                 proc->getExitSignal());
+    return 1;
+  }
+  int code = proc->getExitCode();
+  std::fprintf(stderr, "MUTATEE_EXIT=%d\n", code);
+  return code;  // 0 iff the mutatee caught and returned cleanly
+}

--- a/tests/integration/dyninstAPI/exceptions/eh_hotcold.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_hotcold.cpp
@@ -1,0 +1,48 @@
+// eh_hotcold: a try/catch inside a function the compiler hot/cold-splits, so the
+// throwing call-site and the landing pad can land in different (non-contiguous)
+// code fragments -- the .text.unlikely cold partition vs. the hot body. This
+// exercises the generator's per-run FDE emission and its cross-run LSDA /
+// landing-pad handling for a *single function* (distinct from eh_align, where the
+// split coincides with a stack realign). Built at both -O2 and -O3 because the
+// block-partitioning heuristics -- and thus the split shape -- differ by level.
+//
+// Prints "CAUGHT-6 ..." only on full success (right handler + destructor ran).
+
+#include <cstdio>
+#include <stdexcept>
+
+// Marked cold + noinline: GCC pushes the call to this into its callers' cold
+// (.text.unlikely) partition.
+static __attribute__((noinline, cold)) void cold_throw(const char* w) {
+    throw std::runtime_error(w);
+}
+
+struct Cleanup {
+    bool* ran;
+    ~Cleanup() { *ran = true; }   // must run while unwinding out of the cold path
+};
+
+static __attribute__((noinline)) int worker(int n) {
+    bool cleaned = false;
+    try {
+        Cleanup c{&cleaned};
+        long acc = 0;
+        for (int i = 1; i <= n; ++i) acc += (long)i * i;   // hot loop
+        // acc > 0 is ALWAYS true here (n >= 1), but predicting it false makes the
+        // compiler compile the throwing edge as cold -- so the cold_throw call
+        // site is in the split-out fragment while the try body / landing pad are
+        // in the hot body. The edge is nonetheless taken at runtime, so it throws.
+        if (__builtin_expect(acc > 0, 0))
+            cold_throw("hotcold");
+        std::printf("MISSED-6\n");                          // unreachable at runtime
+        return 1;
+    } catch (const std::exception& e) {
+        if (!cleaned) { std::printf("NO-CLEANUP-6\n"); return 2; }
+        std::printf("CAUGHT-6 %s\n", e.what());
+        return 0;
+    }
+}
+
+int main(int argc, char**) {
+    return worker(argc + 5);
+}

--- a/tests/integration/dyninstAPI/exceptions/eh_multi.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_multi.cpp
@@ -1,0 +1,21 @@
+// EH mutatee: multiple catch clauses; the matching (non-first) one must fire.
+#include <cstdio>
+#include <stdexcept>
+struct Pick { const char* w; };
+__attribute__((noinline)) static void thrower() { throw Pick{"pick-me"}; }
+int main() {
+  try {
+    thrower();
+  } catch (const std::runtime_error& e) {
+    std::printf("WRONG-runtime %s\n", e.what());
+    return 2;
+  } catch (int) {
+    std::printf("WRONG-int\n");
+    return 2;
+  } catch (const Pick& p) {
+    std::printf("CAUGHT-2 %s\n", p.w);
+    return 0;
+  }
+  std::printf("NOT-CAUGHT-2\n");
+  return 2;
+}

--- a/tests/integration/dyninstAPI/exceptions/eh_multi.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_multi.cpp
@@ -16,6 +16,6 @@ int main() {
     std::printf("CAUGHT-2 %s\n", p.w);
     return 0;
   }
-  std::printf("NOT-CAUGHT-2\n");
+  std::printf("MISSED-2\n");
   return 2;
 }

--- a/tests/integration/dyninstAPI/exceptions/eh_nested.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_nested.cpp
@@ -18,6 +18,6 @@ int main() {
     std::printf("CAUGHT-3 %s\n", o.w);
     return 0;
   }
-  std::printf("NOT-CAUGHT-3\n");
+  std::printf("MISSED-3\n");
   return 2;
 }

--- a/tests/integration/dyninstAPI/exceptions/eh_nested.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_nested.cpp
@@ -1,0 +1,23 @@
+// EH mutatee: nested try/catch with type discrimination. The inner catch
+// declines (rethrows implicitly via a non-matching type) and the outer,
+// correctly-typed handler must fire -- exercises the action-chain / type-table.
+#include <cstdio>
+#include <stdexcept>
+struct Inner {};
+struct Outer { const char* w; };
+__attribute__((noinline)) static void thrower() { throw Outer{"deep"}; }
+int main() {
+  try {
+    try {
+      thrower();
+    } catch (const Inner&) {
+      std::printf("WRONG-inner\n");
+      return 2;
+    }
+  } catch (const Outer& o) {
+    std::printf("CAUGHT-3 %s\n", o.w);
+    return 0;
+  }
+  std::printf("NOT-CAUGHT-3\n");
+  return 2;
+}

--- a/tests/integration/dyninstAPI/exceptions/eh_rethrow.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_rethrow.cpp
@@ -17,6 +17,6 @@ int main() {
     std::printf("CAUGHT-4 %s\n", e.what());
     return 0;
   }
-  std::printf("NOT-CAUGHT-4\n");
+  std::printf("MISSED-4\n");
   return 2;
 }

--- a/tests/integration/dyninstAPI/exceptions/eh_rethrow.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_rethrow.cpp
@@ -1,0 +1,22 @@
+// EH mutatee: catch then re-throw; an outer frame must catch the re-thrown
+// exception (exercises unwinding resumed from a landing pad).
+#include <cstdio>
+#include <stdexcept>
+__attribute__((noinline)) static void thrower() { throw std::runtime_error("again"); }
+__attribute__((noinline)) static void middle() {
+  try {
+    thrower();
+  } catch (const std::exception&) {
+    throw;  // re-throw to the caller
+  }
+}
+int main() {
+  try {
+    middle();
+  } catch (const std::exception& e) {
+    std::printf("CAUGHT-4 %s\n", e.what());
+    return 0;
+  }
+  std::printf("NOT-CAUGHT-4\n");
+  return 2;
+}

--- a/tests/integration/dyninstAPI/exceptions/eh_rewrite_driver.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_rewrite_driver.cpp
@@ -1,0 +1,67 @@
+/*
+ * Exception-handling integration test driver.
+ *
+ * Opens the input binary as a rewriter, relocates every one of its functions
+ * (no instrumentation needed -- relocation alone moves the code out of .text
+ * into the instrumentation section, which is what forces Dyninst to synthesize
+ * the .eh_frame / .gcc_except_table for the relocated code), and writes the
+ * result. The companion mutatees throw and catch C++ exceptions; if the
+ * synthesized unwind info is wrong the rewritten mutatee terminates instead of
+ * catching, so the "did it still catch?" check in CMake is the actual test.
+ *
+ * Mirrors the classic testsuite `test_reloc` mutator, minus the harness.
+ */
+#include "BPatch.h"
+#include "BPatch_binaryEdit.h"
+#include "BPatch_image.h"
+#include "BPatch_function.h"
+#include "BPatch_object.h"
+#include "BPatch_module.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static BPatch bpatch;
+
+int main(int argc, char* argv[]) {
+  if (argc != 3) {
+    std::fprintf(stderr, "usage: %s <input-binary> <output-binary>\n", argv[0]);
+    return 2;
+  }
+  const char* in = argv[1];
+  const char* out = argv[2];
+
+  BPatch_binaryEdit* be = bpatch.openBinary(in, /*openDependencies=*/false);
+  if (!be) {
+    std::fprintf(stderr, "eh_rewrite_driver: openBinary(%s) failed\n", in);
+    return 2;
+  }
+
+  BPatch_image* image = be->getImage();
+  std::vector<BPatch_function*>* funcs = image->getProcedures();
+  if (!funcs || funcs->empty()) {
+    std::fprintf(stderr, "eh_rewrite_driver: no procedures in %s\n", in);
+    return 2;
+  }
+
+  // Relocate everything at once (per-function relocation of thousands of
+  // functions individually would be pathologically slow).
+  be->beginInsertionSet();
+  for (BPatch_function* f : *funcs) {
+    if (!f) continue;
+    // Never relocate the runtime library itself.
+    BPatch_module* m = f->getModule();
+    if (m && m->getObject() &&
+        m->getObject()->name().find("libdyninstAPI_RT") != std::string::npos)
+      continue;
+    f->relocateFunction();
+  }
+  be->finalizeInsertionSet(/*atomic=*/false, /*modified=*/nullptr);
+
+  if (!be->writeFile(out)) {
+    std::fprintf(stderr, "eh_rewrite_driver: writeFile(%s) failed\n", out);
+    return 2;
+  }
+  return 0;
+}

--- a/tests/integration/dyninstAPI/exceptions/eh_single.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_single.cpp
@@ -9,6 +9,6 @@ int main() {
     std::printf("CAUGHT-1 %s\n", e.what());
     return 0;
   }
-  std::printf("NOT-CAUGHT-1\n");
+  std::printf("MISSED-1\n");
   return 2;
 }

--- a/tests/integration/dyninstAPI/exceptions/eh_single.cpp
+++ b/tests/integration/dyninstAPI/exceptions/eh_single.cpp
@@ -1,0 +1,14 @@
+// EH mutatee: a single try/catch of a class-type exception.
+#include <cstdio>
+#include <stdexcept>
+__attribute__((noinline)) static void thrower() { throw std::runtime_error("boom"); }
+int main() {
+  try {
+    thrower();
+  } catch (const std::exception& e) {
+    std::printf("CAUGHT-1 %s\n", e.what());
+    return 0;
+  }
+  std::printf("NOT-CAUGHT-1\n");
+  return 2;
+}


### PR DESCRIPTION
## Summary

When Dyninst relocates a function — whether by the static rewriter or dynamic
instrumentation — it copies the instructions to new addresses but does not
reconstruct the DWARF unwind info (`.eh_frame`) or the C++ LSDA
(`.gcc_except_table`) that describe them. A C++ exception thrown from, or
propagating through, relocated code then finds no CFI and no call-site table at
the new PC, the unwinder fails, and the process calls `std::terminate` instead
of running the matching `catch`.

This PR synthesizes both tables for relocated code from the original function's
unwind info, mapped through the relocation's orig→reloc tracker, and delivers
them so libgcc can unwind through instrumented frames.

Fixes #1437.

## Approach

- **Generator** (`eh_frame_gen.C`): three passes over the `CodeTracker`s build an
  orig→reloc address map and per-function runs, decode each LSDA-bearing
  function's call sites, and emit one CIE/FDE (+LSDA) per relocated run. Handles
  the awkward cases that otherwise silently `terminate`: instrumentation snippets
  sharing an original address, hot/cold-split functions (`.cold` fragments),
  stack-realigning frames, mixed C/C++ personalities, interleaved neighbors, and
  foreign code pulled in by the runtime. (The per-decision rationale lives in the
  commit messages.)
- **Delivery** — static: the blobs are added as loadable regions and a
  `DT_DYNINST_EH_FRAME` dynamic tag points the runtime at them; the RT registers
  them at load via `dl_iterate_phdr` + `__register_frame`. Dynamic: an inferior
  region is allocated, the tables written in, and `__register_frame` invoked over
  an iRPC.
- **PIE**: the generator is load-bias–aware so link-time CFI/LSDA addresses
  resolve against runtime tracker addresses (non-PIE path is byte-for-byte
  unchanged).

## Platform support

| Arch | Static rewrite | Dynamic instrumentation |
|------|:--:|:--:|
| x86-64 | ✅ | ✅ |
| aarch64 | ✅ | — (dynamic instrumentation unimplemented, #449) |
| ppc64le | ✅ | — (blocked on a separate TOC/r2 relocation gap, not EH) |

## Testing

New in-tree CTest integration tests under
`tests/integration/dyninstAPI/exceptions/`: a driver + mutatees covering
single/nested/rethrow/cleanup/multi/base-catch/deep and hot-cold-split throws,
run through both the static rewriter and dynamic instrumentation, each built
position-independent and not, with per-test artifact isolation. Tests match only
the success sentinel, so any wrong-catch/crash/terminate/timeout fails.

- x86-64: full matrix green; the #1437 reproducer now catches.
- aarch64 / ppc64le: static + hot-cold matrices green.
- SPEC CPU 2017 spot checks (via `code_coverage`): leela byte-identical,
  deepsjeng clean, omnetpp instruments to a valid PIE ELF (0 section overlaps,
  4003 FDEs) and runs to completion.

## Merge dependencies

For ppc64le, this depends on the instruction-decoder fixes in #2335 / #2337
(`bc`/`bclr`) and #2338 (`isel`) — those are kept out of this branch and should
merge first.

## Notes

- Exception support is intentionally excluded for static (non-dynamic) binaries —
  the runtime is linked at emit time and would mis-relocate its reference to the
  region.
- Debug output is on the `DYNINST_DEBUG_EH` channel.