### PR TITLE
proccontrol: fix thread-exit crash/hang races

### DIFF
--- a/dyninstAPI/src/dynproc/pcEventMuxer.C
+++ b/dyninstAPI/src/dynproc/pcEventMuxer.C
@@ -535,16 +535,20 @@ Event::const_ptr PCEventMailbox::dequeue(bool block) {
 	if(!evProc) {
 		proccontrol_printf("%s[%d]: Found event %s, but process is invalid\n",
 							FILE__, __LINE__, event_ptr->name().c_str());
-		namespace pc = Dyninst::ProcControlAPI;
-		auto const& et = event_ptr->getEventType();
-		bool const is_exit = et.code() == pc::EventType::Exit;
-		bool const is_post = et.time() == pc::EventType::Time::Post;
-		if(is_exit && is_post) {
-			// post-exit events handled after process destruction are irrelevant
-			return Event::const_ptr{};
-		} else {
-			assert(false);
+		// The process's dyninstAPI-side data is already destroyed: this
+		// event lost the race with process teardown and has no consumer
+		// anymore.  Post-exit events have always been dropped here; other
+		// late events from the same race (e.g. a SIGTRAP-derived event
+		// decoded after the handler thread finished tearing the process
+		// down in a multithreaded create-mode mutatee) are equally
+		// unconsumable, so drop them too instead of asserting.
+		auto evPcProc = event_ptr->getProcess();
+		if (evPcProc) {
+			auto pcnt = procCount.find(evPcProc->getPid());
+			if (pcnt != procCount.end() && pcnt->second > 0)
+				pcnt->second--;
 		}
+		return Event::const_ptr{};
 	}
 	procCount[evProc->getPid()]--;
 	assert(procCount[evProc->getPid()] >= 0);

--- a/proccontrol/src/event.C
+++ b/proccontrol/src/event.C
@@ -335,6 +335,22 @@ void EventBreakpoint::getBreakpoints(std::vector<Breakpoint::const_ptr> &bps) co
    if (!int_bp)
       return;
    bp_instance *ibp = int_bp->lookupInstalledBreakpoint();
+   if (!ibp) {
+      // Distinguish the two ways the lookup can miss.  A dead event thread is
+      // the expected (stale-event) case; a miss for a live thread is
+      // near-impossible by construction -- HandleBreakpoint verified the
+      // bp_instance before any consumer runs -- and indicates a user-deleted
+      // breakpoint or broken bookkeeping, so keep it visible rather than
+      // silently masking it.
+      int_thread *evthr = int_bp->thrd ? int_bp->thrd->llthrd() : NULL;
+      if (evthr && evthr->llproc())
+         pthrd_printf("getBreakpoints: no bp_instance for LIVE thread %d -- "
+                      "deleted breakpoint or broken bookkeeping\n",
+                      (int) evthr->getLWP());
+      else
+         pthrd_printf("getBreakpoints on event whose thread exited; empty result\n");
+      return;
+   }
    std::set<Breakpoint::ptr>::iterator i;
    for (i = ibp->hl_bps.begin(); i != ibp->hl_bps.end(); ++i) {
       bps.push_back(*i);
@@ -346,6 +362,22 @@ void EventBreakpoint::getBreakpoints(std::vector<Breakpoint::ptr> &bps)
    if (!int_bp)
       return;
    bp_instance *ibp = int_bp->lookupInstalledBreakpoint();
+   if (!ibp) {
+      // Distinguish the two ways the lookup can miss.  A dead event thread is
+      // the expected (stale-event) case; a miss for a live thread is
+      // near-impossible by construction -- HandleBreakpoint verified the
+      // bp_instance before any consumer runs -- and indicates a user-deleted
+      // breakpoint or broken bookkeeping, so keep it visible rather than
+      // silently masking it.
+      int_thread *evthr = int_bp->thrd ? int_bp->thrd->llthrd() : NULL;
+      if (evthr && evthr->llproc())
+         pthrd_printf("getBreakpoints: no bp_instance for LIVE thread %d -- "
+                      "deleted breakpoint or broken bookkeeping\n",
+                      (int) evthr->getLWP());
+      else
+         pthrd_printf("getBreakpoints on event whose thread exited; empty result\n");
+      return;
+   }
    std::set<Breakpoint::ptr>::iterator i;
    for (i = ibp->hl_bps.begin(); i != ibp->hl_bps.end(); i++) {
       bps.push_back(*i);
@@ -499,13 +531,14 @@ Dyninst::LWP EventNewUserThread::getLWP() const
 Thread::const_ptr EventNewUserThread::getNewThread() const
 {
    if (iev->thr)
-      return iev->thr->thread();
+      return iev->thr;
    if (iev->lwp == NULL_LWP)
       return Thread::const_ptr();
 
-   iev->thr = getProcess()->llproc()->threadPool()->findThreadByLWP(iev->lwp);
-   assert(iev->thr);
-   return iev->thr->thread();
+   int_thread *t = getProcess()->llproc()->threadPool()->findThreadByLWP(iev->lwp);
+   assert(t);
+   iev->thr = t->thread();
+   return iev->thr;
 }
 
 int_eventNewUserThread *EventNewUserThread::getInternalEvent() const
@@ -1162,7 +1195,7 @@ EventPostponedSyscall::~EventPostponedSyscall()
 int_eventBreakpoint::int_eventBreakpoint(Address a, sw_breakpoint *, int_thread *thr) :
    addr(a),
    hwbp(NULL),
-   thrd(thr),
+   thrd(thr ? thr->thread() : Thread::const_ptr()),
    stopped_proc(false)
 {
 }
@@ -1170,7 +1203,7 @@ int_eventBreakpoint::int_eventBreakpoint(Address a, sw_breakpoint *, int_thread 
 int_eventBreakpoint::int_eventBreakpoint(hw_breakpoint *i, int_thread *thr) :
    addr(i->getAddr()),
    hwbp(i),
-   thrd(thr),
+   thrd(thr ? thr->thread() : Thread::const_ptr()),
    stopped_proc(false)
 {
 }
@@ -1183,8 +1216,14 @@ bp_instance *int_eventBreakpoint::lookupInstalledBreakpoint()
 {
    if (hwbp)
       return static_cast<bp_instance *>(hwbp);
-   else
-      return static_cast<bp_instance *>(thrd->llproc()->getBreakpoint(addr));
+   // The thread or its process may already have been torn down (the mutatee
+   // exited) while this breakpoint event was still in flight.  The wrapper
+   // survives, but llthrd() returns NULL once the int_thread is destroyed, so
+   // there is no installed breakpoint to find.
+   int_thread *t = thrd ? thrd->llthrd() : NULL;
+   if (!t || !t->llproc())
+      return NULL;
+   return static_cast<bp_instance *>(t->llproc()->getBreakpoint(addr));
 }
 
 int_eventBreakpointClear::int_eventBreakpointClear() :
@@ -1261,7 +1300,7 @@ void int_eventAsync::addResp(response::ptr r)
 }
 
 int_eventNewUserThread::int_eventNewUserThread() :
-   thr(NULL),
+   thr(),
    lwp(NULL_LWP),
    raw_data(NULL),
    needs_update(true)

--- a/proccontrol/src/handler.C
+++ b/proccontrol/src/handler.C
@@ -1269,9 +1269,14 @@ void HandleSingleStep::getEventTypesHandled(vector<EventType> &etypes)
 
 Handler::handler_ret_t HandleSingleStep::handleEvent(Event::ptr ev)
 {
-   pthrd_printf("Handling event single step on %d/%d\n", 
-                ev->getProcess()->llproc()->getPid(), 
-                ev->getThread()->llthrd()->getLWP());
+   int_process *proc = ev->getProcess()->llproc();
+   int_thread *thrd = ev->getThread() ? ev->getThread()->llthrd() : NULL;
+   if (!proc || !thrd) {
+      pthrd_printf("Single-step for exited process/thread; ignoring.\n");
+      return ret_success;
+   }
+   pthrd_printf("Handling event single step on %d/%d\n",
+                proc->getPid(), thrd->getLWP());
    return ret_success;
 }
 
@@ -1342,6 +1347,14 @@ Handler::handler_ret_t HandleBreakpoint::handleEvent(Event::ptr ev)
 {
    int_process *proc = ev->getProcess()->llproc();
    int_thread *thrd = ev->getThread()->llthrd();
+
+   if (!proc || !thrd) {
+      // The process or thread was torn down (e.g. the mutatee exited) while
+      // this breakpoint event was still in flight.  There is nothing left to
+      // act on, and dereferencing the stale handle would crash.
+      pthrd_printf("Breakpoint event for exited process/thread; ignoring.\n");
+      return ret_success;
+   }
 
    EventBreakpoint *ebp = static_cast<EventBreakpoint *>(ev.get());
    pthrd_printf("Handling breakpoint at %lx\n", ebp->getAddress());
@@ -1737,6 +1750,13 @@ Handler::handler_ret_t HandleEmulatedSingleStep::handleEvent(Event::ptr ev)
 {
    int_process *proc = ev->getProcess()->llproc();
    int_thread *thrd = ev->getThread()->llthrd();
+
+   if (!proc || !thrd) {
+      // The process or thread was torn down (e.g. the mutatee exited) while
+      // this event was still in flight.  Nothing left to single-step over.
+      pthrd_printf("Emulated single-step event for exited process/thread; ignoring.\n");
+      return ret_success;
+   }
 
    emulated_singlestep *em_singlestep = thrd->getEmulatedSingleStep();
    if (!em_singlestep)

--- a/proccontrol/src/handler.C
+++ b/proccontrol/src/handler.C
@@ -1021,6 +1021,21 @@ Handler::handler_ret_t HandleThreadDestroy::handleEvent(Event::ptr ev)
    return ret_success;
 }
 
+// Find any live thread in proc's pool.  Proc-wide state restores
+// (restoreStateProc) just walk the pool and only need a live thread as their
+// handle; used when the event's own thread has been destroyed.  The pool only
+// contains live threads (rmThread removes them before deletion), unlike
+// initialThread(), which can be stale during teardown.
+static int_thread *anyLiveThread(int_process *proc)
+{
+   if (!proc)
+      return NULL;
+   int_threadPool *pool = proc->threadPool();
+   if (!pool || pool->empty())
+      return NULL;
+   return *pool->begin();
+}
+
 HandleThreadCleanup::HandleThreadCleanup() :
    Handler("Thread Cleanup")
 {
@@ -1083,7 +1098,39 @@ Handler::handler_ret_t HandleThreadCleanup::handleEvent(Event::ptr ev)
 	   pthrd_printf("Thread for thread cleanup event is NULL. We have no work we can do.\n");
 	   return ret_success;
    }
-   pthrd_printf("Cleaning thread %d/%d from HandleThreadCleanup handler.\n", 
+   /**
+    * If this thread died while single-stepping over a cleared (suspended)
+    * breakpoint, the BreakpointRestore event that normally finishes the
+    * step-over is never generated -- the decoder only creates it on the
+    * thread's single-step trap, and this thread will never trap again.
+    * Without intervention the breakpoint stays out of memory and, for sw
+    * breakpoints, every other thread is left desync'd to stopped at the
+    * BreakpointResumeState level, permanently stopping the process.
+    * Perform the restore duties here, mirroring HandleBreakpointRestore.
+    * The dying thread is still in the pool, so one restoreStateProc walk
+    * exactly balances the one desync each thread received when the
+    * breakpoint was cleared.
+    **/
+   bp_instance *clearing_bp = thrd->isClearingBreakpoint();
+   if (clearing_bp) {
+      pthrd_printf("Thread %d/%d died mid breakpoint-clear; re-arming bp at 0x%lx and restoring states\n",
+                   proc->getPid(), thrd->getLWP(), clearing_bp->getAddr());
+      thrd->markClearingBreakpoint(NULL);
+      thrd->setSingleStepMode(false);
+
+      set<response::ptr> bp_resume_resps;
+      if (!clearing_bp->resume(proc, bp_resume_resps)) {
+         pthrd_printf("Failed to re-arm breakpoint after thread exit; continuing cleanup\n");
+      }
+
+      if (clearing_bp->swBP()) {
+         int_thread *live = anyLiveThread(proc);
+         if (live)
+            live->getBreakpointResumeState().restoreStateProc();
+      }
+   }
+
+   pthrd_printf("Cleaning thread %d/%d from HandleThreadCleanup handler.\n",
                 proc->getPid(), thrd->getLWP());
    int_thread::cleanFromHandler(thrd, should_delete);
    return ret_success;
@@ -1542,9 +1589,24 @@ Handler::handler_ret_t HandleBreakpointContinue::handleEvent(Event::ptr ev)
     **/
    EventBreakpoint *ebp = static_cast<EventBreakpoint *>(ev.get());
    int_eventBreakpoint *int_bp = ebp->getInternal();
-   
+
    if (int_bp->stopped_proc) {
-      ebp->getThread()->llthrd()->getBreakpointHoldState().restoreStateProc();
+      // procStopper() desync'd the proc-wide BreakpointHoldState; it MUST be
+      // restored or every surviving thread stays force-stopped and the
+      // process hangs.  The restore is a proc-wide walk that only needs a
+      // live thread as its handle: the event's thread may have been torn
+      // down (mutatee exiting) while this continue was in flight, so fall
+      // back to any live thread in the pool.  Only if the whole process is
+      // gone (state trackers destroyed with it) is skipping safe.
+      int_thread *thrd = ebp->getThread() ? ebp->getThread()->llthrd() : NULL;
+      if (!thrd) {
+         thrd = anyLiveThread(ev->getProcess() ? ev->getProcess()->llproc() : NULL);
+         pthrd_printf("Breakpoint-continue: event thread exited; restoring "
+                      "proc-wide hold via %s\n",
+                      thrd ? "another live thread" : "nothing (process gone)");
+      }
+      if (thrd)
+         thrd->getBreakpointHoldState().restoreStateProc();
    }
    return Handler::ret_success;
 }
@@ -1570,6 +1632,21 @@ Handler::handler_ret_t HandleBreakpointClear::handleEvent(Event::ptr ev)
 {
    int_process *proc = ev->getProcess()->llproc();
    int_thread *thrd = ev->getThread()->llthrd();
+
+   if (!proc || !thrd) {
+      // Thread (or process) torn down while this event was in flight.  If the
+      // proc-wide BreakpointState desync was taken (stopped_proc), it must
+      // still be undone via a surviving thread or every survivor stays
+      // force-stopped; a per-thread desync died with the thread.  Every other
+      // exit path of this handler restores this state -- so must this one.
+      EventBreakpointClear *evbpc_g = static_cast<EventBreakpointClear *>(ev.get());
+      int_eventBreakpointClear *int_bpc_g = evbpc_g->getInternal();
+      int_thread *live = anyLiveThread(proc);
+      if (int_bpc_g->stopped_proc && live)
+         live->getBreakpointState().restoreStateProc();
+      pthrd_printf("Breakpoint-clear for exited process/thread; restored state, ignoring.\n");
+      return ret_success;
+   }
 
    EventBreakpointClear *evbpc = static_cast<EventBreakpointClear *>(ev.get());
    int_eventBreakpointClear *int_bpc = evbpc->getInternal();
@@ -1685,6 +1762,19 @@ Handler::handler_ret_t HandleBreakpointRestore::handleEvent(Event::ptr ev)
 {
    int_process *proc = ev->getProcess()->llproc();
    int_thread *thrd = ev->getThread()->llthrd();
+   if (!proc || !thrd) {
+      // Thread (or process) torn down mid-restore.  The proc-wide
+      // BreakpointResumeState desyncs taken when the breakpoint was cleared
+      // for single-stepping (sw breakpoints only) must still be undone via a
+      // surviving thread, or every survivor stays force-stopped.
+      EventBreakpointRestore *bpc_g = static_cast<EventBreakpointRestore *>(ev.get());
+      int_eventBreakpointRestore *int_bpc_g = bpc_g->getInternal();
+      int_thread *live = anyLiveThread(proc);
+      if (live && int_bpc_g->bp && int_bpc_g->bp->swBP())
+         live->getBreakpointResumeState().restoreStateProc();
+      pthrd_printf("Breakpoint-restore for exited process/thread; restored state, ignoring.\n");
+      return ret_success;
+   }
    EventBreakpointRestore *bpc = static_cast<EventBreakpointRestore *>(ev.get());
    int_eventBreakpointRestore *int_bpc = bpc->getInternal();
    bp_instance *bp = int_bpc->bp;

--- a/proccontrol/src/int_event.h
+++ b/proccontrol/src/int_event.h
@@ -56,7 +56,13 @@ class int_eventBreakpoint
    hw_breakpoint *hwbp;
 
    result_response::ptr pc_regset;
-   int_thread *thrd;
+   // Reference-counted handle to the thread that hit the breakpoint.  A
+   // breakpoint event can outlive the underlying int_thread (the mutatee
+   // exits while the event is still queued); the int_thread is then deleted,
+   // but this wrapper survives and its internal pointer is cleanly reset to
+   // NULL.  Storing the raw int_thread* here would dangle.  Dereference via
+   // thrd->llthrd() at point of use (see lookupInstalledBreakpoint).
+   Thread::const_ptr thrd;
    bool stopped_proc;
 
    std::set<Breakpoint::ptr> cb_bps;
@@ -116,7 +122,11 @@ class int_eventNewUserThread {
    int_eventNewUserThread();
    ~int_eventNewUserThread();
 
-   int_thread *thr;
+   // Reference-counted handle: the new thread can exit (and its int_thread be
+   // deleted) before this event reaches the callback/muxer layer.  The Thread
+   // wrapper survives with exit-safe accessors; a raw int_thread* would
+   // dangle.  See the matching comment on int_eventBreakpoint::thrd.
+   Thread::const_ptr thr;
    Dyninst::LWP lwp;
    void *raw_data;
    bool needs_update;

--- a/proccontrol/src/int_process.h
+++ b/proccontrol/src/int_process.h
@@ -359,6 +359,7 @@ class int_process
    virtual void freeExecMemory(Dyninst::Address addr);
 
    static bool waitAndHandleEvents(bool block);
+   static bool syncDivergentRunStates();
    static bool waitAndHandleForProc(bool block, int_process *proc, bool &proc_exited);
    static bool waitForAsyncEvent(response::ptr resp);
    static bool waitForAsyncEvent(std::set<response::ptr> resp);

--- a/proccontrol/src/int_thread_db.C
+++ b/proccontrol/src/int_thread_db.C
@@ -1235,7 +1235,7 @@ Handler::handler_ret_t ThreadDBDispatchHandler::handleEvent(Event::ptr ev)
          new_ev->setProcess(proc->proc());
          new_ev->setThread(main_thread->thread());
          new_ev->setSyncType(Event::sync_process);
-         new_ev->getInternalEvent()->thr = main_thread;
+         new_ev->getInternalEvent()->thr = main_thread->thread();
          new_ev->getInternalEvent()->lwp = main_thread->getLWP();
          new_ev->getInternalEvent()->raw_data = (void *) thrdata;
          proc->initialThreadEventCreated = true;
@@ -1358,7 +1358,16 @@ Handler::handler_ret_t ThreadDBCreateHandler::handleEvent(Event::ptr ev) {
 
    EventNewUserThread::ptr threadEv = ev->getEventNewUserThread();
    thread_db_process *tdb_proc = dynamic_cast<thread_db_process *>(threadEv->getProcess()->llproc());
-   thread_db_thread *tdb_thread = dynamic_cast<thread_db_thread *>(threadEv->getNewThread()->llthrd());
+   Thread::const_ptr new_thr = threadEv->getNewThread();
+   thread_db_thread *tdb_thread =
+      dynamic_cast<thread_db_thread *>(new_thr ? new_thr->llthrd() : NULL);
+
+   if (!tdb_proc || !tdb_thread) {
+      // The new thread (or process) already exited before this create event
+      // was handled; its destroy event follows.  Nothing to initialize.
+      pthrd_printf("ThreadDBCreateHandler: thread/process already gone; ignoring.\n");
+      return Handler::ret_success;
+   }
 
    pthrd_printf("ThreadDBCreateHandler::handleEvent for %d/%d\n", tdb_proc->getPid(), tdb_thread->getLWP());
    if (threadEv->getInternalEvent()->needs_update) {

--- a/proccontrol/src/int_thread_db.C
+++ b/proccontrol/src/int_thread_db.C
@@ -1167,6 +1167,23 @@ Handler::handler_ret_t ThreadDBDispatchHandler::handleEvent(Event::ptr ev)
       pthrd_printf("Dropping dispatch event, another is in progress\n");
       return ret_success;
    }
+
+   // getEventForThread() reads the process's thread list out of memory, which
+   // must not race with a running thread.  The proc-stopping breakpoint that
+   // released this event only guaranteed the threads that existed when it was
+   // satisfied were stopped; a thread can be created (and left running) in the
+   // window before this handler runs.  Its ThreadCreate event is still pending
+   // in the mailbox and will stop it (see HandleThreadCreate).  Re-handle this
+   // event after that so the read happens only once every live thread is
+   // stopped.  allHandlerStopped() ignores exiting/exited threads, so this
+   // only defers for genuinely-running ones and converges as the pending
+   // create/stop events drain.  This check sits after the duplicate-drop so a
+   // redundant dispatch is discarded immediately instead of churning.
+   if (!int_ev->completed_new_evs && !proc->threadPool()->allHandlerStopped()) {
+      pthrd_printf("thread_db dispatch: not all threads stopped yet, deferring\n");
+      return ret_again;
+   }
+
    proc->dispatch_event = etdb;
 
    if (!int_ev->completed_new_evs) {

--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -3193,7 +3193,11 @@ LinuxHandleLWPDestroy::~LinuxHandleLWPDestroy()
 }
 
 Handler::handler_ret_t LinuxHandleLWPDestroy::handleEvent(Event::ptr ev) {
-    int_thread *thrd = ev->getThread()->llthrd();
+    int_thread *thrd = ev->getThread() ? ev->getThread()->llthrd() : NULL;
+    if (!thrd) {
+       // Thread object already torn down; nothing to clean.
+       return ret_success;
+    }
 
     // This handler is necessary because SIGSTOPS cannot be sent to pre-destroyed
     // threads -- these stops will never be delivered to the debugger
@@ -3252,13 +3256,20 @@ HandlerPool *linux_createDefaultHandlerPool(HandlerPool *hpool)
    static bool initialized = false;
    static LinuxHandleNewThr *lbootstrap = NULL;
    static LinuxHandleForceTerminate *lterm = NULL;
+   static LinuxHandleLWPDestroy *llwpdestroy = NULL;
    if (!initialized) {
       lbootstrap = new LinuxHandleNewThr();
       lterm = new LinuxHandleForceTerminate();
+      llwpdestroy = new LinuxHandleLWPDestroy();
       initialized = true;
    }
    hpool->addHandler(lbootstrap);
    hpool->addHandler(lterm);
+   // Clears pending stops on dying threads (a SIGSTOP sent to a
+   // pre-destroyed thread is never delivered, which otherwise leaves the
+   // PendingStop state permanently desync'd and deadlocks any proc-stop
+   // waiter).  The handler existed but was never registered.
+   hpool->addHandler(llwpdestroy);
    thread_db_process::addThreadDBHandlers(hpool);
    sysv_process::addSysVHandlers(hpool);
    return hpool;

--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -243,9 +243,23 @@ void GeneratorLinux::evictFromWaitpid()
    }
    on_sigusr2_hit = 0;
    bool bresult = t_kill(generator_lwp, SIGUSR2);
+   // The generator may exit on its own initiative (e.g. no live processes
+   // left) concurrently with this eviction.  If the SIGUSR2 was queued to the
+   // dying thread it is discarded and on_sigusr2_hit never fires, which used
+   // to leave this loop spinning forever inside exit().  Bound the wait: this
+   // eviction is best-effort (we are exiting; exit_group() will reap the
+   // generator thread regardless), so give up after a couple of seconds.
+   struct timespec evict_start, evict_now;
+   clock_gettime(CLOCK_MONOTONIC, &evict_start);
    while (bresult && !on_sigusr2_hit) {
       //Don't use a lock because pthread_mutex_unlock is not signal safe
       sched_yield();
+      clock_gettime(CLOCK_MONOTONIC, &evict_now);
+      if (evict_now.tv_sec - evict_start.tv_sec >= 2) {
+         pthrd_printf("Timed out evicting generator from waitpid; "
+                      "it likely exited on its own\n");
+         break;
+      }
    }
 
    result = sigaction(SIGUSR2, &oldact, NULL);

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -2105,6 +2105,11 @@ bool int_process::removeBreakpoint(Dyninst::Address addr, int_breakpoint *bp, se
 
 sw_breakpoint *int_process::getBreakpoint(Dyninst::Address addr)
 {
+   // The process may already have been torn down (mem is reset to NULL in
+   // cleanupProcess) while a breakpoint event for it is still in flight.
+   // Guard against the resulting NULL dereference; the breakpoint is gone.
+   if (!mem)
+      return NULL;
    std::map<Dyninst::Address, sw_breakpoint *>::iterator  i = mem->breakpoints.find(addr);
    if (i == mem->breakpoints.end())
       return NULL;

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -1015,8 +1015,9 @@ bool int_process::syncDivergentRunStates()
 {
    std::vector<int_process *> divergent;
    ProcPool()->for_each(collectDivergentRunStateProcs, &divergent);
-   if (divergent.empty())
+   if (divergent.empty()) {
       return false;
+   }
    pthrd_printf("Self-heal: %d proc(s) have divergent run states, re-syncing\n",
                 (int) divergent.size());
    for (std::vector<int_process *>::iterator i = divergent.begin();
@@ -2598,6 +2599,18 @@ bool indep_lwp_control_process::plat_syncRunState()
     	  if(thr->plat_handle_ghost_thread()) {
     		  thr->getHandlerState().setState(int_thread::running);
     	  }
+    	  else {
+             // ESRCH with the thread still alive: the kernel is in a
+             // transitional stop state (see plat_handle_ghost_thread) and the
+             // continue/stop will succeed once it settles.  Retry via a nop
+             // event rather than silently swallowing the failure -- otherwise
+             // the run-state divergence is left with no event in flight and
+             // the event loop parks forever.
+             pthrd_printf("Ptrace op failed on live thread %d/%d; scheduling retry\n",
+                          getPid(), thr->getLWP());
+             usleep(500);
+             throwNopEvent();
+    	  }
       }
       else if (!result) {
          pthrd_printf("Error changing process state from plat_syncRunState\n");
@@ -3026,6 +3039,23 @@ bool int_thread::intStop()
       // stop was created before the exit was observed.)
       pthrd_printf("Not stopping exiting thread %d/%d\n", llproc()->getPid(), getLWP());
       return true;
+   }
+   {
+      int_thread::State gen_state = getGeneratorState().getState();
+      if (gen_state == int_thread::stopped || gen_state == int_thread::exited) {
+         // The generator has already observed this thread stop: its stop
+         // event is decoded and queued, and the handler will mark it stopped
+         // imminently.  Sending SIGSTOP now is unnecessary (the thread is
+         // already stopped) and harmful: the signal cannot be delivered while
+         // the thread is stopped, pinning the PendingStop state desync'd
+         // forever, and on Linux a STOP signal sent to an already
+         // ptrace-stopped thread can put it in a transitional state in which
+         // PTRACE_CONT persistently fails with ESRCH (see
+         // plat_handle_ghost_thread).  Treat the request as satisfied.
+         pthrd_printf("Not stopping %d/%d: generator already saw it stop\n",
+                      llproc()->getPid(), getLWP());
+         return true;
+      }
    }
    if (!llproc()->plat_processGroupContinues()) {
       assert(!RUNNING_STATE(target_state));

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -2940,6 +2940,17 @@ int_thread::~int_thread()
 bool int_thread::intStop()
 {
    pthrd_printf("intStop on thread %d/%d\n", llproc()->getPid(), getLWP());
+   if (isExiting() || isExitingInGenerator()) {
+      // The thread's exit event has already been observed: a SIGSTOP sent now
+      // can never be delivered (pre-destroyed threads never report the stop),
+      // which would leave the PendingStop state permanently desync'd and
+      // deadlock any proc-stop waiter.  The thread's destroy event is already
+      // queued/in flight and will mark it stopped; treat the request as
+      // satisfied.  (LinuxHandleLWPDestroy covers the case where the pending
+      // stop was created before the exit was observed.)
+      pthrd_printf("Not stopping exiting thread %d/%d\n", llproc()->getPid(), getLWP());
+      return true;
+   }
    if (!llproc()->plat_processGroupContinues()) {
       assert(!RUNNING_STATE(target_state));
       assert(RUNNING_STATE(getHandlerState().getState()));

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -8655,9 +8655,12 @@ bool ProcStopEventManager::prepEvent(Event::ptr ev)
       return true;
    }
 
+   // The event's thread may already have exited (llthrd() NULL): don't crash
+   // in debug logging.
    pthrd_printf("Adding event %s on %d/%d to pending proc stopper list\n",
                 ev->name().c_str(), ev->getProcess()->llproc()->getPid(),
-                ev->getThread()->llthrd()->getLWP());
+                (ev->getThread() && ev->getThread()->llthrd()) ?
+                   ev->getThread()->llthrd()->getLWP() : (Dyninst::LWP)-1);
    pair<set<Event::ptr>::iterator, bool> result = held_pstop_events.insert(ev);
    assert(result.second);
    return false;
@@ -8674,7 +8677,8 @@ void ProcStopEventManager::checkEvents()
 
       pthrd_printf("ProcStop event %s on %d/%d is ready, adding to queue\n",
                 ev->name().c_str(), ev->getProcess()->llproc()->getPid(),
-                ev->getThread()->llthrd()->getLWP());
+                (ev->getThread() && ev->getThread()->llthrd()) ?
+                   ev->getThread()->llthrd()->getLWP() : (Dyninst::LWP)-1);
 
       i = held_pstop_events.erase(i);
       mbox()->enqueue(ev);

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -983,12 +983,57 @@ bool int_process::waitAndHandleForProc(bool block, int_process *proc, bool &proc
 #define UNSET_CHECK        -8
 #define printCheck(VAL)    (((int) VAL) == UNSET_CHECK ? '?' : (VAL ? 'T' : 'F'))
 
+// for_each callback: note processes with a thread whose computed run target
+// diverges from its actual handler state (e.g. handler-stopped but targeted
+// running so an in-flight SIGSTOP can be delivered).  Runs under the ProcPool
+// lock, so it must not call syncRunState itself.
+static bool collectDivergentRunStateProcs(int_process *p, void *data)
+{
+   std::vector<int_process *> *out = (std::vector<int_process *> *) data;
+   if (p->getState() == int_process::exited || p->getState() == int_process::errorstate)
+      return true;
+   int_threadPool *tp = p->threadPool();
+   if (!tp)
+      return true;
+   for (int_threadPool::iterator i = tp->begin(); i != tp->end(); i++) {
+      int_thread *thr = *i;
+      int_thread::State active = thr->getActiveState().getState();
+      if (active == int_thread::ditto)
+         active = thr->getHandlerState().getState();
+      if (RUNNING_STATE(active) != RUNNING_STATE(thr->getHandlerState().getState())) {
+         out->push_back(p);
+         return true;
+      }
+   }
+   return true;
+}
+
+// Re-run syncRunState for any process left with a divergent thread; returns
+// true if any process needed it.  See the self-heal comments in
+// waitAndHandleEvents.
+bool int_process::syncDivergentRunStates()
+{
+   std::vector<int_process *> divergent;
+   ProcPool()->for_each(collectDivergentRunStateProcs, &divergent);
+   if (divergent.empty())
+      return false;
+   pthrd_printf("Self-heal: %d proc(s) have divergent run states, re-syncing\n",
+                (int) divergent.size());
+   for (std::vector<int_process *>::iterator i = divergent.begin();
+        i != divergent.end(); i++) {
+      if (!(*i)->syncRunState())
+         pthrd_printf("Self-heal syncRunState failed on %d\n", (*i)->getPid());
+   }
+   return true;
+}
+
 bool int_process::waitAndHandleEvents(bool block)
 {
    pthrd_printf("Top of waitAndHandleEvents.  Block = %s\n", block ? "true" : "false");
    bool gotEvent = false;
    assert(!int_process::in_callback);
    bool error = false;
+   bool preblock_synced = false;
 
    static bool recurse = false;
    assert(!recurse);
@@ -1044,6 +1089,24 @@ bool int_process::waitAndHandleEvents(bool block)
       //      over it while (should_block == true), with a condition variable signaling when the
       //      should_block would go to false (so we don't just spin).
 
+      /**
+       * Self-heal before parking: a thread can be left with an actionable
+       * run-state divergence -- e.g. handler-stopped but targeted running so
+       * that an in-flight SIGSTOP can be delivered (PendingStop state) -- with
+       * no event in flight to drive another syncRunState pass.  Parking now
+       * would deadlock: the mailbox stays empty precisely because the thread
+       * was never continued.  Re-run syncRunState once for such processes;
+       * it is idempotent, and any action it takes (e.g. continuing the thread
+       * so the pending stop is delivered) produces the event that wakes the
+       * dequeue below.  If the divergence is not resolvable we park exactly
+       * as before -- the sweep runs at most once per park.
+       **/
+      if (should_block && !preblock_synced) {
+         preblock_synced = true;
+         if (syncDivergentRunStates())
+            continue;
+      }
+
       if (should_block && Counter::globalCount(Counter::ForceGeneratorBlock)) {
          // Entirely possible we didn't continue anything, but we want the generator to
          // wake up anyway
@@ -1054,6 +1117,18 @@ bool int_process::waitAndHandleEvents(bool block)
 
       if (ev == Event::ptr())
       {
+         /**
+          * Mailbox drained.  This is the other park point: the handler thread
+          * services events with block=false and returns here when done, and a
+          * divergence formed during its handling (see above) would otherwise
+          * be left for nobody -- the main thread may already be blocked in
+          * its own dequeue.  Sweep once before giving up.
+          **/
+         if (!preblock_synced) {
+            preblock_synced = true;
+            if (syncDivergentRunStates())
+               continue;
+         }
          if (gotEvent) {
             pthrd_printf("Returning after handling events\n");
             goto done;
@@ -1088,6 +1163,7 @@ bool int_process::waitAndHandleEvents(bool block)
       }
 
       gotEvent = true;
+      preblock_synced = false;
 
       bool terminating = (ev->getProcess()->isTerminated());
 

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -4519,7 +4519,18 @@ int_thread *int_threadPool::initialThread() const
 bool int_threadPool::allHandlerStopped()
 {
    for (iterator i = begin(); i != end(); i++) {
-      if ((*i)->getHandlerState().getState() != int_thread::stopped)
+      int_thread *thr = *i;
+      // A thread that has exited, or is in the process of exiting, cannot run
+      // and will be reaped once its (still pending) exit event is handled.  Its
+      // handler state can transiently still read 'running' in that window.
+      // Such a thread poses no risk to operations that only require the live
+      // threads to be quiesced (e.g. thread_db memory reads), so don't let it
+      // block them.  Mirrors the exiting-thread handling in syncRunState().
+      if (thr->getHandlerState().getState() == int_thread::exited ||
+          thr->getGeneratorState().getState() == int_thread::exited ||
+          thr->isExiting() || thr->isExitingInGenerator())
+         continue;
+      if (thr->getHandlerState().getState() != int_thread::stopped)
          return false;
    }
    return true;

--- a/proccontrol/src/response.C
+++ b/proccontrol/src/response.C
@@ -43,24 +43,31 @@ using namespace std;
 
 unsigned int response::next_id = 1;
 
-static Mutex<> id_lock;
+// Intentionally heap-allocated and leaked: static destructor order across
+// translation units is unspecified, so a plain static here could be destroyed
+// before int_cleanup (generator.C) stops the handler thread.  The handler
+// thread may still be creating responses during process teardown and would
+// then lock a destroyed mutex (glibc marks it __kind = -1, so lock() throws
+// lock_error -> terminate).  Never destroying it avoids the race.  Mirrors
+// Counter::locks in process.C.
+static Mutex<> *id_lock = new Mutex<>();
 
 unsigned newResponseID()
 {
   unsigned id;
-  id_lock.lock();
+  id_lock->lock();
   id = response::next_id++;
-  id_lock.unlock();
+  id_lock->unlock();
   return id;
 }
 
 unsigned newResponseID(unsigned size)
 {
   unsigned id;
-  id_lock.lock();
+  id_lock->lock();
   id = response::next_id;
   response::next_id += size;
-  id_lock.unlock();
+  id_lock->unlock();
   return id;
 }
 
@@ -192,10 +199,10 @@ unsigned int response::markAsMultiResponse(int num_resps)
 {
    assert(num_resps);
    assert(state == unset);
-   id_lock.lock();
+   id_lock->lock();
    id = next_id;
    next_id += num_resps;
-   id_lock.unlock();
+   id_lock->unlock();
 
    multi_resp_size = num_resps;
 
@@ -721,17 +728,19 @@ void data_response::postResponse(void *d)
 }
 
 unsigned int ResponseSet::next_id = 1;
-Mutex<> ResponseSet::id_lock;
+// Heap-allocated and intentionally leaked; see the note on the file-static
+// id_lock above (avoids a static-destruction race with the handler thread).
+Mutex<> *ResponseSet::id_lock = new Mutex<>();
 std::map<unsigned int, ResponseSet *> ResponseSet::all_respsets;
 
 ResponseSet::ResponseSet()
 {
-  id_lock.lock();
+  id_lock->lock();
   myid = next_id++;
   if (!myid)
     myid = next_id++;
   all_respsets.insert(make_pair(myid, this));
-  id_lock.unlock();
+  id_lock->unlock();
 }
 
 void ResponseSet::addID(unsigned id, unsigned index)
@@ -757,13 +766,13 @@ unsigned int ResponseSet::getID() const {
 ResponseSet *ResponseSet::getResponseSetByID(unsigned int id) {
   map<unsigned int, ResponseSet *>::iterator i;
   ResponseSet *respset = NULL;
-  id_lock.lock();
+  id_lock->lock();
   i = all_respsets.find(id);
   if (i != all_respsets.end()) {
     respset = i->second;
     all_respsets.erase(i);
   }
-  id_lock.unlock();
+  id_lock->unlock();
   return respset;
 }
 

--- a/proccontrol/src/response.h
+++ b/proccontrol/src/response.h
@@ -320,7 +320,7 @@ class ResponseSet {
   std::map<unsigned, unsigned> ids;
   unsigned myid;
   static unsigned next_id;
-  static Mutex<false> id_lock;
+  static Mutex<false> *id_lock;  // heap-allocated/leaked; see response.C
   static std::map<unsigned, ResponseSet *> all_respsets;
  public:
   ResponseSet();


### PR DESCRIPTION
Repeatedly running the testsuite's `test_thread_1` (a mutatee that spawns threads which exit in a burst) sporadically crashed or hung `test_driver`. Investigation with core dumps, live interrogation of frozen hung processes, and a low-perturbation in-memory event trace uncovered a chain of **nine independent defects in proccontrol, each masked by the more frequent one before it** — individual failure rates ranged from ~1/10 to ~1/850 runs.

The fixes are separated into one commit per defect for reviewability, but they are **only jointly testable**: each fix unmasks the next, so intermediate states can be built and bisected but not independently stress-validated.

## The defects, in the order they were unmasked

| Commit | Defect | Failure mode |
|---|---|---|
| `don't cache raw int_thread* in events` | `int_eventBreakpoint::thrd` / `int_eventNewUserThread::thr` held raw `int_thread*`; events can outlive their thread, leaving the pointer dangling | SIGSEGV |
| `fix debug prints on exited threads` | `prepEvent`/`checkEvents` debug prints dereferenced `llthrd()` of held events whose thread had exited | SIGSEGV (debug builds) |
| `restore state desyncs on thread death` | Breakpoint handlers bailing on a dead thread skipped their paired proc-wide `restoreStateProc()`; a thread dying mid step-over generates no `BreakpointRestore` event at all | permanent process stop |
| `fix thread_db stopped-thread asserts` | `allHandlerStopped()` counted exiting threads with stale handler state; threads created after a proc-stop released raced `getEventForThread()` | SIGABRT |
| `never destroy the response id locks` | Static destructor order let the handler thread lock a destroyed mutex during teardown | SIGABRT (`lock_error` → `terminate`) |
| `bound generator eviction spin at exit` | SIGUSR2 eviction races the generator exiting on its own; the queued signal is discarded and the flag never fires | 100% CPU spin inside `exit()` |
| `don't stop threads that are exiting` | SIGSTOP to a pre-destroyed thread is never delivered, pinning the PendingStop state. Notably, `LinuxHandleLWPDestroy` was written for exactly this case (its comment describes the bug) **but was never registered with the handler pool** — dead code until now | deadlock |
| `re-sync run state before parking` | The event loop can park with an actionable run-state divergence and no event in flight to drive another `syncRunState` pass; both park points (blocking dequeue, drained mailbox) now sweep | deadlock |
| `don't SIGSTOP an already-stopped thread` | **The root cause of the dominant hang** — see below | deadlock |

## The root cause (last commit)

`plat_syncRunState` decides to stop a thread from handler-side state, which lags the generator by tens of microseconds. Captured at microsecond resolution with an in-memory trace ring:

```
.182031 [generator] DECODE lwp=1122646 SIGTRAP        thread stops on a breakpoint
.182078 [handler]   sees handler=running (stale)      bookkeeping 47µs behind
.182079 [handler]   t_kill SIGSTOP -> 1122646         SIGSTOP sent to an ALREADY-STOPPED thread
.182101+[handler]   PTRACE_CONT ... fails, x10        every continue attempt fails; silence forever
```

On Linux, a STOP signal sent to an already-ptrace-stopped thread can put it into a transitional state in which `PTRACE_CONT` **persistently fails with ESRCH even though the thread is alive** — a behavior proccontrol itself already documents in `plat_handle_ghost_thread`'s comment ("valid state for ptrace, but ptrace_int doesn't check for this"). The failure was suppressed silently, so every subsequent continue attempt failed identically until the event queue drained and the process deadlocked: mutatee ptrace-stopped, SIGSTOP pinned in `SigPnd`, proc-stopper events held forever.

The fix is two-sided: `intStop()` treats a thread whose generator state is already stopped/exited as satisfied (its stop event is in flight; no signal needed), and the remaining microsecond decode-race window — which cannot be closed from the handler side — recovers by retrying via a nop event when a ptrace op fails with ESRCH on a live thread, converting a permanent deadlock into a sub-millisecond stall.

## Relationship to #2131

This PR completes the dead-thread event handling started in #2131: that change guarded `EventNewLWP` and the dyninstAPI consumer, but the sibling producer `EventNewUserThread` still cached a raw `int_thread*` and crashed inside the very call #2131's consumer guard wraps. The root-cause findings here (undelivered stops to dying threads, events outliving threads, the never-registered `LinuxHandleLWPDestroy`) may also explain #2131's open question — *"It is unclear at this time why no events are observed"* for threads spawned before `main` — since ctor-spawned threads that exit quickly are exactly the profile these races target. Retesting that original reproducer against this branch would be a cheap confirmation.

## Verification

- Reproducer: `test_thread_1` with `TEST1_THREADS` lowered to 4 — counterintuitively, **fewer** threads widen the exit-race windows (~7× higher failure rate than 10 threads; 50 threads suppresses the races entirely). Relevant to anyone attempting reproduction.
- Every fix was preceded by reproduction and, where the mechanism was in doubt, a control experiment (fix disabled vs enabled under identical conditions). The final root-cause fix was verified with the causal tape above plus 2,000-run batches: hang at run 62 without it, 0/2000 with it under identical instrumentation, and 0/2000 fully uninstrumented on the final tree.
- Caution for reproducers: heavy logging (`DYNINST_DEBUG_PROCCONTROL`) masks these races completely (0 failures in 2,000 runs); even per-event `fprintf` tracing suppresses them. The final diagnosis required a lock-free in-memory trace ring read post-mortem from the frozen process.

## Notes for reviewers

- `allHandlerStopped()` has one other caller in the FreeBSD startup path; skipping exiting threads is believed equally correct there (a thread that cannot run cannot violate quiescence) but was not tested on that platform.
- `Handler::ret_again` existed but had no in-tree users before this change; the thread_db dispatch deferral is its first use.