### PR TITLE
AMDGPU: fix SOPP short-branch relocation off-by-one (S_BRANCH PC+4)

### DIFF
--- a/dyninstAPI/src/codegen/codegen-amdgpu.C
+++ b/dyninstAPI/src/codegen/codegen-amdgpu.C
@@ -50,7 +50,9 @@ void insnCodeGen::generateIllegal(codeGen & /* gen */) {
 void insnCodeGen::generateBranch(codeGen &gen, Dyninst::Address from, Dyninst::Address to,
                                  bool /* link */) {
   long disp = (to - from);
-  long wordOffset = disp / 4;
+  // S_BRANCH target = (PC_of_branch + 4) + SIMM16*4, so SIMM16 = disp/4 - 1
+  // (the -1 is the +4 in dword units; same for forward and backward jumps).
+  long wordOffset = disp / 4 - 1;
 
   Emitter *emitter = gen.emitter();
 
@@ -104,7 +106,8 @@ bool insnCodeGen::modifyJump(Dyninst::Address target, NS_amdgpu::instruction & /
                              codeGen &gen) {
   long disp = target - gen.currAddr();
   Emitter *emitter = gen.emitter();
-  int16_t wordOffset = disp / 4;
+  // S_BRANCH target = (PC_of_branch + 4) + SIMM16*4, so SIMM16 = disp/4 - 1.
+  int16_t wordOffset = disp / 4 - 1;
 
   assert(wordOffset > INT16_MIN && wordOffset < INT16_MAX &&
          "wordOffset must fit in a 16-bit signed value");
@@ -142,10 +145,13 @@ bool insnCodeGen::modifyJcc(Dyninst::Address target, NS_amdgpu::instruction &ins
   Emitter *emitter = gen.emitter();
   emitter->emitShortJump(1, gen); // GPU does (1)*4 + 4 and computes target = <X+4> + 8 = X+12 i.e C
 
-  // Now emit jump A, the original target
+  // Now emit jump A, the original target.
+  // S_BRANCH target = (PC_of_branch + 4) + SIMM16*4, so SIMM16 = disp/4 - 1;
+  // without the -1 the branch lands one instruction past the target (e.g. a loop
+  // back-edge would skip the loop head's first instruction).
   long from = gen.currAddr();
   long disp = target - from;
-  int16_t wordOffset = disp / 4;
+  int16_t wordOffset = disp / 4 - 1;
 
   assert(wordOffset > INT16_MIN && wordOffset < INT16_MAX &&
          "wordOffset must fit in a 16-bit signed value");


### PR DESCRIPTION
gfx908 S_BRANCH / s_cbranch_* (SOPP) compute their destination relative to the instruction AFTER the branch: target = (PC_of_branch + 4) + SIMM16*4. The short-branch emitters in codegen-amdgpu.C encoded SIMM16 = disp/4, omitting the -1 that accounts for that +4, so every displacement-computed short branch landed one instruction (4 bytes) past its intended target.

Fix the three displacement-based emitters to compute SIMM16 = disp/4 - 1:
  - insnCodeGen::generateBranch (short-jump path)
  - insnCodeGen::modifyJump
  - insnCodeGen::modifyJcc (the jump-to-target of the conditional-branch expansion)

The -1 is direction-agnostic (it is +4 expressed in dword units) and holds for both forward and backward jumps. emitLongJump already accounts for this (fromAddress + 4); the literal emitShortJump(1) skip-jumps in modifyJcc are intentionally SIMM16=1 and are unchanged.

This affects short branches only, which are emitted when relocating a function that has internal control flow (loops, if/else); straight-line functions relocate using only long jumps, so the bug was previously latent.