### PR TITLE
AMDGPU: represent vcc/exec/flat_scratch as their 32-bit halves

### DIFF
--- a/common/h/registers/AMDGPU/amdgpu_gfx908_regs.h
+++ b/common/h/registers/AMDGPU/amdgpu_gfx908_regs.h
@@ -120,16 +120,13 @@ namespace Dyninst { namespace amdgpu_gfx908 {
   DEF_REGISTER(                src_vccz,   1 |  BITS_1 |      MISC |Arch_amdgpu_gfx908);
   DEF_REGISTER(                  vcc_lo,   2 | BITS_32 |      MISC |Arch_amdgpu_gfx908);
   DEF_REGISTER(                  vcc_hi,   3 | BITS_32 |      MISC |Arch_amdgpu_gfx908);
-  DEF_REGISTER(                     vcc,   2 | BITS_64 |      MISC |Arch_amdgpu_gfx908);
 
   DEF_REGISTER(               src_execz,   4 |  BITS_1 |      MISC |Arch_amdgpu_gfx908);
   DEF_REGISTER(                 exec_lo,   5 | BITS_32 |      MISC |Arch_amdgpu_gfx908);
   DEF_REGISTER(                 exec_hi,   6 | BITS_32 |      MISC |Arch_amdgpu_gfx908);
-  DEF_REGISTER(                    exec,   5 | BITS_64 |      MISC |Arch_amdgpu_gfx908);
 
-  DEF_REGISTER(         flat_scratch_lo,   7 | BITS_64 |      MISC |Arch_amdgpu_gfx908);
+  DEF_REGISTER(         flat_scratch_lo,   7 | BITS_32 |      MISC |Arch_amdgpu_gfx908);
   DEF_REGISTER(         flat_scratch_hi,   8 | BITS_32 |      MISC |Arch_amdgpu_gfx908);
-  DEF_REGISTER(        flat_scratch_all,   7 | BITS_32 |      MISC |Arch_amdgpu_gfx908);
 
   DEF_REGISTER(                      m0,   9 | BITS_32 |      MISC |Arch_amdgpu_gfx908);
 

--- a/common/h/registers/AMDGPU/amdgpu_gfx90a_regs.h
+++ b/common/h/registers/AMDGPU/amdgpu_gfx90a_regs.h
@@ -120,16 +120,13 @@ namespace Dyninst { namespace amdgpu_gfx90a {
   DEF_REGISTER(                src_vccz,   1 |  BITS_1 |      MISC |Arch_amdgpu_gfx90a);
   DEF_REGISTER(                  vcc_lo,   2 | BITS_32 |      MISC |Arch_amdgpu_gfx90a);
   DEF_REGISTER(                  vcc_hi,   3 | BITS_32 |      MISC |Arch_amdgpu_gfx90a);
-  DEF_REGISTER(                     vcc,   2 | BITS_64 |      MISC |Arch_amdgpu_gfx90a);
 
   DEF_REGISTER(               src_execz,   4 |  BITS_1 |      MISC |Arch_amdgpu_gfx90a);
   DEF_REGISTER(                 exec_lo,   5 | BITS_32 |      MISC |Arch_amdgpu_gfx90a);
   DEF_REGISTER(                 exec_hi,   6 | BITS_32 |      MISC |Arch_amdgpu_gfx90a);
-  DEF_REGISTER(                    exec,   5 | BITS_64 |      MISC |Arch_amdgpu_gfx90a);
 
   DEF_REGISTER(         flat_scratch_lo,   7 | BITS_32 |      MISC |Arch_amdgpu_gfx90a);
   DEF_REGISTER(         flat_scratch_hi,   8 | BITS_32 |      MISC |Arch_amdgpu_gfx90a);
-  DEF_REGISTER(        flat_scratch_all,   7 | BITS_64 |      MISC |Arch_amdgpu_gfx90a);
 
   DEF_REGISTER(                      m0,   9 | BITS_32 |      MISC |Arch_amdgpu_gfx90a);
 

--- a/common/h/registers/AMDGPU/amdgpu_gfx940_regs.h
+++ b/common/h/registers/AMDGPU/amdgpu_gfx940_regs.h
@@ -124,16 +124,13 @@ const signed int BITS_512 = 0x00001000;
   DEF_REGISTER(                src_vccz,   1 |  BITS_1 |      MISC |Arch_amdgpu_gfx940);
   DEF_REGISTER(                  vcc_lo,   2 | BITS_32 |      MISC |Arch_amdgpu_gfx940);
   DEF_REGISTER(                  vcc_hi,   3 | BITS_32 |      MISC |Arch_amdgpu_gfx940);
-  DEF_REGISTER(                     vcc,   2 | BITS_64 |      MISC |Arch_amdgpu_gfx940);
 
   DEF_REGISTER(               src_execz,   4 |  BITS_1 |      MISC |Arch_amdgpu_gfx940);
   DEF_REGISTER(                 exec_lo,   5 | BITS_32 |      MISC |Arch_amdgpu_gfx940);
   DEF_REGISTER(                 exec_hi,   6 | BITS_32 |      MISC |Arch_amdgpu_gfx940);
-  DEF_REGISTER(                    exec,   5 | BITS_64 |      MISC |Arch_amdgpu_gfx940);
 
-  DEF_REGISTER(         flat_scratch_lo,   7 | BITS_64 |      MISC |Arch_amdgpu_gfx940);
+  DEF_REGISTER(         flat_scratch_lo,   7 | BITS_32 |      MISC |Arch_amdgpu_gfx940);
   DEF_REGISTER(         flat_scratch_hi,   8 | BITS_32 |      MISC |Arch_amdgpu_gfx940);
-  DEF_REGISTER(        flat_scratch_all,   7 | BITS_32 |      MISC |Arch_amdgpu_gfx940);
 
   DEF_REGISTER(                      m0,   9 | BITS_32 |      MISC |Arch_amdgpu_gfx940);
 

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -172,56 +172,23 @@ namespace Dyninst {
         return *this;
       }
 
-      case Arch_amdgpu_gfx908: {
-        if(category == amdgpu_gfx908::MISC) {
-          switch(val()) {
-            case amdgpu_gfx908::ivcc_lo:
-            case amdgpu_gfx908::ivcc_hi:
-              return amdgpu_gfx908::vcc;
-            case amdgpu_gfx908::iexec_lo:
-            case amdgpu_gfx908::iexec_hi:
-              return amdgpu_gfx908::exec;
-            case amdgpu_gfx908::iflat_scratch_lo:
-            case amdgpu_gfx908::iflat_scratch_hi:
-              return amdgpu_gfx908::flat_scratch_all;
-          }
-        }
+      case Arch_amdgpu_gfx908:
+      case Arch_amdgpu_gfx90a:
+      case Arch_amdgpu_gfx940:
+        // On AMDGPU each of vcc_lo/vcc_hi, exec_lo/exec_hi and
+        // flat_scratch_lo/flat_scratch_hi IS a base register: an independently
+        // addressable 32-bit SGPR, and exactly the entries used by the liveness
+        // index map (machRegIndex_amdgpu_*) and the register-conversion maps.
+        // These must NOT alias to the combined 64-bit vcc/exec/flat_scratch_all:
+        // those combined registers are absent from those maps, so aliasing made
+        //   - LivenessAnalyzer::calcRWSets getIndex() return -1 -> VCC/EXEC/
+        //     FLAT_SCRATCH reads AND writes were silently dropped, so e.g. VCC was
+        //     reported dead across a live carry chain (v_add_co/v_addc_co) and a
+        //     liveness-driven register spill would clobber it, and
+        //   - convertRegID() miss the lookup and return "ignored".
+        // A 64-bit VCC/EXEC operand is already emitted by the decoder as a
+        // MultiRegister of its two halves, so nothing needs the combined form here.
         return *this;
-      }
-
-      case Arch_amdgpu_gfx90a: {
-        if(category == amdgpu_gfx90a::MISC) {
-          switch(val()) {
-            case amdgpu_gfx90a::ivcc_lo:
-            case amdgpu_gfx90a::ivcc_hi:
-              return amdgpu_gfx90a::vcc;
-            case amdgpu_gfx90a::iexec_lo:
-            case amdgpu_gfx90a::iexec_hi:
-              return amdgpu_gfx90a::exec;
-            case amdgpu_gfx90a::iflat_scratch_lo:
-            case amdgpu_gfx90a::iflat_scratch_hi:
-              return amdgpu_gfx90a::flat_scratch_all;
-          }
-        }
-        return *this;
-      }
-
-      case Arch_amdgpu_gfx940: {
-        if(category == amdgpu_gfx940::MISC) {
-          switch(val()) {
-            case amdgpu_gfx940::ivcc_lo:
-            case amdgpu_gfx940::ivcc_hi:
-              return amdgpu_gfx940::vcc;
-            case amdgpu_gfx940::iexec_lo:
-            case amdgpu_gfx940::iexec_hi:
-              return amdgpu_gfx940::exec;
-            case amdgpu_gfx940::iflat_scratch_lo:
-            case amdgpu_gfx940::iflat_scratch_hi:
-              return amdgpu_gfx940::flat_scratch_all;
-          }
-        }
-        return *this;
-      }
 
       case Arch_ppc32: {
         auto ppc_id = [](MachRegister r) {

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -174,22 +174,9 @@ namespace Dyninst {
 
       case Arch_amdgpu_gfx908:
       case Arch_amdgpu_gfx90a:
-      case Arch_amdgpu_gfx940:
-        // On AMDGPU each of vcc_lo/vcc_hi, exec_lo/exec_hi and
-        // flat_scratch_lo/flat_scratch_hi IS a base register: an independently
-        // addressable 32-bit SGPR, and exactly the entries used by the liveness
-        // index map (machRegIndex_amdgpu_*) and the register-conversion maps.
-        // These must NOT alias to the combined 64-bit vcc/exec/flat_scratch_all:
-        // those combined registers are absent from those maps, so aliasing made
-        //   - LivenessAnalyzer::calcRWSets getIndex() return -1 -> VCC/EXEC/
-        //     FLAT_SCRATCH reads AND writes were silently dropped, so e.g. VCC was
-        //     reported dead across a live carry chain (v_add_co/v_addc_co) and a
-        //     liveness-driven register spill would clobber it, and
-        //   - convertRegID() miss the lookup and return "ignored".
-        // A 64-bit VCC/EXEC operand is already emitted by the decoder as a
-        // MultiRegister of its two halves, so nothing needs the combined form here.
-        return *this;
-
+      case Arch_amdgpu_gfx940: {
+              return *this;
+      }
       case Arch_ppc32: {
         auto ppc_id = [](MachRegister r) {
           return r.val() & 0x0000FFFF;

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -958,10 +958,8 @@ namespace Dyninst {
 
       case Arch_amdgpu_gfx908: {
         switch(val()) {
-        case amdgpu_gfx908::ivcc:
         case amdgpu_gfx908::ivcc_lo:
         case amdgpu_gfx908::ivcc_hi:
-        case amdgpu_gfx908::iexec:
         case amdgpu_gfx908::iexec_lo:
         case amdgpu_gfx908::iexec_hi:
         case amdgpu_gfx908::isrc_scc:
@@ -976,10 +974,8 @@ namespace Dyninst {
 
       case Arch_amdgpu_gfx90a: {
         switch(val()) {
-        case amdgpu_gfx90a::ivcc:
         case amdgpu_gfx90a::ivcc_lo:
         case amdgpu_gfx90a::ivcc_hi:
-        case amdgpu_gfx90a::iexec:
         case amdgpu_gfx90a::iexec_lo:
         case amdgpu_gfx90a::iexec_hi:
         case amdgpu_gfx90a::isrc_scc:
@@ -995,10 +991,8 @@ namespace Dyninst {
 
       case Arch_amdgpu_gfx940: {
         switch(val()) {
-        case amdgpu_gfx940::ivcc:
         case amdgpu_gfx940::ivcc_lo:
         case amdgpu_gfx940::ivcc_hi:
-        case amdgpu_gfx940::iexec:
         case amdgpu_gfx940::iexec_lo:
         case amdgpu_gfx940::iexec_hi:
         case amdgpu_gfx940::isrc_scc:
@@ -1052,10 +1046,8 @@ namespace Dyninst {
 
       case Arch_amdgpu_gfx908: {
         switch(val()) {
-        case amdgpu_gfx908::ivcc:
         case amdgpu_gfx908::ivcc_lo:
         case amdgpu_gfx908::ivcc_hi:
-        case amdgpu_gfx908::iexec:
         case amdgpu_gfx908::iexec_lo:
         case amdgpu_gfx908::iexec_hi:
         case amdgpu_gfx908::isrc_scc:
@@ -1071,10 +1063,8 @@ namespace Dyninst {
 
       case Arch_amdgpu_gfx90a: {
         switch(val()) {
-        case amdgpu_gfx90a::ivcc:
         case amdgpu_gfx90a::ivcc_lo:
         case amdgpu_gfx90a::ivcc_hi:
-        case amdgpu_gfx90a::iexec:
         case amdgpu_gfx90a::iexec_lo:
         case amdgpu_gfx90a::iexec_hi:
         case amdgpu_gfx90a::isrc_scc:
@@ -1090,10 +1080,8 @@ namespace Dyninst {
 
       case Arch_amdgpu_gfx940: {
         switch(val()) {
-        case amdgpu_gfx940::ivcc:
         case amdgpu_gfx940::ivcc_lo:
         case amdgpu_gfx940::ivcc_hi:
-        case amdgpu_gfx940::iexec:
         case amdgpu_gfx940::iexec_lo:
         case amdgpu_gfx940::iexec_hi:
         case amdgpu_gfx940::isrc_scc:

--- a/instructionAPI/src/AMDGPU/gfx908/decodeOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx908/decodeOperands.C
@@ -573,7 +573,7 @@ namespace InstructionAPI {
     Expression::Ptr InstructionDecoder_amdgpu_gfx908::decodeOPR_FLAT_SCRATCH(uint64_t input, uint32_t output_vec_len)
     {
         switch (input)  {
-            case 0:  return makeRegisterExpression(amdgpu_gfx908::flat_scratch_all, output_vec_len );
+            case 0:  return makeRegisterExpression(amdgpu_gfx908::flat_scratch_lo, output_vec_len );
             default: return makeRegisterExpression(amdgpu_gfx908::invalid);
         }
     }

--- a/instructionAPI/src/AMDGPU/gfx90a/decodeOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx90a/decodeOperands.C
@@ -533,7 +533,7 @@ namespace InstructionAPI {
     Expression::Ptr InstructionDecoder_amdgpu_gfx90a::decodeOPR_FLAT_SCRATCH(uint64_t input, uint32_t output_vec_len)
     {
         switch (input)  {
-            case 0:  return makeRegisterExpression(amdgpu_gfx90a::flat_scratch_all, output_vec_len );
+            case 0:  return makeRegisterExpression(amdgpu_gfx90a::flat_scratch_lo, output_vec_len );
             default: return makeRegisterExpression(amdgpu_gfx90a::invalid);
         }
     }
@@ -5551,7 +5551,7 @@ namespace InstructionAPI {
     Expression::Ptr InstructionDecoder_amdgpu_gfx90a::decodeOPR_VCC(uint64_t input, uint32_t )
     {
         switch (input)  {
-            case 0:  return makeRegisterExpression(amdgpu_gfx90a::vcc);
+            case 0:  return makeRegisterExpression(amdgpu_gfx90a::vcc_lo);
             default: return makeRegisterExpression(amdgpu_gfx90a::invalid);
         }
     }

--- a/instructionAPI/src/AMDGPU/gfx940/decodeOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx940/decodeOperands.C
@@ -533,7 +533,7 @@ namespace InstructionAPI {
     Expression::Ptr InstructionDecoder_amdgpu_gfx940::decodeOPR_FLAT_SCRATCH(uint64_t input, uint32_t output_vec_len)
     {
         switch (input)  {
-            case 0:  return makeRegisterExpression(amdgpu_gfx940::flat_scratch_all, output_vec_len );
+            case 0:  return makeRegisterExpression(amdgpu_gfx940::flat_scratch_lo, output_vec_len );
             default: return makeRegisterExpression(amdgpu_gfx940::invalid);
         }
     }
@@ -5556,7 +5556,7 @@ namespace InstructionAPI {
     Expression::Ptr InstructionDecoder_amdgpu_gfx940::decodeOPR_VCC(uint64_t input, uint32_t )
     {
         switch (input)  {
-            case 0:  return makeRegisterExpression(amdgpu_gfx940::vcc);
+            case 0:  return makeRegisterExpression(amdgpu_gfx940::vcc_lo);
             default: return makeRegisterExpression(amdgpu_gfx940::invalid);
         }
     }

--- a/tests/unit/MachRegister/base_registers/amdgpu_gfx908.cpp
+++ b/tests/unit/MachRegister/base_registers/amdgpu_gfx908.cpp
@@ -16,18 +16,12 @@ int main() {
 
   BASEREG_CHECK(amdgpu_gfx908::acc0, amdgpu_gfx908::acc0);
   BASEREG_CHECK(amdgpu_gfx908::acc255, amdgpu_gfx908::acc255);
-
-  BASEREG_CHECK(amdgpu_gfx908::vcc, amdgpu_gfx908::vcc);
-  BASEREG_CHECK(amdgpu_gfx908::vcc_lo, amdgpu_gfx908::vcc);
-  BASEREG_CHECK(amdgpu_gfx908::vcc_hi, amdgpu_gfx908::vcc);
-
-  BASEREG_CHECK(amdgpu_gfx908::exec, amdgpu_gfx908::exec);
-  BASEREG_CHECK(amdgpu_gfx908::exec_lo, amdgpu_gfx908::exec);
-  BASEREG_CHECK(amdgpu_gfx908::exec_hi, amdgpu_gfx908::exec);
-
-  BASEREG_CHECK(amdgpu_gfx908::flat_scratch_all, amdgpu_gfx908::flat_scratch_all);
-  BASEREG_CHECK(amdgpu_gfx908::flat_scratch_lo, amdgpu_gfx908::flat_scratch_all);
-  BASEREG_CHECK(amdgpu_gfx908::flat_scratch_hi, amdgpu_gfx908::flat_scratch_all);
+  BASEREG_CHECK(amdgpu_gfx908::vcc_lo, amdgpu_gfx908::vcc_lo);
+  BASEREG_CHECK(amdgpu_gfx908::vcc_hi, amdgpu_gfx908::vcc_hi);
+  BASEREG_CHECK(amdgpu_gfx908::exec_lo, amdgpu_gfx908::exec_lo);
+  BASEREG_CHECK(amdgpu_gfx908::exec_hi, amdgpu_gfx908::exec_hi);
+  BASEREG_CHECK(amdgpu_gfx908::flat_scratch_lo, amdgpu_gfx908::flat_scratch_lo);
+  BASEREG_CHECK(amdgpu_gfx908::flat_scratch_hi, amdgpu_gfx908::flat_scratch_hi);
 
   return EXIT_SUCCESS;
 }

--- a/tests/unit/MachRegister/base_registers/amdgpu_gfx90a.cpp
+++ b/tests/unit/MachRegister/base_registers/amdgpu_gfx90a.cpp
@@ -16,18 +16,12 @@ int main() {
 
   BASEREG_CHECK(amdgpu_gfx90a::acc0, amdgpu_gfx90a::acc0);
   BASEREG_CHECK(amdgpu_gfx90a::acc255, amdgpu_gfx90a::acc255);
-
-  BASEREG_CHECK(amdgpu_gfx90a::vcc, amdgpu_gfx90a::vcc);
-  BASEREG_CHECK(amdgpu_gfx90a::vcc_lo, amdgpu_gfx90a::vcc);
-  BASEREG_CHECK(amdgpu_gfx90a::vcc_hi, amdgpu_gfx90a::vcc);
-
-  BASEREG_CHECK(amdgpu_gfx90a::exec, amdgpu_gfx90a::exec);
-  BASEREG_CHECK(amdgpu_gfx90a::exec_lo, amdgpu_gfx90a::exec);
-  BASEREG_CHECK(amdgpu_gfx90a::exec_hi, amdgpu_gfx90a::exec);
-
-  BASEREG_CHECK(amdgpu_gfx90a::flat_scratch_all, amdgpu_gfx90a::flat_scratch_all);
-  BASEREG_CHECK(amdgpu_gfx90a::flat_scratch_lo, amdgpu_gfx90a::flat_scratch_all);
-  BASEREG_CHECK(amdgpu_gfx90a::flat_scratch_hi, amdgpu_gfx90a::flat_scratch_all);
+  BASEREG_CHECK(amdgpu_gfx90a::vcc_lo, amdgpu_gfx90a::vcc_lo);
+  BASEREG_CHECK(amdgpu_gfx90a::vcc_hi, amdgpu_gfx90a::vcc_hi);
+  BASEREG_CHECK(amdgpu_gfx90a::exec_lo, amdgpu_gfx90a::exec_lo);
+  BASEREG_CHECK(amdgpu_gfx90a::exec_hi, amdgpu_gfx90a::exec_hi);
+  BASEREG_CHECK(amdgpu_gfx90a::flat_scratch_lo, amdgpu_gfx90a::flat_scratch_lo);
+  BASEREG_CHECK(amdgpu_gfx90a::flat_scratch_hi, amdgpu_gfx90a::flat_scratch_hi);
 
   return EXIT_SUCCESS;
 }

--- a/tests/unit/MachRegister/base_registers/amdgpu_gfx940.cpp
+++ b/tests/unit/MachRegister/base_registers/amdgpu_gfx940.cpp
@@ -16,18 +16,12 @@ int main() {
 
   BASEREG_CHECK(amdgpu_gfx940::acc0, amdgpu_gfx940::acc0);
   BASEREG_CHECK(amdgpu_gfx940::acc255, amdgpu_gfx940::acc255);
-
-  BASEREG_CHECK(amdgpu_gfx940::vcc, amdgpu_gfx940::vcc);
-  BASEREG_CHECK(amdgpu_gfx940::vcc_lo, amdgpu_gfx940::vcc);
-  BASEREG_CHECK(amdgpu_gfx940::vcc_hi, amdgpu_gfx940::vcc);
-
-  BASEREG_CHECK(amdgpu_gfx940::exec, amdgpu_gfx940::exec);
-  BASEREG_CHECK(amdgpu_gfx940::exec_lo, amdgpu_gfx940::exec);
-  BASEREG_CHECK(amdgpu_gfx940::exec_hi, amdgpu_gfx940::exec);
-
-  BASEREG_CHECK(amdgpu_gfx940::flat_scratch_all, amdgpu_gfx940::flat_scratch_all);
-  BASEREG_CHECK(amdgpu_gfx940::flat_scratch_lo, amdgpu_gfx940::flat_scratch_all);
-  BASEREG_CHECK(amdgpu_gfx940::flat_scratch_hi, amdgpu_gfx940::flat_scratch_all);
+  BASEREG_CHECK(amdgpu_gfx940::vcc_lo, amdgpu_gfx940::vcc_lo);
+  BASEREG_CHECK(amdgpu_gfx940::vcc_hi, amdgpu_gfx940::vcc_hi);
+  BASEREG_CHECK(amdgpu_gfx940::exec_lo, amdgpu_gfx940::exec_lo);
+  BASEREG_CHECK(amdgpu_gfx940::exec_hi, amdgpu_gfx940::exec_hi);
+  BASEREG_CHECK(amdgpu_gfx940::flat_scratch_lo, amdgpu_gfx940::flat_scratch_lo);
+  BASEREG_CHECK(amdgpu_gfx940::flat_scratch_hi, amdgpu_gfx940::flat_scratch_hi);
 
   return EXIT_SUCCESS;
 }

--- a/tests/unit/MachRegister/type_queries/amdgpu_gfx908.cpp
+++ b/tests/unit/MachRegister/type_queries/amdgpu_gfx908.cpp
@@ -39,10 +39,8 @@ int main() {
   TYPE_QUERIES_CHECK_FALSE(Dyninst::amdgpu_gfx908::v255, isControlStatus);
   TYPE_QUERIES_CHECK_FALSE(Dyninst::amdgpu_gfx908::acc0, isControlStatus);
   TYPE_QUERIES_CHECK_FALSE(Dyninst::amdgpu_gfx908::acc255, isControlStatus);
-  TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx908::vcc, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx908::vcc_lo, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx908::vcc_hi, isControlStatus);
-  TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx908::exec, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx908::exec_lo, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx908::exec_hi, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx908::src_scc, isControlStatus);

--- a/tests/unit/MachRegister/type_queries/amdgpu_gfx90a.cpp
+++ b/tests/unit/MachRegister/type_queries/amdgpu_gfx90a.cpp
@@ -39,10 +39,8 @@ int main() {
   TYPE_QUERIES_CHECK_FALSE(Dyninst::amdgpu_gfx90a::v255, isControlStatus);
   TYPE_QUERIES_CHECK_FALSE(Dyninst::amdgpu_gfx90a::acc0, isControlStatus);
   TYPE_QUERIES_CHECK_FALSE(Dyninst::amdgpu_gfx90a::acc255, isControlStatus);
-  TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx90a::vcc, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx90a::vcc_lo, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx90a::vcc_hi, isControlStatus);
-  TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx90a::exec, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx90a::exec_lo, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx90a::exec_hi, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx90a::src_scc, isControlStatus);

--- a/tests/unit/MachRegister/type_queries/amdgpu_gfx940.cpp
+++ b/tests/unit/MachRegister/type_queries/amdgpu_gfx940.cpp
@@ -39,10 +39,8 @@ int main() {
   TYPE_QUERIES_CHECK_FALSE(Dyninst::amdgpu_gfx940::v255, isControlStatus);
   TYPE_QUERIES_CHECK_FALSE(Dyninst::amdgpu_gfx940::acc0, isControlStatus);
   TYPE_QUERIES_CHECK_FALSE(Dyninst::amdgpu_gfx940::acc255, isControlStatus);
-  TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx940::vcc, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx940::vcc_lo, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx940::vcc_hi, isControlStatus);
-  TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx940::exec, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx940::exec_lo, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx940::exec_hi, isControlStatus);
   TYPE_QUERIES_CHECK(Dyninst::amdgpu_gfx940::src_scc, isControlStatus);


### PR DESCRIPTION
Summary

On AMDGPU, MachRegister::getBaseRegister() aliased the 32-bit halves to a combined 64-bit register (vcc_lo/vcc_hi → vcc, exec_lo/hi → exec, flat_scratch_lo/hi → flat_scratch_all). Those combined registers are not the entries used by any consumer — the liveness index map (machRegIndex_amdgpu_*), the register-conversion maps (RegisterConversion-amdgpu.C), and the register space are all keyed on the _lo/_hi halves. This made two things silently misbehave:

- Liveness: LivenessAnalyzer::calcRWSets computes getIndex(getBaseRegister(reg)); for the halves this resolved to the combined register, which isn't in the map, so getIndex returned -1 and the if (index >= 0) guard dropped the read and the write. VCC/EXEC/FLAT_SCRATCH were never tracked — e.g. VCC was reported dead across a live carry chain (v_add_co_u32 defines VCC, v_addc_co_u32 uses it).
- Register conversion: convertRegID() looked up the combined register, missed, and returned ignored.

Investigating the fix also surfaced inconsistencies in the generated decoder/register data across architectures (decodeOPR_VCC returned vcc_lo on gfx908 but the combined vcc on gfx90a/gfx940; decodeOPR_FLAT_SCRATCH returned the combined register everywhere; flat_scratch_lo was declared BITS_64 on gfx908/gfx940 but BITS_32 on gfx90a).

Changes

Commit 1 — treat the halves as base registers. getBaseRegister returns *this for vcc_lo/vcc_hi, exec_lo/exec_hi, and flat_scratch_lo/flat_scratch_hi on all three AMDGPU arches. They are independently addressable 32-bit registers and exactly what the maps above are keyed on. A 64-bit VCC/EXEC operand is already decoded as a MultiRegister of its two halves, so the combined form is not needed.

Commit 2 — remove the now-redundant combined registers. With nothing aliasing to them, vcc, exec, and flat_scratch_all are deleted from the register definitions. Supporting changes for uniformity/correctness:
- Decoders emit the _lo half (expanded to [lo, hi]) for VCC and FLAT_SCRATCH on all three arches.
- flat_scratch_lo is BITS_32 everywhere.
- Dead vcc/exec cases removed from MachRegister.C's type-query switches (the halves already carry the control-status classification).
- Unit tests (base_registers, type_queries) updated: each half is now its own base.

Removing the combined registers means any future code — or inconsistent generator data — that references a whole special register now fails to compile rather than silently corrupting liveness.

Testing

- Builds clean; all six AMDGPU MachRegister unit tests pass.
- Verified (via an instruction-level liveness dump) that VCC is now live across v_add_co/v_addc_co carry chains and each half reports itself as its base register.
- A downstream liveness-driven register-spill pass that previously faulted (clobbering an untracked live VCC) now runs correctly.

