### PR TITLE
proccontrol: fix UAF in ProcessSet::terminate

### DIFF
--- a/proccontrol/src/procset.C
+++ b/proccontrol/src/procset.C
@@ -1624,12 +1624,19 @@ bool ProcessSet::terminate() const
    int_process::waitAndHandleEvents(false);
 #endif
 
-   // Clean out the event queue before we terminate; otherwise we can race
-   set<int_process *> procs;
+   // Clean out the event queue before we terminate; otherwise we can race.
+   // Hold the reference-counted Process wrappers rather than raw int_process*:
+   // the waitAndHandleEvents() calls below can finish an in-flight exit and
+   // delete the underlying int_process, which nulls the wrapper's llproc_.
+   // Re-derive llproc() after each such call and skip any process that was
+   // freed, so we neither terminate nor delete a dangling int_process.
+   set<Process::ptr> procs;
    procset_iter iter("terminate", had_error, ERR_CHCK_NORM);
    for (int_processSet::iterator i = iter.begin(procset); i != iter.end(); i = iter.inc()) {
       Process::ptr p = *i;
       int_process *proc = p->llproc();
+      if (!proc)
+         continue;
 
       pthrd_printf("User terminating process %d\n", proc->getPid());
 
@@ -1639,7 +1646,7 @@ bool ProcessSet::terminate() const
          had_error = true;
          continue;
       }
-      procs.insert(proc);
+      procs.insert(p);
    }
 
    // Handle anything from preTerminate
@@ -1649,8 +1656,13 @@ bool ProcessSet::terminate() const
 
    ProcPool()->condvar()->lock();
 
-   for (set<int_process *>::iterator i = procs.begin(); i != procs.end();) {
-      int_process *proc = *i;
+   for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end();) {
+      int_process *proc = (*i)->llproc();
+      if (!proc) {
+         // Process exited and was deleted during the event handling above.
+         procs.erase(i++);
+         continue;
+      }
 
       bool needsSync = false;
       bool result = proc->terminate(needsSync);
@@ -1683,8 +1695,10 @@ bool ProcessSet::terminate() const
          had_error = true;
       }
    }
-   for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); i++) {
-      int_process *proc = *i;
+   for (auto &p : procs) {
+      int_process *proc = p->llproc();
+      if (!proc)
+         continue;   // already deleted during terminate/waitAndHandleEvents
       HandlerPool *hp = proc->handlerPool();
       delete proc;
       delete hp;


### PR DESCRIPTION
ProcessSet::terminate snapshots the group's processes as raw int_process* pointers, then calls waitAndHandleEvents(false) to drain preTerminate side effects before looping over the snapshot to terminate() and finally delete each process.

If one of the snapshotted processes finishes exiting during that intervening event handling, its int_process is deleted: ~int_process nulls the owning Process wrapper's llproc_, but the raw int_process* captured in the snapshot is left dangling.  The later terminate() then makes a virtual call (plat_terminate) on freed memory -- observed as "pure virtual method called" / SIGABRT once the freed block still carries the base-class vtable -- and the final loop double-deletes it.

The window is narrow, so this is normally latent; it becomes a reliable, roaming crash under anything that shifts teardown event timing (e.g. a full testsuite -all run, where whichever managed process exits inside the window is the victim, while each test passes in isolation).

Snapshot the reference-counted Process::ptr wrappers instead of raw int_process*.  The wrapper always outlives the int_process, so llproc() is always safe to call and returns NULL exactly when the int_process has been freed.  Re-derive llproc() after each waitAndHandleEvents and skip any process that was freed, in both the terminate loop and the final delete loop, so a process reclaimed mid-teardown is never terminated or double-deleted.