### PR TITLE
Harden proccontrol against concurrent process exit during event handling

### DIFF
--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -5068,6 +5068,12 @@ sw_breakpoint *sw_breakpoint::create(int_process *proc, int_breakpoint *bp, Dyni
    is.addr = addr;
    is.bp = bp;
 
+   // The waitForAsyncEvent calls below can finish an in-flight exit of this
+   // process and delete it; hold the wrapper and check liveness after each
+   // wait.  (While the wrapper's llproc() is non-NULL it is still this same
+   // int_process; ~int_process nulls it on deletion.)
+   Process::ptr wrapper = proc->proc();
+
    result = proc->addBreakpoint_phase1(&is);
    if (!result)
       return NULL;
@@ -5075,6 +5081,10 @@ sw_breakpoint *sw_breakpoint::create(int_process *proc, int_breakpoint *bp, Dyni
       result = int_process::waitForAsyncEvent(is.mem_resp);
       if (!result) {
          perr_printf("Error waiting for result of memory response\n");
+         return NULL;
+      }
+      if (!wrapper->llproc()) {
+         perr_printf("Process exited during breakpoint install\n");
          return NULL;
       }
    }
@@ -5086,6 +5096,10 @@ sw_breakpoint *sw_breakpoint::create(int_process *proc, int_breakpoint *bp, Dyni
       result = int_process::waitForAsyncEvent(is.res_resp);
       if (!result) {
          perr_printf("Error waiting for result of result response\n");
+         return NULL;
+      }
+      if (!wrapper->llproc()) {
+         perr_printf("Process exited during breakpoint install\n");
          return NULL;
       }
    }

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -87,13 +87,18 @@ void Process::version(int& major, int& minor, int& maintenance)
 
 bool int_process::create(int_processSet *ps) {
    bool had_error = false;
-   set<int_process *> procs;
-   transform(ps->begin(), ps->end(), inserter(procs, procs.end()), ProcToIntProc());
+   // Hold reference-counted Process wrappers, not raw int_process*: a process
+   // can exit/crash during bootstrap and be deleted inside the
+   // waitForAsyncEvent() below (post_create), which nulls the wrapper's
+   // llproc_.  Re-derive llproc() after each event-handling point and skip
+   // any process that was freed.
+   set<Process::ptr> procs(ps->begin(), ps->end());
 
    //Should be called with procpool lock held
    pthrd_printf("Calling plat_create for %d processes\n", (int) procs.size());
-   for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); ) {
-      int_process *proc = *i;
+   for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); ) {
+      int_process *proc = (*i)->llproc();
+      if (!proc) { i = procs.erase(i); had_error = true; continue; }
       bool result = proc->plat_create();
       if (!result) {
          pthrd_printf("Could not create debuggee, %s\n", proc->executable.c_str());
@@ -106,8 +111,9 @@ bool int_process::create(int_processSet *ps) {
    }
 
    pthrd_printf("Creating initial threads for %d processes\n", (int) procs.size());
-   for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); i++) {
-      int_process *proc = *i;
+   for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); i++) {
+      int_process *proc = (*i)->llproc();
+      if (!proc) continue;
 	  // Because yo, windows processes have threads when they're created...
 	  if (proc->threadPool()->empty()) {
         int_thread::createThread(proc, NULL_THR_ID, NULL_LWP, true, int_thread::as_created_attached);
@@ -122,8 +128,9 @@ bool int_process::create(int_processSet *ps) {
 
 
    pthrd_printf("Waiting for startup for %d processes\n", (int) procs.size());
-   for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); ) {
-      int_process *proc = *i;
+   for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); ) {
+      int_process *proc = (*i)->llproc();
+      if (!proc) { i = procs.erase(i); continue; }
       string executable = proc->executable;
       Dyninst::PID pid = proc->pid;
 
@@ -142,8 +149,13 @@ bool int_process::create(int_processSet *ps) {
    while (!procs.empty()) {
       set<response::ptr> async_responses;
       bool ret_async = false;
-      for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); ) {
-         int_process *proc = *i;
+      for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); ) {
+         int_process *proc = (*i)->llproc();
+         if (!proc) {
+            // Process exited during a prior post_create waitForAsyncEvent.
+            i = procs.erase(i);
+            continue;
+         }
 
          async_ret_t result = proc->post_create(async_responses);
          if (result == aret_error) {
@@ -265,17 +277,21 @@ bool int_process::plat_attachThreadsSync()
 bool int_process::attach(int_processSet *ps, bool reattach)
 {
    bool had_error = false, should_sync = false;
-   set<int_process *> procs;
+   // Hold reference-counted Process wrappers, not raw int_process*: a process
+   // can exit during attach bootstrap and be deleted inside the
+   // waitAndHandleEvents/waitForAsyncEvent/waitfor_startup calls below, which
+   // nulls the wrapper's llproc_.  Re-derive llproc() after each such point
+   // and skip any process that was freed.
+   set<Process::ptr> procs(ps->begin(), ps->end());
    vector<Event::ptr> observedEvents;
    set<response::ptr> async_responses;
-   transform(ps->begin(), ps->end(), inserter(procs, procs.end()), ProcToIntProc());
 
    //Should be called with procpool lock held
 
 	pthrd_printf("Calling plat_attach for %d processes\n", (int) procs.size());
    map<pair<int_process *, Dyninst::LWP>, bool> runningStates;
-   for (set<int_process *>::iterator i = procs.begin(); i != procs.end();) {
-	   int_process *proc = *i;
+   for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end();) {
+	   int_process *proc = (*i)->llproc();
       if (!proc) {
          i = procs.erase(i);
          continue;
@@ -324,8 +340,9 @@ bool int_process::attach(int_processSet *ps, bool reattach)
 
    //Create the int_thread objects via attach_threads
    if (!reattach) {
-      for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); i++) {
-         int_process *proc = *i;
+      for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); i++) {
+         int_process *proc = (*i)->llproc();
+         if (!proc) continue;
          ProcPool()->addProcess(proc);
          int_thread::createThread(proc, NULL_THR_ID, NULL_LWP, true,
                                   int_thread::as_created_attached); //initial thread
@@ -337,9 +354,9 @@ bool int_process::attach(int_processSet *ps, bool reattach)
       ProcPool()->condvar()->unlock();
       for (;;) {
          bool have_neonatal = false;
-         for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); i++) {
-            int_process *proc = *i;
-            if (proc->getState() == neonatal) {
+         for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); i++) {
+            int_process *proc = (*i)->llproc();
+            if (proc && proc->getState() == neonatal) {
                have_neonatal = true;
                break;
             }
@@ -356,15 +373,17 @@ bool int_process::attach(int_processSet *ps, bool reattach)
    }
    else {
       pthrd_printf("Attach done, moving processes to neonatal_intermediate\n");
-      for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); i++) {
-         int_process *proc = *i;
+      for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); i++) {
+         int_process *proc = (*i)->llproc();
+         if (!proc) continue;
          proc->setState(neonatal_intermediate);
       }
    }
 
 
-   for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); ) {
-      int_process *proc = *i;
+   for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); ) {
+      int_process *proc = (*i)->llproc();
+      if (!proc) { i = procs.erase(i); continue; }
       if (proc->getState() == errorstate) {
          pthrd_printf("Removing process %d in error state\n", proc->getPid());
          i = procs.erase(i);
@@ -439,13 +458,15 @@ bool int_process::attach(int_processSet *ps, bool reattach)
    ProcPool()->condvar()->unlock();
 
    //Wait for each process to make it to the 'running' state.
-   for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); ) {
-      int_process *proc = *i;
-      pthrd_printf("Wait for attach from process %d\n", proc->pid);
+   for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); ) {
+      int_process *proc = (*i)->llproc();
+      if (!proc) { i = procs.erase(i); continue; }
+      Dyninst::PID pid = proc->pid;   // save: waitfor_startup can delete proc
+      pthrd_printf("Wait for attach from process %d\n", pid);
 
       bool result = proc->waitfor_startup();
       if (!result) {
-         pthrd_printf("Error waiting for attach to %d\n", proc->pid);
+         pthrd_printf("Error waiting for attach to %d\n", pid);
          i = procs.erase(i);
          had_error = true;
          continue;
@@ -455,10 +476,13 @@ bool int_process::attach(int_processSet *ps, bool reattach)
 
    //Some OSs need to do their attachThreads here.  Since the operation is supposed to be
    //idempotent after success, then just do it again.
-   for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); ) {
-      int_process *proc = *i;
-      if (proc->getState() == errorstate)
+   for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); ) {
+      int_process *proc = (*i)->llproc();
+      if (!proc) { i = procs.erase(i); continue; }
+      if (proc->getState() == errorstate) {
+         i = procs.erase(i);   // was: continue (no advance -> would loop forever)
          continue;
+      }
       bool result = proc->plat_attachThreadsSync();
       if (!result) {
          pthrd_printf("Failed to attach to threads in %d\n", proc->pid);
@@ -487,12 +511,17 @@ bool int_process::attach(int_processSet *ps, bool reattach)
    }
 
    pthrd_printf("Triggering post-attach for %d processes\n", (int) procs.size());
-   std::set<int_process *> pa_procs = procs;
+   std::set<Process::ptr> pa_procs = procs;
    while (!pa_procs.empty()) {
       async_responses.clear();
       bool ret_async = false;
-      for (set<int_process *>::iterator i = pa_procs.begin(); i != pa_procs.end(); ) {
-         int_process *proc = *i;
+      for (set<Process::ptr>::iterator i = pa_procs.begin(); i != pa_procs.end(); ) {
+         int_process *proc = (*i)->llproc();
+         if (!proc) {
+            // Process exited during a prior post_attach waitForAsyncEvent.
+            i = pa_procs.erase(i);
+            continue;
+         }
 
          async_ret_t result = proc->post_attach(false, async_responses);
          if (result == aret_error) {
@@ -523,9 +552,10 @@ bool int_process::attach(int_processSet *ps, bool reattach)
       return !had_error;
 
    async_responses.clear();
-   for (set<int_process *>::iterator i = procs.begin(); i != procs.end(); i++) {
+   for (set<Process::ptr>::iterator i = procs.begin(); i != procs.end(); i++) {
       // Resume all breakpoints
-      int_process *proc = *i;
+      int_process *proc = (*i)->llproc();
+      if (!proc) continue;
       for(std::map<Dyninst::Address, sw_breakpoint *>::iterator j = proc->mem->breakpoints.begin();
           j != proc->mem->breakpoints.end(); j++)
       {
@@ -543,6 +573,8 @@ bool int_process::attach(int_processSet *ps, bool reattach)
    for(vector<Event::ptr>::iterator i = observedEvents.begin(); i!= observedEvents.end(); i++)
    {
        int_thread *thrd = (*i)->getThread()->llthrd();
+       if (!thrd)
+          continue;   // thread deleted during the resume wait above
        pthrd_printf("Queuing event %s for thread %d/%d\n",
                     (*i)->getEventType().name().c_str(), (*i)->getProcess()->getPid(),
                     (*i)->getThread()->getLWP());

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -1633,7 +1633,10 @@ bool int_process::infFree(Address addr) {
 bool int_process::infMalloc(unsigned long size, int_addressSet *aset, bool use_addr)
 {
    bool had_error = false;
-   set<pair<int_process *, int_iRPC::ptr> > active_mallocs;
+   // Hold reference-counted Process wrappers, not raw int_process*: the
+   // waitAndHandleEvents() below runs the inferior RPCs and can finish an
+   // in-flight exit, deleting an int_process (see infFree for the template).
+   set<pair<Process::ptr, int_iRPC::ptr> > active_mallocs;
    int_addressSet direct_results;
 
    for (int_addressSet::iterator i = aset->begin(); i != aset->end(); i++) {
@@ -1670,7 +1673,7 @@ bool int_process::infMalloc(unsigned long size, int_addressSet *aset, bool use_a
 
       int_thread *thr = rpc->thread();
       assert(thr);
-      active_mallocs.insert(make_pair(proc, rpc));
+      active_mallocs.insert(make_pair(p, rpc));
       thr->getInternalState().desyncState(int_thread::running);
       rpc->setRestoreInternal(true);
       proc->throwNopEvent();
@@ -1692,11 +1695,18 @@ bool int_process::infMalloc(unsigned long size, int_addressSet *aset, bool use_a
       aset->insert(direct_results.begin(), direct_results.end());
 
 
-   for (set<pair<int_process *, int_iRPC::ptr> >::iterator i = active_mallocs.begin();
+   for (set<pair<Process::ptr, int_iRPC::ptr> >::iterator i = active_mallocs.begin();
         i != active_mallocs.end(); i++)
    {
-      int_process *proc = i->first;
+      Process::ptr p = i->first;
       int_iRPC::ptr rpc = i->second;
+      int_process *proc = p->llproc();
+      if (!proc) {
+         perr_printf("Process %d exited during infMalloc\n", p->getPid());
+         p->setLastError(err_exited, "Process exited during infMalloc\n");
+         had_error = true;
+         continue;
+      }
       assert(rpc->getState() == int_iRPC::Finished);
       Dyninst::Address aresult = rpc->infMallocResult();
       pthrd_printf("Inferior malloc returning %lx on %d\n", aresult, proc->getPid());

--- a/proccontrol/src/procset.C
+++ b/proccontrol/src/procset.C
@@ -3410,10 +3410,15 @@ bool LWPTrackingSet::refreshLWPs() const
    int_processSet *procset = wps.lock()->getIntProcessSet();
    procset_iter iter("setTrackLWPs", had_error, ERR_CHCK_ALL);
    set<response::ptr> all_resps;
-   set<int_process *> all_procs;
-   set<int_process *> change_procs;
+   // Hold reference-counted Process wrappers, not raw int_process*: the
+   // waitForAsyncEvent/waitAndHandleEvents calls below can finish an in-flight
+   // exit and delete an int_process.  Re-derive llproc() (and getLWPTracking)
+   // after each such call and skip any process that was freed.
+   set<Process::ptr> all_procs;
+   set<Process::ptr> change_procs;
    for (int_processSet::iterator i = iter.begin(procset); i != iter.end(); i = iter.inc()) {
-      int_LWPTracking *proc = (*i)->llproc()->getLWPTracking();
+      Process::ptr p = *i;
+      int_LWPTracking *proc = p->llproc()->getLWPTracking();
       if (!proc) {
          perr_printf("LWP tracking not supported on process\n");
          had_error = true;
@@ -3427,13 +3432,16 @@ bool LWPTrackingSet::refreshLWPs() const
       if (resp) {
          all_resps.insert(resp);
       }
-      all_procs.insert(proc);
+      all_procs.insert(p);
    }
 
    int_process::waitForAsyncEvent(all_resps);
 
-   for (set<int_process *>::iterator i = all_procs.begin(); i != all_procs.end(); i++) {
-      int_LWPTracking *proc = (*i)->getLWPTracking();
+   for (set<Process::ptr>::iterator i = all_procs.begin(); i != all_procs.end(); i++) {
+      int_process *llp = (*i)->llproc();
+      if (!llp)
+         continue;   // process exited during the wait
+      int_LWPTracking *proc = llp->getLWPTracking();
       if (!proc)
          continue;
       bool changed;
@@ -3443,7 +3451,7 @@ bool LWPTrackingSet::refreshLWPs() const
          had_error = true;
       }
       if (changed) {
-         change_procs.insert(proc);
+         change_procs.insert(*i);
          proc->setForceGeneratorBlock(true);
       }
    }
@@ -3458,9 +3466,11 @@ bool LWPTrackingSet::refreshLWPs() const
 
    int_process::waitAndHandleEvents(false);
 
-   for (set<int_process *>::iterator i = change_procs.begin(); i != change_procs.end(); i++) {
-      int_process *proc = *i;
-      proc->setForceGeneratorBlock(false);      
+   for (set<Process::ptr>::iterator i = change_procs.begin(); i != change_procs.end(); i++) {
+      int_process *proc = (*i)->llproc();
+      if (!proc)
+         continue;   // process exited during the wait
+      proc->setForceGeneratorBlock(false);
    }
    return !had_error;
 }

--- a/proccontrol/src/procset.C
+++ b/proccontrol/src/procset.C
@@ -1987,18 +1987,23 @@ bool ProcessSet::writeMemory(multimap<Process::const_ptr, write_t> &addrs) const
    return !had_error;
 }
 
-static bool addBreakpointWorker(set<pair<int_process *, bp_install_state *> > &bp_installs)
+static bool addBreakpointWorker(set<pair<Process::ptr, bp_install_state *> > &bp_installs)
 {
    bool had_error = false;
    bool result;
 
    set<response::ptr> all_responses;
-   for (set<pair<int_process *, bp_install_state *> >::iterator i = bp_installs.begin(); 
+   for (set<pair<Process::ptr, bp_install_state *> >::iterator i = bp_installs.begin(); 
         i != bp_installs.end();) 
    {
-      int_process *proc = i->first;
+      int_process *proc = i->first->llproc();
       bp_install_state *is = i->second;
-      
+      if (!proc) {
+         // Process exited (e.g. during a prior phase's waitForAsyncEvent).
+         delete is;
+         bp_installs.erase(i++);
+         continue;
+      }
       result = proc->addBreakpoint_phase1(is);
       if (!result) {
          had_error = true;
@@ -2017,12 +2022,17 @@ static bool addBreakpointWorker(set<pair<int_process *, bp_install_state *> > &b
    }
    all_responses.clear();
 
-   for (set<pair<int_process *, bp_install_state *> >::iterator i = bp_installs.begin(); 
+   for (set<pair<Process::ptr, bp_install_state *> >::iterator i = bp_installs.begin(); 
         i != bp_installs.end();) 
    {
-      int_process *proc = i->first;
+      int_process *proc = i->first->llproc();
       bp_install_state *is = i->second;
-      
+      if (!proc) {
+         // Process exited (e.g. during a prior phase's waitForAsyncEvent).
+         delete is;
+         bp_installs.erase(i++);
+         continue;
+      }
       result = proc->addBreakpoint_phase2(is);
       if (!result) {
          had_error = true;
@@ -2040,11 +2050,16 @@ static bool addBreakpointWorker(set<pair<int_process *, bp_install_state *> > &b
       had_error = true;
    }
 
-   for (set<pair<int_process *, bp_install_state *> >::iterator i = bp_installs.begin(); 
+   for (set<pair<Process::ptr, bp_install_state *> >::iterator i = bp_installs.begin(); 
         i != bp_installs.end();) {
-      int_process *proc = i->first;
+      int_process *proc = i->first->llproc();
       bp_install_state *is = i->second;
-      
+      if (!proc) {
+         // Process exited (e.g. during a prior phase's waitForAsyncEvent).
+         delete is;
+         bp_installs.erase(i++);
+         continue;
+      }
       result = proc->addBreakpoint_phase3(is);
       if (!result) {
          had_error = true;
@@ -2062,17 +2077,16 @@ bool ProcessSet::addBreakpoint(AddressSet::ptr addrset, Breakpoint::ptr bp) cons
    MTLock lock_this_func;
    bool had_error = false;
 
-   set<pair<int_process *, bp_install_state *> > bp_installs;
+   set<pair<Process::ptr, bp_install_state *> > bp_installs;
    addrset_iter iter("Breakpoint add", had_error, ERR_CHCK_ALL);
    for (int_addressSet::iterator i = iter.begin(addrset); i != iter.end(); i = iter.inc()) {
       Process::ptr p = i->second;
-      int_process *proc = p->llproc();
       Address addr = i->first;
-      
+
       bp_install_state *is = new bp_install_state();
       is->addr = addr;
       is->bp = bp->llbp();
-      bp_installs.insert(make_pair(proc, is));
+      bp_installs.insert(make_pair(p, is));
    }
 
    return addBreakpointWorker(bp_installs) && !had_error;
@@ -3137,7 +3151,7 @@ bool LibraryTrackingSet::setTrackLibraries(bool b) const
    }
    int_processSet *procset = ps->getIntProcessSet();
 
-   set<pair<int_process *, bp_install_state *> > bps_to_install;
+   set<pair<Process::ptr, bp_install_state *> > bps_to_install;
    set<response::ptr> all_responses;
 
    procset_iter iter("setTrackLibraries", had_error, ERR_CHCK_NORM);
@@ -3168,7 +3182,7 @@ bool LibraryTrackingSet::setTrackLibraries(bool b) const
          is->addr = addr;
          is->bp = bp;
          is->do_install = true;
-         bps_to_install.insert(make_pair(proc, is));
+         bps_to_install.insert(make_pair(p, is));
       }
       else {
          result = proc->removeBreakpoint(addr, bp, all_responses);
@@ -3278,7 +3292,7 @@ bool ThreadTrackingSet::setTrackThreads(bool b) const
    MTLock lock_this_func;
    bool had_error = false;
 
-   set<pair<int_process *, bp_install_state *> > bps_to_install;
+   set<pair<Process::ptr, bp_install_state *> > bps_to_install;
    set<response::ptr> all_responses;
 
    ProcessSet::ptr ps = wps.lock();
@@ -3315,7 +3329,7 @@ bool ThreadTrackingSet::setTrackThreads(bool b) const
             is->addr = j->second;
             is->bp = j->first;
             is->do_install = true;
-            bps_to_install.insert(make_pair(proc, is));
+            bps_to_install.insert(make_pair(p, is));
          }
       }
       else {


### PR DESCRIPTION
# Harden proccontrol against concurrent process exit during event handling

## Summary

Follow-up to #2318. That PR fixed a use-after-free in `ProcessSet::terminate`
where a raw `int_process*` was cached across a `waitAndHandleEvents()` call that
could delete the process. This PR fixes the **same bug class** at every other
site I could find where it occurs.

The pattern, in all cases: a function snapshots a raw `int_process*` (in a
local, a `set<int_process*>`, or a `pair<int_process*, ...>`), then calls a bare
event-processing routine (`waitAndHandleEvents` / `waitForAsyncEvent` /
`waitfor_startup`), then dereferences the raw pointer. If a process finishes
exiting during that call, its `int_process` is deleted — `~int_process()` nulls
the owning `Process` wrapper's `llproc_`, but the raw pointer that was snapshot
is left dangling. The later dereference is a UAF (typically a virtual call on
freed memory → `pure virtual method called` / `SIGABRT`, or a double-free).

The fix idiom (matching #2318): hold the reference-counted `Process::ptr`
wrapper instead of the raw pointer, and after each event-handling call re-derive
`int_process *p = wrapper->llproc()` and skip the process if it is now `NULL`
(NULL means its `int_process` was freed).

## The sites fixed

- **`infMalloc`** (`process.C`). Cached raw `int_process*` in `active_mallocs`,
  ran the inferior-malloc RPCs via `waitAndHandleEvents()`, then dereferenced
  the raw pointers. The RPC runs the target, so it can exit during the wait.
  Its sibling `infFree` was already written the safe way (`Process::ptr` +
  re-derive + NULL-check) — this makes `infMalloc` match.

- **process create / attach bootstrap** (`process.C`). `int_process::create`
  and `int_process::attach` re-dereferenced a raw `set<int_process*>` across the
  `waitForAsyncEvent` / `waitAndHandleEvents` / `waitfor_startup` calls that
  drive `post_create` / `post_attach` and startup; a process that exits during
  bootstrap is deleted inside those calls. (`attach` even read `proc->pid` after
  `waitfor_startup` had already deleted `proc`.) Also fixes a latent infinite
  loop in `attach`'s `plat_attachThreadsSync` loop, where an `errorstate`
  `continue` never advanced the iterator.

- **`LWPTrackingSet::refreshLWPs`** (`procset.C`). Held raw `int_process*` in
  `all_procs` / `change_procs` across `waitForAsyncEvent` and
  `waitAndHandleEvents`, then re-dereferenced them.

- **breakpoint install** (`procset.C`, `process.C`). `addBreakpointWorker`
  cached raw `int_process*` in `bp_installs` and called
  `addBreakpoint_phase2/phase3` after two `waitForAsyncEvent`s;
  `sw_breakpoint::create` held its `int_process*` argument across the
  memory/result waits. Both can lose the process if it exits mid-install.
  `addBreakpointWorker` now carries `Process::ptr` (worker set + its three
  callers); `sw_breakpoint::create` checks the wrapper's liveness after each
  wait.

## Not changed (investigated)

- **`ProcessSet::rmBreakpoint`**: looks like the pattern, but its `resp_to_proc`
  map is populated from an always-empty local, so the raw pointer is never
  actually dereferenced. There is a separate latent bug there (an error-path
  `resp_to_proc[resp]` yields NULL and trips `assert(proc)`), but it is not a
  UAF; left alone to keep this PR focused.

- **`freebsd.C`** has an analogous `set<int_thread*>` in its thread-cleanup
  path. It does not build on the Linux CI here, so it is untested and left for a
  platform owner to confirm/port.

## Verification

- Full testsuite `-all`: **1534/1534 pass, 0 crashes**, run on this branch
  rebased onto current `master` (which contains #2318). The create/attach and
  breakpoint paths are exercised by every test, so a clean run is strong
  evidence the refactor does not regress normal operation.
- The `terminate` UAF that motivated #2318 originally surfaced as a roaming
  ~1-per-`-all`-run flake (each affected test passing in isolation); the same
  presentation is what these siblings would produce under the right timing.

## Notes for reviewers

- Each commit is one site/family for reviewability; all use the identical
  `Process::ptr` + re-derive-`llproc()` + skip-NULL idiom introduced in #2318.
- The `attach` change is the largest (that function has ~9 loops over the
  process set); the infinite-loop fix in it is incidental but real.