### PR TITLE
Revert "Compile parseAPI with -pthread to fix Clang thread-safety"

### DIFF
--- a/cmake/tpls/DyninstThreads.cmake
+++ b/cmake/tpls/DyninstThreads.cmake
@@ -4,14 +4,6 @@ if(DYNINST_OS_UNIX)
   set(_required REQUIRED)
 endif()
 
-# Prefer the compiler's -pthread flag over a bare -lpthread. On GCC and Clang,
-# -pthread also defines _REENTRANT, which Dyninst's bundled Sawyer/ROSE relies
-# on to compile its pool allocator and shared-pointer reference counting as
-# thread-safe (see dataflowAPI/rose/util/Sawyer.h). GCC's -fopenmp defines
-# _REENTRANT implicitly, but Clang's -fopenmp=libomp does not; using -pthread
-# makes the thread-safe path explicit and compiler-independent.
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-
 find_package(Threads ${_required})
 
 if(NOT Threads_FOUND)

--- a/parseAPI/CMakeLists.txt
+++ b/parseAPI/CMakeLists.txt
@@ -94,9 +94,6 @@ dyninst_library(
   DYNINST_DEPS common instructionAPI ${SYMREADER}
   PUBLIC_DEPS Dyninst::Boost_headers
   PRIVATE_DEPS OpenMP::OpenMP_CXX
-               # -pthread (via Threads::Threads) defines _REENTRANT so the
-               # Sawyer/ROSE pool allocator is thread safe
-               Threads::Threads
 )
 # cmake-format: on
 


### PR DESCRIPTION
Reverts dyninst/dyninst#2311

This doesn't fix the CI problem because when glibc is too new (>=2.34), 
pthread is builtinto libc and therefore CMAKE_HAVE_LIBC_PTHREAD=true => THREADS_HAVE_PTHREAD_ARG=false
The linking to Threads::Threads has no effect.