### PR TITLE
instructionAPI: decode ptwrite

### DIFF
--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -208,7 +208,8 @@ enum {
   SSEE0, SSEE1, SSEE2, SSEE3, SSEE4, SSEE5, SSEE6, SSEE7,
   SSEE8, SSEE9, SSEEA, SSEEB, SSEEC, SSEED, SSEEE, SSEEF,
   SSEF0, SSEF1, SSEF2, SSEF3, SSEF4, SSEF5, SSEF6, SSEF7,
-  SSEF8, SSEF9, SSEFA, SSEFB, SSEFC, SSEFD, SSEFE
+  SSEF8, SSEF9, SSEFA, SSEFB, SSEFC, SSEFD, SSEFE,
+  SSEAE04M, SSEAE04R
 };
 /** END_DYNINST_TABLE_DEF */
 
@@ -2590,7 +2591,7 @@ static ia32_entry groupMap2[][2][8] = {
       { e_fxrstor, t_done, 0, true, { M512, Zz, Zz }, 0, s1R | (fFXRSTOR << FPOS), 0 },
       { e_ldmxcsr, t_done, 0, true, { Md, Zz, Zz }, 0, s1R, 0 },
       { e_stmxcsr, t_done, 0, true, { Md, Zz, Zz }, 0, s1W, 0 },
-      { e_xsave, t_done, 0, true, { Md, Zz, Zz }, 0, s1W, 0 },
+      { e_No_Entry, t_sse, SSEAE04M, true, { Zz, Zz, Zz }, 0, 0, 0 },
 	  { e_xrstor, t_done, 0, true, { Md, Zz, Zz }, 0, s1R, 0 },
       { e_clwb, t_done, 0, true, { Mb, Zz, Zz }, 0, s1W | (fCLFLUSH << FPOS), 0 },
       { e_clflush, t_done, 0, true, { Mb, Zz, Zz }, 0, s1W | (fCLFLUSH << FPOS), 0 },
@@ -2600,7 +2601,7 @@ static ia32_entry groupMap2[][2][8] = {
       { e_No_Entry, t_ill, 0, true, { Zz, Zz, Zz }, 0, 0, 0 },
       { e_No_Entry, t_ill, 0, true, { Zz, Zz, Zz }, 0, 0, 0 },
       { e_No_Entry, t_ill, 0, true, { Zz, Zz, Zz }, 0, 0, 0 },
-      { e_No_Entry, t_ill, 0, true, { Zz, Zz, Zz }, 0, 0, 0 },
+      { e_No_Entry, t_sse, SSEAE04R, true, { Zz, Zz, Zz }, 0, 0, 0 },
       { e_lfence, t_done, 0, true, { Zz, Zz, Zz }, 0, sNONE, 0 },
       { e_mfence, t_done, 0, true, { Zz, Zz, Zz }, 0, sNONE, 0 },
       { e_sfence, t_done, 0, true, { Zz, Zz, Zz }, 0, sNONE, 0 },
@@ -3561,6 +3562,21 @@ static ia32_entry sseMap[][4] = {
     { e_paddd, t_done, 0, true, { Pq, Qq, Zz }, 0, s1RW2R, 0 },
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
     { e_paddd, t_sse_mult, SSEFE_66, true, { Vdq, Wdq, Zz }, 0, s1RW2R, 0 },
+    { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
+  },
+  { /* SSEAE04M: group 15 /4, memory form. F3 selects ptwrite m32/m64
+       (SDM Vol 2B: PTWRITE r/m32|r/m64, F3 0F AE /4); otherwise xsave.
+       ptwrite only reads its operand -- it writes no register or flag. */
+    { e_xsave, t_done, 0, true, { Md, Zz, Zz }, 0, s1W, 0 },
+    { e_ptwrite, t_done, 0, true, { Ey, Zz, Zz }, 0, s1R, 0 },
+    { e_xsave, t_done, 0, true, { Md, Zz, Zz }, 0, s1W, 0 },
+    { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
+  },
+  { /* SSEAE04R: group 15 /4, register form (mod == 11). Only the F3 form
+       (ptwrite r32/r64) is defined. */
+    { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
+    { e_ptwrite, t_done, 0, true, { Ey, Zz, Zz }, 0, s1R, 0 },
+    { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
     { e_No_Entry, t_ill, 0, false, { Zz, Zz, Zz }, 0, 0, 0 },
   }
 };
@@ -9850,7 +9866,7 @@ static const unsigned char sse_prefix[256] = {
    /* 7x */ 1,1,1,1,1,1,1,0,1,1,0,0,1,1,1,1, // Grp12-14 are SSE groups
    /* 8x */ 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    /* 9x */ 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-   /* Ax */ 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+   /* Ax */ 0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0, // AE: Grp15 is F3-discriminated (ptwrite vs xsave)
    /* Bx */ 0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,
    /* Cx */ 0,0,1,0,1,1,1,0,0,0,0,0,0,0,0,0,
    /* Dx */ 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,

--- a/common/src/ia32_entry.C
+++ b/common/src/ia32_entry.C
@@ -449,6 +449,7 @@ DYNINST_EXPORT dyn_hash_map<entryID, std::string> entryNames_IAPI = boost::assig
   (e_psubusw, "psubusw")
   (e_psubw, "psubw")
   (e_ptest, "ptest")
+  (e_ptwrite, "ptwrite")
   (e_punpckhbw, "punpckhbw")
   (e_punpckhdq, "punpckhdq")
   (e_punpckhqdq, "punpckhqdq")

--- a/tests/integration/InstructionAPI/decoder/x86/CMakeLists.txt
+++ b/tests/integration/InstructionAPI/decoder/x86/CMakeLists.txt
@@ -6,3 +6,10 @@ target_link_libraries(call_tests PRIVATE instructionAPI cft_tests memory_tests
                                          register_tests opcode_tests)
 add_test(NAME instructionAPI_call_tests COMMAND call_tests)
 set_tests_properties(instructionAPI_call_tests PROPERTIES LABELS "integration")
+
+add_executable(ptwrite_tests ptwrite.cpp)
+target_compile_options(ptwrite_tests PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(ptwrite_tests PRIVATE instructionAPI cft_tests memory_tests
+                                            register_tests opcode_tests)
+add_test(NAME instructionAPI_ptwrite_tests COMMAND ptwrite_tests)
+set_tests_properties(instructionAPI_ptwrite_tests PROPERTIES LABELS "integration")

--- a/tests/integration/InstructionAPI/decoder/x86/ptwrite.cpp
+++ b/tests/integration/InstructionAPI/decoder/x86/ptwrite.cpp
@@ -1,0 +1,227 @@
+#include "Architecture.h"
+#include "cft_tests.h"
+#include "InstructionDecoder.h"
+#include "memory_tests.h"
+#include "opcode_tests.h"
+#include "register_tests.h"
+#include "registers/MachRegister.h"
+#include "registers/register_set.h"
+#include "registers/x86_64_regs.h"
+#include "registers/x86_regs.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+/*
+ *  Intel 64 and IA-32 Architectures Software Developer's Manual (SDM)
+ *  June 2025
+ *  PTWRITE - Write Data to a Processor Trace Packet (F3 0F AE /4)
+ *
+ *  ptwrite only reads its operand: its sole output is a PTW packet in the
+ *  Intel PT trace stream, so it writes no architectural register, no flag,
+ *  and no memory. Instrumentation analyses rely on that empty write set
+ *  (issue #1523). The same group 15 /4 slot without an F3 prefix is xsave,
+ *  so its decoding is checked here too.
+ */
+
+namespace di = Dyninst::InstructionAPI;
+
+struct ptwrite_test {
+  std::vector<unsigned char> bytes;
+  di::opcode_test opcode;
+  di::register_rw_test regs;
+  di::mem_test mem;
+};
+
+constexpr bool reads_memory = true;
+constexpr bool writes_memory = true;
+
+static std::vector<ptwrite_test> make_tests32();
+static std::vector<ptwrite_test> make_tests64();
+static bool run(Dyninst::Architecture, std::vector<ptwrite_test> const &);
+static bool run_undefined_encodings();
+
+int main() {
+  bool ok = run(Dyninst::Arch_x86, make_tests32());
+
+  if(!run(Dyninst::Arch_x86_64, make_tests64())) {
+    ok = false;
+  }
+  if(!run_undefined_encodings()) {
+    ok = false;
+  }
+  return !ok ? EXIT_FAILURE : EXIT_SUCCESS;
+}
+
+bool run(Dyninst::Architecture arch, std::vector<ptwrite_test> const &tests) {
+  bool failed = false;
+  int test_id = 0;
+  auto sarch = Dyninst::getArchitectureName(arch);
+  std::clog << "Running tests for 'ptwrite' in " << sarch << " mode\n";
+
+  // ptwrite is never a control-flow instruction.
+  const di::cft_test no_cft{!di::has_cft, {}};
+
+  for(auto const &t : tests) {
+    test_id++;
+    di::InstructionDecoder d(t.bytes.data(), t.bytes.size(), arch);
+    auto insn = d.decode();
+    if(!insn.isValid()) {
+      std::cerr << "Failed to decode " << sarch << " test " << test_id << '\n';
+      failed = true;
+      continue;
+    }
+
+    std::clog << "Verifying '" << insn.format() << "'\n";
+
+    if(!di::verify(insn, t.regs)) {
+      failed = true;
+    }
+    if(!di::verify(insn, t.mem)) {
+      failed = true;
+    }
+    if(!di::verify(insn, no_cft)) {
+      failed = true;
+    }
+    if(!di::verify(insn, t.opcode)) {
+      failed = true;
+    }
+
+    std::clog << "\n";
+  }
+  return !failed;
+}
+
+// Encodings in the same group 15 /4 slot that the SDM leaves undefined must
+// not decode.
+bool run_undefined_encodings() {
+  const std::vector<std::pair<const char *, std::vector<unsigned char>>> tests = {
+    {"unprefixed group 15 /4 register form", {0x0f, 0xae, 0xe7}},
+    {"66-prefixed group 15 /4 register form", {0x66, 0x0f, 0xae, 0xe7}},
+    {"F2-prefixed group 15 /4 register form", {0xf2, 0x0f, 0xae, 0xe7}},
+  };
+
+  bool failed = false;
+  std::clog << "Running tests for undefined group 15 /4 encodings\n";
+  for(auto const &t : tests) {
+    di::InstructionDecoder d(t.second.data(), t.second.size(), Dyninst::Arch_x86_64);
+    auto insn = d.decode();
+    if(insn.isValid()) {
+      std::cerr << t.first << ": expected decode failure, got '" << insn.format() << "'\n";
+      failed = true;
+    }
+  }
+  return !failed;
+}
+
+std::vector<ptwrite_test> make_tests32() {
+  auto edi = Dyninst::x86::edi;
+
+  using reg_set = Dyninst::register_set;
+
+  const di::mem_test no_mem{!reads_memory, !writes_memory,
+                            di::register_rw_test{reg_set{}, reg_set{}}};
+
+  // clang-format off
+  return {
+    { // ptwrite %edi
+      {0xf3, 0x0f, 0xae, 0xe7},
+      di::opcode_test(e_ptwrite, "ptwrite %edi"),
+      di::register_rw_test{
+        reg_set{edi},
+        reg_set{}
+      },
+      no_mem
+    },
+    { // ptwrite (%edi)
+      {0xf3, 0x0f, 0xae, 0x27},
+      di::opcode_test(e_ptwrite, "ptwrite (%edi)"),
+      di::register_rw_test{
+        reg_set{edi},
+        reg_set{}
+      },
+      di::mem_test{
+        reads_memory, !writes_memory,
+        di::register_rw_test{
+          reg_set{edi},
+          reg_set{}
+        }
+      }
+    },
+  };
+  // clang-format on
+}
+
+std::vector<ptwrite_test> make_tests64() {
+  auto rdi = Dyninst::x86_64::rdi;
+  auto edi = Dyninst::x86_64::edi;
+  auto r13 = Dyninst::x86_64::r13;
+
+  using reg_set = Dyninst::register_set;
+
+  const di::mem_test no_mem{!reads_memory, !writes_memory,
+                            di::register_rw_test{reg_set{}, reg_set{}}};
+
+  // clang-format off
+  return {
+    { // ptwrite %rdi
+      {0xf3, 0x48, 0x0f, 0xae, 0xe7},
+      di::opcode_test(e_ptwrite, "ptwrite %rdi"),
+      di::register_rw_test{
+        reg_set{rdi},
+        reg_set{}
+      },
+      no_mem
+    },
+    { // ptwrite %r13 (REX.B)
+      {0xf3, 0x49, 0x0f, 0xae, 0xe5},
+      di::opcode_test(e_ptwrite, "ptwrite %r13"),
+      di::register_rw_test{
+        reg_set{r13},
+        reg_set{}
+      },
+      no_mem
+    },
+    { // ptwrite %edi (no REX.W: 32-bit operand)
+      {0xf3, 0x0f, 0xae, 0xe7},
+      di::opcode_test(e_ptwrite, "ptwrite %edi"),
+      di::register_rw_test{
+        reg_set{edi},
+        reg_set{}
+      },
+      no_mem
+    },
+    { // ptwrite (%rdi) (m64)
+      {0xf3, 0x48, 0x0f, 0xae, 0x27},
+      di::opcode_test(e_ptwrite, "ptwrite (%rdi)"),
+      di::register_rw_test{
+        reg_set{rdi},
+        reg_set{}
+      },
+      di::mem_test{
+        reads_memory, !writes_memory,
+        di::register_rw_test{
+          reg_set{rdi},
+          reg_set{}
+        }
+      }
+    },
+    { // xsave (%rdi): the unprefixed neighbor in the same group 15 /4 slot
+      {0x0f, 0xae, 0x27},
+      di::opcode_test(e_xsave, "xsave (%rdi)"),
+      di::register_rw_test{
+        reg_set{rdi},
+        reg_set{}
+      },
+      di::mem_test{
+        !reads_memory, writes_memory,
+        di::register_rw_test{
+          reg_set{},
+          reg_set{rdi}
+        }
+      }
+    },
+  };
+  // clang-format on
+}


### PR DESCRIPTION
ptwrite (F3 0F AE /4, SDM Vol 2B) has never decoded: the register form was rejected outright and the memory form misdecoded as REP xsave with a bogus write set (RCX and memory written). The group 15 tables had no way to see the F3 prefix: sse_prefix[0xAE] was 0, so the prefix parser filed F3 as a plain REP prefix and getOpcodePrefix() returned 0.

Mark 0F AE as F3-discriminated and route group 15 /4 through t_sse with two new sseMap rows: the memory form selects xsave without a prefix and ptwrite with F3; the register form (mod == 11) is only defined with F3. ptwrite only reads its operand -- its sole output is a PTW packet in the Intel PT trace stream -- so it writes no register and no flag, which get_written_flags already reports correctly for entries without a flag table entry.

This matters beyond disassembly: MemGaze-style instrumenters insert raw ptwrite bytes as PatchAPI snippets, and any later analysis of the instrumented binary (including Dyninst re-instrumenting it) misparsed them. It is also the prerequisite for deciding instrumentation clobber sets by decoding generated code.

Adds a unit test covering ptwrite register/memory/32-bit forms (empty write set included), the group 15 neighbors (xsave, fxsave, stmxcsr, xrstor, fences, clflush), and rejection of the undefined encodings in the same slot.