### PR TITLE
Fix cmake format issue for AMDGPU regression tests

### DIFF
--- a/tests/regression/parseAPI/IndirectControlFlowAnalysis/CMakeLists.txt
+++ b/tests/regression/parseAPI/IndirectControlFlowAnalysis/CMakeLists.txt
@@ -2,20 +2,29 @@ include_guard(GLOBAL)
 
 if(DYNINST_ENABLE_EXTERNAL_BINARY_TESTS)
 
-set(_targ IndirectControlFlowAnalysis)
-add_executable(${_targ} branchInfo.cpp)
-target_compile_options(${_targ} PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
-target_link_libraries(${_targ} PRIVATE parseAPI)
-set(_fpath "${DYNINST_TEST_BINARIES_DIR}/parseAPI/IndirectControlFlowAnalysis")
+  set(_targ IndirectControlFlowAnalysis)
+  add_executable(${_targ} branchInfo.cpp)
+  target_compile_options(${_targ} PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+  target_link_libraries(${_targ} PRIVATE parseAPI)
+  set(_fpath "${DYNINST_TEST_BINARIES_DIR}/parseAPI/IndirectControlFlowAnalysis")
 
-foreach(_arch 908 90a 940)
-set(_tfname parseAPI_${_targ}_${_arch})
-add_test(NAME parseAPI_${_targ}_${_arch} COMMAND ${_targ} "${_fpath}/${_tfname}.gpubin" ${_tfname}.out)
-add_test(NAME  compare_${_targ}_${_arch} COMMAND ${CMAKE_COMMAND} -E compare_files ${_tfname}.out "${_fpath}/expected_result/${_tfname}.ref.out")
-add_test(NAME  cleanup_${_targ}_${_arch} COMMAND ${CMAKE_COMMAND} -E rm -f ${_tfname}.out)
-set_tests_properties(parseAPI_${_targ}_${_arch} PROPERTIES LABELS "regression" FIXTURES_SETUP    ${_targ}_${_arch})
-set_tests_properties( compare_${_targ}_${_arch} PROPERTIES LABELS "regression" FIXTURES_REQUIRED ${_targ}_${_arch})
-set_tests_properties( cleanup_${_targ}_${_arch} PROPERTIES LABELS "regression" FIXTURES_CLEANUP  ${_targ}_${_arch})
-endforeach()
+  foreach(_arch 908 90a 940)
+    set(_tfname parseAPI_${_targ}_${_arch})
+    add_test(NAME parseAPI_${_targ}_${_arch}
+             COMMAND ${_targ} "${_fpath}/${_tfname}.gpubin" ${_tfname}.out)
+    add_test(NAME compare_${_targ}_${_arch}
+             COMMAND ${CMAKE_COMMAND} -E compare_files ${_tfname}.out
+                     "${_fpath}/expected_result/${_tfname}.ref.out")
+    add_test(NAME cleanup_${_targ}_${_arch} COMMAND ${CMAKE_COMMAND} -E rm -f
+                                                    ${_tfname}.out)
+    set_tests_properties(parseAPI_${_targ}_${_arch}
+                         PROPERTIES LABELS "regression" FIXTURES_SETUP ${_targ}_${_arch})
+    set_tests_properties(
+      compare_${_targ}_${_arch} PROPERTIES LABELS "regression" FIXTURES_REQUIRED
+                                           ${_targ}_${_arch})
+    set_tests_properties(
+      cleanup_${_targ}_${_arch} PROPERTIES LABELS "regression" FIXTURES_CLEANUP
+                                           ${_targ}_${_arch})
+  endforeach()
 
 endif()


### PR DESCRIPTION
This is required otherwise all future PRs' CI will die on the cmake-format check.