### PR TITLE
Improve AMDGPU Indirect Control Flow Parsing

### DIFF
--- a/dataflowAPI/rose/semantics/SymEvalSemantics.C
+++ b/dataflowAPI/rose/semantics/SymEvalSemantics.C
@@ -124,8 +124,9 @@ Dyninst::Absloc SymEvalSemantics::RegisterStateAST_amdgpu_gfx908::convert(const 
         break;
     }
     case amdgpu_regclass_misc : {
-        Dyninst::MachRegister base = Dyninst::amdgpu_gfx908::src_scc;
-        mreg  = Dyninst::MachRegister(base.val() + minor) ;
+        Dyninst::MachRegister base = (size == 1) ? Dyninst::amdgpu_gfx908::src_scc
+                                                 : Dyninst::amdgpu_gfx908::vcc_lo;
+        mreg = Dyninst::MachRegister((base.val() & 0xffffff00) | minor);
         found = true;
         break;
     }
@@ -164,8 +165,9 @@ Dyninst::Absloc SymEvalSemantics::RegisterStateAST_amdgpu_gfx90a::convert(const 
         break;
     }
     case amdgpu_regclass_misc : {
-        Dyninst::MachRegister base = Dyninst::amdgpu_gfx90a::src_scc;
-        mreg  = Dyninst::MachRegister(base.val() + minor) ;
+        Dyninst::MachRegister base = (size == 1) ? Dyninst::amdgpu_gfx90a::src_scc
+                                                 : Dyninst::amdgpu_gfx90a::vcc_lo;
+        mreg = Dyninst::MachRegister((base.val() & 0xffffff00) | minor);
         found = true;
         break;
     }
@@ -197,8 +199,9 @@ Dyninst::Absloc SymEvalSemantics::RegisterStateAST_amdgpu_gfx940::convert(const 
         break;
     }
     case amdgpu_regclass_misc : {
-        Dyninst::MachRegister base = Dyninst::amdgpu_gfx940::src_scc;
-        mreg  = Dyninst::MachRegister(base.val() + minor) ;
+        Dyninst::MachRegister base = (size == 1) ? Dyninst::amdgpu_gfx940::src_scc
+                                                 : Dyninst::amdgpu_gfx940::vcc_lo;
+        mreg = Dyninst::MachRegister((base.val() & 0xffffff00) | minor);
         found = true;
         break;
     }

--- a/instructionAPI/src/AMDGPU/gfx908/finalizeOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx908/finalizeOperands.C
@@ -1607,8 +1607,9 @@ namespace InstructionAPI {
                 appendOPR_SDST(layout.SDST,true,false);
                 break;
             case 21:   // S_CALL_B64,
+                setCall();
                 appendOPR_SDST(layout.SDST,false,true,2);
-                insn_in_progress->appendOperand(decodeOPR_LABEL(layout.SIMM16),true,false);
+                makeBranchTarget(isCall,isConditional,layout.SIMM16);
                 appendOPR_PC(0,false,true,1,true);
                 appendOPR_PC(0,true,false,1,true);
                 break;

--- a/instructionAPI/src/AMDGPU/gfx90a/finalizeOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx90a/finalizeOperands.C
@@ -1550,8 +1550,9 @@ namespace InstructionAPI {
                 appendOPR_SDST(layout.SDST,true,false);
                 break;
             case 21:   // S_CALL_B64,
+                setCall();
                 appendOPR_SDST(layout.SDST,false,true,2);
-                insn_in_progress->appendOperand(decodeOPR_LABEL(layout.SIMM16),true,false);
+                makeBranchTarget(isCall,isConditional,layout.SIMM16);
                 appendOPR_PC(0,false,true,1,true);
                 appendOPR_PC(0,true,false,1,true);
                 break;

--- a/instructionAPI/src/AMDGPU/gfx940/finalizeOperands.C
+++ b/instructionAPI/src/AMDGPU/gfx940/finalizeOperands.C
@@ -1527,8 +1527,9 @@ namespace InstructionAPI {
                 appendOPR_SDST(layout.SDST,true,false);
                 break;
             case 21:   // S_CALL_B64,
+                setCall();
                 appendOPR_SDST(layout.SDST,false,true,2);
-                insn_in_progress->appendOperand(decodeOPR_LABEL(layout.SIMM16),true,false);
+                makeBranchTarget(isCall,isConditional,layout.SIMM16);
                 appendOPR_PC(0,false,true,1,true);
                 appendOPR_PC(0,true,false,1,true);
                 break;

--- a/instructionAPI/src/InstructionCategories.C
+++ b/instructionAPI/src/InstructionCategories.C
@@ -48,6 +48,12 @@ namespace Dyninst { namespace InstructionAPI {
       case e_call:
       case aarch64_op_bl:
       case aarch64_op_blr:
+      case amdgpu_gfx908_op_S_SWAPPC_B64:
+      case amdgpu_gfx908_op_S_CALL_B64:
+      case amdgpu_gfx90a_op_S_SWAPPC_B64:
+      case amdgpu_gfx90a_op_S_CALL_B64:
+      case amdgpu_gfx940_op_S_SWAPPC_B64:
+      case amdgpu_gfx940_op_S_CALL_B64:
         return c_CallInsn;
 
       case e_jmp:

--- a/instructionAPI/src/amdgpu_branchinsn_table.h
+++ b/instructionAPI/src/amdgpu_branchinsn_table.h
@@ -9,11 +9,9 @@ case amdgpu_gfx908_op_S_CBRANCH_CDBGSYS:
 case amdgpu_gfx908_op_S_CBRANCH_CDBGUSER:
 case amdgpu_gfx908_op_S_CBRANCH_CDBGSYS_AND_USER:
 case amdgpu_gfx908_op_S_SETPC_B64:
-case amdgpu_gfx908_op_S_SWAPPC_B64:
 case amdgpu_gfx908_op_S_RFE_B64:
 case amdgpu_gfx908_op_S_CBRANCH_G_FORK:
 case amdgpu_gfx908_op_S_CBRANCH_I_FORK:
-case amdgpu_gfx908_op_S_CALL_B64:
 case amdgpu_gfx90a_op_S_BRANCH:
 case amdgpu_gfx90a_op_S_CBRANCH_SCC0:
 case amdgpu_gfx90a_op_S_CBRANCH_SCC1:
@@ -25,11 +23,9 @@ case amdgpu_gfx90a_op_S_CBRANCH_CDBGSYS:
 case amdgpu_gfx90a_op_S_CBRANCH_CDBGUSER:
 case amdgpu_gfx90a_op_S_CBRANCH_CDBGSYS_AND_USER:
 case amdgpu_gfx90a_op_S_SETPC_B64:
-case amdgpu_gfx90a_op_S_SWAPPC_B64:
 case amdgpu_gfx90a_op_S_RFE_B64:
 case amdgpu_gfx90a_op_S_CBRANCH_G_FORK:
 case amdgpu_gfx90a_op_S_CBRANCH_I_FORK:
-case amdgpu_gfx90a_op_S_CALL_B64:
 case amdgpu_gfx940_op_S_BRANCH:
 case amdgpu_gfx940_op_S_CBRANCH_SCC0:
 case amdgpu_gfx940_op_S_CBRANCH_SCC1:
@@ -41,8 +37,6 @@ case amdgpu_gfx940_op_S_CBRANCH_CDBGSYS:
 case amdgpu_gfx940_op_S_CBRANCH_CDBGUSER:
 case amdgpu_gfx940_op_S_CBRANCH_CDBGSYS_AND_USER:
 case amdgpu_gfx940_op_S_SETPC_B64:
-case amdgpu_gfx940_op_S_SWAPPC_B64:
 case amdgpu_gfx940_op_S_RFE_B64:
 case amdgpu_gfx940_op_S_CBRANCH_G_FORK:
 case amdgpu_gfx940_op_S_CBRANCH_I_FORK:
-case amdgpu_gfx940_op_S_CALL_B64:

--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -536,9 +536,11 @@ void IA_IAPI::getNewEdges(std::vector<std::pair< Address, EdgeTypeEnum> >& outEd
     // Only call this on control flow instructions!
     if(ci.isCall())
     {
-        bool success; 
+        bool success;
         Address target;
         boost::tie(success, target) = getCFT();
+        if (!success)
+            boost::tie(success, target) = resolveDynamicCallTarget(context, currBlk);
         bool callEdge = true;
         bool ftEdge = true;
         if( success && !isDynamicCall() )

--- a/parseAPI/src/IA_IAPI.h
+++ b/parseAPI/src/IA_IAPI.h
@@ -110,6 +110,11 @@ class IA_IAPI : public InstructionAdapter {
                                 unsigned int,
                                 const std::set<Address> &) const = 0;
         virtual std::pair<bool, Address> getCFT() const;
+        virtual std::pair<bool, Address> resolveDynamicCallTarget(Dyninst::ParseAPI::Function *,
+                                                                  Dyninst::ParseAPI::Block *) const
+        {
+            return std::make_pair(false, 0);
+        }
         virtual bool isStackFramePreamble() const = 0;
         virtual bool savesFP() const = 0;
         virtual bool cleansStack() const = 0;

--- a/parseAPI/src/IA_amdgpu.C
+++ b/parseAPI/src/IA_amdgpu.C
@@ -33,6 +33,7 @@
 #include "Immediate.h"
 #include "BinaryFunction.h"
 
+#include "parseAPI/src/IndirectAnalyzer.h"
 #include "parseAPI/src/debug_parse.h"
 
 #include <deque>
@@ -139,6 +140,19 @@ bool IA_amdgpu::isLinkerStub() const
 bool IA_amdgpu::isNopJump() const
 {
     return false;
+}
+
+std::pair<bool, Address> IA_amdgpu::resolveDynamicCallTarget(Dyninst::ParseAPI::Function * context,
+                                                             Dyninst::ParseAPI::Block* currBlk) const
+{
+    Address target = 0;
+    IndirectControlFlowAnalyzer icfa(context, currBlk);
+    if (icfa.ResolveCallTargetBySlicing(target)) {
+        cachedCFT = std::make_pair(true, target);
+        validCFT = true;
+        return cachedCFT;
+    }
+    return std::make_pair(false, 0);
 }
 
 bool IA_amdgpu::isSoftwareException() const

--- a/parseAPI/src/IA_amdgpu.h
+++ b/parseAPI/src/IA_amdgpu.h
@@ -66,6 +66,8 @@ class IA_amdgpu : public IA_IAPI {
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
 	virtual bool isSoftwareException() const;
+	virtual std::pair<bool, Address> resolveDynamicCallTarget(Dyninst::ParseAPI::Function * context,
+	                                                          Dyninst::ParseAPI::Block* currBlk) const;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -58,6 +58,70 @@ static bool IsVariableArgumentFormat(AST::Ptr t, AbsRegion &index) {
     return IsIndexing(rt->child(1), index);
 
 }
+namespace {
+class CallTargetPred : public Slicer::Predicates {
+public:
+    virtual bool endAtPoint(AssignmentPtr a) {
+        switch (a->insn().getOperation().getID()) {
+            case amdgpu_gfx908_op_S_ADD_U32:
+            case amdgpu_gfx908_op_S_ADDC_U32:
+            case amdgpu_gfx908_op_S_MOV_B32:
+            case amdgpu_gfx908_op_S_MOV_B64:
+            case amdgpu_gfx90a_op_S_ADD_U32:
+            case amdgpu_gfx90a_op_S_ADDC_U32:
+            case amdgpu_gfx90a_op_S_MOV_B32:
+            case amdgpu_gfx90a_op_S_MOV_B64:
+            case amdgpu_gfx940_op_S_ADD_U32:
+            case amdgpu_gfx940_op_S_ADDC_U32:
+            case amdgpu_gfx940_op_S_MOV_B32:
+            case amdgpu_gfx940_op_S_MOV_B64:
+                return false;
+            default:
+                return true;
+        }
+    }
+};
+}
+
+bool IndirectControlFlowAnalyzer::ResolveCallTargetBySlicing(Dyninst::Address& target) {
+
+    parsing_printf("Apply call target slicing at %lx for function %s\n", block->last(), func->name().c_str());
+
+    boost::make_lock_guard(*func);
+
+    const unsigned char * buf = (const unsigned char*) block->region()->getPtrToInstruction(block->last());
+    InstructionDecoder dec(buf, InstructionDecoder::maxInstructionLength, block->obj()->cs()->getArch());
+
+    Instruction insn = dec.decode();
+    AssignmentConverter ac(true, false);
+    vector<Assignment::Ptr> assignments;
+    ac.convert(insn, block->last(), func, block, assignments);
+    if (assignments.empty()) return false;
+
+    Slicer formatSlicer(assignments[0], block, func, true, false);
+
+    SymbolicExpression se;
+    se.cs = block->obj()->cs();
+    se.cr = block->region();
+    CallTargetPred pred;
+
+    GraphPtr slice = formatSlicer.backwardSlice(pred);
+
+    Result_t symRet;
+    SymEval::expand(slice, symRet);
+
+    auto old_ast = symRet[assignments[0]];
+    if (!old_ast) return false;
+
+    auto new_ast = se.SimplifyAnAST(old_ast, 0, false);
+    if (!new_ast || new_ast->getID() != AST::V_ConstantAST) return false;
+
+    ConstantAST::Ptr constAST = boost::static_pointer_cast<ConstantAST>(new_ast);
+    target = Address(constAST->val().val);
+    parsing_printf("\t call target resolved to %lx\n", target);
+    return true;
+}
+
 /*
  * Insert edges found into the edges vector, and return true if the vector is non-empty
  *
@@ -96,43 +160,6 @@ bool IndirectControlFlowAnalyzer::NewJumpTableAnalysis(std::vector<std::pair< Ad
     JumpTableFormatPred jtfp(func, block, rf, thunks, se);
 
     GraphPtr slice = formatSlicer.backwardSlice(jtfp);
-    if ((se.cs->getArch() == Arch_amdgpu_gfx908 && insn.getOperation().getID() == amdgpu_gfx908_op_S_SETPC_B64) ||
-        (se.cs->getArch() == Arch_amdgpu_gfx908 && insn.getOperation().getID() == amdgpu_gfx908_op_S_SWAPPC_B64) ||
-        (se.cs->getArch() == Arch_amdgpu_gfx90a && insn.getOperation().getID() == amdgpu_gfx90a_op_S_SETPC_B64 ) ||
-        (se.cs->getArch() == Arch_amdgpu_gfx90a && insn.getOperation().getID() == amdgpu_gfx90a_op_S_SWAPPC_B64 ) ||
-        (se.cs->getArch() == Arch_amdgpu_gfx940 && insn.getOperation().getID() == amdgpu_gfx940_op_S_SETPC_B64 ) ||
-        (se.cs->getArch() == Arch_amdgpu_gfx940 && insn.getOperation().getID() == amdgpu_gfx940_op_S_SWAPPC_B64 )){
-
-        Result_t symRet;
-        SymEval::expand(slice,symRet);
-        
-        //for (auto const & cd : symRet) {
-        //    std::cout << " f: " << cd.first << " " << cd.second << std::endl; 
-        //}
-
-        auto old_ast = symRet[assignments[0]];
-
-	if (!old_ast) return false;
-
-        auto new_ast = se.SimplifyAnAST(old_ast,0,false);
-
-        /*do {
-            old_ast = new_ast; 
-            new_ast = se.SimplifyAnAST(old_ast, 0, false);
-            std::cout  << " simplified: =  " << new_ast->format() << std::endl;
-        }while(old_ast -> format() != new_ast->format());*/
-
-        if( new_ast->getID() == AST::V_ConstantAST) {
-            ConstantAST::Ptr constAST = 
-                boost::static_pointer_cast<ConstantAST>(new_ast);
-            uint64_t val = constAST->val().val;
-            //std::cerr << " resolved, value = " <<  std::hex <<val <<std::endl;
-            outEdges.push_back(std::make_pair(Address(val),CALL));
-            Address ft_addr =  Address(block->last() +insn.size());
-            outEdges.push_back(std::make_pair(Address(ft_addr),CALL_FT));
-            return true;
-        }
-    }
     // If the jump target expression is not in a form we recognize,
     // we do not try to resolve it
     //

--- a/parseAPI/src/IndirectAnalyzer.h
+++ b/parseAPI/src/IndirectAnalyzer.h
@@ -39,6 +39,7 @@ class IndirectControlFlowAnalyzer {
 
 public:
     bool NewJumpTableAnalysis(std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges);
+    bool ResolveCallTargetBySlicing(Dyninst::Address& target);
     IndirectControlFlowAnalyzer(ParseAPI::Function *f, ParseAPI::Block *b): func(f), block(b) {}
 
 };


### PR DESCRIPTION
## Summary

On AMDGPU (gfx908/gfx90a/gfx940), ParseAPI abandons a function at the first
procedure call whose target it cannot resolve statically. Everything after such
a call — blocks, edges, instrumentation points, liveness/footprint — is missing
from the CFG. This is the concrete form of #1470 ("Dyninst doesn't continue
parsing AMDGPU code after a procedure call"); the precise trigger is not "a
call" but an **unresolved-target (indirect) call**.

## Background: AMDGPU call/return encoding

AMDGPU has no call instruction with a wide immediate target. The compiler lowers
**every** call — direct or indirect — through a register pair:

- **Call**: `s_swappc_b64 s[30:31], <reg-pair>` — saves the return PC into the
  destination pair and jumps. It returns, so the next instruction is a valid
  return point (a real fall-through).
- **Direct call**: the target is materialized first with the PC-relative idiom
  `s_getpc_b64` / `s_add_u32` / `s_addc_u32`, then `s_swappc_b64` through that
  pair. Statically knowable, but only via data-flow, not from the call
  instruction alone.
- **Indirect call**: the target is loaded (e.g. from a function-pointer table)
  into a pair, then `s_swappc_b64`. Not statically knowable.
- **Return / tail call / jump table**: `s_setpc_b64` — a terminator with no
  fall-through.

## Root cause

Three independent defects combine:

1. **`s_swappc_b64` was classified as a branch.** An indirect `s_swappc` has a
   register target that can't be resolved, so it fell into the indirect-jump
   path — and that path **couples the fall-through edge to target resolution**:
   when the target can't be resolved, the block is abandoned with no
   fall-through, so all code after the call is left unparsed. A returning call
   must always get a call fall-through regardless of whether its target is
   known.

2. **Direct call targets weren't recovered on the call path.** Because there's
   no wide-immediate call, direct calls are also register-targeted, so
   `getCFT()` fails for them too; their target is only recoverable by
   backward-slicing the `getpc`/`add`/`addc` chain. That resolution existed only
   inside the jump-table machinery reachable from the (wrong) branch path.

3. **A register-modeling bug blocked `vcc`-materialized targets.** When the
   target pair is `vcc` (rather than an SGPR pair), the ROSE->Dyninst register
   reverse-conversion reconstructed MISC-class registers from `src_scc` (a
   `BITS_1` register), producing the wrong size encoding and an invalid register
   (`INVALID_REG`). The slice couldn't fold the value, so `vcc`-based calls
   never resolved.

## Impact

- **Correctness-level, not cosmetic.** Any code dominated by an unresolved call
  disappears from ParseAPI's view of the function.
- It bites function-pointer / virtual dispatch, `-O0`/`-fno-inline`, and any code where a callee isn't
  statically resolvable — notably the device-function-pointer pattern GPU binary
  instrumentation often targets.
- Reproduced on gfx908 with a function-pointer test kernel: ParseAPI stopped
  dead at the indirect `s_swappc`, dropping the trailing `global_store` +
  `s_endpgm`; and on the gfx940 regression binary, whole function tails after
  indirect calls were absent.

## Fix

Split across two changes:

**1. Reorganize AMDGPU indirect control flow analysis.** Reclassify
`s_swappc_b64`/`s_call_b64` as calls so an unresolved target yields a
`CALL`-to-sink edge **plus an unconditional call fall-through**, letting parsing
continue; `s_setpc_b64` stays a branch (return / tail call / jump table) and
never gets a fall-through. Recover direct/register-materialized targets with a
dedicated `CallTargetPred` backward slice over the `getpc`/`add`/`addc`/`mov`
affine chain, invoked from the call path when `getCFT()` fails and cached into
the CFT so `isDynamicCall()` and callee parsing stay consistent. Give
`s_call_b64` real decoder successors so its immediate target resolves directly.

**2. Fix MISC-class register reverse-conversion.** Reconstruct MISC registers
(`vcc`, `exec`, `flat_scratch`, `m0`) from a size-appropriate template
(`src_scc` for 1-bit flags, `vcc_lo` for 32-bit) preserving `arch|category|size`,
so `vcc`-materialized call targets resolve.

## Known limitation

Resolving a target across intervening calls currently treats `s_swappc` as
non-clobbering (the value is assumed to survive the call). That's correct when
the holding register is callee-saved, which is the case here, but it's an
unmodeled assumption — Dyninst has no AMDGPU calling-convention register model
(`ABI::initialize64` is a stub for these arches). Making it fully sound
(correctly refusing to resolve a target held in a caller-saved register)
requires populating the AMDGPU callee-saved/caller-saved sets and teaching the
call-clobber check that `s_swappc`/`s_call` are calls — a follow-up. Genuinely
indirect calls (target from memory / a live-in argument) correctly remain
unresolved (sink call edge + fall-through).

