### PR TITLE
dyninst-api -> dyninst-announce, add contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,14 @@ the main thread of a process
 * Stackwalker is fragile on Windows
 
 * Parsing a binary with no functions (typically a single object file) will crash at CodeObject destruction time.
+
+## Contacting the Dyninst Project
+
+Below are the mechanisms that are available for you to contact us about any
+concerns and to keep in touch with announcements related to Dyyninst.
+
+| Contact | Description |
+| :---: | :--- |
+| [Github issues](/dyninst/dyninst/issues) | Dyninst's issue tracker for problems wth building or the functioning of the Dyninst libraries including bugs or new feature requests. |
+| [Dyninst Announcements](https://groups.google.com/a/g-groups.wisc.edu/g/dyninst-announce/) | Mailing list of announcements related to Dyyninst. |
+| dyninst-team@g-groups.wisc.edu           | Email address to privately contact the Dyninst Team. |

--- a/common/doc/manual_frontpage.tex
+++ b/common/doc/manual_frontpage.tex
@@ -100,7 +100,7 @@
     \node [anchor=west,font=\sffamily] (email1) at ($(umd3.south west)+(-0.5em,-2.5em)$)
         %{Email \code{bugs@dyninst.org}};
         {\begin{tabular}{ll}%
-         Email & \texttt{dyninst-api@cs.wisc.edu} \\
+         Email & \texttt{dyninst-team@g-groups.wisc.edu} \\
          Web & \texttt{https://github.com/dyninst/dyninst} \\
         \end{tabular}};
         


### PR DESCRIPTION
Change dyninst-api@cs.wisc.edu to dynint-announce@g-groups.wisc.edu in the Dyninst manuals.

Also added a _Contacting the Dyninst Project_ to the README, with github issue link, the dyninst-announce mailing list, and the new dyninst-team@g-groups.wisc.edu email address.