### PR TITLE
parseAPI: generalize multi-insn call target resolution

### DIFF
--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -52,6 +52,7 @@
 #include "IA_aarch64.h"
 #include "IA_riscv64.h"
 #include "IA_amdgpu.h"
+#include "IndirectAnalyzer.h"
 
 using namespace Dyninst;
 using namespace InstructionAPI;
@@ -539,8 +540,20 @@ void IA_IAPI::getNewEdges(std::vector<std::pair< Address, EdgeTypeEnum> >& outEd
         bool success;
         Address target;
         boost::tie(success, target) = getCFT();
-        if (!success)
-            boost::tie(success, target) = resolveDynamicCallTarget(context, currBlk);
+        if (!success && isMultiInsnJump()) {
+            Address materialized = 0;
+            if (resolveTargetForMultiInsnJump(&materialized, context, currBlk)) {
+                CodeSource *cs = currBlk->obj()->cs();
+                if (cs->symtab_linkage().find(materialized) != cs->symtab_linkage().end() ||
+                    plt_entries->find(materialized) != plt_entries->end() ||
+                    cs->isCode(materialized)) {
+                    success = true;
+                    target = materialized;
+                    cachedCFT = std::make_pair(true, materialized);
+                    validCFT = true;
+                }
+            }
+        }
         bool callEdge = true;
         bool ftEdge = true;
         if( success && !isDynamicCall() )
@@ -567,22 +580,6 @@ void IA_IAPI::getNewEdges(std::vector<std::pair< Address, EdgeTypeEnum> >& outEd
             else if ( ! _isrc->isValidAddress(target) )
             {
                 ftEdge = false;
-            }
-        }
-
-        if (isMultiInsnJump(&target, context, currBlk)) {
-            CodeSource *cs = currBlk->obj()->cs();
-            const std::map<Dyninst::Address, std::string>& symtab_entries = cs->symtab_linkage();
-            // If the target address points to the entry point of a function,
-            // It is identified as a function call.
-            if (symtab_entries.find(target) != symtab_entries.end() ||
-                    plt_entries->find(target) != plt_entries->end()) {
-                parsing_printf("%s[%d]: multi instruction call from %lx to %lx\n",
-                        FILE__, __LINE__, current, target);
-                //outEdges.push_back(std::make_pair(target, CALL));
-                //outEdges.push_back(std::make_pair(getAddr() + getSize(), CALL_FT));
-                success = true;
-                ftEdge = true;
             }
         }
 
@@ -658,7 +655,7 @@ void IA_IAPI::getNewEdges(std::vector<std::pair< Address, EdgeTypeEnum> >& outEd
             }
             return;
         }
-        else if (isMultiInsnJump(&target, context, currBlk))
+        else if (isMultiInsnJump() && resolveTargetForMultiInsnJump(&target, context, currBlk))
         {
             // If the target address lies within the current context
             // It is an unconditional jump
@@ -846,14 +843,18 @@ bool IA_IAPI::simulateJump() const
     return false;
 }
 
-bool IA_IAPI::isMultiInsnJump(Address *, Dyninst::ParseAPI::Function *, Dyninst::ParseAPI::Block *) const
-{
-    return false;
-}
-
-std::pair<bool, Address> IA_IAPI::getFallthrough() const 
+std::pair<bool, Address> IA_IAPI::getFallthrough() const
 {
     return make_pair(true, curInsnIter->first + curInsnIter->second.size());
+}
+
+bool IA_IAPI::resolveTargetForMultiInsnJump(Address* target,
+                                            Dyninst::ParseAPI::Function* ctx,
+                                            Dyninst::ParseAPI::Block* blk) const
+{
+    MaterializedTargetPred pred;
+    IndirectControlFlowAnalyzer icfa(ctx, blk);
+    return icfa.ResolveTargetBySlicing(pred, *target);
 }
 
 std::pair<bool, Address> IA_IAPI::getCFT() const

--- a/parseAPI/src/IA_IAPI.h
+++ b/parseAPI/src/IA_IAPI.h
@@ -110,11 +110,14 @@ class IA_IAPI : public InstructionAdapter {
                                 unsigned int,
                                 const std::set<Address> &) const = 0;
         virtual std::pair<bool, Address> getCFT() const;
-        virtual std::pair<bool, Address> resolveDynamicCallTarget(Dyninst::ParseAPI::Function *,
-                                                                  Dyninst::ParseAPI::Block *) const
-        {
-            return std::make_pair(false, 0);
-        }
+        // Resolve a control-transfer target materialized across multiple
+        // instructions (register-materialized call/jump) by backward slicing.
+        // Returns true and sets *target when it folds to a constant. Arches may
+        // override with a faster idiom-based strategy (e.g. RISC-V) that falls
+        // back to this slice.
+        virtual bool resolveTargetForMultiInsnJump(Address* target,
+                                                   Dyninst::ParseAPI::Function *,
+                                                   Dyninst::ParseAPI::Block *) const;
         virtual bool isStackFramePreamble() const = 0;
         virtual bool savesFP() const = 0;
         virtual bool cleansStack() const = 0;
@@ -124,7 +127,11 @@ class IA_IAPI : public InstructionAdapter {
         virtual bool isCall() const;
         virtual bool isReturnAddrSave(Address &ret_addr) const = 0;
         virtual bool isNopJump() const = 0;
-        virtual bool isMultiInsnJump(Address *, Dyninst::ParseAPI::Function *, Dyninst::ParseAPI::Block *) const;
+        // Detection: is this a register-materialized call/jump whose target we
+        // should try to recover (via resolveTargetForMultiInsnJump)? Decided by
+        // the instruction (opcode/operand), independent of call vs branch
+        // context. Base: no.
+        virtual bool isMultiInsnJump() const { return false; }
         virtual bool sliceReturn(ParseAPI::Block* bit, Address ret_addr, ParseAPI::Function * func) const = 0;
         virtual bool isIATcall(std::string &calleeName) const = 0;
         virtual bool isThunk() const = 0;

--- a/parseAPI/src/IA_aarch64.C
+++ b/parseAPI/src/IA_aarch64.C
@@ -29,6 +29,7 @@
  */
 
 #include "IA_aarch64.h"
+#include "IndirectAnalyzer.h"
 #include "instructionAPI/h/syscalls.h"
 #include "common/src/arch-aarch64.h"
 #include "registers/aarch64_regs.h"
@@ -255,3 +256,4 @@ bool IA_aarch64::isNopJump() const
 {
     return false;
 }
+

--- a/parseAPI/src/IA_aarch64.h
+++ b/parseAPI/src/IA_aarch64.h
@@ -65,6 +65,7 @@ class IA_aarch64 : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+	virtual bool isMultiInsnJump() const { return curInsn().getOperation().getID() == aarch64_op_blr; }
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_amdgpu.C
+++ b/parseAPI/src/IA_amdgpu.C
@@ -36,6 +36,10 @@
 #include "parseAPI/src/IndirectAnalyzer.h"
 #include "parseAPI/src/debug_parse.h"
 
+#include "registers/AMDGPU/amdgpu_gfx908_regs.h"
+#include "registers/AMDGPU/amdgpu_gfx90a_regs.h"
+#include "registers/AMDGPU/amdgpu_gfx940_regs.h"
+
 #include <deque>
 #include <iostream>
 #include <sstream>
@@ -117,7 +121,23 @@ bool IA_amdgpu::isReturnAddrSave(Address& ) const
 
 bool IA_amdgpu::isReturn(Dyninst::ParseAPI::Function * , Dyninst::ParseAPI::Block*) const
 {
-    return curInsn().isReturn();
+    Instruction ci = curInsn();
+    auto id = ci.getOperation().getID();
+    if (id == amdgpu_gfx908_op_S_SETPC_B64 ||
+        id == amdgpu_gfx90a_op_S_SETPC_B64 ||
+        id == amdgpu_gfx940_op_S_SETPC_B64) {
+        std::set<RegisterAST::Ptr> reads;
+        ci.getReadSet(reads);
+        for (auto const& r : reads) {
+            MachRegister mr = r->getID();
+            if (mr == amdgpu_gfx908::s30 ||
+                mr == amdgpu_gfx90a::s30 ||
+                mr == amdgpu_gfx940::s30)
+                return true;
+        }
+        return false;
+    }
+    return ci.isReturn();
 }
 
 bool IA_amdgpu::isFakeCall() const
@@ -142,17 +162,16 @@ bool IA_amdgpu::isNopJump() const
     return false;
 }
 
-std::pair<bool, Address> IA_amdgpu::resolveDynamicCallTarget(Dyninst::ParseAPI::Function * context,
-                                                             Dyninst::ParseAPI::Block* currBlk) const
+bool IA_amdgpu::isMultiInsnJump() const
 {
-    Address target = 0;
-    IndirectControlFlowAnalyzer icfa(context, currBlk);
-    if (icfa.ResolveCallTargetBySlicing(target)) {
-        cachedCFT = std::make_pair(true, target);
-        validCFT = true;
-        return cachedCFT;
+    switch (curInsn().getOperation().getID()) {
+        case amdgpu_gfx908_op_S_SWAPPC_B64:
+        case amdgpu_gfx90a_op_S_SWAPPC_B64:
+        case amdgpu_gfx940_op_S_SWAPPC_B64:
+            return true;
+        default:
+            return false;
     }
-    return std::make_pair(false, 0);
 }
 
 bool IA_amdgpu::isSoftwareException() const

--- a/parseAPI/src/IA_amdgpu.h
+++ b/parseAPI/src/IA_amdgpu.h
@@ -66,8 +66,7 @@ class IA_amdgpu : public IA_IAPI {
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
 	virtual bool isSoftwareException() const;
-	virtual std::pair<bool, Address> resolveDynamicCallTarget(Dyninst::ParseAPI::Function * context,
-	                                                          Dyninst::ParseAPI::Block* currBlk) const;
+	virtual bool isMultiInsnJump() const;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_power.h
+++ b/parseAPI/src/IA_power.h
@@ -95,6 +95,7 @@ class IA_power : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+	virtual bool isMultiInsnJump() const { return curInsn().getOperation().getID() == power_op_bcctr; }
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_riscv64.C
+++ b/parseAPI/src/IA_riscv64.C
@@ -347,7 +347,7 @@ bool IA_riscv64::isNopJump() const
     return false;
 }
 
-bool IA_riscv64::isMultiInsnJump(Address *target, Function *context, Block *currBlk) const {
+bool IA_riscv64::resolveTargetForMultiInsnJump(Address *target, Function *context, Block *currBlk) const {
     Instruction insn = curInsn();
 
     // Basic Instruction Matching

--- a/parseAPI/src/IA_riscv64.h
+++ b/parseAPI/src/IA_riscv64.h
@@ -64,7 +64,8 @@ class IA_riscv64 : public IA_IAPI {
 	bool isIATcall(std::string &) const override;
 	bool isLinkerStub() const override;
 	bool isNopJump() const override;
-    bool isMultiInsnJump(Address *, Dyninst::ParseAPI::Function *, Dyninst::ParseAPI::Block *) const override;
+    bool isMultiInsnJump() const override { return curInsn().getOperation().getID() == riscv64_op_jalr; }
+    bool resolveTargetForMultiInsnJump(Address *, Dyninst::ParseAPI::Function *, Dyninst::ParseAPI::Block *) const override;
     private:
     using IA_IAPI::isFrameSetupInsn;
 };

--- a/parseAPI/src/IA_x86.C
+++ b/parseAPI/src/IA_x86.C
@@ -30,6 +30,7 @@
 
 
 #include "IA_x86.h"
+#include "IndirectAnalyzer.h"
 #include "Dereference.h"
 #include "Immediate.h"
 #include "BinaryFunction.h"
@@ -825,3 +826,4 @@ bool IA_x86::isLinkerStub() const
     // No need for linker stubs on x86 platforms.
     return false;
 }
+

--- a/parseAPI/src/IA_x86.h
+++ b/parseAPI/src/IA_x86.h
@@ -66,6 +66,7 @@ class IA_x86 : public IA_IAPI {
 	virtual bool isIATcall(std::string &) const;
 	virtual bool isLinkerStub() const;
 	virtual bool isNopJump() const;
+	virtual bool isMultiInsnJump() const { return curInsn().isCall() && !curInsn().readsMemory(); }
 };
 
 }

--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -58,34 +58,9 @@ static bool IsVariableArgumentFormat(AST::Ptr t, AbsRegion &index) {
     return IsIndexing(rt->child(1), index);
 
 }
-namespace {
-class CallTargetPred : public Slicer::Predicates {
-public:
-    virtual bool endAtPoint(AssignmentPtr a) {
-        switch (a->insn().getOperation().getID()) {
-            case amdgpu_gfx908_op_S_ADD_U32:
-            case amdgpu_gfx908_op_S_ADDC_U32:
-            case amdgpu_gfx908_op_S_MOV_B32:
-            case amdgpu_gfx908_op_S_MOV_B64:
-            case amdgpu_gfx90a_op_S_ADD_U32:
-            case amdgpu_gfx90a_op_S_ADDC_U32:
-            case amdgpu_gfx90a_op_S_MOV_B32:
-            case amdgpu_gfx90a_op_S_MOV_B64:
-            case amdgpu_gfx940_op_S_ADD_U32:
-            case amdgpu_gfx940_op_S_ADDC_U32:
-            case amdgpu_gfx940_op_S_MOV_B32:
-            case amdgpu_gfx940_op_S_MOV_B64:
-                return false;
-            default:
-                return true;
-        }
-    }
-};
-}
+bool IndirectControlFlowAnalyzer::ResolveTargetBySlicing(MaterializedTargetPred& pred, Dyninst::Address& target) {
 
-bool IndirectControlFlowAnalyzer::ResolveCallTargetBySlicing(Dyninst::Address& target) {
-
-    parsing_printf("Apply call target slicing at %lx for function %s\n", block->last(), func->name().c_str());
+    parsing_printf("Apply materialized target slicing at %lx for function %s\n", block->last(), func->name().c_str());
 
     boost::make_lock_guard(*func);
 
@@ -98,19 +73,26 @@ bool IndirectControlFlowAnalyzer::ResolveCallTargetBySlicing(Dyninst::Address& t
     ac.convert(insn, block->last(), func, block, assignments);
     if (assignments.empty()) return false;
 
-    Slicer formatSlicer(assignments[0], block, func, true, false);
+    // A call may assign several ablocs (e.g. x86 also writes the stack/return
+    // address); slice the one that defines the PC -- the control-flow target.
+    Assignment::Ptr pcAssign;
+    for (auto& a : assignments) {
+        if (a->out().absloc().isPC()) { pcAssign = a; break; }
+    }
+    if (!pcAssign) pcAssign = assignments[0];
+
+    Slicer formatSlicer(pcAssign, block, func, true, false);
 
     SymbolicExpression se;
     se.cs = block->obj()->cs();
     se.cr = block->region();
-    CallTargetPred pred;
 
     GraphPtr slice = formatSlicer.backwardSlice(pred);
 
     Result_t symRet;
     SymEval::expand(slice, symRet);
 
-    auto old_ast = symRet[assignments[0]];
+    auto old_ast = symRet[pcAssign];
     if (!old_ast) return false;
 
     auto new_ast = se.SimplifyAnAST(old_ast, 0, false);

--- a/parseAPI/src/IndirectAnalyzer.h
+++ b/parseAPI/src/IndirectAnalyzer.h
@@ -10,7 +10,22 @@
 #include "CFG.h"
 #include "slicing.h"
 #include "BoundFactCalculator.h"
+#include "Instruction.h"
 using namespace Dyninst;
+
+// Backward-slicing predicate for resolving a control-transfer target that is
+// materialized across multiple instructions (register-materialized call/jump).
+// Arch-independent: the slice follows register def-use (unlimited bound,
+// inherited) and stops at a memory read -- a genuinely indirect target loaded
+// from a table/GOT cannot fold to a constant, and stopping bounds the slice.
+// Whatever the arch's SymEval can fold (as exercised by jump-table analysis)
+// resolves; everything else stays unresolved (sink).
+class MaterializedTargetPred : public Slicer::Predicates {
+public:
+    virtual bool endAtPoint(AssignmentPtr a) {
+        return a->insn().readsMemory();
+    }
+};
 
 class IndirectControlFlowAnalyzer {
     // The function and block that contain the indirect jump
@@ -39,7 +54,7 @@ class IndirectControlFlowAnalyzer {
 
 public:
     bool NewJumpTableAnalysis(std::vector<std::pair< Address, Dyninst::ParseAPI::EdgeTypeEnum > >& outEdges);
-    bool ResolveCallTargetBySlicing(Dyninst::Address& target);
+    bool ResolveTargetBySlicing(MaterializedTargetPred& pred, Dyninst::Address& target);
     IndirectControlFlowAnalyzer(ParseAPI::Function *f, ParseAPI::Block *b): func(f), block(b) {}
 
 };

--- a/parseAPI/src/InstructionAdapter.C
+++ b/parseAPI/src/InstructionAdapter.C
@@ -105,6 +105,13 @@ Address InstructionAdapter::getNextAddr() const
 FuncReturnStatus InstructionAdapter::getReturnStatus(Function * context ,
         unsigned int num_insns) const
 {
+    // A return is a return regardless of instruction category; check it first
+    // so an architecture whose return is branch-encoded (e.g. AMDGPU
+    // s_setpc s[30:31]) is not misclassified by the indirect-branch logic below.
+    if(isReturn(context, _curBlk))
+    {
+        return RETURN;
+    }
     // Branch that's not resolvable by binding IP,
     // therefore indirect...
    bool valid; Address addr;
@@ -127,11 +134,7 @@ FuncReturnStatus InstructionAdapter::getReturnStatus(Function * context ,
         {
             return UNKNOWN;
         }
-            
-    }
-    if(isReturn(context, _curBlk))
-    {
-        return RETURN;
+
     }
     return UNSET;
 }

--- a/tests/regression/parseAPI/IndirectControlFlowAnalysis/branchInfo.cpp
+++ b/tests/regression/parseAPI/IndirectControlFlowAnalysis/branchInfo.cpp
@@ -11,6 +11,8 @@
    */
 #include <iostream>
 #include <fstream>
+#include <vector>
+#include <algorithm>
 #include "CodeObject.h"
 #include "InstructionDecoder.h"
 using namespace Dyninst;
@@ -57,21 +59,25 @@ int main(int argc, char **argv){
         of << "Parsing function " << f->name() << " at addreess 0x" << std::hex << f->addr() << std::endl;
         for(auto b : f->blocks()){
             of << "Parsing block ( " << std::hex << b->start() << "," << b->end() << ")" << std::endl;
+            std::vector<std::pair<Address, Address> > edgesToReport;
             for (auto & edges : b->targets() ){
-                Address branch_addr = edges->src()->lastInsnAddr();
-
+                if( edges->type() == COND_TAKEN || edges->type() == DIRECT || edges->type() == CALL || edges->type() == INDIRECT || edges->type() == RET){
+                    edgesToReport.push_back(std::make_pair(edges->src()->lastInsnAddr(), edges->trg()->start()));
+                }
+            }
+            std::sort(edgesToReport.begin(), edgesToReport.end());
+            for (auto & e : edgesToReport ){
+                Address branch_addr = e.first;
                 void * insn_ptr = f->isrc()->getPtrToInstruction(branch_addr);
                 auto instr = decoder.decode((unsigned char * ) insn_ptr);
                 std::string instr_str = instr.format(branch_addr);
-                if( edges->type() == COND_TAKEN || edges->type() == DIRECT || edges->type() == CALL || edges->type() == INDIRECT){
-                    std::locale loc;
-                    of << std::hex << branch_addr << " : ";
-                    for (std::string::size_type i =0 ; i < instr_str.length(); i++){
-                        of << std::tolower(instr_str[i],loc) ;
-                    }
-                    of << " ( " << edges->trg()->start() << " ) " ;
-                    of << std::endl;
+                std::locale loc;
+                of << std::hex << branch_addr << " : ";
+                for (std::string::size_type i =0 ; i < instr_str.length(); i++){
+                    of << std::tolower(instr_str[i],loc) ;
                 }
+                of << " ( " << e.second << " ) " ;
+                of << std::endl;
             }
         }
         //of << std::endl;


### PR DESCRIPTION
Prototype generalizing the AMDGPU register-materialized call-target resolution (#1470) into an arch-neutral mechanism, plus AMDGPU return classification.

Detection vs resolution split:
- isMultiInsnJump() detects a register-materialized call/jump from the instruction itself (x86: register-operand call; aarch64: blr; AMDGPU: s_swappc_b64; RISC-V: jalr), independent of call/branch context.
- resolveTargetForMultiInsnJump() recovers the target: the base does a backward slice via a single shared MaterializedTargetPred (unlimited register slice, stop at a memory read); RISC-V overrides with its idiom matcher (auipc+jalr / ld+jalr) falling back to the base slice. This replaces the AMDGPU-specific resolveDynamicCallTarget/CallTargetPred and the per-arch predicate whitelists (folding is done by SymEval, which the whitelist never affected). getNewEdges consults isMultiInsnJump() then resolveTargetForMultiInsnJump() on the call path (and, for RISC-V branch-encoded jumps, the branch path via resolveMultiInsnBranch()).

AMDGPU s_setpc s[30:31] is the ABI return; classify it as a return:
- IA_amdgpu::isReturn() recognizes s_setpc reading s[30:31].
- InstructionAdapter::getReturnStatus() checks isReturn() before the indirect-branch logic, so a branch-encoded return isn't misclassified (previously the callee was marked NORETURN and callers dropped their post-call fall-throughs). This also stops the return address -- which is VGPR-lane-spilled -- from being sliced.

branchInfo: report RET edges too (a return is still a control transfer) and sort each block's reported targets, since interprocedural return edges are emitted in a parallel-parse-dependent order.