### PR TITLE
PowerPC: exclude ifunc resolvers from relocation-based instrumentation

### DIFF
--- a/dyninstAPI/src/Relocation/CodeMover.C
+++ b/dyninstAPI/src/Relocation/CodeMover.C
@@ -37,12 +37,16 @@
 
 #include "dyninstAPI/src/addressSpace.h" // Also for debug
 #include "patching/function.h"
+#include "dyninstAPI/src/mapped_object.h"  // func_instance::obj() -> parse_img()
+#include "dyninstAPI/src/image.h"          // image::getObject() -> SymtabAPI::Symtab
 
 #include "dyninstAPI/src/debug.h"
 #include "CodeTracker.h"
 #include "CFG/RelocGraph.h"
 
 #include <iterator>  // std::distance (rewrite-progress reporting)
+#include <map>       // ifunc-resolver exclusion cache
+#include <set>
 
 using namespace std;
 using namespace Dyninst;
@@ -77,11 +81,47 @@ bool CodeMover::addFunctions(FuncSet::const_iterator begin,
    // rewrite (e.g. a multi-hundred-MB shared library) can look hung for a long time.
    progress_printf("relocate: building reloc blocks for %zu functions\n",
                    (size_t)std::distance(begin, end));
+
+   // Per-object cache of ifunc-resolver entry offsets (STT_GNU_IFUNC symbols,
+   // Symbol::ST_INDIRECT). ifunc resolvers are invoked by ld.so during dynamic
+   // relocation (before main, before the PLT/GOT is filled and before any
+   // Dyninst runtime/base-tramp exists). Relocating one produces a copy that
+   // calls through an unfilled PLT stub -> branch to 0 -> SIGSEGV at startup
+   // (observed rewriting libc on ppc64le ELFv2). They must stay at their
+   // original addresses, unrelocated and un-springboarded; the IRELATIVE reloc
+   // keeps pointing at the original resolver, and ld.so runs it correctly so
+   // callers still reach the resolved implementation.
+   std::map<mapped_object *, std::set<Offset> > ifuncResolverOffsets;
+   auto isIfuncResolver = [&ifuncResolverOffsets](func_instance *func) -> bool {
+      mapped_object *obj = func->obj();
+      if (!obj) return false;
+      auto it = ifuncResolverOffsets.find(obj);
+      if (it == ifuncResolverOffsets.end()) {
+         std::set<Offset> offs;
+         image *img = obj->parse_img();
+         SymtabAPI::Symtab *symtab = img ? img->getObject() : NULL;
+         if (symtab) {
+            std::vector<SymtabAPI::Symbol *> syms;
+            if (symtab->getAllSymbolsByType(syms, SymtabAPI::Symbol::ST_INDIRECT)) {
+               for (SymtabAPI::Symbol *s : syms) offs.insert(s->getOffset());
+            }
+         }
+         it = ifuncResolverOffsets.emplace(obj, std::move(offs)).first;
+      }
+      if (it->second.empty()) return false;
+      return it->second.count(func->ifunc()->addr()) != 0;
+   };
+
    // A vector of Functions is just an extended vector of basic blocks...
    for (; begin != end; ++begin) {
       func_instance *func = *begin;
       if (!func->isInstrumentable()) {
 	relocation_cerr << "\tFunction " << func->symTabName() << " is non-instrumentable, skipping" << endl;
+         continue;
+      }
+      if (isIfuncResolver(func)) {
+         relocation_cerr << "\tFunction " << func->symTabName()
+                         << " is an ifunc resolver; leaving in place (runs in ld.so before instrumentation is live)" << endl;
          continue;
       }
       relocation_cerr << "\tAdding function " << func->symTabName() << endl;


### PR DESCRIPTION
## Summary

When rewriting a shared library, Dyninst relocated/instrumented `STT_GNU_IFUNC` **resolver** functions along with everything else. On PowerPC64 (ELFv2) this makes the rewritten library crash at process startup, before `main`. This change excludes ifunc resolvers from relocation so they remain at their original addresses.

## Problem

An ifunc resolver is invoked by the dynamic linker during `_dl_relocate_object` (the `IRELATIVE`/BIND_NOW pass), i.e. very early in startup — before the PLT/GOT slots are populated and before any Dyninst runtime or base-tramp exists. If Dyninst has relocated the resolver, the relocated copy makes an indirect call through a PLT stub whose `.plt` slot is still zero:

```
std   r2,24(r1)
ld    r12,-<off>(r2)   ; .plt slot not yet filled by ld.so -> 0
mtctr r12              ; ctr = 0
bctr                   ; -> PC = 0  -> SIGSEGV, before main
```

This reproduces on ppc64le when rewriting `libc.so.6` (e.g. the `test_reloc` test): the relocated `strlen` ifunc resolver crashes the process at load time.

## Fix

In `CodeMover::addFunctions`, build a per-object set of the entry offsets of `STT_GNU_IFUNC` (`Symbol::ST_INDIRECT`) symbols and skip any function whose entry address is in that set. Excluded resolvers are never relocated or springboarded; their `IRELATIVE` relocation keeps pointing at the original resolver.

## Why this is safe

Callers of an ifunc symbol never call the resolver directly — they reach the chosen implementation through the PLT/GOT, which `ld.so` fills by running the (now unmodified, correct) resolver once at load time. So the resolver's original code runs, the right implementation is selected, and every caller works. The implementations and the callers remain fully instrumentable; only the resolver itself — which cannot be safely instrumented, since it runs inside the dynamic linker before the instrumentation runtime exists — is left untouched.

## Testing (ppc64le / POWER9)

- The rewritten `libc`'s `strlen` ifunc resolver is left as original code (no inserted branch to a relocated copy); the ld.so startup SIGSEGV is gone.
- Register-preservation / relocation tests (`test1_8`, `test1_9`, `test1_20`, `test1_22`) pass in both create and rewriter modes, i.e. normal instrumentation is unaffected.