### PR TITLE
instructionAPI: don't decode conditional returns (bclr) as unconditional

### DIFF
--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -291,19 +291,18 @@ which are both 0).
       }
       else {
         // 2. The conventional return sequence is to use `bclr` with BH=0b00
-        bool const is_subroutine_return = [this]() {
-          auto const bh_field = field<19,20>(insn);
-          return bh_field == 0;
-        }();
-
-        if(is_subroutine_return) {
-          // This is _not_ a fallthrough conditional
-          this->bcIsConditional = false;
-
-          // Indirectly branch through the link register
-          auto lr = makeRegisterExpression(ppc32::lr);
-          insn_in_progress->addSuccessor(lr, !is_call, is_indirect, !is_conditional, !is_fallthrough);
-        }
+        //
+        // BH is only a usage hint, though: whether the branch is taken is
+        // governed solely by BO (and BI). Conditional returns -- beqlr,
+        // bnelr, bdnzlr, etc. -- also use BH=0b00, so classifying every
+        // BH=0b00 bclr as an unconditional return would drop the fallthrough
+        // successor of conditional returns. That truncates parsing of any
+        // function at its first conditional return, and the binary rewriter
+        // then lays out unrelated code where the not-taken path falls
+        // through. Use the conditionality derived from BO in BO() instead.
+        auto lr = makeRegisterExpression(ppc32::lr);
+        insn_in_progress->addSuccessor(std::move(lr), !is_call, is_indirect,
+                                       this->bcIsConditional, !is_fallthrough);
       }
 
       if(bcIsConditional) {

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -286,8 +286,13 @@ which are both 0).
 
       if(LK == 1) {
         // 1. Do not use bclrl as a subroutine call
+        //
+        // As with the LK=0 case below, whether the branch is taken is
+        // governed by BO, so use the conditionality derived in BO() rather
+        // than marking the LR successor unconditionally conditional.
         auto lr = makeRegisterExpression(ppc32::lr);
-        insn_in_progress->addSuccessor(std::move(lr), !is_call, is_indirect, is_conditional, !is_fallthrough);
+        insn_in_progress->addSuccessor(std::move(lr), !is_call, is_indirect, this->bcIsConditional,
+                                       !is_fallthrough);
       }
       else {
         // 2. The conventional return sequence is to use `bclr` with BH=0b00

--- a/tests/integration/InstructionAPI/decoder/ppc64le/branches.cpp
+++ b/tests/integration/InstructionAPI/decoder/ppc64le/branches.cpp
@@ -329,13 +329,13 @@ std::vector<test_insn> make_tests() {
       {},
       test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}},
     },
-    { //  bnslr
-      0x4ca30020, !is_branch, is_return,
+    { //  bnslr  (conditional return: keeps its fallthrough successor)
+      0x4ca30020, is_branch, !is_return,
       {},
       {},
-      test_cft{lr_value, {!is_call, !is_conditional, is_indirect, !is_fallthrough}},
+      test_cft{lr_value, {!is_call, is_conditional, is_indirect, !is_fallthrough}},
       {},
-      {}
+      test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}}
     },
 
     /*

--- a/tests/integration/InstructionAPI/decoder/ppc64le/branches.cpp
+++ b/tests/integration/InstructionAPI/decoder/ppc64le/branches.cpp
@@ -303,13 +303,10 @@ std::vector<test_insn> make_tests() {
       {}
     },
     { // bclrl  (LK=1; BO=branch-always)
-      // The LR target is still marked conditional even though BO says
-      // branch-always (there is no fallthrough successor, so the flag is
-      // inconsistent); this documents current decoder behavior.
       0x4e800021, !is_branch, is_return,
       {},
       {},
-      test_cft{lr_value, {!is_call, is_conditional, is_indirect, !is_fallthrough}},
+      test_cft{lr_value, {!is_call, !is_conditional, is_indirect, !is_fallthrough}},
       {},
       {}
     },


### PR DESCRIPTION
The bclr (LK=0) handler classifies every bclr with BH=0b00 as "the conventional subroutine return" and force-clears the conditionality that BO() derived from the BO field:

    bool const is_subroutine_return = (BH == 0);
    if (is_subroutine_return) {
      this->bcIsConditional = false;        // ignores BO entirely
      ...unconditional LR successor, no fallthrough...
    }

BH is only a usage hint, though: whether the branch is taken is governed solely by BO (and BI). Conditional returns -- beqlr, bnelr, bdnzlr, ... -- also use BH=0b00, so they decode exactly like blr: an unconditional indirect branch with no fallthrough successor. (The bcctr handler right below gets this right by testing (BO & 0b10100) == 0b10100; the bclr handler never checks BO.)

ParseAPI consequently ends the block at a conditional return with no fallthrough edge, truncating the function there. In the binary rewriter this is fatal: the relocated copy of the truncated function is laid out with unrelated code immediately after it, and the conditional return's not-taken path falls through into that code at run time.

Observed failure (ppc64le, testsuite test_reloc rewriter mode, which rewrites libstdc++): the ~basic_string() D1 destructor begins with the SSO check

    addi  r9,r3,16
    ld    r3,0(r3)
    cmpd  cr7,r3,r9
    beqlr cr7              <- decoded as blr; destructor truncated here
    ...
    bl    <operator delete>   <- never parsed, never relocated

The relocated destructor consists of only that block, and the block laid out after it happens to be the body of basic_string::operator=. For a heap-allocated global string the beqlr falls through into operator=, which calls _M_assign(this, src) with the src argument register r4 never set -- the destructor was invoked by __cxa_finalize as func(obj), passing only r3. _M_assign dereferences r4=NULL and the process dies inside exit() after main() returned, reported as "CRASHED (Group Teardown)".

Fix: in the bclr LK=0 path, keep the BO-derived conditionality (bcIsConditional) instead of overriding it based on BH. Conditional returns now get a conditional LR successor plus a fallthrough successor; unconditional blr is unchanged, as are bcctr and B-form bc.

Decoded successors (before -> after):

  beqlr cr7  : {ind}                  -> {ind,cond} {fallthrough}
  bnelr cr7  : {ind}                  -> {ind,cond} {fallthrough}
  bdnzlr     : {ind}                  -> {ind,cond} {fallthrough}
  blr        : {ind}                  -> unchanged
  bctr       : {ind}                  -> unchanged
  beqctr cr7 : {ind,cond} {ft}        -> unchanged

Verified on ppc64le (RHEL 8, gcc 8.5): the rewritten libstdc++ no longer crashes at exit, and the previously failing testsuite run

    test_reloc g++ none 64 rewriter dynamic nonPIC: CRASHED -> PASSED

This is the XL-form sibling of the B-form BO mis-decode ("bc decoded as branch-always"); both are regressions introduced by #1929.