### PR TITLE
instructionAPI: decode isel for all condition-bit values

### DIFF
--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -966,6 +966,19 @@ which are both 0).
         return invalid_entry;
       return entry_it->second;
     }
+    // isel is A-form: its extended opcode is only bits 26-30 (value 15);
+    // bits 21-25 hold the BC (condition-bit) operand, and per the ISA the
+    // whole 10-bit-XO column 0b01111 belongs to isel. The generic 9/10-bit
+    // XO lookups below therefore only match the table's isel entry when
+    // BC == 0, and every other condition decoded as INVALID -- which
+    // ParseAPI conservatively treats as an unknown control transfer,
+    // truncating the enclosing function at a plain conditional move.
+    if(field<26, 30>(insn) == 15) {
+      const power_table::const_iterator entry_it = power_entry::extended_op_31.find(15);
+      if(entry_it == power_entry::extended_op_31.end())
+        return invalid_entry;
+      return entry_it->second;
+    }
     const power_entry* xoform_entry;
     const power_table::const_iterator entry_it =
         power_entry::extended_op_31.find(field<22, 30>(insn));

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -696,8 +696,11 @@ which are both 0).
   }
 
   void InstructionDecoder_power::BC() {
-    //        fprintf(stderr, "Unimplemented operand type BC. Please create an issue at
-    //        https://github.com/dyninst/dyninst/issues\n");
+    // BC (bits 21-25) selects the condition-register bit tested by isel;
+    // model it as a read of the containing CR field, as BFA does.
+    Expression::Ptr condReg =
+        makeRegisterExpression(makePowerRegID(ppc32::cr0, field<21, 25>(insn) >> 2));
+    insn_in_progress->appendOperand(std::move(condReg), true, false);
   }
 
   void InstructionDecoder_power::RC() {

--- a/tests/integration/InstructionAPI/decoder/ppc64le/decode.cpp
+++ b/tests/integration/InstructionAPI/decoder/ppc64le/decode.cpp
@@ -76,11 +76,15 @@ std::vector<decode_test> make_tests() {
   auto r0 = Dyninst::ppc32::r0;
   auto r1 = Dyninst::ppc32::r1;
   auto r2 = Dyninst::ppc32::r2;
+  auto r3 = Dyninst::ppc32::r3;
+  auto r4 = Dyninst::ppc32::r4;
   auto r5 = Dyninst::ppc32::r5;
   auto r7 = Dyninst::ppc32::r7;
   auto r8 = Dyninst::ppc32::r8;
   auto r9 = Dyninst::ppc32::r9;
+  auto r10 = Dyninst::ppc32::r10;
   auto cr0 = Dyninst::ppc32::cr0;
+  auto cr1 = Dyninst::ppc32::cr1;
   auto cr2 = Dyninst::ppc32::cr2;
   auto cr4 = Dyninst::ppc32::cr4;
   auto cr6 = Dyninst::ppc32::cr6;
@@ -213,6 +217,28 @@ std::vector<decode_test> make_tests() {
     { // bctrl (LK=1; BO=branch-always)
       0x4e800421,
       di::register_rw_test{ reg_set{lr, ctr}, reg_set{lr, pc} }
+    },
+    /*
+     *  isel is A-form: XO is only bits 26-30 (value 15) and bits 21-25 are
+     *  the BC (condition-bit) operand, so only the BC=0 encoding is found by
+     *  the generic 9/10-bit XO lookups; the others decoded as INVALID until
+     *  the dispatch handled the A-form split.
+     *
+     *  The BC operand is modeled as a read of the containing CR field;
+     *  RA=0 is decoded as a read of r0 (documents current decoder
+     *  behavior).
+     */
+    { // isel r3, r4, r5, 0  (isellt; BC=0 -> cr0)
+      0x7c64281e,
+      di::register_rw_test{ reg_set{r4, r5, cr0}, reg_set{r3} }
+    },
+    { // isel r10, 0, r10, 30  (BC=30 -> cr7; glibc _IO_old_init)
+      0x7d40579e,
+      di::register_rw_test{ reg_set{r0, r10, cr7}, reg_set{r10} }
+    },
+    { // isel r7, r8, r9, 6  (BC=6 -> cr1)
+      0x7ce8499e,
+      di::register_rw_test{ reg_set{r8, r9, cr1}, reg_set{r7} }
     },
   };
   // clang-format on


### PR DESCRIPTION
Title: instructionAPI: decode isel for all condition-bit values

isel is an A-form instruction under primary opcode 31: its extended opcode is
only bits 26-30 (value 0b01111 = 15), and bits 21-25 hold the BC (condition
bit) operand. The opcode table has the instruction at `extended_op_31[15]`,
but the opcode-31 dispatch only performs 9-bit (`field<22,30>`) and 10-bit
(`field<21,30>`) XO lookups, so the entry is found only when BC == 0. Every
other isel -- e.g. glibc's

    9b680:  isel r10,0,r10,30        (in _IO_old_init)

-- decodes as INVALID.

ParseAPI conservatively treats an undecodable instruction as an unknown
control transfer, ending the block with an edge to the sink and leaving the
rest of the function unparsed. The consequences cascade:

- `_IO_old_init` is truncated at the isel, its beqlr/blr become unreachable,
  and the function is marked NORETURN;
- the NORETURN poisons its callers (`_IO_no_init`, `_IO_init`,
  `_IO_init_internal`): their post-call blocks lose the call-fallthrough edge
  and are dropped;
- the binary rewriter and relocation-based instrumentation then emit those
  callers truncated right after the call, so at run time the call's return
  falls through into whatever code is laid out next. In the testsuite's
  test_reloc (create mode, ppc64le) the relocated `_IO_no_init` fell into the
  body of `_IO_init`, which calls `_IO_no_init` again: infinite mutual
  recursion until stack overflow, crashing the instrumented process inside
  exit().

**Commit 1 -- `instructionAPI: decode isel for all condition-bit values`**

Match the isel column directly in the opcode-31 dispatch (the ISA reserves
the whole XO column 0b01111 for isel, and the table holds no other key
congruent to 15 mod 32), the same way the dispatch already special-cases
sradi's 9-bit XO.

**Commit 2 -- `instructionAPI: model the isel BC operand`**

The BC operand decoder was an unimplemented stub, so isel carried no trace of
the condition-register bit it tests: the CR read was missing from the
instruction's register read set (liveness/dataflow around an isel saw CR as
dead) and the operand was absent from `format()`. Model it as a read of the
containing CR field, the same way `BFA` does. isel is the only opcode-table
entry using BC, so nothing else changes. (`BI` is intentionally left as-is:
for branches the CR-bit read is appended conditionally in `BO()`, which knows
whether BO actually tests it -- that is what keeps branch-always encodings
CR-free per #2335.)

**Commit 3 -- `tests/ppc64le: add isel decode coverage`**

Three isel encodings, assembler-verified on ppc64le:

| encoding | instruction | note |
|---|---|---|
| `0x7c64281e` | `isel r3,r4,r5,0` (isellt) | BC=0, the only form the old dispatch found |
| `0x7d40579e` | `isel r10,0,r10,30` | the glibc `_IO_old_init` regression case |
| `0x7ce8499e` | `isel r7,r8,r9,6` | mid-range BC, third CR field |

Expected sets: reads {RA, RB, crN} (cr0/cr7/cr1 respectively), writes {RT};
RA=0 decodes as a read of r0 (documents current decoder behavior). The crN
read expectations are the test coverage for commit 2; without commit 1 the
two BC!=0 entries fail to decode (verified as a negative control against the
master decoder).

**Verification**

- Decoding verified for BC=0 and BC!=0 (valid, no control-flow successors,
  unchanged otherwise); on ppc64le the previously-crashing
  `test_reloc g++ none 64 create dynamic nonPIC: CRASHED -> PASSED`, with
  `_IO_old_init` parsing as RETURN and its callers keeping their
  call-fallthrough edges.
- Full integration test suite (`ctest -L integration`): 20/20 on x86_64 and
  20/20 on native ppc64le (POWER9).