### PR TITLE
dyninstAPI: repair ppc64le findMain for stripped PIE binaries

### DIFF
--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -148,6 +148,7 @@ int codeBytesSeen = 0;
 #include <dataflowAPI/h/AbslocInterface.h>
 #include <dataflowAPI/h/Absloc.h>
 #include <dataflowAPI/h/DynAST.h>
+#include <instructionAPI/h/InstructionAST.h>
 
 namespace {
     /* On PPC GLIBC (32 & 64 bit) the address of main is in a structure
@@ -282,10 +283,27 @@ namespace {
         RegisterAST::Ptr r2( new RegisterAST(ppc32::r2) );
         RegisterAST::Ptr r8( new RegisterAST(ppc32::r8) );
 
+        // Register operands produced by the decoder are normalized to the
+        // decoding architecture (ppc64) but do not necessarily carry the
+        // same bit range as a RegisterAST built directly from a ppc64
+        // register. RegisterAST equality -- used by Instruction::isWritten/
+        // isRead and Expression::bind -- compares the register id AND the
+        // bit range, so those queries silently never match here. Match and
+        // bind registers by id instead.
+        auto usesRegID = [](std::set<RegisterAST::Ptr> const& regs,
+                            MachRegister reg) {
+            for (std::set<RegisterAST::Ptr>::const_iterator i = regs.begin();
+                 i != regs.end(); ++i)
+                if ((*i)->getID() == reg) return true;
+            return false;
+        };
+
         Address cur_addr = b->start();
         while(cur_addr < b->end()) {
             Instruction cur = dec.decode();
-            if(cur.isWritten(r8)) {
+            std::set<RegisterAST::Ptr> written;
+            cur.getWriteSet(written);
+            if(usesRegID(written, ppc64::r8)) {
                 find = true;
                 r8_def = cur;
                 r8_def_addr = cur_addr;  
@@ -298,13 +316,38 @@ namespace {
         Address ss_addr = 0;
 
         // Try a TOC-based lookup first
-        if (r8_def.isRead(r2)) {
+        std::set<RegisterAST::Ptr> readRegs;
+        r8_def.getReadSet(readRegs);
+        if (usesRegID(readRegs, ppc64::r2)) {
             set<Expression::Ptr> memReads;
             r8_def.getMemoryReadOperands(memReads);
             Address TOC = f->obj()->cs()->getTOC(r8_def_addr);
+            // ELFv2 (ppc64le) has no .opd section, so the code source's TOC
+            // table is empty and getTOC() returns 0 for every address.
+            // Derive the TOC from the function's global entry point instead:
+            // the ABI-prescribed entry sequence
+            //     addis r2,r12,H ; addi r2,r2,L
+            // with r12 holding the entry address gives
+            //     TOC = entry + (H << 16) + L.
+            if (TOC == 0) {
+                const uint32_t *entry_code = (const uint32_t *)
+                    b->region()->getPtrToInstruction(f->addr());
+                if (entry_code
+                    && (entry_code[0] & 0xffff0000) == 0x3c4c0000  // addis r2,r12,H
+                    && (entry_code[1] & 0xffff0000) == 0x38420000) // addi  r2,r2,L
+                {
+                    TOC = f->addr()
+                        + ((Address)(int16_t)(entry_code[0] & 0xffff) << 16)
+                        + (Address)(int16_t)(entry_code[1] & 0xffff);
+                }
+            }
             if (TOC != 0 && memReads.size() == 1) {
                 Expression::Ptr expr = *memReads.begin();
-                expr->bind(r2.get(), Result(u64, TOC));
+                // Bind the r2 instance used by the expression itself so the
+                // bind's equality test matches it.
+                for (RegisterAST::Ptr const& ru : getUsedRegisters(expr))
+                    if (ru->getID() == ppc64::r2)
+                        expr->bind(ru.get(), Result(u64, TOC));
                 const Result &res = expr->eval();
                 if (res.defined) {
                     void *res_addr =

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -324,21 +324,29 @@ namespace {
             Address TOC = f->obj()->cs()->getTOC(r8_def_addr);
             // ELFv2 (ppc64le) has no .opd section, so the code source's TOC
             // table is empty and getTOC() returns 0 for every address.
-            // Derive the TOC from the function's global entry point instead:
-            // the ABI-prescribed entry sequence
+            // Derive the TOC from the function's global entry point instead.
+            // The ABI-prescribed entry sequence
             //     addis r2,r12,H ; addi r2,r2,L
             // with r12 holding the entry address gives
-            //     TOC = entry + (H << 16) + L.
+            //     TOC = entry + (H << 16) + L,
+            // and the linker may relax it (static links below 2 GB) to the
+            // absolute form
+            //     lis r2,H ; addi r2,r2,L    =>    TOC = (H << 16) + L.
+            // (POWER10 pc-relative code sets up no TOC at all; its r8 load
+            // does not read r2, so this branch is never reached for it.)
             if (TOC == 0) {
                 const uint32_t *entry_code = (const uint32_t *)
                     b->region()->getPtrToInstruction(f->addr());
                 if (entry_code
-                    && (entry_code[0] & 0xffff0000) == 0x3c4c0000  // addis r2,r12,H
-                    && (entry_code[1] & 0xffff0000) == 0x38420000) // addi  r2,r2,L
+                    && f->addr() + 8 <= b->region()->high()
+                    && (entry_code[1] & 0xffff0000) == 0x38420000) // addi r2,r2,L
                 {
-                    TOC = f->addr()
-                        + ((Address)(int16_t)(entry_code[0] & 0xffff) << 16)
-                        + (Address)(int16_t)(entry_code[1] & 0xffff);
+                    Address hi = (Address)(int16_t)(entry_code[0] & 0xffff) << 16;
+                    Address lo = (Address)(int16_t)(entry_code[1] & 0xffff);
+                    if ((entry_code[0] & 0xffff0000) == 0x3c4c0000)      // addis r2,r12,H
+                        TOC = f->addr() + hi + lo;
+                    else if ((entry_code[0] & 0xffff0000) == 0x3c400000) // lis r2,H
+                        TOC = hi + lo;
                 }
             }
             if (TOC != 0 && memReads.size() == 1) {

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -544,26 +544,34 @@ int image::findMain()
                 return -1;
             }
 
-            Block * b = NULL;
+            // Candidate blocks for the __libc_start_main call setup:
+            // glibc's dynamic _start makes the call from its entry block,
+            // but a tail-branching _start (static link) parses into one
+            // function with several call edges further in.
+            // evaluate_main_address() is fail-to-zero per block, so rather
+            // than guessing the one right block, try the entry block and
+            // then each call-edge source until one yields a valid address.
+            std::vector<Block *> candidates;
+            Block * entryBlock = tco.findBlockByEntry(reg,eAddr);
+            if (entryBlock)
+                candidates.push_back(entryBlock);
             const Function::edgelist & calls = func->callEdges();
-            if (calls.empty()) {
-                // when there are no calls, let's hope the entry block is it
-                b = tco.findBlockByEntry(reg,eAddr);
-            } else if(calls.size() == 1) {
-                Function::edgelist::iterator cit = calls.begin();
-                b = (*cit)->src();
-            } else {
-                startup_printf("%s[%d] _start has unexpected number (%lu) of"
-                        " call edges, bailing on findMain()\n",
-                        FILE__,__LINE__,calls.size());
-                return -1;
+            for (Function::edgelist::const_iterator cit = calls.begin();
+                 cit != calls.end(); ++cit) {
+                if ((*cit)->src() && (*cit)->src() != entryBlock)
+                    candidates.push_back((*cit)->src());
             }
-            if (!b) return -1;
 
-            Address mainAddress = evaluate_main_address(linkedFile,func,b);
-            mainAddress = deref_opd(linkedFile, mainAddress);
+            Address mainAddress = 0;
+            for (std::vector<Block *>::const_iterator bit = candidates.begin();
+                 bit != candidates.end() && mainAddress == 0; ++bit) {
+                Address cand = evaluate_main_address(linkedFile,func,*bit);
+                cand = deref_opd(linkedFile, cand);
+                if (cand != 0 && scs.isValidAddress(cand))
+                    mainAddress = cand;
+            }
 
-            if(0 == mainAddress || !scs.isValidAddress(mainAddress)) {
+            if(0 == mainAddress) {
                 startup_printf("%s[%d] failed to find main\n",FILE__,__LINE__);
                 return -1;
             } else {

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -280,9 +280,6 @@ namespace {
             b->end()-b->start(),
             b->region()->getArch());
 
-        RegisterAST::Ptr r2( new RegisterAST(ppc32::r2) );
-        RegisterAST::Ptr r8( new RegisterAST(ppc32::r8) );
-
         // Register operands produced by the decoder are normalized to the
         // decoding architecture (ppc64) but do not necessarily carry the
         // same bit range as a RegisterAST built directly from a ppc64
@@ -292,9 +289,8 @@ namespace {
         // bind registers by id instead.
         auto usesRegID = [](std::set<RegisterAST::Ptr> const& regs,
                             MachRegister reg) {
-            for (std::set<RegisterAST::Ptr>::const_iterator i = regs.begin();
-                 i != regs.end(); ++i)
-                if ((*i)->getID() == reg) return true;
+            for (auto const& i : regs)
+                if (i->getID() == reg) return true;
             return false;
         };
 
@@ -377,7 +373,7 @@ namespace {
             for( ; ait != assigns.end(); ++ait) {
                 AbsRegion & outReg = (*ait)->out();
                 Absloc const& loc = outReg.absloc();
-                if(loc.reg() == r8->getID())
+                if(loc.reg() == ppc64::r8)
                     break;
             }
             if(ait == assigns.end()) {


### PR DESCRIPTION
Creating a process from a stripped executable fails to bootstrap on
ppc64le (BPatch reports fatal error 68, "create process failed
bootstrap"). Without a `main` symbol, `image::findMain()` runs the
`evaluate_main_address()` heuristic -- locate the `start_addresses`
structure that `_start` passes to `__libc_start_main` in r8 and read
`main`'s address from its second field -- and on ppc64le that heuristic
never succeeds, so the bootstrap breakpoint at `main` cannot be
inserted. The testsuite's `test_pt_ls` (parseThat on `/bin/ls`, create
mode) fails this way.

**Commit 1 -- `dyninstAPI: repair ppc64le findMain for stripped PIE binaries`**

Two independent defects:

1. *The register queries never matched.* The heuristic scans `_start`'s
   block with `Instruction::isWritten(RegisterAST(r8))` to find the r8
   definition, checks `isRead(r2)`, and binds a fresh
   `RegisterAST(r2)` to evaluate the TOC-relative load. All three rely
   on `RegisterAST` equality, which compares the register id AND the
   bit range (`m_Low`/`m_High`). The power decoder normalizes operand
   registers to the decoding architecture but constructs them with the
   width of the opcode table's register definitions, so an operand's
   `RegisterAST` does not compare equal to `RegisterAST(ppc64::r8)`
   even when both print the same id -- `isWritten`/`isRead`/`bind` all
   silently fail, and the scan finds no r8 definition at all.

   Fix: match registers by id (`getWriteSet`/`getReadSet` +
   `getID() == ppc64::rX`), and bind the r2 instance obtained from the
   expression's own uses (via `InstructionAPI::getUsedRegisters()`),
   whose equality with itself always holds.

2. *`getTOC()` returns 0 for every ELFv2 binary.* The symtab TOC table
   is populated only while parsing the ELFv1 `.opd` section; ELFv2
   (ppc64le) has no `.opd`, so the TOC-based evaluation of the r8 load
   was always skipped (and the slicing fallback cannot resolve r2
   either, since r2 derives from r12/the entry address, unknown to the
   slicer). ELFv1 binaries are unaffected by this change: their
   `getTOC()` is nonzero, so the new derivation is never consulted.

   Fix: when the code source reports no TOC, derive it from the ELFv2
   global-entry convention

       addis r2,r12,H ; addi r2,r2,L      (r12 = entry address)

   giving `TOC = entry + (H << 16) + L`. E.g. `/bin/ls`: entry
   `0x6d80`, H=4, L=0x1180 -> TOC `0x47f00` (= `.got` + 0x8000).

**Commit 2 -- `dyninstAPI: accept the linker-relaxed TOC entry sequence`**

The ELFv2 ABI (sec. 2.3.3) allows the linker to rewrite the
r12-relative sequence into the absolute form

    lis r2,.TOC.@ha ; addi r2,r2,.TOC.@l

when the module is linked at a known address below 2 GB -- which is
every non-PIE executable (default `gcc -no-pie` output starts this
way, as does `/sbin/ldconfig`). Commit 1 only matched the
r12-relative form, so a stripped non-PIE executable still failed to
bootstrap. Accept both forms: `addis r2,r12` gives
`TOC = entry + (H << 16) + L`; `lis r2` gives the absolute
`TOC = (H << 16) + L`. Also bound the two-instruction read against
the region end.

**Commit 3 -- `dyninstAPI: try all candidate blocks in ppc64 findMain`**

`findMain()` located the block that sets up the `__libc_start_main`
call by counting the parsed `_start` function's call edges: none ->
entry block, exactly one -> its source block, anything else -> bail.
Statically linked glibc's `_start` reaches `__libc_start_main` by a
tail branch, so ParseAPI merges the two into one function with several
call edges, and `findMain()` gave up before ever running the heuristic
-- even though the r8 setup sits in the entry block as usual. Since
`evaluate_main_address()` is fail-to-zero per block, collect the
candidates (entry block, then each call-edge source) and accept the
first that yields a valid address. Behavior is unchanged for the
previous 0- and 1-call-edge cases.

This makes findMain succeed on stripped *static* executables too.
Process creation on them still fails later for an independent,
pre-existing reason (the runtime library cannot be injected without
`dlopen`), but binary rewriting and analysis consumers get a correct
synthesized `main`.

**Prologue forms covered.** The global-entry TOC setup has three known
shapes:

| form | where it appears | handling |
|---|---|---|
| `addis r2,r12,H ; addi r2,r2,L` | PIE/PIC (relaxation impossible: no known absolute address) | commit 1 |
| `lis r2,H ; addi r2,r2,L` | linker-relaxed non-PIE below 2 GB | commit 2 |
| no TOC setup (pc-relative, `.localentry f,1`) | POWER10 `-mcpu=power10` code | n/a by construction |

The POWER10 pc-relative case establishes no TOC at all; there the
`start_addresses` load is a `pld r8,...@pcrel` that does not read r2,
so the heuristic's r2-read gate skips the TOC path before this code is
reached. Supporting that form is a prefixed-instruction decoding work
item, independent of this change. All miss paths (unrecognized
prologue, out-of-range read) leave TOC = 0 and fall back to the
pre-existing slicing path, i.e. degrade to the previous behavior
rather than producing a wrong answer.

**Verification (native ppc64le, POWER9)**

Note that create-mode bootstrap is itself a runtime check: Dyninst
inserts a trap at the synthesized `main` and runs the process until it
is hit, so every successful `processCreate` below means execution
actually reached the derived address.

- `/bin/ls` (stripped PIE): process creation bootstraps and the
  synthesized `main` lands at load-base + `0x4820` (GOT slot `0x3ff10`
  -> `start_addresses` `0x3ef50` -> `main` `0x4820`, matching a hand
  trace of the ELF image); the process then runs to a normal exit 0.
  On RHEL ppc64le (llnl): `parseThat -i 1 /bin/ls`: fatal error 68 ->
  exit 0; `test_pt_ls none 64 create dynamic nonPIC: FAILED -> PASSED`.
  On the POWER9 box, master's parseThat shows the fatal 68 and the
  fixed build does not (its remaining nonzero exit is a separate,
  post-bootstrap parseThat issue also seen there on master baselines).
- stripped `gcc -no-pie` binary (linker-relaxed prologue
  `lis r2 ; addi r2,r2`): bootstraps with `main` synthesized at the
  exact address the binary's pre-strip symbol table gives
  (`0x100005cc`), then runs to completion returning its expected exit
  code (42).
- `/sbin/ldconfig` (stripped *static*, linker-relaxed prologue
  `lis r2,4111 ; addi r2,r2,31488`): findMain synthesizes `main` at
  `0x10001700`, matching a hand trace of the ELF image (TOC
  `0x100f7b00` -> GOT slot `0x100efb10` -> `start_addresses`
  `0x100a8260` -> `main` `0x10001700`), via both the create path
  (startup log `found main at 10001700`) and
  `BPatch_binaryEdit::openBinary` (`findFunction("main")` with
  `incUninstrumentable=true`). Without commit 3, findMain bails with
  "_start has unexpected number (2) of call edges". Create mode still
  stops afterward at the pre-existing static-binary limitation
  ("Couldn't find dlopen address") -- the RT library cannot be
  injected without `dlopen`; rewriting/analysis are the consumers.
- Negative controls: with commit 2 reverted, the non-PIE binary fails
  to bootstrap while `/bin/ls` still resolves (the lis arm is what
  covers non-PIE); with both commits reverted, both fail as on master.
- Full integration suite (`ctest -L integration`): 20/20 after each
  commit.