### PR TITLE
patchAPI: restore memoization of PatchFunction::exitBlocks()

### DIFF
--- a/patchAPI/src/PatchFunction.C
+++ b/patchAPI/src/PatchFunction.C
@@ -95,10 +95,21 @@ PatchFunction::entry() {
 
 const PatchFunction::Blockset&
 PatchFunction::exitBlocks() {
-  for (auto iter = func_->exitBlocks().begin();
-       iter != func_->exitBlocks().end(); ++iter) {
-    PatchBlock* pblk = obj()->getBlock(*iter);
-    exit_blocks_.insert(pblk);
+  // Build the set only when it is empty (never built, or invalidated by
+  // blocks()/invalidateBlocks()); addBlock/removeBlock/splitBlock maintain
+  // it incrementally afterwards, exactly like call_blocks_. Rebuilding on
+  // every call made each lookup O(|exits| log |exits|), and verifyExit()
+  // -- run twice per untrusted-Location findPoint() -- sits on the hot
+  // path of function-exit instrumentation: relocating a large binary
+  // became quadratic in its block count. On ppc64le, where conditional
+  // returns make exit blocks plentiful, instrumenting all functions of a
+  // process burned hours of CPU and presented as a hang.
+  if (exit_blocks_.empty()) {
+    for (auto iter = func_->exitBlocks().begin();
+         iter != func_->exitBlocks().end(); ++iter) {
+      PatchBlock* pblk = obj()->getBlock(*iter);
+      exit_blocks_.insert(pblk);
+    }
   }
   return exit_blocks_;
 }


### PR DESCRIPTION
PatchFunction::exitBlocks() rebuilds the exit-block set from ParseAPI on every call:

    const PatchFunction::Blockset&
    PatchFunction::exitBlocks() {
      for (auto iter = func_->exitBlocks().begin(); ...)
        exit_blocks_.insert(obj()->getBlock(*iter));
      return exit_blocks_;
    }

It used to be guarded by a staleness check
(func_->exitBlocks().size() != exit_blocks_.size()); the guard was dropped in 86ace565f ("Remove ParseAPI's per-function vector of blocks, ...", 2014) when the ParseAPI block list became an iterator range without a cheap size(). Every other part of the class still assumes memoization: exit_blocks_ is maintained incrementally by addBlock()/removeBlock()/ splitBlock() and is explicitly cleared by blocks() (when the block list grows) and invalidateBlocks() -- exactly like call_blocks_, whose callBlocks() accessor kept its guard.

The unguarded rebuild is quadratic in practice: verifyExit() calls exitBlocks() twice per untrusted-Location findPoint(), and the relocation Instrumenter looks up a function-exit point for every relocated block. Instrumenting all functions of a process (testsuite test_reloc in create mode) on ppc64le -- where conditional returns make exit blocks plentiful -- degraded from ~1500 relocated blocks/second to ~130/s and falling, projecting to hours of CPU, and presented as a hang.

Fix: build the set only when it is empty (never built, or invalidated), matching callBlocks(). With the guard restored the same test_reloc create instrumentation completes in 21 seconds.

An empty set is rebuilt on every call for functions with no exit blocks, but that walk visits nothing and is cheap.