### PR TITLE
parseAPI: resolve the get-PC-thunk base register for i386 PIC jump tables

### DIFF
--- a/parseAPI/src/JumpTableFormatPred.C
+++ b/parseAPI/src/JumpTableFormatPred.C
@@ -213,6 +213,29 @@ bool JumpTableFormatPred::modifyCurrentFrame(Slicer::SliceFrame &frame, Graph::P
             inputs.insert(make_pair(VariableAST::create(Variable(AbsRegion(Absloc(ppc64::r2)))),
                         ConstantAST::create(Constant(toc_address, 64))));
         }
+        else if (block->obj()->cs()->getArch() == Arch_x86 && !g->isExitNode(n)) {
+            // i386 position-independent code loads the GOT/anchor base into a
+            // register via a get-PC thunk ("call __x86.get_pc_thunk.REG; add
+            // $imm, %REG"), and GOT-relative jump tables compute their target
+            // as base_reg + table[index]. Substitute the thunk register with
+            // its constant value so the table base resolves to a concrete
+            // address -- the i386 analogue of the r2->TOC substitution above.
+            // Only apply a thunk whose defining block reaches this indirect
+            // jump (rf.thunk_outs), so an unrelated thunk value is not used.
+            // Skip the exit node (the indirect jump itself): there the thunk
+            // register holds the fully-computed target (base + table[index]),
+            // not the base, so substituting the base value would collapse the
+            // target to a constant and hide the jump table.
+            for (auto tit = thunks.begin(); tit != thunks.end(); ++tit) {
+                ParseAPI::Block *tb = tit->second.block;
+                auto oit = rf.thunk_outs.find(tb);
+                if (oit != rf.thunk_outs.end() && oit->second.count(block)) {
+                    inputs.insert(make_pair(
+                        VariableAST::create(Variable(AbsRegion(Absloc(tit->second.reg)))),
+                        ConstantAST::create(Constant(tit->second.value, 32))));
+                }
+            }
+        }
         if (aliases.find(n->assign()) != aliases.end()) {
             inputs.insert(aliases[n->assign()]);
             parsing_printf("\t Replacing %s with %s\n", aliases[n->assign()].first->format().c_str(),aliases[n->assign()].second->format().c_str());


### PR DESCRIPTION
On 32-bit x86 position-independent code, the GOT/anchor base is materialized
into a general register by a get-PC thunk ("call __x86.get_pc_thunk.REG; add
$imm, %REG"), and a GOT-relative jump table then computes its target as
base_reg + table[index]. The jump-table format predicate resolved the
analogous base for ppc64 (r2 -> TOC) but never substituted this i386 thunk
register, so the base remained the symbolic register value. With the base
unresolved the table address could not be reduced to a concrete constant, the
format visitor rejected the expression (isJumpTableFormat == false), and the
indirect jump was left unparsed -- its switch targets were missing from the
CFG (a switch of N cases parsed as ~3 blocks instead of >= N).

Substitute the thunk register with its constant value at every slice node
except the indirect jump itself, gated on the thunk's defining block actually
reaching the jump (ReachFact::thunk_outs) so an unrelated thunk value is not
applied. The exit node is skipped because there the register already holds the
fully-computed target (base + table[index]); substituting the base there would
collapse the whole target to a constant and hide the table. This mirrors the
existing ppc64 r2->TOC substitution for the i386 PIC idiom.

Depends on PR https://github.com/dyninst/dyninst/pull/1745 (Simplify RoseAST based on the associative property of
addition). This resolution only takes effect once the folded table base is a
single constant, and that folding is what https://github.com/dyninst/dyninst/pull/1745 provides in SymbolicExpression
(SimplifyRoot, addOp): the base and the memory displacement arrive in nested
additions and must be combined before the format visitor can recognize the
table base.

Verified on i386 (coriander, 32-bit runtime): test1_33 (an 18-case switch) now
parses the jump table (isJumpTableFormat 1, all case edges added) and passes in
create mode; x86_64 test1_33 continues to pass.