### PR TITLE
symtab: strip directory prefix when recording a library prereq

### DIFF
--- a/symtabAPI/src/Symtab.C
+++ b/symtabAPI/src/Symtab.C
@@ -2046,14 +2046,10 @@ DYNINST_EXPORT bool Symtab::addLibraryPrereq(std::string const& name)
 	{
 		return false;
 	}
-   // remove forward slashes and back slashes
-   size_t size = name.find_last_of("/");
-   size_t lastBS = name.find_last_of("\\");
-   if (lastBS > size) {
-      size = lastBS;
-   }
-
-   string filename = name.substr(size+1);
+   // Record only the basename: a path-qualified DT_NEEDED entry (e.g.,
+   // "./lib.so") is resolved by the loader relative to the CWD instead of
+   // through the normal search path.
+   string filename = Dyninst::filesystem::extract_filename(name);
 
 #if ! defined(os_windows) 
    obj->insertPrereqLibrary(filename);


### PR DESCRIPTION
This change simplifies extracting the library basename by dropping Windows path handling and using only the Unix path separator ('/').

The previous implementation searched for both '/' and '\\' to support Unix and Windows paths. If Windows support is no longer required, the logic can be reduced to a single find_last_of('/') call, making the code easier to read and avoiding the subtle std::string::npos comparison that the previous implementation relied on.

For example, given:

name = "./libtestA.so";

the desired result is:

filename = "libtestA.so";

With the old implementation:

size_t slash = name.find_last_of('/');
size_t backslash = name.find_last_of('\\');

if (backslash > slash)
    slash = backslash;

find_last_of('\\') returns std::string::npos, which compares greater than any valid index because npos is the maximum size_t value. As a result, slash becomes npos, and the basename extraction falls back to returning the original string:

"./libtestA.so"

instead of:

"libtestA.so"

--
As a result a caller that loads a library by a path containing a slash (e.g. loadLibrary("./libtestA.so"), or an absolute path) leaks that literal path into the rewritten binary as a "./libtestA.so" DT_NEEDED. Because the entry contains a slash, the dynamic loader resolves it CWD-relative to the ORIGINAL, un-rewritten library instead of searching LD_LIBRARY_PATH for the rewritten copy, so redirects written into the rewritten library (e.g. BPatch::replaceFunction) are bypassed.

This is arch-independent; it is observable via testsuite test1_22 in rewriter mode when test1_21 (which loads with a "./" prefix) is rewritten into the same binary ahead of test1_22. 