### PR TITLE
Port PowerPC decoder tests from the testsuite to tests/integration

### DIFF
--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -3,6 +3,7 @@ include_guard(GLOBAL)
 message(STATUS "Enabling integration tests")
 
 add_subdirectory(InstructionAPI/decoder/aarch64)
+add_subdirectory(InstructionAPI/decoder/ppc64le)
 add_subdirectory(InstructionAPI/decoder/x86)
 
 if(DYNINST_ENABLE_CAPSTONE)

--- a/tests/integration/InstructionAPI/decoder/ppc64le/CMakeLists.txt
+++ b/tests/integration/InstructionAPI/decoder/ppc64le/CMakeLists.txt
@@ -1,0 +1,13 @@
+include_guard(GLOBAL)
+
+add_executable(ppc64le_decode_test decode.cpp)
+target_compile_options(ppc64le_decode_test PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(ppc64le_decode_test PRIVATE instructionAPI register_tests)
+add_test(NAME instructionAPI_ppc64le_decode_test COMMAND ppc64le_decode_test)
+set_tests_properties(instructionAPI_ppc64le_decode_test PROPERTIES LABELS "integration")
+
+add_executable(ppc64le_branches_test branches.cpp)
+target_compile_options(ppc64le_branches_test PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(ppc64le_branches_test PRIVATE instructionAPI)
+add_test(NAME instructionAPI_ppc64le_branches_test COMMAND ppc64le_branches_test)
+set_tests_properties(instructionAPI_ppc64le_branches_test PROPERTIES LABELS "integration")

--- a/tests/integration/InstructionAPI/decoder/ppc64le/branches.cpp
+++ b/tests/integration/InstructionAPI/decoder/ppc64le/branches.cpp
@@ -1,0 +1,381 @@
+#include "Architecture.h"
+#include "Instruction.h"
+#include "InstructionDecoder.h"
+#include "Register.h"
+#include "registers/ppc64_regs.h"
+
+#include <boost/make_shared.hpp>
+#include <boost/optional.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+/*
+ *  PowerPC control-flow target (CFT) tests
+ *
+ *  These verify the control-flow targets produced by the decoder for the
+ *  branch instruction families (I-form, B-form, and XL-form). Each target
+ *  expression is evaluated by binding the PC, count, and link registers
+ *  (or the target itself for absolute branches) to known values, and both
+ *  the resulting address and the CFT properties (call, conditional,
+ *  indirect, fallthrough) are checked. A conditional branch has several
+ *  targets with different properties (e.g., the taken target is
+ *  conditional while the fallthrough target is not), so this test checks
+ *  each target individually.
+ */
+
+namespace di = Dyninst::InstructionAPI;
+
+namespace {
+
+struct cft_expected {
+  bool is_call;
+  bool is_conditional;
+  bool is_indirect;
+  bool is_fallthrough;
+};
+
+struct test_cft {
+  uint32_t value;
+  cft_expected cft;
+};
+
+struct test_insn {
+  uint32_t opcode;
+  bool is_branch;
+  bool is_return;
+  boost::optional<test_cft> pc;   // program counter
+  boost::optional<test_cft> ctr;  // count register
+  boost::optional<test_cft> lr;   // link register
+  boost::optional<test_cft> abs;  // absolute value (AA=1 instructions)
+  boost::optional<test_cft> ft;   // fallthrough target
+};
+
+constexpr auto pc_value = uint32_t{0x400};
+constexpr auto ctr_value = uint32_t{44};
+constexpr auto lr_value = uint32_t{0x200};
+
+constexpr auto result_val_t = di::u64;
+
+std::vector<test_insn> make_tests();
+
+bool verifyTargetType(di::Instruction::CFT const &actual, cft_expected const &expected) {
+  bool failed = false;
+  if(actual.isCall != expected.is_call) {
+    std::cerr << std::boolalpha << "Expected isCall = " << expected.is_call << ", got '" << actual.isCall << "'\n";
+    failed = true;
+  }
+  if(actual.isIndirect != expected.is_indirect) {
+    std::cerr << std::boolalpha << "Expected isIndirect = " << expected.is_indirect << ", got '" << actual.isIndirect
+              << "'\n";
+    failed = true;
+  }
+  if(actual.isConditional != expected.is_conditional) {
+    std::cerr << std::boolalpha << "Expected isConditional = " << expected.is_conditional << ", got '"
+              << actual.isConditional << "'\n";
+    failed = true;
+  }
+  if(actual.isFallthrough != expected.is_fallthrough) {
+    std::cerr << std::boolalpha << "Expected isFallthrough = " << expected.is_fallthrough << ", got '"
+              << actual.isFallthrough << "'\n";
+    failed = true;
+  }
+  return !failed;
+}
+
+bool verifyTargetValue(di::Expression::Ptr target, uint32_t expected_value) {
+  auto result = target->eval();
+  if(!result.defined) {
+    std::cerr << "Target '" << target->format(Dyninst::Arch_ppc64) << "' did not evaluate to a defined value\n";
+    return false;
+  }
+  if(result.type != result_val_t) {
+    std::cerr << "Expected result type " << result_val_t << ", got '" << result.type << "'\n";
+    return false;
+  }
+  if(result.convert<uint64_t>() != expected_value) {
+    std::cerr << std::hex << "Expected target value 0x" << expected_value << ", got '0x" << result.convert<uint64_t>()
+              << "'\n"
+              << std::dec;
+    return false;
+  }
+  return true;
+}
+
+bool check_cft(di::Instruction::CFT const &cur_cft, boost::optional<test_cft> const &test_reg) {
+  if(!test_reg) {
+    std::cerr << "Test does not use register, but should\n";
+    return false;
+  }
+  if(!verifyTargetValue(cur_cft.target, test_reg->value)) {
+    return false;
+  }
+  return verifyTargetType(cur_cft, test_reg->cft);
+}
+
+} // namespace
+
+int main() {
+  bool failed = false;
+  int test_id = 0;
+
+  auto pc = boost::make_shared<di::RegisterAST>(Dyninst::ppc64::pc);
+  auto ctr = boost::make_shared<di::RegisterAST>(Dyninst::ppc64::ctr);
+  auto lr = boost::make_shared<di::RegisterAST>(Dyninst::ppc64::lr);
+
+  auto bind_val = [](di::Instruction::CFT const &cur_cft, di::Expression::Ptr target, uint32_t value) {
+    cur_cft.target->bind(target.get(), di::Result(result_val_t, value));
+  };
+
+  for(auto const &t : make_tests()) {
+    test_id++;
+
+    di::InstructionDecoder d(&t.opcode, sizeof(t.opcode), Dyninst::Arch_ppc64);
+    auto insn = d.decode();
+
+    if(!insn.isValid()) {
+      std::cerr << "Failed to decode test " << test_id << '\n';
+      failed = true;
+      continue;
+    }
+
+    std::clog << "Verifying '" << insn.format() << "'\n";
+
+    auto all_cfts = boost::make_iterator_range(insn.cft_begin(), insn.cft_end());
+    const auto num_cft = std::distance(insn.cft_begin(), insn.cft_end());
+
+    if(!num_cft) {
+      std::cerr << "No control flow targets found\n";
+      failed = true;
+      continue;
+    }
+
+    int const num_targets_expected = [&t]() {
+      int n = 0;
+      if(t.pc) n++;
+      if(t.ctr) n++;
+      if(t.lr) n++;
+      if(t.abs) n++;
+      if(t.ft) n++;
+      return n;
+    }();
+
+    int num_targets_seen = 0;
+    bool abs_was_used = false;
+    for(auto const &cur_cft : all_cfts) {
+      std::clog << "Target " << (num_targets_seen + 1) << ": '" << cur_cft.target->format(Dyninst::Arch_ppc64)
+                << "'\n";
+
+      if(t.abs && !abs_was_used) {
+        std::clog << "Checking absolute address\n";
+        num_targets_seen++;
+        bind_val(cur_cft, cur_cft.target, t.abs->value);
+        if(!check_cft(cur_cft, t.abs)) {
+          failed = true;
+        }
+        abs_was_used = true;
+      }
+      if(cur_cft.target->isUsed(pc)) {
+        std::clog << "Checking PC\n";
+        num_targets_seen++;
+        bind_val(cur_cft, pc, pc_value);
+        if(!check_cft(cur_cft, t.pc)) {
+          std::clog << "  Trying fallthrough...\n";
+          if(!t.ft || !check_cft(cur_cft, t.ft)) {
+            failed = true;
+          }
+        }
+      }
+      if(cur_cft.target->isUsed(ctr)) {
+        std::clog << "Checking count register\n";
+        num_targets_seen++;
+        bind_val(cur_cft, ctr, ctr_value);
+        if(!check_cft(cur_cft, t.ctr)) {
+          failed = true;
+        }
+      }
+      if(cur_cft.target->isUsed(lr)) {
+        std::clog << "Checking link register\n";
+        num_targets_seen++;
+        bind_val(cur_cft, lr, lr_value);
+        if(!check_cft(cur_cft, t.lr)) {
+          failed = true;
+        }
+      }
+    }
+    if(num_targets_seen != num_targets_expected) {
+      std::cerr << "Instruction has too " << ((num_targets_seen < num_targets_expected) ? "few" : "many")
+                << " targets; expected " << num_targets_expected << ", found " << num_targets_seen << '\n';
+      failed = true;
+    }
+    if(insn.isBranch() != t.is_branch) {
+      std::cerr << "Instruction should " << (t.is_branch ? "" : "not ") << "be a branch\n";
+      failed = true;
+    }
+    if(insn.isReturn() != t.is_return) {
+      std::cerr << "Instruction should " << (t.is_return ? "" : "not ") << "be a return\n";
+      failed = true;
+    }
+
+    std::clog << '\n';
+  }
+
+  return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}
+
+namespace {
+
+constexpr auto is_call = true;
+constexpr auto is_conditional = true;
+constexpr auto is_indirect = true;
+constexpr auto is_fallthrough = true;
+constexpr auto is_branch = true;
+constexpr auto is_return = true;
+
+// clang-format off
+std::vector<test_insn> make_tests() {
+  return {
+    /*
+     *  --- Branch I-form ---
+     */
+    { //  b +16
+      0x48000010, is_branch, !is_return,
+      test_cft{pc_value + 16, {!is_call, !is_conditional, !is_indirect, !is_fallthrough}},
+      {}, {}, {}, {}
+    },
+    { //  ba -48
+      0x4bffffd2, is_branch, !is_return,
+      {}, {}, {}, {}, {}
+    },
+    { //  bl 0x100
+      0x48000101, !is_branch, !is_return,
+      test_cft{pc_value + 0x100, {is_call, !is_conditional, !is_indirect, !is_fallthrough}},
+      {}, {}, {}, {}
+    },
+    { //  bla 0x100
+      0x48000103, !is_branch, !is_return,
+      {}, {}, {}, {}, {}
+    },
+
+    /*
+     *  --- Branch Conditional B-form ---
+     */
+    { //  bc +32
+      0x42f00020, is_branch, !is_return,
+      test_cft{pc_value + 32, {!is_call, is_conditional, !is_indirect, !is_fallthrough}},
+      {},
+      {},
+      {},
+      test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}}
+    },
+    { //  bca 32
+      0x42f00022, is_branch, !is_return,
+      {},
+      {},
+      {},
+      test_cft{32, {!is_call, is_conditional, !is_indirect, !is_fallthrough}},
+      test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}},
+    },
+    { //  bcl +32  (subroutine call to relative address)
+      0x42f00021, !is_branch, !is_return,
+      test_cft{pc_value + 32, {is_call, is_conditional, !is_indirect, !is_fallthrough}},
+      {},
+      {},
+      {},
+      test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}},
+    },
+    { //  bcla 32  (subroutine call to immediate target)
+      0x42f00023, !is_branch, !is_return,
+      {},
+      {},
+      {},
+      test_cft{pc_value + 32, {is_call, is_conditional, !is_indirect, !is_fallthrough}},
+      test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}}
+    },
+
+    /*
+     *  --- Branch Conditional to Link Register XL-form ---
+     *
+     *  There are a large number of uses for this instruction.
+     */
+    { //  bclr with BH=0 (subroutine return)
+      0x4e800020, !is_branch, is_return,
+      {},
+      {},
+      test_cft{lr_value, {!is_call, !is_conditional, is_indirect, !is_fallthrough}},
+      {},
+      {}
+    },
+    { // bclrl  (LK=1)
+      0x4e800021, is_branch, !is_return,
+      {},
+      {},
+      test_cft{lr_value, {!is_call, is_conditional, is_indirect, !is_fallthrough}},
+      {},
+      test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}},
+    },
+    { // bdnzfl gt, 0x100
+      0x40010101, !is_branch, !is_return,
+      test_cft{pc_value + 0x100, {is_call, is_conditional, !is_indirect, !is_fallthrough}},
+      {},
+      {},
+      {},
+      test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}}
+    },
+    { //  bdnzf gt, 0x100   (bdnz cr0)
+      0x40010100, is_branch, !is_return,
+      test_cft{pc_value + 0x100, {!is_call, is_conditional, !is_indirect, !is_fallthrough}},
+      {},
+      {},
+      {},
+      test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}},
+    },
+    { //  bnslr
+      0x4ca30020, !is_branch, is_return,
+      {},
+      {},
+      test_cft{lr_value, {!is_call, !is_conditional, is_indirect, !is_fallthrough}},
+      {},
+      {}
+    },
+
+    /*
+     *  --- Branch Conditional to Count Register XL-form ---
+     */
+    { //  bctr  (LK=0)
+      0x4e800420, is_branch, !is_return,
+      {},
+      test_cft{ctr_value, {!is_call, !is_conditional, is_indirect, !is_fallthrough}},
+      {}, {}, {}
+    },
+    { //  bctrl  (LK=1)
+      0x4e800421, !is_branch, !is_return,
+      {},
+      test_cft{ctr_value, {is_call, !is_conditional, is_indirect, !is_fallthrough}},
+      {}, {}, {}
+    },
+    { //  bcctr 0x17, 4*cr4+lt, 0
+      0x4ef00420, is_branch, !is_return,
+      {},
+      test_cft{ctr_value, {!is_call, !is_conditional, is_indirect, !is_fallthrough}},
+      {}, {}, {}
+    },
+
+    /*
+     *  --- Branch Conditional to Branch Target Address Register XL-form ---
+     *
+     *  Dyninst can't decode these.
+     */
+//      { // bctar   (LK=0)
+//        0x4e800460
+//      },
+//      { // bctarl  (LK=1)
+//        0x4e800461
+//      },
+  };
+  // clang-format on
+}
+
+} // namespace

--- a/tests/integration/InstructionAPI/decoder/ppc64le/decode.cpp
+++ b/tests/integration/InstructionAPI/decoder/ppc64le/decode.cpp
@@ -1,0 +1,219 @@
+#include "Architecture.h"
+#include "InstructionDecoder.h"
+#include "Register.h"
+#include "register_tests.h"
+#include "registers/MachRegister.h"
+#include "registers/register_set.h"
+#include "registers/ppc32_regs.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+/*
+ *  PowerPC instruction decoding tests
+ *
+ *  These verify the register read/write sets produced by the decoder for a
+ *  selection of fixed-point, floating-point, load/store, and branch
+ *  instructions.
+ *
+ *  NOTE: The decoder currently produces registers from the ppc32 namespace
+ *  even when decoding in 64-bit mode, so these tests decode with
+ *  Dyninst::Arch_ppc32 and expect ppc32 registers.
+ */
+
+namespace di = Dyninst::InstructionAPI;
+
+struct decode_test {
+  uint32_t opcode;
+  di::register_rw_test regs;
+};
+
+static std::vector<decode_test> make_tests();
+
+int main() {
+  bool failed = false;
+  int test_id = 0;
+  const auto arch = Dyninst::Arch_ppc32;
+
+  for(auto const &t : make_tests()) {
+    test_id++;
+    di::InstructionDecoder d(&t.opcode, sizeof(t.opcode), arch);
+    auto insn = d.decode();
+    if(!insn.isValid()) {
+      std::cerr << "Failed to decode test " << test_id << '\n';
+      failed = true;
+      continue;
+    }
+
+    std::clog << "Verifying '" << insn.format() << "'\n";
+
+    if(!di::verify(insn, t.regs)) {
+      failed = true;
+    }
+
+    std::clog << '\n';
+  }
+
+  { // lhzux r5, r7, r9 must read memory
+    const uint32_t lhzux = 0x7ca74a6e;
+    di::InstructionDecoder d(&lhzux, sizeof(lhzux), arch);
+    auto insn = d.decode();
+    if(!insn.isValid()) {
+      std::cerr << "Failed to decode memory-read test\n";
+      failed = true;
+    } else if(!insn.readsMemory()) {
+      std::cerr << "'" << insn.format() << "' did not read memory\n";
+      failed = true;
+    }
+  }
+
+  return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}
+
+std::vector<decode_test> make_tests() {
+  auto r0 = Dyninst::ppc32::r0;
+  auto r1 = Dyninst::ppc32::r1;
+  auto r2 = Dyninst::ppc32::r2;
+  auto r5 = Dyninst::ppc32::r5;
+  auto r7 = Dyninst::ppc32::r7;
+  auto r8 = Dyninst::ppc32::r8;
+  auto r9 = Dyninst::ppc32::r9;
+  auto cr0 = Dyninst::ppc32::cr0;
+  auto cr2 = Dyninst::ppc32::cr2;
+  auto cr4 = Dyninst::ppc32::cr4;
+  auto cr6 = Dyninst::ppc32::cr6;
+  auto cr7 = Dyninst::ppc32::cr7;
+  auto xer = Dyninst::ppc32::xer;
+  auto fpr0 = Dyninst::ppc32::fpr0;
+  auto fpr1 = Dyninst::ppc32::fpr1;
+  auto fpr2 = Dyninst::ppc32::fpr2;
+  auto fsr0 = Dyninst::ppc32::fsr0;
+  auto fsr1 = Dyninst::ppc32::fsr1;
+  auto fsr2 = Dyninst::ppc32::fsr2;
+  auto fpscw = Dyninst::ppc32::fpscw;
+  auto fpscw0 = Dyninst::ppc32::fpscw0;
+  auto fpscw2 = Dyninst::ppc32::fpscw2;
+  auto fpscw4 = Dyninst::ppc32::fpscw4;
+  auto fpscw6 = Dyninst::ppc32::fpscw6;
+  auto fpscw7 = Dyninst::ppc32::fpscw7;
+  auto pc = Dyninst::ppc32::pc;
+  auto ctr = Dyninst::ppc32::ctr;
+  auto lr = Dyninst::ppc32::lr;
+
+  using reg_set = Dyninst::register_set;
+
+  // clang-format off
+  return {
+    { // add. r9, r0, r8
+      0x7d204215,
+      di::register_rw_test{ reg_set{r0, r8}, reg_set{r9, cr0} }
+    },
+    { // add r9, r0, r8
+      0x7d204214,
+      di::register_rw_test{ reg_set{r0, r8}, reg_set{r9} }
+    },
+    { // addo r9, r0, r8
+      0x7d204614,
+      di::register_rw_test{ reg_set{r0, r8}, reg_set{r9, xer} }
+    },
+    { // fadd fpr0, fpr1, fpr2
+      0xfc01102a,
+      di::register_rw_test{ reg_set{fpr1, fpr2}, reg_set{fpr0} }
+    },
+    { // fadd. fpr0, fpr1, fpr2
+      0xfc01102b,
+      di::register_rw_test{ reg_set{fpr1, fpr2}, reg_set{fpr0, fpscw} }
+    },
+    { // addi r1, 0, 1
+      0x38200001,
+      di::register_rw_test{ reg_set{}, reg_set{r1} }
+    },
+    { // addi r1, r1, 1
+      0x38210001,
+      di::register_rw_test{ reg_set{r1}, reg_set{r1} }
+    },
+    { // fcmpu fpscw7, fpr0, fpr1
+      0xff800800,
+      di::register_rw_test{ reg_set{fpr0, fpr1}, reg_set{fpscw7} }
+    },
+    { // fcmpu cr7, r0, r1
+      0x7f800800,
+      di::register_rw_test{ reg_set{r0, r1}, reg_set{cr7} }
+    },
+    { // mtcrf cr0, cr2, cr4, cr6, r0
+      0x7c0aa120,
+      di::register_rw_test{ reg_set{r0}, reg_set{cr0, cr2, cr4, cr6} }
+    },
+    { // mtfsf fpscw0, fpscw2, fpscw4, fpscw6, fpr0
+      0xfd54058e,
+      di::register_rw_test{ reg_set{fpr0}, reg_set{fpscw0, fpscw2, fpscw4, fpscw6} }
+    },
+    { // lwz r0, 0(r1)
+      0x80010000,
+      di::register_rw_test{ reg_set{r1}, reg_set{r0} }
+    },
+    { // lwzu r0, 0(r1)
+      0x84010000,
+      di::register_rw_test{ reg_set{r1}, reg_set{r0, r1} }
+    },
+    { // lwzx r0, r2(r1)
+      0x7c01102e,
+      di::register_rw_test{ reg_set{r1, r2}, reg_set{r0} }
+    },
+    { // lwzux r0, r2(r1)
+      0x7c01106e,
+      di::register_rw_test{ reg_set{r1, r2}, reg_set{r0, r1} }
+    },
+    { // rlimi r0, r1
+      0x7801440c,
+      di::register_rw_test{ reg_set{r0}, reg_set{r1} }
+    },
+    { // fpmul fpr0, fpr1
+      0x00010090,
+      di::register_rw_test{ reg_set{fpr1, fpr2, fsr1, fsr2}, reg_set{fpr0, fsr0} }
+    },
+    { // fxmul fpr0, fpr1, or qvfxmadds
+      0x00010092,
+      di::register_rw_test{ reg_set{fpr1, fpr2, fsr1, fsr2}, reg_set{fpr0, fsr0} }
+    },
+    { // fxcpmul fpr0, fpr1
+      0x00010094,
+      di::register_rw_test{ reg_set{fpr1, fpr2, fsr2}, reg_set{fpr0, fsr0} }
+    },
+    { // fxcsmul fpr0, fpr1, or qvfxxnpmadds
+      0x00010096,
+      di::register_rw_test{ reg_set{fpr2, fsr1, fsr2}, reg_set{fpr0, fsr0} }
+    },
+    { // bdnzl cr0, +0x100
+      0x40010101,
+      di::register_rw_test{ reg_set{pc, cr0, ctr}, reg_set{pc, ctr, lr} }
+    },
+    { // bdnz cr0, +0x100
+      0x40010100,
+      di::register_rw_test{ reg_set{pc, cr0, ctr}, reg_set{pc, ctr} }
+    },
+    { // lhzux r5, r7, r9
+      0x7ca74a6e,
+      di::register_rw_test{ reg_set{r7, r9}, reg_set{r5, r7} }
+    },
+    { // bclr (with BH=0, return from subroutine)
+      0x4e800020,
+      di::register_rw_test{ reg_set{ctr, lr, cr0}, reg_set{pc, ctr} }
+    },
+    { // bclrl
+      0x4e800021,
+      di::register_rw_test{ reg_set{ctr, lr, cr0}, reg_set{ctr, lr, pc} }
+    },
+    { // bctr (LK=0)
+      0x4e800420,
+      di::register_rw_test{ reg_set{ctr, cr0}, reg_set{pc} }
+    },
+    { // bctrl (LK=1)
+      0x4e800421,
+      di::register_rw_test{ reg_set{lr, ctr, cr0}, reg_set{lr, pc} }
+    },
+  };
+  // clang-format on
+}


### PR DESCRIPTION
Ports the two PowerPC InstructionAPI tests from the dyninst/testsuite repository (src/instruction/power_decode.C and
src/instruction/power_cft.C) into the modern integration test tree as tests/integration/InstructionAPI/decoder/ppc64le/, following the layout of the existing aarch64/riscv/x86 decoder tests. The testsuite framework boilerplate (TestMutator, test factories, test_results_t) was stripped; the checks themselves carry over unchanged. Both tests decode fixed in-memory byte buffers, so they run on any host architecture.

- decode.cpp (instructionAPI_ppc64le_decode_test): port of power_decode. Verifies register read/write sets for 27 fixed-point, floating-point, load/store, and branch instructions, plus a readsMemory() check for lhzux. Uses the shared register_tests harness (exact set equality, same semantics as the testsuite's verify_read_write_sets). As in the original, decoding is done with Dyninst::Arch_ppc32 and the expected registers come from the ppc32 namespace, because the decoder currently produces ppc32-namespace registers even in 64-bit mode. Once the decoder is switched to the ppc64 register namespace, this test needs a mechanical update (Arch_ppc64 + ppc64:: registers).

- branches.cpp (instructionAPI_ppc64le_branches_test): port of power_cft. Verifies control-flow targets for the branch instruction families (I-form, B-form, XL-form to LR/CTR): each target expression is evaluated by binding PC/CTR/LR to known values and checking the resulting address as well as the per-target call/conditional/ indirect/fallthrough properties, plus isBranch()/isReturn(). This test does not use the shared cft_tests harness because that harness assumes all CFTs of an instruction share the same properties and does not evaluate target addresses; PowerPC conditional branches have a taken target and a fallthrough target with different properties, and the value checks would be lost.

Notes on the original tests, preserved faithfully:
- The buffer comment "lhzux r9, r7, r5" in power_decode was misleading; the encoding 0x7ca74a6e is lhzux r5, r7, r9 (fixed the comment only, the expected sets are unchanged).
- power_decode passed a 1-byte buffer length when re-decoding lhzux; the port passes the correct 4-byte length.
- The bctar/bctarl cases remain commented out (the decoder cannot decode them), same as the testsuite.

Verified with gcc 11.1 / Boost 1.78 (RelWithDebInfo, DYNINST_ENABLE_TESTS=INTEGRATION): both tests pass under ctest -R ppc64le.