### PR TITLE
Port x86 decoder tests from the testsuite

### DIFF
--- a/tests/integration/InstructionAPI/decoder/x86/CMakeLists.txt
+++ b/tests/integration/InstructionAPI/decoder/x86/CMakeLists.txt
@@ -13,3 +13,35 @@ target_link_libraries(ptwrite_tests PRIVATE instructionAPI cft_tests memory_test
                                             register_tests opcode_tests)
 add_test(NAME instructionAPI_ptwrite_tests COMMAND ptwrite_tests)
 set_tests_properties(instructionAPI_ptwrite_tests PROPERTIES LABELS "integration")
+
+add_executable(x86_bind_eval_tests bind_eval.cpp)
+target_compile_options(x86_bind_eval_tests PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(x86_bind_eval_tests PRIVATE instructionAPI)
+add_test(NAME instructionAPI_x86_bind_eval_tests COMMAND x86_bind_eval_tests)
+set_tests_properties(instructionAPI_x86_bind_eval_tests PROPERTIES LABELS "integration")
+
+add_executable(x86_farcall_tests farcall.cpp)
+target_compile_options(x86_farcall_tests PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(x86_farcall_tests PRIVATE instructionAPI)
+add_test(NAME instructionAPI_x86_farcall_tests COMMAND x86_farcall_tests)
+set_tests_properties(instructionAPI_x86_farcall_tests PROPERTIES LABELS "integration")
+
+add_executable(x86_fucompp_tests fucompp.cpp)
+target_compile_options(x86_fucompp_tests PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(x86_fucompp_tests PRIVATE instructionAPI register_tests)
+add_test(NAME instructionAPI_x86_fucompp_tests COMMAND x86_fucompp_tests)
+set_tests_properties(instructionAPI_x86_fucompp_tests PROPERTIES LABELS "integration")
+
+add_executable(x86_mov_size_details_tests mov_size_details.cpp)
+target_compile_options(x86_mov_size_details_tests PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(x86_mov_size_details_tests PRIVATE instructionAPI)
+add_test(NAME instructionAPI_x86_mov_size_details_tests
+         COMMAND x86_mov_size_details_tests)
+set_tests_properties(instructionAPI_x86_mov_size_details_tests PROPERTIES LABELS
+                                                                          "integration")
+
+add_executable(x86_read_write_tests read_write.cpp)
+target_compile_options(x86_read_write_tests PRIVATE ${SUPPORTED_CXX_WARNING_FLAGS})
+target_link_libraries(x86_read_write_tests PRIVATE instructionAPI register_tests)
+add_test(NAME instructionAPI_x86_read_write_tests COMMAND x86_read_write_tests)
+set_tests_properties(instructionAPI_x86_read_write_tests PROPERTIES LABELS "integration")

--- a/tests/integration/InstructionAPI/decoder/x86/bind_eval.cpp
+++ b/tests/integration/InstructionAPI/decoder/x86/bind_eval.cpp
@@ -1,0 +1,138 @@
+#include "Architecture.h"
+#include "Expression.h"
+#include "Instruction.h"
+#include "InstructionDecoder.h"
+#include "Register.h"
+#include "registers/x86_64_regs.h"
+#include "registers/x86_regs.h"
+#include "Result.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+/*
+ *  x86/x86_64 expression bind/eval tests
+ *
+ *  Decodes 'call [8*EAX + ECX + 0xDEADBEEF]' and verifies that the
+ *  control-flow target expression stays undefined until all of its
+ *  terms are bound (the target is a memory dereference, so it can
+ *  never be fully evaluated), while the address computation inside the
+ *  dereference evaluates to the expected value once EAX and ECX are
+ *  bound.
+ */
+
+using namespace Dyninst;
+using namespace Dyninst::InstructionAPI;
+
+namespace {
+
+constexpr auto num_tests = 1;
+
+std::array<const uint8_t, 7> buffer = {{
+    0xFF, 0x94, 0xC1, 0xEF, 0xBE, 0xAD, 0xDE // call [8*EAX + ECX + 0xDEADBEEF]
+}};
+
+bool verifyCFT(Expression::Ptr cft, bool expectedDefined, unsigned long expectedValue, Result_Type expectedType) {
+  Result cftResult = cft->eval();
+  if(cftResult.defined != expectedDefined) {
+    std::cerr << std::boolalpha << "CFT '" << cft->format() << "': expected result defined " << expectedDefined
+              << ", actual " << cftResult.defined << '\n';
+    return false;
+  }
+  if(expectedDefined) {
+    if(cftResult.type != expectedType) {
+      std::cerr << "CFT '" << cft->format() << "': expected result type " << expectedType << ", actual "
+                << cftResult.type << '\n';
+      return false;
+    }
+    if(cftResult.convert<unsigned long long int>() != expectedValue) {
+      std::cerr << std::hex << "CFT '" << cft->format() << "': expected result value 0x" << expectedValue
+                << ", actual 0x" << cftResult.convert<unsigned long>() << std::dec << '\n';
+      return false;
+    }
+  }
+  return true;
+}
+
+bool run(Dyninst::Architecture arch) {
+  InstructionDecoder d(buffer.data(), buffer.size(), arch);
+
+  std::vector<Instruction> decodedInsns;
+  decodedInsns.reserve(num_tests);
+  for(int idx = 0; idx < num_tests; idx++) {
+    Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      std::cerr << "Failed to decode test " << (idx + 1) << '\n';
+      return false;
+    }
+    decodedInsns.push_back(insn);
+  }
+
+  const auto is_64 = (arch == Dyninst::Arch_x86_64);
+  RegisterAST ax(is_64 ? x86_64::rax : x86::eax);
+  RegisterAST cx(is_64 ? x86_64::rcx : x86::ecx);
+
+  for(auto &&insn : decodedInsns) {
+    Expression::Ptr theCFT = insn.getControlFlowTarget();
+    if(!theCFT) {
+      std::cerr << "No CFT found for '" << insn.format() << "'\n";
+      return false;
+    }
+    if(!verifyCFT(theCFT, false, 0x1000, u32)) {
+      return false;
+    }
+
+    if(!theCFT->bind(&ax, Result(u32, 3))) {
+      std::cerr << "Bind of EAX failed (insn '" << insn.format() << "')\n";
+      return false;
+    }
+    if(!verifyCFT(theCFT, false, 0x1000, u32)) {
+      return false;
+    }
+    if(!theCFT->bind(&cx, Result(u32, 5))) {
+      std::cerr << "Bind of ECX failed\n";
+      return false;
+    }
+    if(!verifyCFT(theCFT, false, 0x1000, u32)) {
+      return false;
+    }
+    auto subExpressions = theCFT->getSubexpressions();
+    if(subExpressions.size() != 1) {
+      std::cerr << "Expected dereference with one child, got " << subExpressions.size() << " children\n";
+      return false;
+    }
+    Expression::Ptr memRef = subExpressions[0];
+    if(!memRef) {
+      std::cerr << "memRef was not an expression\n";
+      return false;
+    }
+    using res_t = typename Result_type2type<u32>::type;
+    auto expected_value = static_cast<res_t>(0xDEADBEEF + (0x03 * 0x08 + 0x05));
+    if(!verifyCFT(memRef, true, expected_value, u32)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+int main() {
+  bool ok = true;
+  {
+    std::clog << "**** Running x86 ********\n";
+    if(!run(Dyninst::Arch_x86)) {
+      ok = false;
+    }
+  }
+  {
+    std::clog << "**** Running x86_64 ********\n";
+    if(!run(Dyninst::Arch_x86_64)) {
+      ok = false;
+    }
+  }
+  return !ok ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/integration/InstructionAPI/decoder/x86/farcall.cpp
+++ b/tests/integration/InstructionAPI/decoder/x86/farcall.cpp
@@ -1,0 +1,37 @@
+#include "Architecture.h"
+#include "Instruction.h"
+#include "InstructionDecoder.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+
+/*
+ *  x86 far call decoding test
+ *
+ *  Verifies that the decoder can decode a far call with an immediate
+ *  segment:offset operand. This form is only valid on 32-bit x86.
+ */
+
+namespace di = Dyninst::InstructionAPI;
+
+int main() {
+  constexpr auto num_tests = 1;
+
+  std::array<const uint8_t, 9> buffer = {{
+      0x9A, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0xFF, 0xFE // CALL 0504030201, with FF/FE as fenceposts
+  }};
+
+  di::InstructionDecoder d(buffer.data(), buffer.size(), Dyninst::Arch_x86);
+
+  for(int idx = 0; idx < num_tests; idx++) {
+    di::Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      std::cerr << "Failed to decode test " << (idx + 1) << '\n';
+      return EXIT_FAILURE;
+    }
+    std::clog << "Decoded '" << insn.format() << "'\n";
+  }
+  return EXIT_SUCCESS;
+}

--- a/tests/integration/InstructionAPI/decoder/x86/fucompp.cpp
+++ b/tests/integration/InstructionAPI/decoder/x86/fucompp.cpp
@@ -1,0 +1,202 @@
+#include "Architecture.h"
+#include "InstructionDecoder.h"
+#include "Register.h"
+#include "register_tests.h"
+#include "registers/MachRegister.h"
+#include "registers/register_set.h"
+#include "registers/x86_regs.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+/*
+ *  x87 floating-point comparison decoding tests
+ *
+ *  These verify the register read/write sets produced by the decoder
+ *  for the fcom/fcomp/fcompp, fcomi/fcomip, and fucom/fucomp/fucompp/
+ *  fucomi/fucomip families.
+ */
+
+namespace di = Dyninst::InstructionAPI;
+
+int main() {
+  constexpr auto num_tests = 24;
+
+  // clang-format off
+  constexpr std::array<const uint8_t, 52> buffer = {{
+      // ordered comparisons
+      0xd8, 0x55, 0x00,   // fcom dword ptr [ebp]
+      0xdc, 0x55, 0x00,   // fcom qword ptr [ebp]
+      0xd8, 0xd0,         // fcom st0
+      0xd8, 0xd1,         // fcom st1
+      0xd8, 0xd2,         // fcom st2
+      0xd8, 0x5d, 0x00,   // fcomp dword ptr [ebp]
+      0xdc, 0x5d, 0x00,   // fcomp qword ptr [ebp]
+      0xd8, 0xd8,         // fcomp st0
+      0xd8, 0xd9,         // fcomp st1
+      0xd8, 0xda,         // fcomp st2
+      0xde, 0xd9,         // fcompp
+
+      // compare and set eflags
+      0xdb, 0xf0,         // fcomi st0, st0
+      0xdf, 0xf0,         // fcomip st0, st0
+      0xdf, 0xf1,         // fcomip st0, st1
+      0xdb, 0xe8,         // fucomi st0, st0
+      0xdb, 0xe9,         // fucomi st0, st1
+      0xdf, 0xe8,         // fucomip st0, st0
+      0xdf, 0xe9,         // fucomip st0, st1
+
+      // unordered comparisons
+      0xdd, 0xe0,     // fucom st0
+      0xdd, 0xe1,     // fucom st1 (aka, 'fucom')
+      0xdd, 0xe2,     // fucom st2
+      0xdd, 0xe8,     // fucomp
+      0xdd, 0xe9,     // fucompp
+      0xdd, 0xea,     // fucomp st2
+  }};
+  // clang-format on
+
+  std::vector<di::Instruction> decodedInsns;
+  decodedInsns.reserve(num_tests);
+
+  di::InstructionDecoder d(buffer.data(), buffer.size(), Dyninst::Arch_x86);
+  for(int idx = 0; idx < num_tests; idx++) {
+    di::Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      std::cerr << "Failed to decode x86 test " << (idx + 1) << '\n';
+      return EXIT_FAILURE;
+    }
+    decodedInsns.push_back(insn);
+  }
+
+  auto st0 = Dyninst::x86::st0;
+  auto st1 = Dyninst::x86::st1;
+  auto st2 = Dyninst::x86::st2;
+  auto ebp = Dyninst::x86::ebp;
+
+  using reg_set = Dyninst::register_set;
+
+  std::vector<reg_set> expectedRead, expectedWritten;
+
+  // fcom dword ptr [ebp]
+  expectedRead.push_back(reg_set{st0, ebp});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcom qword ptr [ebp]
+  expectedRead.push_back(reg_set{st0, ebp});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcom st0
+  expectedRead.push_back(reg_set{st0});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcom st1
+  expectedRead.push_back(reg_set{st0, st1});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcom st2
+  expectedRead.push_back(reg_set{st0, st2});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcomp dword ptr [ebp]
+  expectedRead.push_back(reg_set{st0, ebp});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcomp qword ptr [ebp]
+  expectedRead.push_back(reg_set{st0, ebp});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcomp st0
+  expectedRead.push_back(reg_set{st0});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcomp st1
+  expectedRead.push_back(reg_set{st0, st1});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcomp st2
+  expectedRead.push_back(reg_set{st0, st2});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcompp
+  expectedRead.push_back(reg_set{st0, st1});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcomi st0, st0
+  expectedRead.push_back(reg_set{st0});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcomip st0, st0
+  expectedRead.push_back(reg_set{st0});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fcomip st0, st1
+  expectedRead.push_back(reg_set{st0, st1});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fucomi st0, st0
+  expectedRead.push_back(reg_set{st0});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fucomi st0, st1
+  expectedRead.push_back(reg_set{st0, st1});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fucomip st0, st0
+  expectedRead.push_back(reg_set{st0});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fucomip st0, st1
+  expectedRead.push_back(reg_set{st0, st1});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fucom st0
+  expectedRead.push_back(reg_set{st0});
+  expectedWritten.push_back(reg_set{});
+
+  // fucom st1 (aka, 'fucom')
+  expectedRead.push_back(reg_set{st0, st1});
+  expectedWritten.push_back(reg_set{});
+
+  // fucom st2
+  expectedRead.push_back(reg_set{st0, st2});
+  expectedWritten.push_back(reg_set{});
+
+  // fucomp
+  expectedRead.push_back(reg_set{st0});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fucompp
+  expectedRead.push_back(reg_set{st0, st1});
+  expectedWritten.push_back(reg_set{st0});
+
+  // fucomp st(3)
+  expectedRead.push_back(reg_set{st0, st2});
+  expectedWritten.push_back(reg_set{st0});
+
+  if(expectedRead.size() != expectedWritten.size()) {
+    std::cerr << "FATAL: expectedRead.size() != expectedWritten.size()\n";
+    return EXIT_FAILURE;
+  }
+
+  if(expectedRead.size() != decodedInsns.size()) {
+    std::cerr << "FATAL: expectedRead.size() != decodedInsns.size()\n";
+    return EXIT_FAILURE;
+  }
+
+  bool failed = false;
+  for(size_t i = 0; i < decodedInsns.size(); i++) {
+    auto const &insn = decodedInsns[i];
+
+    std::clog << "Verifying '" << insn.format() << "'\n";
+
+    if(!di::verify(insn, di::register_rw_test{expectedRead[i], expectedWritten[i]})) {
+      failed = true;
+    }
+  }
+
+  return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/integration/InstructionAPI/decoder/x86/mov_size_details.cpp
+++ b/tests/integration/InstructionAPI/decoder/x86/mov_size_details.cpp
@@ -1,0 +1,94 @@
+#include "Architecture.h"
+#include "Instruction.h"
+#include "InstructionDecoder.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <tuple>
+#include <vector>
+
+/*
+ *  x86 operand size tests
+ *
+ *  These verify the sizes of the value expressions computed for both
+ *  operands of a few instructions with interesting operand sizes.
+ */
+
+namespace di = Dyninst::InstructionAPI;
+
+int main() {
+  constexpr auto num_tests = 5;
+
+  // clang-format off
+  constexpr std::array<const uint8_t, 16> buffer = {{
+    0x66, 0x8c, 0xe8,               // mov ax, gs
+    0x89, 0xe8,                     // mov eax, ebp
+    0xf2, 0x0f, 0x12, 0xc0,         // movddup xmm0, xmm0
+    0x05, 0xef, 0xbe, 0xad, 0xde,   // add eax, 0xdeadbeef
+    0xd8, 0xd8,                     // fcomp st0, st0
+  }};
+  // clang-format on
+
+  std::vector<di::Instruction> decodedInsns;
+  decodedInsns.reserve(num_tests);
+
+  di::InstructionDecoder d(buffer.data(), buffer.size(), Dyninst::Arch_x86);
+  for(int idx = 0; idx < num_tests; idx++) {
+    di::Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      std::cerr << "Failed to decode x86 test " << (idx + 1) << '\n';
+      return EXIT_FAILURE;
+    }
+    decodedInsns.push_back(insn);
+  }
+
+  std::vector<std::tuple<int, int>> expected_sizes;
+
+  // mov ax, gs
+  expected_sizes.push_back(std::make_tuple(2, 2));
+
+  // mov eax, ebp
+  expected_sizes.push_back(std::make_tuple(4, 4));
+
+  // movddup xmm0, xmm0
+  expected_sizes.push_back(std::make_tuple(16, 16));
+
+  // add eax, 0xdeadbeef
+  expected_sizes.push_back(std::make_tuple(4, 4));
+
+  // fcomp st0, st0
+  expected_sizes.push_back(std::make_tuple(8, 8)); // wrong. should be 80 bits
+
+  if(decodedInsns.size() != expected_sizes.size()) {
+    std::cerr << "FATAL: decodedInsns.size() != expected_sizes.size()\n";
+    return EXIT_FAILURE;
+  }
+
+  bool failed = false;
+  for(size_t i = 0; i < decodedInsns.size(); i++) {
+    auto const &insn = decodedInsns[i];
+
+    std::clog << "Verifying '" << insn.format() << "'\n";
+
+    const auto lhs_size = std::get<0>(expected_sizes[i]);
+    const auto rhs_size = std::get<1>(expected_sizes[i]);
+
+    di::Expression::Ptr lhs = insn.getOperand(0).getValue();
+    di::Expression::Ptr rhs = insn.getOperand(1).getValue();
+
+    if(static_cast<int>(lhs->size()) != lhs_size) {
+      std::cerr << "LHS expected " << (lhs_size * 8) << "-bit, actual " << (lhs->size() * 8) << "-bit ("
+                << lhs->format() << ")\n";
+      failed = true;
+    }
+    if(static_cast<int>(rhs->size()) != rhs_size) {
+      std::cerr << "RHS expected " << (rhs_size * 8) << "-bit, actual " << (rhs->size() * 8) << "-bit ("
+                << rhs->format() << ")\n";
+      failed = true;
+    }
+  }
+
+  return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/integration/InstructionAPI/decoder/x86/read_write.cpp
+++ b/tests/integration/InstructionAPI/decoder/x86/read_write.cpp
@@ -1,0 +1,216 @@
+#include "Architecture.h"
+#include "InstructionDecoder.h"
+#include "Register.h"
+#include "register_tests.h"
+#include "registers/MachRegister.h"
+#include "registers/register_set.h"
+#include "registers/x86_64_regs.h"
+#include "registers/x86_regs.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+/*
+ *  x86/x86_64 register read/write set tests
+ *
+ *  These verify the register read/write sets produced by the decoder
+ *  for a mix of arithmetic, stack, control-flow, mov, SSE, and lea
+ *  instructions, in both 32- and 64-bit modes.
+ */
+
+namespace di = Dyninst::InstructionAPI;
+
+namespace {
+
+bool run(Dyninst::Architecture arch) {
+  constexpr auto num_tests = 11;
+
+  // clang-format off
+  constexpr std::array<const uint8_t, 40> buffer = {{
+      0x05, 0xef, 0xbe, 0xad, 0xde,             // add eax, 0xdeadbeef
+      0x50,                                     // push eax
+      0x74, 0x10,                               // jz +0x10(8)
+      0xe8, 0x20, 0x00, 0x00, 0x00,             // call +0x20(32)
+      0xf8,                                     // clc
+      0x04, 0x30,                               // add al, 0x30(8)
+      0xc7, 0x45, 0xfc, 0x01, 0x00, 0x00, 0x00, // movl 0x01, -0x4(ebp)
+      0x88, 0x55, 0xcc,                         // movb dl, -0x34(ebp)
+      0xf2, 0x0f, 0x12, 0xc0,                   // movddup xmm0, xmm0
+      0x66, 0x0f, 0x7c, 0xc9,                   // haddpd xmm1, xmm1
+      0x8d, 0x83, 0x18, 0xff, 0xff, 0xff        // lea -0xe8(%ebx), %eax
+  }};
+  // clang-format on
+
+  auto sarch = Dyninst::getArchitectureName(arch);
+  std::clog << "Running tests in " << sarch << " mode\n";
+
+  std::vector<di::Instruction> decodedInsns;
+  decodedInsns.reserve(num_tests);
+
+  di::InstructionDecoder d(buffer.data(), buffer.size(), arch);
+  for(int idx = 0; idx < num_tests; idx++) {
+    di::Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      std::cerr << "Failed to decode " << sarch << " test " << (idx + 1) << '\n';
+      return false;
+    }
+    decodedInsns.push_back(insn);
+  }
+
+  const auto is_64 = (arch == Dyninst::Arch_x86_64);
+
+  auto eax = is_64 ? Dyninst::x86_64::eax : Dyninst::x86::eax;
+  auto ebx = is_64 ? Dyninst::x86_64::rbx : Dyninst::x86::ebx;
+  auto af = is_64 ? Dyninst::x86_64::af : Dyninst::x86::af;
+  auto zf = is_64 ? Dyninst::x86_64::zf : Dyninst::x86::zf;
+  auto of = is_64 ? Dyninst::x86_64::of : Dyninst::x86::of;
+  auto pf = is_64 ? Dyninst::x86_64::pf : Dyninst::x86::pf;
+  auto sf = is_64 ? Dyninst::x86_64::sf : Dyninst::x86::sf;
+  auto cf = is_64 ? Dyninst::x86_64::cf : Dyninst::x86::cf;
+  auto al = is_64 ? Dyninst::x86_64::al : Dyninst::x86::al;
+  auto bp = is_64 ? Dyninst::x86_64::rbp : Dyninst::x86::ebp;
+  auto dl = is_64 ? Dyninst::x86_64::dl : Dyninst::x86::dl;
+  auto xmm0 = is_64 ? Dyninst::x86_64::xmm0 : Dyninst::x86::xmm0;
+  auto xmm1 = is_64 ? Dyninst::x86_64::xmm1 : Dyninst::x86::xmm1;
+
+  auto sp = Dyninst::MachRegister::getStackPointer(arch);
+  auto ip = Dyninst::MachRegister::getPC(arch);
+
+  auto rax = Dyninst::x86_64::rax;
+
+  using reg_set = Dyninst::register_set;
+
+  std::vector<reg_set> expectedRead, expectedWritten;
+
+  // add eax, 0xdeadbeef
+  expectedRead.push_back(reg_set{eax});
+  expectedWritten.push_back(reg_set{eax, af, zf, of, pf, sf, cf});
+
+  // push eax
+  expectedRead.push_back(reg_set{sp, (is_64 ? rax : eax)});
+  expectedWritten.push_back(reg_set{sp});
+
+  // jz +0x10(8)
+  expectedRead.push_back(reg_set{zf, sf, cf, pf, of, ip});
+  expectedWritten.push_back(reg_set{ip});
+
+  // call +0x20(32)
+  expectedRead.push_back(reg_set{sp, ip});
+  expectedWritten.push_back(reg_set{sp, ip});
+
+  // clc
+  expectedRead.push_back(reg_set{});
+  expectedWritten.push_back(reg_set{cf});
+
+  // add al, 0x30(8)
+  expectedRead.push_back(reg_set{al});
+  expectedWritten.push_back(reg_set{al, zf, cf, sf, of, pf, af});
+
+  // movl 0x01, -0x4(ebp)
+  expectedRead.push_back(reg_set{bp});
+  expectedWritten.push_back(reg_set{});
+
+  // movb dl, -0x34(ebp)
+  expectedRead.push_back(reg_set{bp, dl});
+  expectedWritten.push_back(reg_set{});
+
+  // movddup xmm0, xmm0
+  expectedRead.push_back(reg_set{xmm0});
+  expectedWritten.push_back(reg_set{xmm0});
+
+  // haddpd xmm1, xmm1
+  expectedRead.push_back(reg_set{xmm1});
+  expectedWritten.push_back(reg_set{xmm1});
+
+  // lea -0xe8(%ebx), %eax
+  expectedRead.push_back(reg_set{ebx});
+  expectedWritten.push_back(reg_set{eax});
+
+  if(expectedRead.size() != expectedWritten.size()) {
+    std::cerr << "FATAL: expectedRead.size() != expectedWritten.size()\n";
+    return false;
+  }
+
+  if(expectedRead.size() != decodedInsns.size()) {
+    std::cerr << "FATAL: expectedRead.size() != decodedInsns.size()\n";
+    return false;
+  }
+
+  bool failed = false;
+  for(size_t i = 0; i < decodedInsns.size(); i++) {
+    auto const &insn = decodedInsns[i];
+
+    std::clog << "Verifying '" << insn.format() << "'\n";
+
+    if(!di::verify(insn, di::register_rw_test{expectedRead[i], expectedWritten[i]})) {
+      failed = true;
+    }
+  }
+
+  return !failed;
+}
+
+bool run64_only() {
+  constexpr auto arch = Dyninst::Arch_x86_64;
+  constexpr auto num_tests = 1;
+
+  // clang-format off
+  constexpr std::array<const uint8_t, 4> buffer = {{
+      0x44, 0x89, 0x45, 0xc4 // mov dword ptr [rbp - 0x3c], r8d
+  }};
+  // clang-format on
+
+  std::vector<di::Instruction> decodedInsns;
+  decodedInsns.reserve(num_tests);
+
+  di::InstructionDecoder d(buffer.data(), buffer.size(), arch);
+  for(int idx = 0; idx < num_tests; idx++) {
+    di::Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      std::cerr << "Failed to decode x86_64 test " << (idx + 1) << '\n';
+      return false;
+    }
+    decodedInsns.push_back(insn);
+  }
+
+  auto r8d = Dyninst::x86_64::r8d;
+  auto rbp = Dyninst::x86_64::rbp;
+
+  using reg_set = Dyninst::register_set;
+
+  std::vector<reg_set> expectedRead, expectedWritten;
+
+  // mov dword ptr [rbp - 0x3c], r8d
+  expectedRead.push_back(reg_set{rbp, r8d});
+  expectedWritten.push_back(reg_set{});
+
+  bool failed = false;
+  for(size_t i = 0; i < decodedInsns.size(); i++) {
+    auto const &insn = decodedInsns[i];
+
+    std::clog << "Verifying '" << insn.format() << "'\n";
+
+    if(!di::verify(insn, di::register_rw_test{expectedRead[i], expectedWritten[i]})) {
+      failed = true;
+    }
+  }
+
+  return !failed;
+}
+
+} // namespace
+
+int main() {
+  bool ok = run(Dyninst::Arch_x86);
+
+  if(!run(Dyninst::Arch_x86_64)) {
+    ok = false;
+  }
+  if(!run64_only()) {
+    ok = false;
+  }
+  return !ok ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
Ports the five remaining self-contained x86 InstructionAPI tests from the dyninst/testsuite repository (src/instruction/) into the integration test tree under
tests/integration/InstructionAPI/decoder/x86/. The testsuite framework boilerplate was stripped; the checks carry over unchanged. All of these decode fixed in-memory byte buffers, so they run on any host architecture. They are grouped on one branch because they are small, share one CMakeLists.txt, and have a single theme (x86 decoder checks).

- fucompp.cpp (from fucompp.C): register read/write sets for the x87 fcom/fcomp/fcompp, fcomi/fcomip, and fucom* comparison families, using the shared register_tests harness.
- read_write.cpp (from test_instruction_read_write.C): register read/write sets for arithmetic/stack/branch/mov/SSE/lea instructions in both 32- and 64-bit modes, plus a 64-bit-only mov test, using the shared register_tests harness.
- bind_eval.cpp (from test_instruction_bind_eval.C): decodes 'call [8*EAX + ECX + 0xDEADBEEF]' in both modes and verifies Expression::bind/eval behavior: the CFT (a dereference) stays undefined even when fully bound, while the inner address computation evaluates to the expected value.
- mov_size_details.cpp (from mov_size_details.C): operand value sizes for mov/movddup/add/fcomp. The x87 case still expects the wrong 8-byte size (should be 80-bit); kept verbatim with the original comment. The original's RHS error message printed the raw byte count as bits; the message (only the message) was fixed to print bits.
- farcall.cpp (from test_instruction_farcall.C): decodes a 32-bit far call with an immediate segment:offset operand and checks validity. This complements the existing call.cpp far-call test, which uses a different encoding and checks semantics rather than just decode success.