### PR TITLE
GitHub CI: remove patch for extrae

### DIFF
--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -356,6 +356,8 @@ jobs:
           apt install -y wget libxml2-dev autoconf m4 libtool gcc-13 g++-13 gfortran-13 libiberty-dev binutils-dev
 
       - name: Build extrae
+        env:
+          - FC: gfortran-13
         shell: bash
         run: |
           set -ex

--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -365,9 +365,6 @@ jobs:
           git clone --depth=1 https://github.com/bsc-performance-tools/extrae
           cd extrae
           
-          wget https://patch-diff.githubusercontent.com/raw/bsc-performance-tools/extrae/pull/140.patch
-          git apply 140.patch
-
           ./bootstrap
           
           lib_dir_suffix=

--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -355,9 +355,9 @@ jobs:
           apt update
           apt install -y wget libxml2-dev autoconf m4 libtool gcc-13 g++-13 gfortran-13 libiberty-dev binutils-dev
 
+        # extrae does not build with gcc-14 (the default compiler on the latest fedora)
       - name: Build extrae
-        env:
-          FC: gfortran-13
+        if: ${{ startsWith(matrix.os, 'ubuntu')}}
         shell: bash
         run: |
           set -ex
@@ -373,6 +373,8 @@ jobs:
           fi
           
           lib_dir="/usr/lib${lib_dir_suffix}"
+          
+          export CC=gcc-13 CXX=g++-13 FC=gfortran-13
           
           ./configure                               \
             --disable-doc                           \

--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -355,9 +355,7 @@ jobs:
           apt update
           apt install -y wget libxml2-dev autoconf m4 libtool gcc-13 g++-13 gfortran-13 libiberty-dev binutils-dev
 
-        # extrae does not build with gcc-14 (the default compiler on the latest fedora)
       - name: Build extrae
-        if: ${{ startsWith(matrix.os, 'ubuntu')}}
         shell: bash
         run: |
           set -ex
@@ -373,8 +371,6 @@ jobs:
           fi
           
           lib_dir="/usr/lib${lib_dir_suffix}"
-          
-          export CC=gcc-13 CXX=g++-13 FC=gfortran-13
           
           ./configure                               \
             --disable-doc                           \

--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -357,7 +357,7 @@ jobs:
 
       - name: Build extrae
         env:
-          - FC: gfortran-13
+          FC: gfortran-13
         shell: bash
         run: |
           set -ex


### PR DESCRIPTION
It's no longer needed.