### PR TITLE
GitHub CI: fix fromJson expressions missing output references

### DIFF
--- a/.github/actions/build-fedora/action.yaml
+++ b/.github/actions/build-fedora/action.yaml
@@ -47,7 +47,7 @@ runs:
         esac
         echo "value={ \"c\" : \"${cc}\", \"cxx\" : \"${cxx}\" }" >> $GITHUB_OUTPUT
 
-    - name: Build Dyninst (${{ fromJson(steps.compiler-name.outputs).c }}, ${{ inputs.build-type }} ${{ inputs.extra-cmake-flags }})
+    - name: Build Dyninst (${{ fromJson(steps.compiler-name.outputs.value).c }}, ${{ inputs.build-type }} ${{ inputs.extra-cmake-flags }})
       shell: bash
       run: |
         cmake_args="-DCMAKE_C_COMPILER=${{ fromJson(steps.compiler-name.outputs.value).c }} "

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -397,7 +397,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJson(needs.get-oses.outputs.latest) }}
-        bt: ${{ fromJson(needs.get-build-types.outputs.all }}
+        bt: ${{ fromJson(needs.get-build-types.outputs.all) }}
     steps:
     - name: Checkout Dyninst
       uses: actions/checkout@v4


### PR DESCRIPTION
In build-fedora, the step name read fromJson(steps.compiler-name.outputs) instead of the 'value' output that the step actually sets, as the cmake flags below already do. 

Also add a missing closing parenthesis in a workflow README example.