### PR TITLE
GitHubCI: retain workflow runs for 60 days

### DIFF
--- a/.github/workflows/purge-workflows.yaml
+++ b/.github/workflows/purge-workflows.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           token: ${{ secrets.github_token }}
           repository: ${{ github.repository }}
-          # remove anything older than two weeks
-          retain_days: 14
+          # remove anything older than two months
+          retain_days: 60
           # keep at least one run of any workflow
           keep_minimum_runs: 1


### PR DESCRIPTION
The OpenSSF scorecard checks if continuous integration tests are run for pull requests by checking the "check-runs" endpoint[1] for the last 30 PRs. However, the old workflow runs are purged once per month and only the last two
weeks worth are saved. By extending the retention window, there should be workflow runs remaining for it to give
a passing score.

[1] https://docs.github.com/en/rest/checks/runs?apiVersion=2026-03-10#list-check-runs-for-a-git-reference