### PR TITLE
Create a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+Security vulnerabilities are addressed only in the development branch. Unless otherwise specified, fixes are not backported to previous releases.
+
+## Reporting a Vulnerability
+
+You can report a vulnerability by sending a message to dyninst-security@g-groups.wisc.edu.
+
+**Please do not create a public issue when disclosing a security vulnerability.**
+
+## Responses
+
+We attempt to be as prompt as possible, but we cannot guarantee a specific time window for responding
+to security reports.


### PR DESCRIPTION
This establishes a basic policy for reporting security vulnerabilities. In addition to being a useful GitHub feature, it satisfies a component of the FLOSS Best Practices Badge[1].

[1] https://www.bestpractices.dev/en/criteria/0