### PR TITLE
GitHubCI: reduce repository permissions in workflows

### DIFF
--- a/.github/workflows/binary-tests.yaml
+++ b/.github/workflows/binary-tests.yaml
@@ -25,6 +25,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   # Don't run the check if the PR is a draft

--- a/.github/workflows/build-opts.yaml
+++ b/.github/workflows/build-opts.yaml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   # Don't run the check if the PR is a draft

--- a/.github/workflows/cmake-formatting.yaml
+++ b/.github/workflows/cmake-formatting.yaml
@@ -13,6 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   cmake-formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/codegen-cross-build.yaml
+++ b/.github/workflows/codegen-cross-build.yaml
@@ -19,6 +19,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   # Don't run the check if the PR is a draft

--- a/.github/workflows/compiler-multibuild.yaml
+++ b/.github/workflows/compiler-multibuild.yaml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   get-build-types:

--- a/.github/workflows/consumers.yaml
+++ b/.github/workflows/consumers.yaml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   get-oses:

--- a/.github/workflows/dependency-version.yaml
+++ b/.github/workflows/dependency-version.yaml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   dependency-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-containers.yaml
+++ b/.github/workflows/dev-containers.yaml
@@ -7,6 +7,8 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions: {}
+
 jobs:
 
   get-oses:

--- a/.github/workflows/libabigail.yaml
+++ b/.github/workflows/libabigail.yaml
@@ -21,6 +21,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   # Don't run the check if the PR is a draft or already marked as an ABI break

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -18,6 +18,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   # Don't run the check if the PR is a draft

--- a/.github/workflows/purge-workflows.yaml
+++ b/.github/workflows/purge-workflows.yaml
@@ -5,6 +5,8 @@ on:
     - cron: '0 5 1 * *'  # 5AM on the first of the month
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
 
   purge:

--- a/.github/workflows/refresh-containers.yaml
+++ b/.github/workflows/refresh-containers.yaml
@@ -5,6 +5,8 @@ on:
     - cron: '0 3 25 * *'  # 3AM on the 25th of every month
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
 
   get-oses:
@@ -102,3 +104,4 @@ jobs:
     uses: ./.github/workflows/dev-containers.yaml
     permissions:
       packages: write
+      actions: read

--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -3,6 +3,8 @@ name: Build and deploy release containers
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
 
   get-oses:

--- a/.github/workflows/spack-build.yaml
+++ b/.github/workflows/spack-build.yaml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   get-oses:

--- a/.github/workflows/system-libs.yaml
+++ b/.github/workflows/system-libs.yaml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   get-oses:


### PR DESCRIPTION
The OpenSSF scorecard Token-Permissions check requires minimizing permissions on workflows by

1) setting a global permission for the workflow
2) using job-specific permission overrides