### PR TITLE
[dyninstAPI] Have DelayedParsing delay CFG parse until needed

### DIFF
--- a/dyninstAPI/src/Relocation/DynCFGMaker.C
+++ b/dyninstAPI/src/Relocation/DynCFGMaker.C
@@ -46,6 +46,10 @@ PatchFunction* DynCFGMaker::makeFunction(Function* f,
                                          PatchObject* obj) {
   Address code_base = obj->codeBase();
   mapped_object* mo = SCAST_MO(obj);
+
+  // func_instance being constructed is unusable without blocks
+  if (!f->entry()) mo->analyzeIfDeferred();
+
   parse_func* img_func = SCAST_PF(f);
   if (!img_func) return NULL;
   assert(img_func->getSymtabFunction());

--- a/dyninstAPI/src/dynproc/dynProcess.C
+++ b/dyninstAPI/src/dynproc/dynProcess.C
@@ -1701,6 +1701,30 @@ void PCProcess::installInstrRequests(const std::vector<dapi::instMapping*> &requ
                         FILE__, __LINE__, matchingFuncs.size(), req->func.c_str());
         }
 
+        // Matches in libraries that import the symbol are PLT stubs that
+        // jump to the definition, so instrumenting the definition covers them.
+        // Dropping them also avoids relocate()'s overlap check, whose
+        // Block::getFuncs() forces a full CFG parse of the stub's library.
+        // If nothing is left, every match was a stub and we keep them all,
+        // since then only the stub can carry the probe. Static binaries have
+        // no stubs and are unaffected.
+        if (!matchingFuncs.empty()) {
+            std::vector<func_instance *> definitions;
+            for (func_instance *func : matchingFuncs) {
+                if (func && func->ifunc() && !func->ifunc()->isPLTFunction())
+                    definitions.push_back(func);
+            }
+
+            if (!definitions.empty() && definitions.size() < matchingFuncs.size()) {
+                inst_printf("%s[%d]: %lu of %lu matches for %s are PLT stubs, "
+                            "instrumenting the definition(s) only\n",
+                            FILE__, __LINE__,
+                            matchingFuncs.size() - definitions.size(),
+                            matchingFuncs.size(), req->func.c_str());
+                matchingFuncs.swap(definitions);
+            }
+        }
+
         for (unsigned funcIter = 0; funcIter < matchingFuncs.size(); funcIter++) {
            func_instance *func = matchingFuncs[funcIter];
            if (!func) {

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -1026,7 +1026,6 @@ image::getAllFunctions()
 
 const std::vector<image_variable*> &image::getAllVariables()
 {
-    analyzeIfNeeded();
     return everyUniqueVariable;
 }
 
@@ -1034,7 +1033,6 @@ const std::vector<image_variable*> &image::getExportedVariables() const { return
 
 const std::vector<image_variable*> &image::getCreatedVariables()
 {
-  analyzeIfNeeded();
   return createdVariables;
 }
 
@@ -1103,7 +1101,8 @@ void image::findModByAddr (const Symbol *lookUp, vector<Symbol *> &mods,
 
 image *image::parseImage(fileDescriptor &desc, 
                          BPatch_hybridMode mode, 
-                         bool parseGaps)
+                         bool parseGaps,
+                         bool delayedParse)
 {
   /*
    * Check to see if we have parsed this image before. We will
@@ -1135,7 +1134,7 @@ image *image::parseImage(fileDescriptor &desc,
 #endif
 
   startup_printf("%s[%d]:  about to create image\n", FILE__, __LINE__);
-  image *ret = new image(desc, err, mode, parseGaps); 
+  image *ret = new image(desc, err, mode, parseGaps, delayedParse); 
   if(err) {
     return nullptr;
   }
@@ -1222,6 +1221,12 @@ void image::analyzeIfNeeded() {
 	  clearNewBlocks();
   }
 }
+
+void image::analyzeIfDeferred() {
+  if (deferredParse_)
+      analyzeIfNeeded();
+}
+  
 
 static bool CheckForPowerPreamble(parse_block* entryBlock, Address &tocBase) {
     ParseAPI::Block::Insns insns;
@@ -1328,7 +1333,8 @@ void image::analyzeImage() {
 image::image(fileDescriptor &desc, 
              bool &err, 
              BPatch_hybridMode mode, 
-             bool parseGaps) :
+             bool parseGaps,
+             bool delayedParse) :
    desc_(desc),
    imageOffset_(0),
    imageLen_(0),
@@ -1350,9 +1356,11 @@ image::image(fileDescriptor &desc,
    trackNewBlocks_(false),
    refCount(1),
    parseState_(unparsed),
+   deferredParse_(false),
    parseGaps_(parseGaps),
    mode_(mode),
-   arch(Dyninst::Arch_none)
+   arch(Dyninst::Arch_none),
+   pltStubAddrsInitialized_(false)
 {
 #if defined(os_linux) || defined(os_freebsd)
    string const& file = desc_.file();
@@ -1458,7 +1466,12 @@ image::image(fileDescriptor &desc,
    // Continue ParseAPI init
    img_fact_ = new Dyninst::DyninstAPI::DynCFGFactory(this);
    parse_cb_ = new Dyninst::DyninstAPI::DynParseCallback(this);
-   obj_ = new CodeObject(cs_,img_fact_,parse_cb_,BPatch_defensiveMode == mode);
+
+   // Only normal mode defers CFG when delayedParsing is enabled
+   // Also skipped when arch is ppc64 as it walks functions are their entry blocks below
+   const bool is_ppc64 = (cs_->getArch() == Arch_ppc64);
+   deferredParse_ = delayedParse && (mode == BPatch_normalMode) && !is_ppc64;
+   obj_ = new CodeObject(cs_,img_fact_,parse_cb_,BPatch_defensiveMode == mode, deferredParse_);
 
      if (obj_->cs()->getArch() == Arch_ppc64) {
         // The PowerPC new ABI typically generate two entries per function.
@@ -1804,6 +1817,27 @@ const std::vector<parse_func *> *image::findFuncVectorByPretty(const std::string
     }
 }
 
+
+// A PLT stub has no symbol of its own, so only parsing creates its parse_func
+bool image::parsePltStubs(const std::string &name)
+{
+    // linkage() is address -> name; we need name -> addresses. Build it once
+    if (!pltStubAddrsInitialized_) {
+        pltStubAddrsInitialized_ = true;
+        for (auto const &entry : cs_->linkage()) {
+            pltStubAddrs_[entry.second].push_back(entry.first);
+        }
+    }
+
+    // The parser names stubs from this same table, so absent means none exists
+    auto iter = pltStubAddrs_.find(name);
+    if (iter == pltStubAddrs_.end())
+        return false;
+
+    codeObject()->parse(iter->second, false);
+    return true;
+}
+
 // Return the vector of functions associated with a mangled name
 // Very well might be more than one! -- multiple static functions in different .o files
 
@@ -1826,6 +1860,15 @@ const std::vector <parse_func *> *image::findFuncVectorByMangled(const std::stri
     if (res->empty()) {
         // Lookup PLT stubs
         auto it = plt_parse_funcs.find(name);
+
+        // Miss above might be false. Only parsing fills plt_parse_funcs, and image
+        // may not have been parsed yet.
+        // Parse only the stubs to avoid parsing the whole image.
+        if (it == plt_parse_funcs.end() && deferredParse_ && !isParsed()) {
+            if (parsePltStubs(name))
+                it = plt_parse_funcs.find(name);
+        }
+
         if (it != plt_parse_funcs.end()) {
             res->push_back(it->second);
         }

--- a/dyninstAPI/src/image.h
+++ b/dyninstAPI/src/image.h
@@ -261,7 +261,8 @@ class image : public codeRange {
  public:
    static image *parseImage(fileDescriptor &desc, 
                             BPatch_hybridMode mode,
-                            bool parseGaps);
+                            bool parseGaps,
+                            bool delayedParse);
 
    // And to get rid of them if we need to re-parse
    static void removeImage(image *img);
@@ -274,9 +275,11 @@ class image : public codeRange {
 
    image(fileDescriptor &desc, bool &err, 
          BPatch_hybridMode mode,
-         bool parseGaps);
+         bool parseGaps,
+         bool delayedParse);
 
    void analyzeIfNeeded();
+   void analyzeIfDeferred();
    bool isParsed() { return parseState_ == analyzed; }
    parse_func* addFunction(Address functionEntryAddr, const char *name=NULL);
 
@@ -421,6 +424,10 @@ class image : public codeRange {
    bool determineImageType();
    bool addSymtabVariables();
 
+   // Parse the PLT stubs for an external name, located via the linkage table so
+   // no CFG is needed. False when the name is not linked through a stub.
+   bool parsePltStubs(const std::string &name);
+
    void setModuleLanguages(std::unordered_map<std::string, SymtabAPI::supportedLanguages> *mod_langs);
 
    // We have a _lot_ of lookup types; this handles proper entry
@@ -498,11 +505,14 @@ class image : public codeRange {
 
    int refCount;
    imageParseState_t parseState_;
+   bool deferredParse_;
    bool parseGaps_;
    BPatch_hybridMode mode_;
    Dyninst::Architecture arch;
 
    dyn_hash_map<string, parse_func*> plt_parse_funcs;
+   std::map<std::string, std::vector<Address> > pltStubAddrs_;
+   bool pltStubAddrsInitialized_;
 
 };
 

--- a/dyninstAPI/src/mapped_object.C
+++ b/dyninstAPI/src/mapped_object.C
@@ -46,6 +46,7 @@
 #include "InstructionDecoder.h"
 #include "patching/instPoint.h"
 #include <boost/tuple/tuple.hpp>
+#include "BPatch.h"
 #include "BPatch_image.h"
 #include "PatchCFG.h"
 #include "PCProcess.h"
@@ -142,7 +143,9 @@ mapped_object *mapped_object::createMappedObject(fileDescriptor &desc,
    startup_printf("%s[%d]:  about to parseImage\n", FILE__, __LINE__);
    startup_printf("%s[%d]: name %s, codeBase 0x%lx, dataBase 0x%lx\n",
                   FILE__, __LINE__, desc.file().c_str(), desc.code(), desc.data());
-   image *img = image::parseImage( desc, analysisMode, parseGaps);
+   const bool delayedParse = 
+       BPatch::bpatch != NULL && BPatch::bpatch->delayedParsingOn();
+   image *img = image::parseImage( desc, analysisMode, parseGaps, delayedParse);
    if (!img)  {
       startup_printf("%s[%d]:  failed to parseImage\n", FILE__, __LINE__);
       return NULL;
@@ -600,6 +603,9 @@ func_instance *mapped_object::findFuncByEntry(const Address addr) {
    return NULL;
 }
 
+void mapped_object::analyzeIfDeferred() { parse_img()->analyzeIfDeferred(); }
+
+void mapped_object::ensureParsed() { analyzeIfDeferred(); }
 
 const std::vector<mapped_module *> &mapped_object::getModules() {
     // everyModule may be out of date...

--- a/dyninstAPI/src/mapped_object.h
+++ b/dyninstAPI/src/mapped_object.h
@@ -202,9 +202,9 @@ class mapped_object : public codeRange, public Dyninst::PatchAPI::DynObject {
     const std::string debugString() const;
 
     // Used for codeRange ONLY! DON'T USE THIS! BAD USER!
-    Address get_address() const { return codeAbs(); }
-    void *get_local_ptr() const;
-    unsigned get_size() const { return imageSize(); }
+    Address get_address() const override { return codeAbs(); }
+    void *get_local_ptr() const override;
+    unsigned get_size() const override { return imageSize(); }
 
     AddressSpace *proc() const;
 
@@ -225,7 +225,7 @@ class mapped_object : public codeRange, public Dyninst::PatchAPI::DynObject {
     block_instance *findOneBlockByAddr(const Address addr);
 
     // codeRange method
-    void *getPtrToInstruction(Address addr) const;
+    void *getPtrToInstruction(Address addr) const override;
     void *getPtrToData(Address addr) const;
 
     // Try to avoid using these if you can, since they'll trigger

--- a/dyninstAPI/src/mapped_object.h
+++ b/dyninstAPI/src/mapped_object.h
@@ -301,6 +301,9 @@ public:
 
     func_instance *findFunction(ParseAPI::Function *img_func);
 
+    // Builds the CFG of an image whose parse was deferred. No-op otherwise.
+    void analyzeIfDeferred();
+
     int_variable *findVariable(image_variable *img_var);
 
     block_instance *findBlock(ParseAPI::Block *);
@@ -321,6 +324,10 @@ public:
     void destroy(PatchAPI::PatchFunction *f);
     void destroy(PatchAPI::PatchBlock *b);
     // void destroy(PatchAPI::PatchEdge *e); // don't need to destroy anything
+
+  protected:
+    // Builds the CFG of a deferred image before PatchObject walks its functions.
+    void ensureParsed() override;
 
   private:
     //

--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -224,6 +224,16 @@ Parser::parse_at(const std::vector<std::pair<Address, CodeRegion*>> & targets,
     if(_parse_state == UNPARSEABLE)
         return;
 
+    // Nothing has consumed hint_funcs yet, so the clear below would strand every
+    // unparsed function and the COMPLETE downgrade would lock parse() out for good.
+    const bool full_parse_pending = (_parse_state == UNPARSED);
+    dyn_c_vector<Function *> pending_hints;
+    dyn_c_vector<Function *> pending_discovered;
+    if (full_parse_pending) {
+        pending_hints.swap(hint_funcs);
+        pending_discovered.swap(discover_funcs);
+    }
+
     // Reset parser status
     _parse_state = PARTIAL;
     hint_funcs.clear();
@@ -270,6 +280,14 @@ Parser::parse_at(const std::vector<std::pair<Address, CodeRegion*>> & targets,
     }
     parse_frames(work,recursive);
     finalize();
+
+    if (full_parse_pending) {
+        // finalize() already took this parse's batch; re-queuing it would double-finalize
+        hint_funcs.swap(pending_hints);
+        discover_funcs.swap(pending_discovered);
+        _parse_state = UNPARSED;
+        return;
+    }
 
     // downgrade state if necessary
     if(_parse_state > COMPLETE)

--- a/patchAPI/h/PatchObject.h
+++ b/patchAPI/h/PatchObject.h
@@ -121,6 +121,10 @@ class DYNINST_EXPORT PatchObject {
     void copyCFG(PatchObject* par_obj);
     bool splitBlock(PatchBlock *first, ParseAPI::Block *second);
 
+    // Allows a subclass to build its CFG before createFuncs() runs.
+    // createFuncs() walks co()->funcs(), requiring a full parse
+    virtual void ensureParsed() {}
+
     void createFuncs();
     void createBlocks();
     void createEdges();

--- a/patchAPI/src/PatchObject.C
+++ b/patchAPI/src/PatchObject.C
@@ -134,6 +134,7 @@ Address PatchObject::codeOffsetToAddr(Address offset) const {
 }
 
 void PatchObject::createFuncs() {
+   ensureParsed();
    for (auto iter = co()->funcs().begin(); iter != co()->funcs().end(); ++iter) {
       getFunc(*iter, true);
    }


### PR DESCRIPTION
**Problem**: When certain binaries that use shared libraries with many functions are instrumented, `processCreate` takes a substantial amount of time to complete even if we later exclude those large libraries from instrumentation. 

Consider `transpose` (https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprofiler-systems/examples/transpose) that was built to use `libLLVM.so` and `libclang-cpp.so` at runtime. In our tool, we by default exclude these from `runtime-instrumentation` to keep instrumentation overhead manageable (the large amount of functions will make fetching the functions from the object take much longer): 
```
[rocprof-sys][exe] [filter] skipping shared lib 'libclang-cpp.so.23.0git' (78832 functions > --max-library-functions=20000)
[rocprof-sys][exe] [filter] skipping shared lib 'libLLVM.so.23.0git' (95293 functions > --max-library-functions=20000)
[rocprof-sys][exe] Filtered objects: 20 of 22 included (2 excluded) (0.000 sec, 1.280 MB)
```
The function count is a lower bound obtained through the SymtabAPI. 

However, the `processCreate` call (done as the first step) reports:
```
[rocprof-sys][exe] processCreate took 74.853 sec
```

`rocprof-sys-intrument -- ./transpose` takes `84` seconds, of which `74` are spent in `processCreate`. Investigation shows a significant chunk of time is spent processing the two libraries that we later exclude from instrumentation:
```
# Custom print statements used
[dyninst][cfg-parse] code object                                         seconds
[dyninst][cfg-parse] ld-linux-x86-64.so.2                                  0.058
[dyninst][cfg-parse] libLLVM.so.23.0git                                   38.965
[dyninst][cfg-parse] libamdhip64.so.7.1.70101                              0.021
[dyninst][cfg-parse] libc.so.6                                             1.240
[dyninst][cfg-parse] libclang-cpp.so.23.0git                              29.128
[dyninst][cfg-parse] libdl.so.2                                            0.000
# ... Other libraries that take <1 second ...
[dyninst][cfg-parse] TOTAL                                                70.837
```

I will note that I had `OMP_NUM_THREADS=2`, and I am aware this will affect performance, but the point remains that if I am going to exclude these libraries later, there is no point on spending the time on parsing the CFG.


**Solution**: The goal here is to implement the `delayedParsing` flag and have it defer `CFG` until it actually needs it

Changes (48334cdbd9e6bd842cfc51a1af6eaceea97f2c5b)
- `image.C`
	- `image::image` respects `delayedParsing` flag IFF `BPatch_normalMode` and we are not using `ppc64`. It sets `ignoreParse` on the `CodeObject`, so hints are recorded but no CFG is built.
	- Removed `analyzeIfNeeded()` from `getAllVariables` as the list should already be completed once the constructor has run `addSymtabVariables()`, and only `createImageVariables()` adds to it afterwards (same holds for `getCreatedVariables()`)
	- The function to gate analysis is `analyzeIfDeferred`, which wraps `analyzeIfNeeded`. Guarding at the call sites leaves the other 7 pre-existing `analyzeIfNeeded` callers untouched.
	- `image::findFuncVectorByMangled` does use `plt_parse_funcs`, which is filled during CFG construction. To avoid this, parse the stub itself through the new `parsePltStubs`, which inverts `cs_->linkage()` (address -> name, from relocations) once and parses only those addresses.
- `analyzeIfDeferred` checks added to the following:
	- `DynCFGMaker.C`'s `makeFunction`, which requires blocks.
	- `PatchObject::createFuncs`, via a new `virtual ensureParsed()` that `mapped_object` overrides. It has to run before the loop: `co()->funcs()` is ordered, so a mid-walk parse misses whatever it inserts below the cursor.
- Value for `analyzeIfDeferred` read in `mapped_object` and passed to `parseImage`, which keeps `image` free of the `BPatch` singleton.
- `Parser.C`
	- `parse_at` assumed a full parse had already run: it cleared `hint_funcs`/`discover_funcs` and downgraded the state to `COMPLETE`. On a deferred `CodeObject` that strands every unparsed function and makes `Parser::parse()` a permanent no-op. It now parks the seed lists when entering at `UNPARSED` and restores them, state included.
	
With the code changes, I now see:
```
[dyninst][cfg-parse] code object                                         seconds
[dyninst][cfg-parse] libLLVM.so.23.0git                                   39.246
# ... Other libraries that take <1 second.
[dyninst][cfg-parse] TOTAL                                                40.982
```

`libLLVM` is still being fully parsed it seems. Problems comes down to when Dyninst searches for `execve`. It seems Dyninst is after libc's `execve`, but we search by name, so we also match the `execve@plt` stub in every shared lib that imports it, which `libLLVM` has, and `libclang-cpp` does not. Instrumenting a stub is what drags in its library's full CFG.

So we drop every match whose address is a PLT slot in its own object, which leaves the definition. If that leaves nothing, every match was a stub and we keep them all. A static binary has no stubs and pays nothing.

Changes (529234f25a397177004e55f285aded91a4049727)
- `dynProcess.C`
	- `installInstrRequests` keeps only real definitions when a request's name resolves to both a definition and PLT stubs. `findFuncsByAll` matches by name across every object, so one `execve` request fans out to libc's definition plus a stub in each importing library. Each stub is expensive: `AddressSpace::relocate()`'s overlap check calls `Block::getFuncs()` on the stub's blocks, which forces the deferred parse of its entire library, hence `libLLVM.so` still being parsed. 
	- The query is object-wide, so deferral cannot help; the stub has to stay out of the modified set (fallback is to do old behavior).

With this change:
```
[dyninst][cfg-parse] code object                                         seconds
# ... Libraries that take <1 second.
[dyninst][cfg-parse] TOTAL                                                 1.732
```

And I see:
```
[rocprof-sys][exe] processCreate took 3.621 sec
```

Overall, the `ctest` that runs `transpose` with `runtime-instrument` went from `84` to `~13` seconds and passes.
Visualizing the generated traces in perfetto showed no differences that could result from this PR.