### PR TITLE
GitHubCI: add OpenSSF scorecard update and badge

### DIFF
--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -1,0 +1,39 @@
+name: OpenSSF scorecard analysis workflow
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+    - master
+  schedule:
+    # Weekly on Saturdays at 1:30AM local time
+    - cron:  '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token to publish results
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Scorecard team runs a weekly scan of public GitHub repos,
+          # see https://github.com/ossf/scorecard#public-data.
+          # Setting `publish_results: true` helps us scale by leveraging your workflow to
+          # extract the results instead of relying on our own infrastructure to run scans.
+          # And it's free for you!
+          publish_results: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dyninst
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/dyninst/dyninst/badge)](https://scorecard.dev/viewer/?uri=github.com/dyninst/dyninst)
+
 ## Notes
 
 * Known issues should have open issues associated with them.


### PR DESCRIPTION
The Open Source Security Foundation (OpenSSF) scoreboard[1] is a tool to track compliance with the FLOSS Best Practices Criteria[2]. The results are posted to the public scorecard[3], and the badge in the Dyninst README.md points to the latest one.

[1] https://scorecard.dev
[2] https://www.bestpractices.dev/en/criteria/0
[3] https://scorecard.dev/viewer/?uri=github.com/dyninst/dyninst

Requires #2361