### PR TITLE
GitHubCI: update permissions for OpenSSF scorecard workflow

### DIFF
--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -7,14 +7,12 @@ on:
   schedule:
     # Weekly on Saturdays at 1:30AM local time
     - cron:  '30 1 * * 6'
-  workflow_dispatch:
-
-permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    environment: "OpenSSF Scorecard"
     permissions:
       # Needed for Code scanning upload
       security-events: write
@@ -30,6 +28,7 @@ jobs:
       - name: "Run analysis"
         uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
+          repo_token: ${{ secrets.OPENSSF_TOKEN }}
           results_file: results.sarif
           results_format: sarif
           # Scorecard team runs a weekly scan of public GitHub repos,


### PR DESCRIPTION
The classic branch protection rules need administration read permissions. The global 'read-all' was being overriden by the job-specific ones so they need to be explicitly listed.

The action can only be run from the master branch, so having a workflow_dispatch is useless.