### PR TITLE
Fix instructionAPI's use of DYNINST_ENABLE_{CAPSTONE,ZYDIS}

### DIFF
--- a/instructionAPI/CMakeLists.txt
+++ b/instructionAPI/CMakeLists.txt
@@ -48,23 +48,16 @@ set(_public_headers
 
 set(_private_headers src/debug.h h/syscalls.h h/interrupts.h)
 
-# Optional decoder used by the built-in "unknown instruction" callback to
-# recover the length of x86-64 instructions InstructionAPI cannot decode.
-if(DYNINST_ENABLE_ZYDIS)
-  set(_unknown_insn_deps Dyninst::Zydis)
-  set(_unknown_insn_defines DYNINST_ENABLE_ZYDIS)
-endif()
-
 # cmake-format: off
 dyninst_library(
   instructionAPI
   PUBLIC_HEADER_FILES ${_public_headers}
   PRIVATE_HEADER_FILES ${_private_headers}
   SOURCE_FILES ${_sources}
-  DEFINES INSTRUCTION_LIB ${_unknown_insn_defines}
+  DEFINES INSTRUCTION_LIB
   DYNINST_DEPS common
   PUBLIC_DEPS Dyninst::Boost_headers
-  PRIVATE_DEPS ${_unknown_insn_deps} ${_subprojects}
+  PRIVATE_DEPS ${_subprojects}
 )
 # cmake-format: on
 

--- a/instructionAPI/src/decoder/CMakeLists.txt
+++ b/instructionAPI/src/decoder/CMakeLists.txt
@@ -15,7 +15,13 @@ dyninst_library(
   INTERNAL_LIBRARY
   SOURCE_FILES ${_sources}
   PRIVATE_HEADER_FILES ${_headers}
-  DYNINST_INTERNAL_DEPS common
+  DYNINST_INTERNAL_DEPS
+    common
+    instructionAPI_aarch64
+    instructionAPI_amdgpu
+    instructionAPI_powerpc
+    instructionAPI_riscv
+    instructionAPI_x86
 )
 
 set(_inc_dirs

--- a/instructionAPI/src/decoder/CMakeLists.txt
+++ b/instructionAPI/src/decoder/CMakeLists.txt
@@ -9,12 +9,20 @@ set(_headers type_conversion.h InstructionDecoderImpl.h)
 
 set(_sources InstructionCategories.C InstructionDecoder.C InstructionDecoderImpl.C)
 
+# Optional decoder used by the built-in "unknown instruction" callback to
+# recover the length of x86-64 instructions InstructionAPI cannot decode.
+if(DYNINST_ENABLE_ZYDIS)
+  set(_unknown_insn_deps Dyninst::Zydis)
+  set(_unknown_insn_defines DYNINST_ENABLE_ZYDIS)
+endif()
+
 # cmake-format: off
 dyninst_library(
   instructionAPI_decoder
   INTERNAL_LIBRARY
   SOURCE_FILES ${_sources}
   PRIVATE_HEADER_FILES ${_headers}
+  DEFINES ${_unknown_insn_defines}
   DYNINST_INTERNAL_DEPS
     common
     instructionAPI_aarch64
@@ -22,6 +30,7 @@ dyninst_library(
     instructionAPI_powerpc
     instructionAPI_riscv
     instructionAPI_x86
+  PRIVATE_DEPS ${_unknown_insn_deps}
 )
 
 set(_inc_dirs
@@ -34,3 +43,5 @@ target_include_directories(instructionAPI_decoder PRIVATE $<BUILD_INTERFACE:${_i
 
 unset(_headers)
 unset(_sources)
+unset(_unknown_insn_deps)
+unset(_unknown_insn_defines)

--- a/instructionAPI/src/decoder/riscv/CMakeLists.txt
+++ b/instructionAPI/src/decoder/riscv/CMakeLists.txt
@@ -2,6 +2,7 @@ include_guard(GLOBAL)
 
 if(NOT DYNINST_ENABLE_CAPSTONE)
   add_library(instructionAPI_riscv INTERFACE)
+  install(TARGETS instructionAPI_riscv EXPORT dyninst-targets)
   return()
 endif()
 

--- a/instructionAPI/src/decoder/riscv/CMakeLists.txt
+++ b/instructionAPI/src/decoder/riscv/CMakeLists.txt
@@ -21,7 +21,7 @@ dyninst_library(
   SOURCE_FILES ${_sources}
   PRIVATE_HEADER_FILES ${_headers}
   DYNINST_INTERNAL_DEPS common
-  PRIVATE_DEPS Dyninst::Capstone
+  PUBLIC_DEPS Dyninst::Capstone
 )
 
 set(_inc_dirs


### PR DESCRIPTION
After the recent directory restructuring, neither DYNINST_ENABLE_CAPSTONE nor DYNINST_ENABLE_ZYDIS function correctly.

DYNINST_ENABLE_CAPSTONE does not work since riscv/decoder.h includes capstone/capstone.h which is included by InstructionDecoderImpl.C.  After the directory restructuring DYNINST_ENABLE_CAPSTONE no longer causes a dependency on Dyninst::Capstone for InstructionDecoderImpl.C.  Made instructionAPI_riscv have capstone as a public dependency and make are architecture decode libraries be a dependency of instructionAPI_decoder.

DYNINST_ENABLE_ZYDIS does not work after the directory restructuring as the files that need zydis moved to instructionAPI/src/decoder the cmake logic also needs to move there.
