### PR TITLE
parseAPI: parse .plt.sec (IBT) stubs without a BND prefix

### DIFF
--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -647,15 +647,20 @@ SymtabCodeSource::init_linkage()
 
         // Each PLT stub is 16 byte long
         const int plt_entry_size = 16;
-        // Each PLT stub starts with a ENDBR64 instruction, which is 4 byte long,
-        // followed by a indirect jump instruction.
-        // The indirect jump instruction has a BND prefix and two byte opcode.
-        // Therefore, the offset to the PC-relative displacement is 7 bytes.
-        const int pc_rela_disp = 7;
+        // Each PLT stub is ENDBR64 (4 bytes) then an indirect jump
+        // `jmp *disp(%rip)` (opcode `ff 25`, then a 4-byte displacement). Some
+        // toolchains prefix the jump with BND (`f2 ff 25 ...`), placing the
+        // displacement at offset 7; others omit it (`ff 25 ...`), offset 6. The
+        // prefix must be detected per stub, not assumed: reading the wrong offset
+        // yields a bogus GOT address and the stub is silently left unnamed.
+        const int plt_endbr_len = 4;
         const unsigned char* buffer = (const unsigned char*)plt_sec->getPtrToRawData();
 
         // Scan each PLT stub
         for (size_t off = 0; off < plt_sec->getMemSize(); off += plt_entry_size) {
+            const int pc_rela_disp =
+                (buffer[off + plt_endbr_len] == 0xf2) ? plt_endbr_len + 3   // BND + `ff 25`
+                                                      : plt_endbr_len + 2;  // plain `ff 25`
             auto disp = Dyninst::read_memory_as<int32_t>(buffer + off + pc_rela_disp);
             Address rel_addr = plt_sec->getMemOffset() + off + pc_rela_disp + 4 /* four byte pc-relative displacment */ + disp;
             if (rel_addr_to_name.find(rel_addr) != rel_addr_to_name.end()) {


### PR DESCRIPTION
SymtabCodeSource::init_linkage reads each .plt.sec (Intel CET/IBT 2-PLT) stub to recover the imported symbol its indirect jump targets. Each stub is an ENDBR64 (4 bytes) followed by `jmp *disp(%rip)` (opcode `ff 25` then a 4-byte displacement):

    endbr64            ; f3 0f 1e fa
    bnd jmp *disp(rip) ; f2 ff 25 <disp32>   -> disp at offset 7   (older binutils)
    jmp *disp(rip)     ;    ff 25 <disp32>   -> disp at offset 6   (newer binutils)

The code hardcoded the displacement at offset 7, assuming every stub carries the BND prefix. Newer binutils omit it, so the displacement is at offset 6; reading at offset 7 there computes a wrong GOT slot, the .rela.plt lookup misses, and every PLT stub is left unnamed.

An unnamed stub is never matched against the non-returning-function list, so a noreturn callee reached through the PLT (__stack_chk_fail, _Unwind_Resume, __cxa_throw, ...) is treated as returning and the parser adds a spurious call-fallthrough edge past the call. Where gcc -O2 lays two functions' cold fragments contiguously, that edge chains one function's cold fragment into the next and merges their CFGs, so ParseAPI reports basic blocks as shared between functions that do not actually share them. Every consumer of the CFG inherits the error -- block/function attribution, instrumentation placement, and relocated-code exception handling (a shared block is duplicated into each function's relocation run, and control can reach the copy that lives under the wrong function's frame/exception info).

Detect the BND prefix per stub instead of assuming it: the displacement is at offset 7 when the byte after ENDBR64 is 0xf2 (BND + `ff 25`), else at offset 6 (plain `ff 25`). Backward-compatible -- stubs that do carry the BND prefix still read at offset 7.

Diagnosed on a gcc -O2 ubuntu-25.04 binary: before the fix __stack_chk_fail@plt was unnamed and RETURN, and two hot/cold-split functions shared 21 phantom blocks; after, the stubs resolve to their imports (__stack_chk_fail NORETURN) and the phantom shared blocks drop to 0. The dyninstAPI exception-handling integration suite, which relocates and then executes native mutatees over the merged-CFG path, goes from flaky/failing to 100% (80/80), deterministic and under parallel parsing -- the merge was also the source of parse-order non-determinism. Built clean under -DDYNINST_WARNINGS_AS_ERRORS=ON with gcc and clang.