### PR TITLE
cleanup/refactor/bug fix emitElf

### DIFF
--- a/common/h/unaligned_memory_access.h
+++ b/common/h/unaligned_memory_access.h
@@ -49,6 +49,18 @@
 namespace Dyninst {
 
 /*
+ * read_memory_as(r, addr)
+ *
+ * Assign to r the object of r's TYPE created by reading sizeof(r) bytes at addr.
+ * The address addr does not have to be properly aligned for the type.
+ */
+template <typename ResultType>
+inline void read_memory_as(ResultType &r, const void *addr)
+{
+    std::memcpy(static_cast<void *>(&r), addr, sizeof r);
+}
+
+/*
  * read_memory_as<TYPE>(addr)
  *
  * Return an object of TYPE created by reading sizeof(TYPE) bytes at addr.
@@ -58,15 +70,15 @@ template <typename ResultType>
 inline ResultType read_memory_as(const void *addr)
 {
     ResultType r;
-    std::memcpy(static_cast<void *>(&r), addr, sizeof r);
+    read_memory_as(r, addr);
     return r;
 }
 
 
 /*
- * write_memory_as<TYPE>(adrr, &data)
+ * write_memory_as(addr, data)
  *
- * Write sizeof(TYPE) bytes to the memory pointed to by addr by copying the
+ * Write sizeof(data) bytes to the memory pointed to by addr by copying the
  * bytes of the supplied parameter.  The address addr does not have to be
  * properly aligned for the type.
  */
@@ -78,10 +90,10 @@ inline void write_memory_as(void *addr, const DataType &data)
 
 
 /*
- * append_memory_as<TYPE>(adrr, &data)
+ * append_memory_as(addr, data)
  *
- * Write sizeof(TYPE) bytes to the memory pointed to by addr by copying the
- * bytes of the supplied parameter, and adjust addr by sizeof(TYPE).  The
+ * Write sizeof(data) bytes to the memory pointed to by addr by copying the
+ * bytes of the supplied parameter, and adjust addr by sizeof(data).  The
  * address addr does not have to be properly aligned for the type.
  */
 template <typename PointerType, typename DataType>
@@ -93,10 +105,10 @@ inline void append_memory_as(PointerType *&addr, const DataType &data)
 
 
 /*
- * append_memory_as_byte(adrr, data)
+ * append_memory_as_byte(addr, data)
  *
  * Convenience function to avoid uint8_t cast when calling append_memory_as
- * with a uint8_t type.
+ * with a parameter that should be cast to a uint8_t type.
  */
 template <typename PointerType>
 inline void append_memory_as_byte(PointerType *&addr, std::uint8_t data)

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -3288,20 +3288,14 @@ bool ObjectELF::emitDriver(string fName, std::set<Symbol *> &allSymbols, unsigne
         Dyninst::SymtabAPI::emitElf<Dyninst::SymtabAPI::ElfTypes32> *em =
                 new Dyninst::SymtabAPI::emitElf<Dyninst::SymtabAPI::ElfTypes32>(elfHdr, isStripped, this, err_func_,
                                                                                 associated_symtab);
-        bool ok = em->createSymbolTables(allSymbols);
-        if (ok) {
-            ok = em->driver(fName);
-        }
+        bool ok{em->driver(fName, allSymbols)};
         delete em;
         return ok;
     } else if (elfHdr->e_ident()[EI_CLASS] == ELFCLASS64) {
         Dyninst::SymtabAPI::emitElf<Dyninst::SymtabAPI::ElfTypes64> *em =
                 new Dyninst::SymtabAPI::emitElf<Dyninst::SymtabAPI::ElfTypes64>(elfHdr, isStripped, this, err_func_,
                                                                                 associated_symtab);
-        bool ok = em->createSymbolTables(allSymbols);
-        if (ok) {
-            ok = em->driver(fName);
-        }
+        bool ok{em->driver(fName, allSymbols)};
         delete em;
         return ok;
     }

--- a/symtabAPI/src/Object-elf.h
+++ b/symtabAPI/src/Object-elf.h
@@ -204,6 +204,7 @@ class open_statement {
 class ObjectELF final : public Object
 {
   friend class Module;
+  template<typename ElfTypes> friend class emitElf;
 
   // declared but not implemented; no copying allowed
   ObjectELF(const ObjectELF &);
@@ -579,6 +580,7 @@ private:
   bool DbgSectionMapSorted;
   dyn_mutex dsm_lock;
   std::vector<DbgAddrConversion_t> DebugSectionMap;
+  int getFD() {return mf->getFD();}
 
  public:  
   std::set<std::string> prereq_libs;

--- a/symtabAPI/src/Symtab-lookup.C
+++ b/symtabAPI/src/Symtab-lookup.C
@@ -488,6 +488,7 @@ bool Symtab::findCatchBlock(ExceptionBlock &excp, Offset addr, unsigned size)
  
 bool Symtab::findRegionByEntry(Region *&ret, const Offset offset)
 {
+    ret = nullptr;
     if(regionsByEntryAddr.find(offset) != regionsByEntryAddr.end())
     {
         ret = regionsByEntryAddr[offset];
@@ -524,11 +525,12 @@ Region *Symtab::findEnclosingRegion(const Offset where)
             first = ((first + last) / 2) + 1;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 bool Symtab::findRegion(Region *&ret, std::string const& secName)
 {
+    ret = nullptr;
     for(unsigned index=0;index<regions_.size();index++)
     {
         if(regions_[index]->getRegionName() == secName)
@@ -544,7 +546,7 @@ bool Symtab::findRegion(Region *&ret, std::string const& secName)
 
 bool Symtab::findRegion(Region *&ret, const Offset addr, const unsigned long size)
 {
-   ret = NULL;
+   ret = nullptr;
    for(unsigned index=0;index<regions_.size();index++) {
       if(regions_[index]->getMemOffset() == addr && regions_[index]->getMemSize() == size) {
          if (ret) {

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -412,7 +412,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
     // ".shstrtab" section: string table for section header names
     const char *shnames = pdelf_get_shnames(oldElfHandle);
     if (shnames == NULL) {
-        log_elferror(err_func_, ".shstrtab section");
+        log_elferror(err_func_, ".shstrtab section not found");
         return false;
     }
 
@@ -1059,7 +1059,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
         sectionNumber++;
         // Add a new loadable section
         if ((newscn = elf_newscn(newElf)) == NULL) {
-            log_elferror(err_func_, "unable to create new function");
+            log_elferror(err_func_, "unable to create new section");
             return false;
         }
         if ((newdata = elf_newdata(newscn)) == NULL) {
@@ -1313,7 +1313,7 @@ bool emitElf<ElfTypes>::addSectionHeaderTable(Elf_Shdr *shdr) {
     Elf_Shdr *newshdr;
 
     if ((newscn = elf_newscn(newElf)) == NULL) {
-        log_elferror(err_func_, "unable to create new function");
+        log_elferror(err_func_, "unable to create new section");
         return false;
     }
     if ((newdata = elf_newdata(newscn)) == NULL) {
@@ -1365,7 +1365,7 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
         secNames.push_back(nonLoadableSecs[i]->getRegionName());
         // Add a new non-loadable section
         if ((newscn = elf_newscn(newElf)) == NULL) {
-            log_elferror(err_func_, "unable to create new function");
+            log_elferror(err_func_, "unable to create new section");
             return false;
         }
         if ((newdata = elf_newdata(newscn)) == NULL) {

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -591,17 +591,16 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
             // A word that is also a RELR relocation target was already shifted by the
             // earlier RELR loop, so skip to avoid offsetting it twice
             std::unordered_set<Offset> relr_addrs(relr_relocs.begin(), relr_relocs.end());
-            for(std::size_t off = 0; off < newdata->d_size; off += sizeof(void*)) {
+            for(std::size_t off = 0; off < newdata->d_size; off += sizeof(Elf_Relr)) {
                 Offset addr = shdr->sh_addr + off;
                 if (relr_addrs.count(addr)) continue;  // already adjusted as a RELR reloc
 
                 char *loc = static_cast<char*>(newdata->d_buf) + off;
-                size_t val{};
-                // The calls to memcpy are required to not break the aliasing rules.
-                memcpy(&val, loc, sizeof(val));
+                Elf_Relr val{};
+                read_memory_as(val, loc);
                 if(val == 0) continue;
                 val += library_adjust;
-                memcpy(loc, &val, sizeof(val));
+                write_memory_as(loc, val);
             }
         }
         // Change offsets of sections based on the newly added sections

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -70,52 +70,15 @@ unsigned int elfHash(const char *name) {
 template<class ElfTypes>
 emitElf<ElfTypes>::emitElf(Elf_X *oldElfHandle_, bool isStripped_, ObjectELF *obj_, void (*err_func)(const char *),
                                Symtab *st) :
-        oldElfHandle(oldElfHandle_), newElf(NULL), oldElf(NULL),
-        obj(st),
-        newEhdr(NULL), oldEhdr(NULL),
-        newPhdr(NULL), oldPhdr(NULL), phdr_offset(0),
-        textData(NULL), symStrData(NULL), dynStrData(NULL),
-        olddynStrData(NULL), olddynStrSize(0),
-        symTabData(NULL), dynsymData(NULL), dynData(NULL),
-        phdrs_scn(NULL), verneednum(0), verdefnum(0),
-        newSegmentStart(0), firstNewLoadSec(NULL),
-        dynSegOff(0), dynSegAddr(0),
-        phdrSegOff(0), phdrSegAddr(0), dynSegSize(0),
-        secNameIndex(0), currEndOffset(0), currEndAddress(0),
-        linkedStaticData(NULL), loadSecTotalSize(0),
-        isStripped(isStripped_), library_adjust(0),
-        object(obj_), err_func_(err_func),
-        hasRewrittenTLS(false), TLSExists(false), newTLSData(NULL) {
-    oldElf = oldElfHandle->e_elfp();
-    curVersionNum = 2;
-
-    //Set variable based on the mechanism to add new load segment
-    // 1) createNewPhdr (Total program headers + 1) - default
-    //    library_adjust - create room for a new program header in a position-indepdent library
-    //    by increasing all virtual addresses for the library
-
-    //If we're dealing with a library that can be loaded anywhere,
-    // then load the program headers into the later part of the binary,
-    // this may trigger a kernel bug that was fixed in Summer 2007,
-    // but is the only reliable way to modify these libraries.
-    //If we're dealing with a library/executable that loads at a specific
-    // address we'll put the phdrs into the page before that address.  This
-    // works and will avoid the kernel bug.
-
-    isStaticBinary = obj_->isStaticBinary();
-
-    //If we want to try a mode where we add the program headers to a library
-    // that can be loaded anywhere, and put the program headers in the first
-    // page (avoiding the kernel bug), then set library_adjust to getpagesize().
-    // This will shift all addresses in the library down by a page, accounting
-    // for the extra page for program headers.  This causes some significant
-    // changes to the binary, and isn't well tested.
-
-    library_adjust = 0;
-    if (!(object && object->getLoadAddress())) {
-        library_adjust = getpagesize();
-    }
-
+    oldElfHandle{oldElfHandle_},
+    oldElf{oldElfHandle->e_elfp()},
+    obj(st),
+    isStripped(isStripped_),
+    library_adjust{getpagesize()},
+    object(obj_),
+    err_func_(err_func),
+    isStaticBinary{obj_->isStaticBinary()}
+{
     assert(obj && object && object == dynamic_cast<ObjectELF*>(obj->getObject()));
 }
 

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -88,9 +88,7 @@ static int elfSymType(Symbol *sym)
      case Symbol::ST_NOTYPE : return STT_NOTYPE;
      case Symbol::ST_UNKNOWN: return sym->getInternalType();
      case Symbol::ST_CODE: return STT_FUNC;	// in ELF, ST_CODE maps to STT_FUNC
-#if defined(STT_GNU_IFUNC)
      case Symbol::ST_INDIRECT: return STT_GNU_IFUNC;
-#endif
      default: return STT_SECTION;
   }
 }
@@ -101,9 +99,7 @@ static int elfSymBind(Symbol::SymbolLinkage sLinkage)
   case Symbol::SL_LOCAL: return STB_LOCAL;
   case Symbol::SL_WEAK: return STB_WEAK;
   case Symbol::SL_GLOBAL: return STB_GLOBAL;
-#if defined(STB_GNU_UNIQUE)
   case Symbol::SL_UNIQUE: return STB_GNU_UNIQUE;
-#endif
   default: return STB_LOPROC;
   }
 }
@@ -143,6 +139,8 @@ std::string phdrTypeStr(Elf64_Word phdr_type) {
             return "STACK";
         case PT_GNU_RELRO:
             return "RELRO";
+        case PT_GNU_PROPERTY:
+            return "PROPERTY";
         case PT_PAX_FLAGS:
             return "PAX";
         default:

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -50,15 +50,7 @@ using namespace Dyninst::SymtabAPI;
 using namespace std;
 
 unsigned int elfHash(const std::string &name) {
-    unsigned int h = 0, g;
-
-    for (auto c : name) {
-        h = (h << 4) + c;
-        if ((g = h & 0xf0000000))
-            h ^= g >> 24;
-        h &= ~g;
-    }
-    return h;
+    return elf_hash(name.c_str());      // calll elfutils function
 }
 
 template<class ElfTypes>
@@ -986,29 +978,29 @@ void emitElf<ElfTypes>::fixPhdrs() {
     data->d_version = 1;
 }
 
-#if !defined(DT_GNU_HASH)
+#ifndef DT_GNU_HASH
 #define DT_GNU_HASH 0x6ffffef5
 #endif
-#if !defined(DT_GNU_CONFLICT)
+#ifndef DT_GNU_CONFLICT
 #define DT_GNU_CONFLICT 0x6ffffef8
 #endif
-#if !defined(DT_TLSDESC_PLT)
+#ifndef DT_TLSDESC_PLT
 #define DT_TLSDESC_PLT 0x6ffffef6
 #endif
-#if !defined(DT_TLSDESC_GOT)
+#ifndef DT_TLSDESC_GOT
 #define DT_TLSDESC_GOT 0x6ffffef7
 #endif
 // Older elf.h headers may not define RELR dynamic tag constants
-#if !defined(DT_RELRSZ)
+#ifndef DT_RELRSZ
 #define DT_RELRSZ 35
 #endif
-#if !defined(DT_RELR)
+#ifndef DT_RELR
 #define DT_RELR 36
 #endif
-#if !defined(DT_RELRENT)
+#ifndef DT_RELRENT
 #define DT_RELRENT 37
 #endif
-#if !defined(SHT_RELR)
+#ifndef SHT_RELR
 #define SHT_RELR 19
 #endif
 
@@ -1755,8 +1747,8 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
             if (secTagRegionMapping.find(DT_HASH) != secTagRegionMapping.end()) {
                 name = secTagRegionMapping[DT_HASH]->getRegionName();
                 obj->addRegion(0, hashsecData, hashsecSize * sizeof(Elf_Word), name, Region::RT_HASH, true);
-            } else if (secTagRegionMapping.find(0x6ffffef5) != secTagRegionMapping.end()) {
-                name = secTagRegionMapping[0x6ffffef5]->getRegionName();
+            } else if (secTagRegionMapping.find(DT_GNU_HASH) != secTagRegionMapping.end()) {
+                name = secTagRegionMapping[DT_GNU_HASH]->getRegionName();
                 obj->addRegion(0, hashsecData, hashsecSize * sizeof(Elf_Word), name, Region::RT_HASH, true);
             } else {
                 name = ".hash";
@@ -2337,7 +2329,7 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
         switch (dyns[i].d_tag) {
             case DT_NULL:
                 break;
-            case 0x6ffffef5: // DT_GNU_HASH (not defined on all platforms)
+            case DT_GNU_HASH:
                 if (!foundHashSection) {
                     dynsecData[curpos].d_tag = DT_HASH;
                     dynsecData[curpos].d_un.d_ptr = dyns[i].d_un.d_ptr;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -517,7 +517,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     std::unordered_map<string, unsigned> newNameIndexMapping;
 
     std::unordered_set<string> updateLinkInfoSecs = {
-        ".dynsym", /*".dynstr",*/ ".rela.dyn", ".rela.plt", ".dynamic", ".symtab"};
+        ".dynsym", /*".dynstr",*/ ".rela.dyn", ".rela.plt", ".dynamic"};
     std::unordered_map<string, pair<unsigned, unsigned>> dataLinkInfo;
 
     bool createdLoadableSections = false;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -38,11 +38,6 @@
 #include "unaligned_memory_access.h"
 
 
-#if defined(os_freebsd)
-#include "common/src/freebsdKludges.h"
-#endif
-
-
 #if defined(os_linux)
 
 #include "common/src/linuxKludges.h"
@@ -183,11 +178,7 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
     sym->st_info = (unsigned char) ELF64_ST_INFO(elfSymBind(symbol->getLinkage()), elfSymType(symbol));
 
     if (symbol->getRegion()) {
-#if defined(os_freebsd)
-        sym->st_shndx = (Elf_Half) symbol->getRegion()->getRegionNumber();
-#else
         sym->st_shndx = (Elf_Section) symbol->getRegion()->getRegionNumber();
-#endif
     }
     else if (symbol->isAbsolute()) {
         sym->st_shndx = SHN_ABS;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -383,7 +383,14 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
     }
     newFName = buf.get();
 
-    fchmod(newfd, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP);
+    struct stat statBuf;
+    decltype(statBuf.st_mode) origFdMode{};
+    if (fstat(object->getFD(), &statBuf) == 0) {
+        origFdMode = statBuf.st_mode & 0777;  // clear sticky, setXid bits
+    } else {
+        origFdMode = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP;
+    }
+    fchmod(newfd, S_IRUSR | S_IWUSR);  // just user while updating
     rewrite_printf("Emitting to temporary file %s\n", buf.get());
 
     if ((newElf = elf_begin(newfd, ELF_C_WRITE, NULL)) == NULL) {
@@ -710,6 +717,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
         return false;
     }
     elf_end(newElf);
+    fchmod(newfd, origFdMode);  // set permission to original file
     close(newfd);
 
     if (rename(newFName.c_str(), fName.c_str())) {

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -1251,6 +1251,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             dynsymIndex = thisSectionIndex;
             updateDynamic(DT_SYMTAB, newshdr->sh_addr);
         } else if (newSec->getRegionType() == Region::RT_DYNAMIC) {
+            newDynamicRegion = newSec;
             newshdr->sh_entsize = sizeof(Elf_Dyn);
             newshdr->sh_type = SHT_DYNAMIC;
             newdata->d_type = ELF_T_DYN;
@@ -1843,38 +1844,14 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
         createRelrRelocationSection(object->getRelrDynRelocs());
 
         //add .dynamic section
-        if (dynsecSize)
+        if (dynsecSize) {
+            obj->findRegion(oldDynamicRegion, ".dynamic");   // before the new one exists
             obj->addRegion(0, dynsecData, dynsecSize * sizeof(Elf_Dyn), ".dynamic", Region::RT_DYNAMIC, true);
+        }
     }
 
     if (!obj->getAllNewRegions(newSecs))
         log_elferror(err_func_, "No new sections to add");
-
-    unsigned int prev_size = 0;
-    unsigned long sec_addr = 0;
-    for (const auto &newSec : newSecs) {
-        // Update the _DYNAMIC symbol; described in the elf standard as:
-        //  The program header table will have an element of type PT_DYNAMIC.
-        //  This "segment" contains the .dynamic section. A special symbol,
-        //  _DYNAMIC, labels the section
-        if (newSec->getDiskOffset())
-          sec_addr = newSec->getDiskOffset() + address_adjust;
-        else
-          sec_addr += prev_size;
-        prev_size = newSec->getDiskSize();
-        if (".dynamic" == newSec->getRegionName()) {
-            // Found the .dynamic section
-            for (unsigned long symi = 0; symi < symbolStrs.size(); symi++)
-              if ("_DYNAMIC" == symbolStrs[symi]) {
-                  // Found the _DYNAMIC symbol
-                  rewrite_printf("update _DYNAMIC symbol from %#lx to %#lx\n",
-                                 (unsigned long) syms[symi].st_value, (unsigned long) sec_addr);
-                  syms[symi].st_value = sec_addr;
-                  break;
-              }
-            break;
-        }
-    }
 
     return true;
 }
@@ -2500,14 +2477,24 @@ void emitElf<ElfTypes>::updateSymbolSectionIndices(Elf_Scn *scn, const std::vect
         Region *region = symRegions[k];
         if (!region)
             continue;
+        bool isSectionSym = ELF64_ST_TYPE(syms[k].st_info) == STT_SECTION;
+        // .dynamic was regenerated elsewhere: symbols into the old one must
+        // follow it, keeping their offset within the section.  In particular
+        // _DYNAMIC, which the ELF standard defines as labeling the .dynamic
+        // section and which glibc's r_debug support relies on.
+        Offset offsetInRegion = 0;
+        if (region == oldDynamicRegion && newDynamicRegion && !isSectionSym) {
+            offsetInRegion = syms[k].st_value - address_adjust - region->getMemOffset();
+            region = newDynamicRegion;
+        }
         auto it = regionNewIndex.find(region);
         if (it == regionNewIndex.end())
             continue;
         syms[k].st_shndx = it->second;
-        if (ELF64_ST_TYPE(syms[k].st_info) == STT_SECTION) {
+        if (isSectionSym || region == newDynamicRegion) {
             if (Elf_Scn *target = elf_getscn(newElf, it->second))
                 if (Elf_Shdr *targetShdr = ElfTypes::elf_getshdr(target))
-                    syms[k].st_value = targetShdr->sh_addr;
+                    syms[k].st_value = targetShdr->sh_addr + offsetInRegion;
         }
     }
 }

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -48,11 +48,11 @@ using namespace Dyninst;
 using namespace Dyninst::SymtabAPI;
 using namespace std;
 
-unsigned int elfHash(const char *name) {
+unsigned int elfHash(const std::string &name) {
     unsigned int h = 0, g;
 
-    while (*name) {
-        h = (h << 4) + *name++;
+    for (auto c : name) {
+        h = (h << 4) + c;
         if ((g = h & 0xf0000000))
             h ^= g >> 24;
         h &= ~g;
@@ -2166,7 +2166,7 @@ void emitElf<ElfTypes>::createSymbolVersions(Elf_Half *&symVers, char *&verneedS
         for (const auto &ver : verneedEntry.second) {
             Elf_Vernaux *vernaux = reinterpret_cast<Elf_Vernaux *>(
                     verneedSecData + curpos + verneed->vn_aux + i * sizeof(Elf_Vernaux));
-            vernaux->vna_hash = elfHash(ver.first.c_str());
+            vernaux->vna_hash = elfHash(ver.first);
             vernaux->vna_flags = 0;
             vernaux->vna_other = ver.second;
             vernaux->vna_name = versionNames[ver.first];
@@ -2194,7 +2194,7 @@ void emitElf<ElfTypes>::createSymbolVersions(Elf_Half *&symVers, char *&verneedS
         verdef->vd_flags = 0;
         verdef->vd_ndx = verdefEntry.second;
         verdef->vd_cnt = verdauxEntries[verdefEntry.second].size();
-        verdef->vd_hash = elfHash(verdefEntry.first.c_str());
+        verdef->vd_hash = elfHash(verdefEntry.first);
         verdef->vd_aux = sizeof(Elf_Verdef);
         verdef->vd_next = sizeof(Elf_Verdef) + verdauxEntries[verdefEntry.second].size() * sizeof(Elf_Verdaux);
         if (curpos + verdef->vd_next == verdefSecSize)
@@ -2277,7 +2277,7 @@ void emitElf<ElfTypes>::createHashSection(Elf_Word *&hashsecData, unsigned &hash
             (index < object->getDynsymSize())) {
             continue;
         }
-        key = elfHash((*iter)->getMangledName().c_str()) % nbuckets;
+        key = elfHash((*iter)->getMangledName()) % nbuckets;
         if (lastHash.find(key) != lastHash.end()) {
             hashsecData[2 + nbuckets + lastHash[key]] = i;
         } else {

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -363,10 +363,24 @@ void emitElf<ElfTypes>::renameSection(const std::string &oldName) {
 }
 
 template<class ElfTypes>
-bool emitElf<ElfTypes>::driver(std::string fName) {
+bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols) {
+    rewrite_printf("::driver for emitElf\n");
+
+    oldEhdr = ElfTypes::elf_getehdr(oldElf);
+
+    getSectionAndSegmentInfo();
+    if (!sectionNameTable)  {
+        return false;
+    }
+    if (object->getLoadAddress() == 0)  {
+        library_adjust = std::max(static_cast<unsigned>(getpagesize()), maxSegmentAlignment);
+    }
+    if (!createSymbolTables(allSymbols))  {
+        return false;  // createSymbolTables failed
+    }
+
     Region *foundSec = NULL;
     unsigned pgSize = getpagesize();
-    rewrite_printf("::driver for emitElf\n");
 
     string newFName = fName + "XXXXXX";
     auto buf = std::unique_ptr<char[]>(new char[newFName.length() + 1]);
@@ -408,16 +422,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
         log_elferror(err_func_, "newEhdr failed\n");
         return false;
     }
-    oldEhdr = ElfTypes::elf_getehdr(oldElf);
     *newEhdr = *oldEhdr;
-
-    getSectionAndSegmentInfo();
-    if (!sectionNameTable)  {
-        return false;
-    }
-    if (object->getLoadAddress() == 0)  {
-        library_adjust = std::max(static_cast<unsigned>(getpagesize()), maxSegmentAlignment);
-    }
 
     newEhdr->e_shnum += newSecs.size();
 

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -410,15 +410,13 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
     }
 
     // Write the Elf header first!
-    newEhdr = ElfTypes::elf_newehdr(
-            newElf);
+    newEhdr = ElfTypes::elf_newehdr(newElf);
     if (!newEhdr) {
         log_elferror(err_func_, "newEhdr failed\n");
         return false;
     }
-    oldEhdr = ElfTypes::elf_getehdr(
-            oldElf);
-    memcpy(newEhdr, oldEhdr, sizeof(Elf_Ehdr));
+    oldEhdr = ElfTypes::elf_getehdr(oldElf);
+    *newEhdr = *oldEhdr;
 
     newEhdr->e_shnum += newSecs.size();
 
@@ -472,8 +470,8 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
         newshdr = ElfTypes::elf_getshdr(newscn);
         newdata = elf_newdata(newscn);
         olddata = elf_getdata(scn, NULL);
-        memcpy(newshdr, shdr, sizeof(Elf_Shdr));
-        memcpy(newdata, olddata, sizeof(Elf_Data));
+        *newshdr = *shdr;
+        *newdata = *olddata;
 
         secNames.push_back(name);
         newshdr->sh_name = secNameIndex;
@@ -2386,13 +2384,13 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
                  * we're dealing with a library without a fixed load address.  We'll be shifting
                  * the addresses of that library by a page.
                  **/
-                memcpy(dynsecData + curpos, dyns + i, sizeof(Elf_Dyn));
+                dynsecData[curpos] = dyns[i];
                 dynsecData[curpos].d_un.d_ptr += library_adjust;
                 dynamicSecData[dyns[i].d_tag].push_back(dynsecData + curpos);
                 curpos++;
                 break;
             default:
-                memcpy(dynsecData + curpos, dyns + i, sizeof(Elf_Dyn));
+                dynsecData[curpos] = dyns[i];
                 dynamicSecData[dyns[i].d_tag].push_back(dynsecData + curpos);
                 curpos++;
                 break;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -49,7 +49,6 @@ using namespace Dyninst;
 using namespace Dyninst::SymtabAPI;
 using namespace std;
 
-
 unsigned int elfHash(const char *name) {
     unsigned int h = 0, g;
 
@@ -69,7 +68,6 @@ emitElf<ElfTypes>::emitElf(Elf_X *oldElfHandle_, bool isStripped_, ObjectELF *ob
     oldElf{oldElfHandle->e_elfp()},
     obj(st),
     isStripped(isStripped_),
-    library_adjust{getpagesize()},
     object(obj_),
     err_func_(err_func),
     isStaticBinary{obj_->isStaticBinary()}
@@ -306,51 +304,50 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
     return true;
 }
 
-// Find the start address of the last section that lies within the last
-// loadable (PT_LOAD) segment. This is the section after which dyninst appends
-// the newly created loadable sections.
-//
-// The old implementation (findSegmentEnds) assumed that some section ended
-// exactly on the boundary of the last loadable segment (p_vaddr + p_memsz).
-// That does not hold for all binaries: e.g. when the highest-addressed
-// loadable segment holds relocated read-only metadata (.gnu.hash/.dynstr) and
-// the segment's memsz is padded past the final section, no section ends on the
-// boundary. In that case the insertion point was never found,
-// createLoadableSections() was never called, and the rewritten file came out
-// without a .dynamic section / new code segment (see issue #2081).
-//
-// Instead, find the boundaries of the last loadable segment and return the
-// start address of the highest-addressed section contained within it.
-template<class ElfTypes>
-typename emitElf<ElfTypes>::Elf_Off emitElf<ElfTypes>::findLastLoadableSec() {
-    Elf_Phdr *tmp = ElfTypes::elf_getphdr(oldElf);
-    Elf_Off lastDataSegStart = 0, lastDataSegEnd = 0, lastLoadableSecStart = 0;
 
-    // Find the boundaries of the last (highest-addressed) loadable segment.
+// Get section name table from .shstrtab section, find the last loaded section,
+// maximum segment alignment and if TLS is used
+template<class ElfTypes>
+void emitElf<ElfTypes>::getSectionAndSegmentInfo() {
+    sectionNameTable = pdelf_get_shnames(oldElfHandle);
+    if (sectionNameTable == NULL) {
+        log_elferror(err_func_, ".shstrtab section not found");
+    }
+
+    Elf_Phdr *phdrs = ElfTypes::elf_getphdr(oldElf);
+
+    // Find the maximum of the loaded segment end addresses, and if TLS exists
+    Elf_Off maxSegmentEndAddr{};
     for (unsigned i = 0; i < oldEhdr->e_phnum; i++) {
-        if (tmp->p_type == PT_LOAD) {
-            if (tmp->p_vaddr + tmp->p_memsz > lastDataSegEnd) {
-                lastDataSegStart = tmp->p_vaddr;
-                lastDataSegEnd = tmp->p_vaddr + tmp->p_memsz;
-            }
-        } else if (PT_TLS == tmp->p_type) {
+        auto phdr{&phdrs[i]};
+        if (phdr->p_type == PT_LOAD) {
+            auto segmentEndAddr{phdr->p_vaddr + phdr->p_memsz};
+            if (maxSegmentEndAddr < segmentEndAddr)
+                maxSegmentEndAddr = segmentEndAddr;
+            if (maxSegmentAlignment < phdr->p_align)
+                maxSegmentAlignment = phdr->p_align;
+        } else if (PT_TLS == phdr->p_type) {
             TLSExists = true;
         }
-        tmp++;
     }
 
-    // Find the section with the highest start address that falls within the
-    // last loadable segment.
-    Elf_Scn *scn = NULL;
-    while ((scn = elf_nextscn(oldElf, scn))) {
-        Elf_Shdr *shdr = ElfTypes::elf_getshdr(scn);
-        Elf_Off secStart = shdr->sh_addr;
-        if (lastDataSegStart <= secStart && secStart < lastDataSegEnd &&
-            secStart > lastLoadableSecStart)
-            lastLoadableSecStart = secStart;
+    // Find the section index containing the max section end address, that is
+    // contained in the max loaded segment.  Ignore the shstrndx section since
+    // this section is always moved to the end.
+    Elf_Off maxSectionEndAddr{};
+    for (unsigned i = 0; i < oldEhdr->e_shnum; ++i)  {
+        if (i == oldEhdr->e_shstrndx)
+            continue;                   // .shstrtab shstrndx section always moved, ignore
+        auto scn{elf_getscn(oldElf, i)};
+        auto shdr{ElfTypes::elf_getshdr(scn)};
+        if (!(shdr->sh_flags & SHF_ALLOC))
+            continue;                   // not allocated, so no address
+        auto endAddr{shdr->sh_addr + shdr->sh_size};
+        if (maxSectionEndAddr <= endAddr && endAddr <= maxSegmentEndAddr)  {
+            maxSectionEndAddr = endAddr;
+            lastLoadedSectionIndex = i;
+        }
     }
-
-    return lastLoadableSecStart;
 }
 
 // Renames 1st oldName section by changing 2nd char to 'o'
@@ -405,13 +402,6 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
     int dirtySecsChange = 0;
     unsigned extraAlignSize = 0;
 
-    // ".shstrtab" section: string table for section header names
-    const char *shnames = pdelf_get_shnames(oldElfHandle);
-    if (shnames == NULL) {
-        log_elferror(err_func_, ".shstrtab section not found");
-        return false;
-    }
-
     // Write the Elf header first!
     newEhdr = ElfTypes::elf_newehdr(newElf);
     if (!newEhdr) {
@@ -421,11 +411,17 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
     oldEhdr = ElfTypes::elf_getehdr(oldElf);
     *newEhdr = *oldEhdr;
 
+    getSectionAndSegmentInfo();
+    if (!sectionNameTable)  {
+        return false;
+    }
+    if (object->getLoadAddress() == 0)  {
+        library_adjust = std::max(static_cast<unsigned>(getpagesize()), maxSegmentAlignment);
+    }
+
     newEhdr->e_shnum += newSecs.size();
 
-    // Find the section after which new loadable sections will be appended
-    Elf_Off lastLoadableSecStart = findLastLoadableSec();
-    unsigned insertPoint = oldEhdr->e_shnum;
+    unsigned insertPoint = oldEhdr->e_shnum + 1;
     unsigned insertPointOffset = 0;
 
     newEhdr->e_phoff = sizeof(Elf_Ehdr);
@@ -447,22 +443,21 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
     std::unordered_map<string, pair<unsigned, unsigned>> dataLinkInfo;
 
     bool createdLoadableSections = false;
-    unsigned scncount;
     unsigned sectionNumber = 0;
 
-    for (scncount = 0; (scn = elf_nextscn(oldElf, scn)); scncount++) {
+    for (unsigned scncount = 1; (scn = elf_nextscn(oldElf, scn)); scncount++) {
         //copy sections from oldElf to newElf
         shdr = ElfTypes::elf_getshdr(scn);
 
         // resolve section name
-        const char *name = &shnames[shdr->sh_name];
+        const char *name = getSectionName(shdr);
         bool result = obj->findRegion(foundSec, shdr->sh_addr, shdr->sh_size);
         if (!result || foundSec->isDirty()) {
             result = obj->findRegion(foundSec, name);
         }
 
         // write the shstrtabsection at the end
-        if (!strcmp(name, ".shstrtab"))
+        if (scncount == oldEhdr->e_shstrndx)
             continue;
 
         sectionNumber++;
@@ -650,7 +645,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
 
         //Insert new loadable sections after the last section of the last
         //loadable segment
-        if (shdr->sh_addr == lastLoadableSecStart && !createdLoadableSections) {
+        if (scncount == lastLoadedSectionIndex && !createdLoadableSections) {
             createdLoadableSections = true;
             insertPoint = scncount;
             if (SHT_NOBITS == shdr->sh_type) {
@@ -686,6 +681,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
 
     // Second iteration to fix the link fields to point to the correct section
     scn = NULL;
+    unsigned scncount;
     for (scncount = 1; (scn = elf_nextscn(newElf, scn)); scncount++) {
         shdr = ElfTypes::elf_getshdr(scn);
         if(dataLinkInfo.count(secNames[scncount]))

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -28,7 +28,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-
 #include <cstring>
 #include <algorithm>
 #include "emitElf.h"
@@ -155,18 +154,18 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
     Elf_Sym *sym = new Elf_Sym();
     sym->st_name = strIndex;
 
-    int offset_adjust;
+    Elf_Off addr_adjust{};
     if(elfSymType(symbol) == STT_TLS) {
-        offset_adjust = 0; // offset relative to TLS section, any new entries go at end
+        addr_adjust = 0; // offset relative to TLS section, any new entries go at end
     } else {
-        offset_adjust = library_adjust;
+        addr_adjust = address_adjust;
     }
     // OPD-based systems
     if (symbol->getPtrOffset()) {
-        sym->st_value = symbol->getPtrOffset() + offset_adjust;
+        sym->st_value = symbol->getPtrOffset() + addr_adjust;
     }
     else if (symbol->getOffset()) {
-        sym->st_value = symbol->getOffset() + offset_adjust;
+        sym->st_value = symbol->getOffset() + addr_adjust;
     }
 
     sym->st_size = symbol->getSize();
@@ -306,7 +305,8 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
 
 
 // Get section name table from .shstrtab section, find the last loaded section,
-// maximum segment alignment and if TLS is used
+// maximum section/segment alignment and if TLS is used, compute address_adjust
+// and offset_adjust
 template<class ElfTypes>
 bool emitElf<ElfTypes>::getSectionAndSegmentInfo() {
     oldNumSections = oldElfHandle->e_shnum();
@@ -330,9 +330,11 @@ bool emitElf<ElfTypes>::getSectionAndSegmentInfo() {
         return false;
     }
 
-    // Find the maximum of the loaded segment end addresses, and if TLS exists
+    // Find the maximum of the loaded segment end addresses, the max segment alignment
+    // LOAD segment containing offset 0, and if TLS exists
     Elf_Off maxSegmentEndAddr{};
     bool foundLoadSegment{};
+    offset0LoadSegmentIndex = oldNumSegments;  // not found value
     for (unsigned i = 0; i < oldNumSegments; ++i) {
         auto phdr{&phdrs[i]};
         if (phdr->p_type == PT_LOAD) {
@@ -342,6 +344,8 @@ bool emitElf<ElfTypes>::getSectionAndSegmentInfo() {
                 maxSegmentEndAddr = segmentEndAddr;
             if (maxSegmentAlignment < phdr->p_align)
                 maxSegmentAlignment = phdr->p_align;
+            if (!phdr->p_offset && !foundOffset0LoadSegment())
+                offset0LoadSegmentIndex = i;
         } else if (PT_TLS == phdr->p_type) {
             TLSExists = true;
         }
@@ -363,7 +367,11 @@ bool emitElf<ElfTypes>::getSectionAndSegmentInfo() {
         auto shdr{ElfTypes::elf_getshdr(scn)};
         if (!shdr || !(shdr->sh_flags & SHF_ALLOC))
             continue;                   // not allocated, so no address
+        if (maxSectionAlignment < shdr->sh_addralign)
+            maxSectionAlignment = shdr->sh_addralign;
         auto endAddr{shdr->sh_addr + shdr->sh_size};
+        if ((shdr->sh_flags & SHF_TLS) && shdr->sh_type == SHT_NOBITS)
+            continue;                   // .tbss does not occupy address space
         if (maxSectionEndAddr <= endAddr && endAddr <= maxSegmentEndAddr)  {
             maxSectionEndAddr = endAddr;
             lastLoadedSectionIndex = i;
@@ -375,13 +383,54 @@ bool emitElf<ElfTypes>::getSectionAndSegmentInfo() {
         return false;
     }
 
+    /* Room has to be made at the front of the file for the new program header
+     * table, which shifts every file offset of the old image by offset_adjust
+     * and, for a PIE/shared object, every address by address_adjust.  There
+     * are two requirements that must be maintained:
+     *
+     *  - a LOAD segment requires p_vaddr == p_offset (mod p_align), so
+     *    address_adjust == offset_adjust (mod p_align) for every segment
+     *  - data alignment requirements of basic types or from alignas implies
+     *    address_adjust must be a multiple of the section alignment holding it
+     *
+     * For a PIE/shared object the whole image moves up, so using one value for
+     * both shifts satisfies the first requirement for any p_align, and it only
+     * has to be a multiple of the largest section alignment.
+     *
+     * An executable loaded at a fixed address keeps its addresses instead: the
+     * segment at file offset 0 grows downwards to cover the new space, leaving
+     * every address unchanged.  Nothing moves, so section alignment is not a
+     * concern, but the file shift alone has to keep every segment congruent,
+     * which makes it a multiple of the largest segment alignment.
+     */
+    auto pageSize = static_cast<Elf_Off>(getpagesize());
+    if (oldEhdr->e_type == ET_DYN)  {
+        address_adjust = std::max(pageSize, maxSectionAlignment); // address can be adjusted for ET_DYN
+        offset_adjust = address_adjust;
+    }  else  {
+        offset_adjust = std::max(pageSize, maxSegmentAlignment);  // addresses fixed so don't move addrs
+    }
+
+    if (offset_adjust % pageSize)  {
+        log_elferror(err_func_, "segment or section alignment is not a multiple of the pagesize");
+        return false;
+    }
+    if (!foundOffset0LoadSegment())  {
+        log_elferror(err_func_, "no loaded segment at file offset 0 to cover the program table");
+        return false;
+    }
+    if (address_adjust == 0 && phdrs[offset0LoadSegmentIndex].p_vaddr <= offset_adjust)  {
+        log_elferror(err_func_, "no room below the first loaded segment for the program headers");
+        return false;
+    }
+
     return true;
 }
 
 // Renames 1st oldName section by changing 2nd char to 'o'
 template<class ElfTypes>
 void emitElf<ElfTypes>::renameSection(const std::string &oldName) {
-    assert(oldName.length() >= 2);
+    assert(oldName.length() >= 2 && oldName[1] != 'o');
     for (auto &secName : secNames)  {
         if (secName == oldName)  {
             secName[1] = 'o';
@@ -398,15 +447,12 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
 
     if (!getSectionAndSegmentInfo())
         return false;
-    if (object->getLoadAddress() == 0)  {
-        library_adjust = std::max(static_cast<unsigned>(getpagesize()), maxSegmentAlignment);
-    }
+
     if (!createSymbolTables(allSymbols))  {
         return false;  // createSymbolTables failed
     }
 
     Region *foundSec = NULL;
-    unsigned pgSize = getpagesize();
 
     string newFName = fName + "XXXXXX";
     auto buf = std::unique_ptr<char[]>(new char[newFName.length() + 1]);
@@ -450,11 +496,11 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     }
     *newEhdr = *oldEhdr;
 
-    unsigned insertPoint = oldNumSections + 1;  // value if loop below fails to set
-    unsigned insertPointOffset = 0;
+    unsigned insertPoint = oldNumSections + 1;  // section index of inserted sections
+    Elf_Off insertPointOffset{};                // file offset of inserted sections
 
     newEhdr->e_phoff = sizeof(Elf_Ehdr);
-    newEhdr->e_entry += library_adjust;
+    newEhdr->e_entry += address_adjust;
 
     /* flag the file for no auto-layout */
     elf_flagelf(newElf, ELF_C_SET, ELF_F_LAYOUT);
@@ -473,6 +519,8 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
 
     bool createdLoadableSections = false;
     unsigned sectionNumber = 0;
+
+    auto moveSecAddrRange = object->getMoveSecAddrRange();
 
     for (unsigned scncount = 1; (scn = elf_nextscn(oldElf, scn)); scncount++) {
         //copy sections from oldElf to newElf
@@ -503,13 +551,13 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         newshdr->sh_name = addSectionName(name);
 
         if (newshdr->sh_addr) {
-            newshdr->sh_addr += library_adjust;
+            newshdr->sh_addr += address_adjust;
 
 #if defined(DYNINST_CODEGEN_ARCH_AARCH64)
             if (strcmp(name, ".plt")==0)
-                updateDynamic(DT_TLSDESC_PLT, library_adjust);
+                updateDynamic(DT_TLSDESC_PLT, address_adjust);
             if (strcmp(name, ".got")==0)
-                updateDynamic(DT_TLSDESC_GOT, library_adjust);
+                updateDynamic(DT_TLSDESC_GOT, address_adjust);
 #endif
         }
 
@@ -529,7 +577,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
             newshdr->sh_entsize = 0x0;
         }
 
-        if (library_adjust > 0 && newdata->d_buf && newdata->d_size) {
+        if (address_adjust != 0 && newdata->d_buf && newdata->d_size) {
             for (auto relr_addr : object->getRelrDynRelocs()) {
                 if (relr_addr < shdr->sh_addr ||
                     relr_addr + sizeof(Elf_Relr) > shdr->sh_addr + shdr->sh_size)
@@ -542,12 +590,10 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
                 char *loc = static_cast<char *>(newdata->d_buf) + relr_off;
                 auto val = Dyninst::read_memory_as<Elf_Relr>(loc);
                 if (!val) continue;
-                val += library_adjust;
+                val += address_adjust;
                 Dyninst::write_memory_as(loc, val);
             }
         }
-
-        auto moveSecAddrRange = object->getMoveSecAddrRange();
 
         for (const auto &m : moveSecAddrRange) {
             if ((m[0] == shdr->sh_addr) ||
@@ -606,12 +652,12 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
 
         }
 
-        if (library_adjust > 0 &&
+        if (address_adjust != 0 &&
                 (strcmp(name, ".init_array") == 0 || strcmp(name, ".fini_array") == 0 ||
                  strcmp(name, "__libc_subfreeres") == 0 || strcmp(name, "__libc_atexit") == 0 ||
                  strcmp(name, "__libc_thread_subfreeres") == 0 || strcmp(name, "__libc_IO_vtables") == 0)) {
             std::vector<Offset> &relr_relocs = object->getRelrDynRelocs();
-            // Every pointer-sized word in this section is shifted by library_adjust.
+            // Every pointer-sized word in this section is shifted by address_adjust.
             // A word that is also a RELR relocation target was already shifted by the
             // earlier RELR loop, so skip to avoid offsetting it twice
             std::unordered_set<Offset> relr_addrs(relr_relocs.begin(), relr_relocs.end());
@@ -623,7 +669,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
                 Elf_Relr val{};
                 read_memory_as(val, loc);
                 if(val == 0) continue;
-                val += library_adjust;
+                val += address_adjust;
                 write_memory_as(loc, val);
             }
         }
@@ -639,23 +685,20 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
          * by the difference in size of the new PHDR segment.
          */
         if (newshdr->sh_offset > 0) {
-            if (newshdr->sh_offset < pgSize && !strcmp(name, INTERP_NAME)) {
-                newshdr->sh_addr -= pgSize;
+            if (newshdr->sh_offset < offset_adjust && !strcmp(name, INTERP_NAME)) {
+                newshdr->sh_addr -= offset_adjust;
                 newshdr->sh_addr += oldEhdr->e_phentsize;
                 newshdr->sh_offset += oldEhdr->e_phentsize;
             } else
-                newshdr->sh_offset += pgSize;
+                newshdr->sh_offset += offset_adjust;
         }
 
-        if (scncount > insertPoint && newshdr->sh_offset >= insertPointOffset)
-            newshdr->sh_offset += loadSecTotalSize;
+        // shift section offsets after the insertPoint that come after the insertPoint's offset
+        if (scncount > insertPoint && shdr->sh_offset >= insertPointOffset)
+            newshdr->sh_offset += loadSecTotalSize + extraAlignSize;
 
         if (newshdr->sh_offset > 0)
             newshdr->sh_offset += dirtySecsChange;
-
-        if (newshdr->sh_offset >= insertPointOffset) {
-            newshdr->sh_offset += extraAlignSize;
-        }
 
         if (foundSec->isDirty())
             dirtySecsChange += newshdr->sh_size - shdr->sh_size;
@@ -677,11 +720,10 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         if (scncount == lastLoadedSectionIndex && !createdLoadableSections) {
             createdLoadableSections = true;
             insertPoint = scncount;
-            if (SHT_NOBITS == shdr->sh_type) {
-                insertPointOffset = shdr->sh_offset;
-            } else {
-                insertPointOffset = shdr->sh_offset + shdr->sh_size;
-            }
+            insertPointOffset = shdr->sh_offset;
+            if (shdr->sh_type != SHT_NOBITS)
+                insertPointOffset += shdr->sh_size;
+
 
             if (!createLoadableSections(newshdr, extraAlignSize, newNameIndexMapping,
                        sectionNumber))
@@ -786,7 +828,6 @@ void emitElf<ElfTypes>::fixPhdrs() {
      * ascending order, sorted on the p_vaddr member.'
      */
     rewrite_printf("::fixPhdrs():\n");
-    unsigned pgSize = getpagesize();
 
     newEhdr->e_phnum = oldNumSegments;
     newEhdr->e_phentsize = oldEhdr->e_phentsize;
@@ -810,7 +851,7 @@ void emitElf<ElfTypes>::fixPhdrs() {
             segments[i].p_filesz = segments[i].p_memsz;
         }
         else if (old->p_type == PT_PHDR) {
-            segments[i].p_vaddr = old->p_vaddr - pgSize + library_adjust;
+            segments[i].p_vaddr = old->p_vaddr - offset_adjust + address_adjust;
             segments[i].p_offset = newEhdr->e_phoff;
             segments[i].p_paddr = segments[i].p_vaddr;
             segments[i].p_filesz = sizeof(Elf_Phdr) * newEhdr->e_phnum;
@@ -823,39 +864,35 @@ void emitElf<ElfTypes>::fixPhdrs() {
             segments[i].p_memsz = newTLSData->sh_size + old->p_memsz - old->p_filesz;
             segments[i].p_align = newTLSData->sh_addralign;
         } else if (old->p_type == PT_LOAD) {
-            if (!old->p_offset) {
-                if (segments[i].p_vaddr) {
-                    segments[i].p_vaddr = old->p_vaddr - pgSize;
-                    segments[i].p_align = pgSize;
-                }
+            if (i == offset0LoadSegmentIndex) {
+                if (segments[i].p_vaddr)
+                    segments[i].p_vaddr = old->p_vaddr - offset_adjust;
 
                 segments[i].p_paddr = segments[i].p_vaddr;
-                segments[i].p_filesz += pgSize;
+                segments[i].p_filesz += offset_adjust;
                 segments[i].p_memsz = segments[i].p_filesz;
             } else {
-                segments[i].p_offset += pgSize;
-                segments[i].p_align = pgSize;
+                segments[i].p_offset += offset_adjust;
             }
             if (segments[i].p_vaddr) {
-                segments[i].p_vaddr += library_adjust;
-                segments[i].p_paddr += library_adjust;
+                segments[i].p_vaddr += address_adjust;
+                segments[i].p_paddr += address_adjust;
             }
         } else if (old->p_type == PT_INTERP && old->p_offset) {
-            Elf_Off addr_shift = library_adjust;
-            Elf_Off offset_shift = pgSize;
-            if (old->p_offset < pgSize) {
+            Elf_Off addr_shift = address_adjust;
+            Elf_Off offset_shift = offset_adjust;
+            if (old->p_offset < offset_adjust) {
                 offset_shift = oldEhdr->e_phentsize;
-                addr_shift -= pgSize - offset_shift;
+                addr_shift -= offset_adjust - offset_shift;
             }
             segments[i].p_offset += offset_shift;
             segments[i].p_vaddr += addr_shift;
             segments[i].p_paddr += addr_shift;
-        }
-        else if (old->p_offset) {
-            segments[i].p_offset += pgSize;
+        } else if (old->p_offset) {
+            segments[i].p_offset += offset_adjust;
             if (segments[i].p_vaddr) {
-                segments[i].p_vaddr += library_adjust;
-                segments[i].p_paddr += library_adjust;
+                segments[i].p_vaddr += address_adjust;
+                segments[i].p_paddr += address_adjust;
             }
         }
 
@@ -874,7 +911,7 @@ void emitElf<ElfTypes>::fixPhdrs() {
         newSeg.p_memsz = (currEndAddress - firstNewLoadSec->sh_addr) -
             (newSegmentStart - firstNewLoadSec->sh_addr);
         newSeg.p_flags = PF_R + PF_W + PF_X;
-        newSeg.p_align = pgSize;
+        newSeg.p_align = getpagesize();
 
         // Insert the new segment(s) before the first segment with a vaddr greater than this one
         unsigned int insertAt = segments.size();
@@ -1107,7 +1144,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
         } else {
             // The offset can be computed by determining the difference from
             // the first new loadable section
-            newshdr->sh_offset = firstNewLoadSec->sh_offset + library_adjust +
+            newshdr->sh_offset = firstNewLoadSec->sh_offset + address_adjust +
                                  (newSec->getDiskOffset() - firstNewLoadSec->sh_addr);
 
             // Account for inter-section spacing due to alignment constraints
@@ -1115,9 +1152,9 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
         }
 
         if (newSec->getDiskOffset())
-            newshdr->sh_addr = newSec->getDiskOffset() + library_adjust;
+            newshdr->sh_addr = newSec->getDiskOffset() + address_adjust;
         else if (!prevshdr) {
-            newshdr->sh_addr = zstart + library_adjust;
+            newshdr->sh_addr = zstart + address_adjust;
         }
         else {
             newshdr->sh_addr = prevshdr->sh_addr + prevshdr->sh_size;
@@ -1589,7 +1626,7 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
 
         if (s->getStrIndex() == -1) {
             // New Symbol - append to the list of strings
-            dynsymbolStrs.push_back(s->getMangledName().c_str());
+            dynsymbolStrs.push_back(s->getMangledName());
             s->setStrIndex(dynsymbolNamesLength);
             dynsymbolNamesLength += s->getMangledName().length() + 1;
         }
@@ -1634,7 +1671,7 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
     i = 0;
     for (const auto &s : allDynSymbols) {
         createElfSymbol(s, s->getStrIndex(), dynsymbols, true);
-        dynSymNameMapping[s->getMangledName().c_str()] = i + nTmp;
+        dynSymNameMapping[s->getMangledName()] = i + nTmp;
         ++i;
         dynsymVector.push_back(s);
     }
@@ -1809,7 +1846,7 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
         //  This "segment" contains the .dynamic section. A special symbol,
         //  _DYNAMIC, labels the section
         if (newSec->getDiskOffset())
-          sec_addr = newSec->getDiskOffset() + library_adjust;
+          sec_addr = newSec->getDiskOffset() + address_adjust;
         else
           sec_addr += prev_size;
         prev_size = newSec->getDiskSize();
@@ -1853,17 +1890,17 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
     //reconstruct .rel
     for (auto &reloc : relocation_table) {
 
-        if (library_adjust) {
+        if (address_adjust) {
             // If we are shifting the library down in memory, we need to update
             // any relative offsets in the library. These relative offsets are 
             // found via relocations
 
             // XXX ...ignore the return value
-            emitElfUtils::updateRelocation(obj, reloc, library_adjust);
+            emitElfUtils::updateRelocation(obj, reloc, address_adjust);
         }
 
         if ((object->getRelType() == Region::RT_REL) && (reloc.regionType() == Region::RT_REL)) {
-            rels[j].r_offset = reloc.rel_addr() + library_adjust;
+            rels[j].r_offset = reloc.rel_addr() + address_adjust;
             unsigned long sym_offset = 0;
             std::string sym_name = reloc.name();
             if (!sym_name.empty()) {
@@ -1884,10 +1921,10 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
             }
             j++;
         } else if ((object->getRelType() == Region::RT_RELA) && (reloc.regionType() == Region::RT_RELA)) {
-            relas[k].r_offset = reloc.rel_addr() + library_adjust;
+            relas[k].r_offset = reloc.rel_addr() + address_adjust;
             relas[k].r_addend = reloc.addend();
             //if (relas[k].r_addend)
-            //   relas[k].r_addend += library_adjust;
+            //   relas[k].r_addend += address_adjust;
             unsigned long sym_offset = 0;
             std::string sym_name = reloc.name();
             if (!sym_name.empty()) {
@@ -1914,7 +1951,7 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
     }
     for (const auto &newRel : newRels) {
         if ((object->getRelType() == Region::RT_REL) && (newRel.regionType() == Region::RT_REL)) {
-            rels[j].r_offset = newRel.rel_addr() + library_adjust;
+            rels[j].r_offset = newRel.rel_addr() + address_adjust;
             if (dynSymNameMapping.find(newRel.name()) != dynSymNameMapping.end()) {
                 rels[j].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRel.name()],
                                                          newRel.getRelType());
@@ -1925,9 +1962,9 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
             j++;
             l++;
         } else if ((object->getRelType() == Region::RT_RELA) && (newRel.regionType() == Region::RT_RELA)) {
-            relas[k].r_offset = newRel.rel_addr() + library_adjust;
+            relas[k].r_offset = newRel.rel_addr() + address_adjust;
             relas[k].r_addend = newRel.addend();
-            //if( relas[k].r_addend ) relas[k].r_addend += library_adjust;
+            //if( relas[k].r_addend ) relas[k].r_addend += address_adjust;
             if (dynSymNameMapping.find(newRel.name()) != dynSymNameMapping.end()) {
                 relas[k].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRel.name()],
                                                           newRel.getRelType());
@@ -2018,7 +2055,7 @@ void emitElf<ElfTypes>::createRelrRelocationSection(std::vector<Offset> &relr_ta
     //           last address
     std::vector<Offset> addrs(relr_table);
     for (auto &a : addrs)
-        a += library_adjust;
+        a += address_adjust;
     std::sort(addrs.begin(), addrs.end());
     addrs.erase(std::unique(addrs.begin(), addrs.end()), addrs.end());
 
@@ -2298,7 +2335,7 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
         long name = entry.first;
         long value = entry.second;
         dynsecData[curpos].d_tag = name;
-        long adjust = 0;
+        Elf_Off adjust = 0;
         switch(name)
         {
 
@@ -2306,7 +2343,7 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
             case DT_INIT:
             case DT_FINI:
             case DT_DYNINST:
-                adjust = library_adjust;
+                adjust = address_adjust;
                 break;
             default:
                 break;
@@ -2318,15 +2355,15 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
         if (name == DT_DYNINST) {
             // If we find the .dyninstInst section and DT_DYNINST dynamic entry, 
             // it means we are doing binary rewriting with trap springboards. 
-            // If library_adjust is non-zero, then we also need to adjust springboard traps
+            // If address_adjust is non-zero, then we also need to adjust springboard traps
             Region *dyninstReg = NULL;
-            if (obj->findRegion(dyninstReg, ".dyninstInst") && library_adjust) {
+            if (obj->findRegion(dyninstReg, ".dyninstInst") && address_adjust) {
                 // The trap mapping header's in-memory offset is specified by the dynamic entry
                 // We now need to get raw section data, and the raw sectiond data offset of the header
                 auto header = alignas_cast<trap_mapping_header>(((char*)dyninstReg->getPtrToRawData() + value - dyninstReg->getMemOffset()));
                 for (unsigned i = 0; i < header->num_entries; i++) {
-                    header->traps[i].source = (void*) ((char*)header->traps[i].source + library_adjust);
-                    header->traps[i].target = (void*) ((char*)header->traps[i].target + library_adjust);
+                    header->traps[i].source = (void*) ((char*)header->traps[i].source + address_adjust);
+                    header->traps[i].target = (void*) ((char*)header->traps[i].target + address_adjust);
                 }
             }
         }
@@ -2400,12 +2437,12 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
 #endif
                 /**
                  * List every dynamic entry that references an address and isn't already
-                 * updated here.  library_adjust will be a page size if
+                 * updated here.  address_adjust will be a page size if
                  * we're dealing with a library without a fixed load address.  We'll be shifting
                  * the addresses of that library by a page.
                  **/
                 dynsecData[curpos] = dyns[i];
-                dynsecData[curpos].d_un.d_ptr += library_adjust;
+                dynsecData[curpos].d_un.d_ptr += address_adjust;
                 dynamicSecData[dyns[i].d_tag].push_back(dynsecData + curpos);
                 curpos++;
                 break;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -394,10 +394,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
         return false;
     }
 
-    //Section name index for all sections
-    secNames.push_back("");
-    secNameIndex = 1;
-    //Section name index for new sections
+    addSectionName("");  // section 0 is always ST_NULL with an empty name
     loadSecTotalSize = 0;
     int dirtySecsChange = 0;
     unsigned extraAlignSize = 0;
@@ -473,9 +470,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
         *newshdr = *shdr;
         *newdata = *olddata;
 
-        secNames.push_back(name);
-        newshdr->sh_name = secNameIndex;
-        secNameIndex += strlen(name) + 1;
+        newshdr->sh_name = addSectionName(name);
 
         if (newshdr->sh_addr) {
             newshdr->sh_addr += library_adjust;
@@ -1036,9 +1031,6 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             nonLoadableSecs.push_back(newSec);
             continue;
         }
-        secNames.push_back(newSec->getRegionName());
-        auto thisSectionIndex = secNames.size() - 1;
-        newNameIndexMapping[newSec->getRegionName()] = thisSectionIndex;
         sectionNumber++;
         // Add a new loadable section
         if ((newscn = elf_newscn(newElf)) == NULL) {
@@ -1053,7 +1045,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
 
         // Fill out the new section header
         newshdr = ElfTypes::elf_getshdr(newscn);
-        newshdr->sh_name = secNameIndex;
+        newshdr->sh_name = addSectionName(newSec->getRegionName());
         newshdr->sh_flags = 0;
         newshdr->sh_type = SHT_PROGBITS;
         switch (newSec->getRegionType()) {
@@ -1073,6 +1065,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
                 break;
         }
 
+        auto thisSectionIndex = secNames.size() - 1;
         newNameIndexMapping[newSec->getRegionName()] = thisSectionIndex;
 
         if (shdr->sh_type == SHT_NOBITS) {
@@ -1171,7 +1164,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newdata->d_type = ELF_T_SYM;
             newdata->d_align = 4;
             dynsymData = newdata;
-            newshdr->sh_link = secNames.size();   //.symtab section should have sh_link = index of .strtab for .dynsym
+            newshdr->sh_link = thisSectionIndex + 1;   //.symtab section should have sh_link = index of .strtab for .dynsym
             newshdr->sh_flags = SHF_ALLOC;
             dynsymIndex = thisSectionIndex;
             updateDynamic(DT_SYMTAB, newshdr->sh_addr);
@@ -1273,7 +1266,6 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
         shdr = newshdr;
         if (!firstNewLoadSec)
             firstNewLoadSec = shdr;
-        secNameIndex += newSec->getRegionName().size() + 1;
         prevshdr = newshdr;
     }
 
@@ -1305,9 +1297,7 @@ bool emitElf<ElfTypes>::addSectionHeaderTable(Elf_Shdr *shdr) {
     }
     //Fill out the new section header
     newshdr = ElfTypes::elf_getshdr(newscn);
-    newshdr->sh_name = secNameIndex;
-    secNames.push_back(".shstrtab");
-    secNameIndex += 10;
+    newshdr->sh_name = addSectionName(".shstrtab");
     newshdr->sh_type = SHT_STRTAB;
     newshdr->sh_entsize = 1;
     newdata->d_type = ELF_T_BYTE;
@@ -1320,15 +1310,15 @@ bool emitElf<ElfTypes>::addSectionHeaderTable(Elf_Shdr *shdr) {
     newshdr->sh_addralign = 4;
 
     //Set up the data
-    newdata->d_buf = allocate_buffer(secNameIndex);
+    newdata->d_buf = allocate_buffer(secNameTableTotalBytes);
     char *ptr = (char *) newdata->d_buf;
     for (const auto &secName : secNames) {
-        memcpy(ptr, secName.c_str(), secName.length());
-        memcpy(ptr + secName.length(), "\0", 1);
-        ptr += secName.length() + 1;
+        auto bytesToCopy(secName.length() + 1);     // string plus null byte
+        memcpy(ptr, secName.c_str(), bytesToCopy);
+        ptr += bytesToCopy;
     }
 
-    newdata->d_size = secNameIndex;
+    newdata->d_size = secNameTableTotalBytes;
     newshdr->sh_size = newdata->d_size;
 
     newdata->d_align = 4;
@@ -1345,7 +1335,6 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
     Elf_Shdr *prevshdr = shdr;
     //All of them that are left are non-loadable. stack'em up at the end.
     for (const auto &sec : nonLoadableSecs) {
-        secNames.push_back(sec->getRegionName());
         // Add a new non-loadable section
         if ((newscn = elf_newscn(newElf)) == NULL) {
             log_elferror(err_func_, "unable to create new section");
@@ -1358,8 +1347,7 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
 
         //Fill out the new section header
         newshdr = ElfTypes::elf_getshdr(newscn);
-        newshdr->sh_name = secNameIndex;
-        secNameIndex += sec->getRegionName().length() + 1;
+        newshdr->sh_name = addSectionName(sec->getRegionName());
         if (sec->getRegionType() == Region::RT_TEXT)        //Text Section
         {
             newshdr->sh_type = SHT_PROGBITS;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -830,37 +830,19 @@ void emitElf<ElfTypes>::fixPhdrs() {
         newSeg.p_flags = PF_R + PF_W + PF_X;
         newSeg.p_align = pgSize;
 
-        // Search position to insert new segment.
-        //
-        // The ELF spec requires loadable segments to appear in the program
-        // header table sorted by ascending p_vaddr. PT_LOAD entries are NOT
-        // necessarily contiguous in the table -- other segment types (e.g.
-        // GNU_STACK) can appear between them -- so we cannot detect "the end
-        // of the loadable phdrs" by looking for the first LOAD->non-LOAD
-        // transition (issue #2081: libtorch_python.so has GNU_STACK as the
-        // second program header, right after the first LOAD).
-        //
-        // Insert the new segment immediately before the first PT_LOAD whose
-        // p_vaddr is greater than newSegmentStart; if there is none (the new
-        // segment has the highest address, which is the common case since it
-        // is appended past the end of the last loadable segment), append it at
-        // the end of the table. Non-loadable entries keep their relative
-        // order, and the PT_LOAD entries stay sorted by p_vaddr.
-        unsigned int position = segments.size();
-        for( unsigned i = 0; i < segments.size(); i++ )
-        {
-            if (segments[i].p_type == PT_LOAD &&
-                segments[i].p_vaddr > newSegmentStart) {
-                position = i;
+        // Insert the new segment(s) before the first segment with a vaddr greater than this one
+        unsigned int insertAt = segments.size();
+        for (unsigned i = 0; i < segments.size(); ++i)   {
+            if (segments[i].p_type == PT_LOAD && segments[i].p_vaddr > newSegmentStart)  {
+                insertAt = i;
                 break;
             }
         }
 
-        // Insert new Segment at position
-        if( position == segments.size() )
+        if( insertAt == segments.size() )
             segments.push_back( newSeg );
         else
-            segments.insert( segments.begin() + position, newSeg );
+            segments.insert( segments.begin() + insertAt, newSeg );
     }
 
     // Create newPhdr and copy segments to it

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -592,15 +592,15 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         if (address_adjust != 0 && newdata->d_buf && newdata->d_size) {
             for (auto relr_addr : object->getRelrDynRelocs()) {
                 if (relr_addr < shdr->sh_addr ||
-                    relr_addr + sizeof(Elf_Relr) > shdr->sh_addr + shdr->sh_size)
+                    relr_addr + sizeof(Elf_Addr) > shdr->sh_addr + shdr->sh_size)
                     continue;
 
                 Offset relr_off = relr_addr - shdr->sh_addr;
-                if (relr_off + sizeof(Elf_Relr) > newdata->d_size)
+                if (relr_off + sizeof(Elf_Addr) > newdata->d_size)
                     continue;
 
                 char *loc = static_cast<char *>(newdata->d_buf) + relr_off;
-                auto val = Dyninst::read_memory_as<Elf_Relr>(loc);
+                auto val = Dyninst::read_memory_as<Elf_Addr>(loc);
                 if (!val) continue;
                 val += address_adjust;
                 Dyninst::write_memory_as(loc, val);
@@ -672,12 +672,12 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
             // A word that is also a RELR relocation target was already shifted by the
             // earlier RELR loop, so skip to avoid offsetting it twice
             std::unordered_set<Offset> relr_addrs(relr_relocs.begin(), relr_relocs.end());
-            for(std::size_t off = 0; off < newdata->d_size; off += sizeof(Elf_Relr)) {
+            for(std::size_t off = 0; off < newdata->d_size; off += sizeof(Elf_Addr)) {
                 Offset addr = shdr->sh_addr + off;
                 if (relr_addrs.count(addr)) continue;  // already adjusted as a RELR reloc
 
                 char *loc = static_cast<char*>(newdata->d_buf) + off;
-                Elf_Relr val{};
+                Elf_Addr val{};
                 read_memory_as(val, loc);
                 if(val == 0) continue;
                 val += address_adjust;
@@ -770,8 +770,8 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         shdr = ElfTypes::elf_getshdr(scn);
         if (shdr->sh_type == SHT_SYMTAB) {
             shdr->sh_link = symtabStrIndex;     // .symtab -> .strtab, wherever it ended up
-            shdr->sh_info = symtabNumLocals;    // index of first non-local symbol
-            updateSymbolSectionIndices(scn, symtabSymRegions);
+            if (updateSymbolSectionIndices(scn, symtabSymRegions))
+                shdr->sh_info = symtabNumLocals;    // index of first non-local symbol
         } else if (shdr->sh_type == SHT_DYNSYM) {
             updateSymbolSectionIndices(scn, dynsymSymRegions);
         }
@@ -2459,19 +2459,20 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
 // Symbols were emitted with st_shndx = the Region's number in the original
 // file.  Inserting the new sections renumbers everything after the insertion
 // point, so point each symbol at its Region's index in the new file, and give
-// section symbols the section's new address.
+// section symbols the section's new address.  Returns false if the table is
+// not one this emitter generated (left untouched).
 template<class ElfTypes>
-void emitElf<ElfTypes>::updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions) {
+bool emitElf<ElfTypes>::updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions) {
     Elf_Data *data = elf_getdata(scn, NULL);
     if (!data || !data->d_buf)
-        return;
+        return false;
     Elf_Sym *syms = static_cast<Elf_Sym *>(data->d_buf);
     size_t numSyms = data->d_size / sizeof(Elf_Sym);
     if (numSyms != symRegions.size()) {
         // not a table we generated (e.g. .dynsym copied unchanged), leave it alone
         rewrite_printf("symbol table has %zu entries, %zu regions recorded; st_shndx not updated\n",
                        numSyms, symRegions.size());
-        return;
+        return false;
     }
     for (size_t k = 0; k < numSyms; ++k) {
         Region *region = symRegions[k];
@@ -2497,6 +2498,7 @@ void emitElf<ElfTypes>::updateSymbolSectionIndices(Elf_Scn *scn, const std::vect
                     syms[k].st_value = targetShdr->sh_addr + offsetInRegion;
         }
     }
+    return true;
 }
 
 template<class ElfTypes>

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -469,7 +469,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
 
         sectionNumber++;
         changeMapping[sectionNumber] = 0;
-        newNameIndexMapping[string(name)] = sectionNumber;
+        newNameIndexMapping[name] = sectionNumber;
 
         newscn = elf_newscn(newElf);
         newshdr = ElfTypes::elf_getshdr(newscn);
@@ -644,8 +644,8 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
         secLinkMapping[sectionNumber] = shdr->sh_link;
         secInfoMapping[sectionNumber] = shdr->sh_info;
 
-        if(updateLinkInfoSecs.find(string(name)) != updateLinkInfoSecs.end())
-            dataLinkInfo[string(name)] = std::make_pair(shdr->sh_link, shdr->sh_info);
+        if(updateLinkInfoSecs.find(name) != updateLinkInfoSecs.end())
+            dataLinkInfo[name] = std::make_pair(shdr->sh_link, shdr->sh_info);
 
         rewrite_printf("section %s addr = %lx off = %lx size = %lx\n",
                        name, (long unsigned int)newshdr->sh_addr, (long unsigned int)newshdr->sh_offset, (long unsigned int)newshdr->sh_size);
@@ -1518,8 +1518,8 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
             linkedStaticData = linker.linkStatic(obj, err, errMsg);
             if (!linkedStaticData) {
                 std::string linkStaticError =
-                        std::string("Failed to link to static library code into the binary: ") +
-                        emitElfStatic::printStaticLinkError(err) + std::string(" = ")
+                        "Failed to link to static library code into the binary: " +
+                        emitElfStatic::printStaticLinkError(err) + " = "
                         + errMsg;
 		Symtab::setSymtabError(Emit_Error);
                 symtab_log_perror(linkStaticError.c_str());
@@ -1983,7 +1983,7 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
     if (secTagRegionMapping.find(dtype) != secTagRegionMapping.end())
         name = secTagRegionMapping[dtype]->getRegionName();
     else
-        name = std::string(new_name);
+        name = new_name;
     obj->addRegion(0, buffer, reloc_size, name, rtype, true);
     updateDynamic(dsize_type, dynamic_reloc_size);
 }
@@ -2451,8 +2451,7 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
 template<class ElfTypes>
 void emitElf<ElfTypes>::log_elferror(void (*err_func)(const char *), const char *msg) {
     const char *err = elf_errmsg(elf_errno());
-    err = err ? err : "(bad elf error)";
-    string str = string(err) + string(msg);
+    std::string str{std::string{err ? err : "(bad elf error)"} + " " + msg};
     err_func(str.c_str());
 }
 

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -414,13 +414,14 @@ bool emitElf<ElfTypes>::getSectionAndSegmentInfo() {
     return true;
 }
 
-// Renames 1st oldName section by changing 2nd char to 'o'
+// Renames 1st oldName section by changing 2nd char to '#' (never compiler/linker generated)
 template<class ElfTypes>
 void emitElf<ElfTypes>::renameSection(const std::string &oldName) {
-    assert(oldName.length() >= 2 && oldName[1] != 'o');
+    const auto renameChar{'#'};
+    assert(oldName.length() >= 2 && oldName[1] != renameChar);
     for (auto &secName : secNames)  {
         if (secName == oldName)  {
-            secName[1] = 'o';
+            secName[1] = renameChar;
             break;
         }
     }

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -308,19 +308,35 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
 // Get section name table from .shstrtab section, find the last loaded section,
 // maximum segment alignment and if TLS is used
 template<class ElfTypes>
-void emitElf<ElfTypes>::getSectionAndSegmentInfo() {
+bool emitElf<ElfTypes>::getSectionAndSegmentInfo() {
+    oldNumSections = oldElfHandle->e_shnum();
+    oldShstrndx = oldElfHandle->e_shstrndx();
+    oldNumSegments = oldElfHandle->e_phnum();
+
+    if (oldNumSegments + 2 >= PN_XNUM)  {
+        log_elferror(err_func_, "Too many segments, libelf fails if > PN_XNUM");
+        return false;
+    }
+
     sectionNameTable = pdelf_get_shnames(oldElfHandle);
     if (sectionNameTable == NULL) {
         log_elferror(err_func_, ".shstrtab section not found");
+        return false;
     }
 
     Elf_Phdr *phdrs = ElfTypes::elf_getphdr(oldElf);
+    if (oldNumSegments && !phdrs)  {
+        log_elferror(err_func_, "program header table missing or corrupted");
+        return false;
+    }
 
     // Find the maximum of the loaded segment end addresses, and if TLS exists
     Elf_Off maxSegmentEndAddr{};
-    for (unsigned i = 0; i < oldEhdr->e_phnum; i++) {
+    bool foundLoadSegment{};
+    for (unsigned i = 0; i < oldNumSegments; ++i) {
         auto phdr{&phdrs[i]};
         if (phdr->p_type == PT_LOAD) {
+            foundLoadSegment = true;
             auto segmentEndAddr{phdr->p_vaddr + phdr->p_memsz};
             if (maxSegmentEndAddr < segmentEndAddr)
                 maxSegmentEndAddr = segmentEndAddr;
@@ -331,16 +347,21 @@ void emitElf<ElfTypes>::getSectionAndSegmentInfo() {
         }
     }
 
+    if (!foundLoadSegment)  {
+        log_elferror(err_func_, "no loadable segments found");
+        return false;
+    }
+
     // Find the section index containing the max section end address, that is
     // contained in the max loaded segment.  Ignore the shstrndx section since
     // this section is always moved to the end.
     Elf_Off maxSectionEndAddr{};
-    for (unsigned i = 0; i < oldEhdr->e_shnum; ++i)  {
-        if (i == oldEhdr->e_shstrndx)
+    for (unsigned i = 0; i < oldNumSections; ++i)  {
+        if (i == oldShstrndx)
             continue;                   // .shstrtab shstrndx section always moved, ignore
         auto scn{elf_getscn(oldElf, i)};
         auto shdr{ElfTypes::elf_getshdr(scn)};
-        if (!(shdr->sh_flags & SHF_ALLOC))
+        if (!shdr || !(shdr->sh_flags & SHF_ALLOC))
             continue;                   // not allocated, so no address
         auto endAddr{shdr->sh_addr + shdr->sh_size};
         if (maxSectionEndAddr <= endAddr && endAddr <= maxSegmentEndAddr)  {
@@ -348,6 +369,13 @@ void emitElf<ElfTypes>::getSectionAndSegmentInfo() {
             lastLoadedSectionIndex = i;
         }
     }
+
+    if (!lastLoadedSectionIndex)  {
+        log_elferror(err_func_, "no loadable sections found to insert after");
+        return false;
+    }
+
+    return true;
 }
 
 // Renames 1st oldName section by changing 2nd char to 'o'
@@ -368,10 +396,8 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
 
     oldEhdr = ElfTypes::elf_getehdr(oldElf);
 
-    getSectionAndSegmentInfo();
-    if (!sectionNameTable)  {
+    if (!getSectionAndSegmentInfo())
         return false;
-    }
     if (object->getLoadAddress() == 0)  {
         library_adjust = std::max(static_cast<unsigned>(getpagesize()), maxSegmentAlignment);
     }
@@ -424,9 +450,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     }
     *newEhdr = *oldEhdr;
 
-    newEhdr->e_shnum += newSecs.size();
-
-    unsigned insertPoint = oldEhdr->e_shnum + 1;
+    unsigned insertPoint = oldNumSections + 1;  // value if loop below fails to set
     unsigned insertPointOffset = 0;
 
     newEhdr->e_phoff = sizeof(Elf_Ehdr);
@@ -462,7 +486,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         }
 
         // write the shstrtabsection at the end
-        if (scncount == oldEhdr->e_shstrndx)
+        if (scncount == oldShstrndx)
             continue;
 
         sectionNumber++;
@@ -698,7 +722,24 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         }
     }
 
-    newEhdr->e_shstrndx = scncount - 1;
+    // libelf does not handle the extended for e_shstrndx, so manually do it here
+    unsigned newShstrndx = scncount - 1;
+    if (newShstrndx >= SHN_LORESERVE) {
+        newEhdr->e_shstrndx = SHN_XINDEX;
+        if (auto scn0 = elf_getscn(newElf, 0))  {
+            if (auto shdr0 = ElfTypes::elf_getshdr(scn0))  {
+                shdr0->sh_link = newShstrndx;
+            }  else  {
+                log_elferror(err_func_, "elf_getshdr(scn0) failed");
+                return false;
+            }
+        }  else  {
+            log_elferror(err_func_, "elf_getscn(newElf, 0) failed");
+            return false;
+        }
+    } else {
+        newEhdr->e_shstrndx = newShstrndx;
+    }
 
     // Move the section header to the end
     newEhdr->e_shoff = shdr->sh_offset + shdr->sh_size;
@@ -747,7 +788,7 @@ void emitElf<ElfTypes>::fixPhdrs() {
     rewrite_printf("::fixPhdrs():\n");
     unsigned pgSize = getpagesize();
 
-    newEhdr->e_phnum = oldEhdr->e_phnum;
+    newEhdr->e_phnum = oldNumSegments;
     newEhdr->e_phentsize = oldEhdr->e_phentsize;
 
     newEhdr->e_phnum++;
@@ -757,7 +798,7 @@ void emitElf<ElfTypes>::fixPhdrs() {
     Elf_Phdr *old = oldPhdr;
     vector<Elf_Phdr> segments;
 
-    for (unsigned i = 0; i < oldEhdr->e_phnum; i++)
+    for (unsigned i = 0; i < oldNumSegments; i++)
     {
         segments.push_back(*old);
 

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -188,9 +188,6 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
     symbols.push_back(sym);
 
     if (dynSymFlag) {
-        char msg[2048];
-        char *mpos = msg;
-        msg[0] = '\0';
         string fileName;
 
         if (!symbol->getVersionFileName(fileName)) {
@@ -203,13 +200,13 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                 }
                 else {
                     versionSymTable.push_back(0);
-                    mpos += sprintf(mpos, "  local\n");
+                    rewrite_printf( "  local\n");
                 }
             }
             else {
                 if (vers->size() > 0) {
                     // new verdef entry
-                    mpos += sprintf(mpos, "verdef: symbol=%s  version=%s ", symbol->getMangledName().c_str(),
+                    rewrite_printf( "verdef: symbol=%s  version=%s ", symbol->getMangledName().c_str(),
                                     (*vers)[0].c_str());
                     if (verdefEntries.find((*vers)[0]) != verdefEntries.end()) {
                         unsigned short index = verdefEntries[(*vers)[0]];
@@ -227,7 +224,7 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                 }
                 // add all versions to the verdef entry
                 for (unsigned i = 0; i < vers->size(); i++) {
-                    mpos += sprintf(mpos, "  {%s}", (*vers)[i].c_str());
+                    rewrite_printf( "  {%s}", (*vers)[i].c_str());
                     if (versionNames.find((*vers)[i]) == versionNames.end()) {
                         versionNames[(*vers)[i]] = 0;
                     }
@@ -238,12 +235,12 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                         verdauxEntries[verdefEntries[(*vers)[0]]].push_back((*vers)[i]);
                     }
                 }
-                mpos += sprintf(mpos, "\n");
+                rewrite_printf( "\n");
             }
         }
         else {
             //verneed entry
-            mpos += sprintf(mpos, "need: symbol=%s    filename=%s\n",
+            rewrite_printf( "need: symbol=%s    filename=%s\n",
                             symbol->getMangledName().c_str(), fileName.c_str());
 
             vector<string> *vers;
@@ -256,13 +253,13 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                         if (find(unversionedNeededEntries.begin(),
                                  unversionedNeededEntries.end(),
                                  fileName) == unversionedNeededEntries.end()) {
-                            mpos += sprintf(mpos, "  new unversioned: %s\n", fileName.c_str());
+                            rewrite_printf( "  new unversioned: %s\n", fileName.c_str());
                             unversionedNeededEntries.push_back(fileName);
                         }
                     }
 
                     if (symbol->getLinkage() == Symbol::SL_GLOBAL) {
-                        mpos += sprintf(mpos, "  global (w/ filename)\n");
+                        rewrite_printf( "  global (w/ filename)\n");
                         versionSymTable.push_back(1);
                     }
                     else {
@@ -277,17 +274,17 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                     //If the version name already exists then add the same version number to the version symbol table
                     //Else give a new number and add it to the mapping.
                     if (versionNames.find((*vers)[0]) == versionNames.end()) {
-                        mpos += sprintf(mpos, "  new version name: %s\n", (*vers)[0].c_str());
+                        rewrite_printf( "  new version name: %s\n", (*vers)[0].c_str());
                         versionNames[(*vers)[0]] = 0;
                     }
 
                     if (verneedEntries.find(fileName) != verneedEntries.end()) {
                         if (verneedEntries[fileName].find((*vers)[0]) != verneedEntries[fileName].end()) {
-                            mpos += sprintf(mpos, "  vernum: %u\n", verneedEntries[fileName][(*vers)[0]]);
+                            rewrite_printf( "  vernum: %u\n", verneedEntries[fileName][(*vers)[0]]);
                             versionSymTable.push_back((unsigned short) verneedEntries[fileName][(*vers)[0]]);
                         }
                         else {
-                            mpos += sprintf(mpos, "  new entry #%d: %s [%s]\n",
+                            rewrite_printf( "  new entry #%d: %s [%s]\n",
                                             curVersionNum, (*vers)[0].c_str(), fileName.c_str());
                             versionSymTable.push_back((unsigned short) curVersionNum);
                             verneedEntries[fileName][(*vers)[0]] = curVersionNum;
@@ -295,7 +292,7 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                         }
                     }
                     else {
-                        mpos += sprintf(mpos, "  new entry #%d: %s [%s]\n",
+                        rewrite_printf( "  new entry #%d: %s [%s]\n",
                                         curVersionNum, (*vers)[0].c_str(), fileName.c_str());
                         versionSymTable.push_back((unsigned short) curVersionNum);
                         verneedEntries[fileName][(*vers)[0]] = curVersionNum;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -507,7 +507,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
         }
 
         if (library_adjust > 0 && newdata->d_buf && newdata->d_size) {
-            for (Offset relr_addr : object->getRelrDynRelocs()) {
+            for (auto relr_addr : object->getRelrDynRelocs()) {
                 if (relr_addr < shdr->sh_addr ||
                     relr_addr + sizeof(Elf_Relr) > shdr->sh_addr + shdr->sh_size)
                     continue;
@@ -524,11 +524,11 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
             }
         }
 
-        vector<vector<unsigned long> > moveSecAddrRange = object->getMoveSecAddrRange();
+        auto moveSecAddrRange = object->getMoveSecAddrRange();
 
-        for (unsigned i = 0; i != moveSecAddrRange.size(); i++) {
-            if ((moveSecAddrRange[i][0] == shdr->sh_addr) ||
-                (shdr->sh_addr >= moveSecAddrRange[i][0] && shdr->sh_addr < moveSecAddrRange[i][1])) {
+        for (const auto &m : moveSecAddrRange) {
+            if ((m[0] == shdr->sh_addr) ||
+                (m[0] <= shdr->sh_addr && shdr->sh_addr < m[1])) {
                 newshdr->sh_type = SHT_PROGBITS;
                 changeMapping[sectionNumber] = 1;
                 renameSection(name);
@@ -870,9 +870,9 @@ void emitElf<ElfTypes>::fixPhdrs() {
     newPhdr = ElfTypes::elf_newphdr(newElf, newEhdr->e_phnum);
     void *phdr_data = (void *) newPhdr;
 
-    for (unsigned i = 0; i < segments.size(); i++)
+    for (const auto &segment : segments)
     {
-        memcpy(newPhdr, &segments[i], oldEhdr->e_phentsize);
+        *newPhdr = segment;
         rewrite_printf("Updated program header: type %u (%s), offset 0x%lx, addr 0x%lx\n",
                 newPhdr->p_type, phdrTypeStr(newPhdr->p_type).c_str(), (long unsigned int)newPhdr->p_offset, (long unsigned int)newPhdr->p_vaddr);
         ++newPhdr;
@@ -1033,13 +1033,14 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
      */
     Address zstart = emitElfUtils::orderLoadableSections(obj, newSecs);
 
-    for (unsigned i = 0; i < newSecs.size(); i++) {
-        if (!newSecs[i]->isLoadable()) {
-            nonLoadableSecs.push_back(newSecs[i]);
+    for (const auto newSec : newSecs) {
+        if (!newSec->isLoadable()) {
+            nonLoadableSecs.push_back(newSec);
             continue;
         }
-        secNames.push_back(newSecs[i]->getRegionName());
-        newNameIndexMapping[newSecs[i]->getRegionName()] = secNames.size() - 1;
+        secNames.push_back(newSec->getRegionName());
+        auto thisSectionIndex = secNames.size() - 1;
+        newNameIndexMapping[newSec->getRegionName()] = thisSectionIndex;
         sectionNumber++;
         // Add a new loadable section
         if ((newscn = elf_newscn(newElf)) == NULL) {
@@ -1057,7 +1058,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
         newshdr->sh_name = secNameIndex;
         newshdr->sh_flags = 0;
         newshdr->sh_type = SHT_PROGBITS;
-        switch (newSecs[i]->getRegionType()) {
+        switch (newSec->getRegionType()) {
             case Region::RT_TEXTDATA:
                 newshdr->sh_flags = SHF_EXECINSTR | SHF_ALLOC | SHF_WRITE;
                 break;
@@ -1074,22 +1075,24 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
                 break;
         }
 
+        newNameIndexMapping[newSec->getRegionName()] = thisSectionIndex;
+
         if (shdr->sh_type == SHT_NOBITS) {
             newshdr->sh_offset = shdr->sh_offset;
-        } else if (!firstNewLoadSec || !newSecs[i]->getDiskOffset()) {
+        } else if (!firstNewLoadSec || !newSec->getDiskOffset()) {
             newshdr->sh_offset = shdr->sh_offset + shdr->sh_size;
         } else {
             // The offset can be computed by determining the difference from
             // the first new loadable section
             newshdr->sh_offset = firstNewLoadSec->sh_offset + library_adjust +
-                                 (newSecs[i]->getDiskOffset() - firstNewLoadSec->sh_addr);
+                                 (newSec->getDiskOffset() - firstNewLoadSec->sh_addr);
 
             // Account for inter-section spacing due to alignment constraints
             loadSecTotalSize += newshdr->sh_offset - (shdr->sh_offset + shdr->sh_size);
         }
 
-        if (newSecs[i]->getDiskOffset())
-            newshdr->sh_addr = newSecs[i]->getDiskOffset() + library_adjust;
+        if (newSec->getDiskOffset())
+            newshdr->sh_addr = newSec->getDiskOffset() + library_adjust;
         else if (!prevshdr) {
             newshdr->sh_addr = zstart + library_adjust;
         }
@@ -1099,17 +1102,17 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
 
         newshdr->sh_link = SHN_UNDEF;
         newshdr->sh_info = 0;
-        newshdr->sh_addralign = newSecs[i]->getMemAlignment();
+        newshdr->sh_addralign = newSec->getMemAlignment();
         newshdr->sh_entsize = 0;
 
         // TLS section
-        if (newSecs[i]->isTLS()) {
+        if (newSec->isTLS()) {
             newTLSData = newshdr;
             newshdr->sh_flags |= SHF_TLS;
         }
 
-        if (newSecs[i]->getRegionType() == Region::RT_REL ||
-            newSecs[i]->getRegionType() == Region::RT_PLTREL)    //Relocation section
+        if (newSec->getRegionType() == Region::RT_REL ||
+            newSec->getRegionType() == Region::RT_PLTREL)    //Relocation section
         {
             newshdr->sh_type = SHT_REL;
             newshdr->sh_flags = SHF_ALLOC;
@@ -1117,13 +1120,13 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             updateDynLinkShdr.push_back(newshdr);
             newdata->d_type = ELF_T_REL;
             newdata->d_align = 4;
-            if (newSecs[i]->getRegionType() == Region::RT_REL)
+            if (newSec->getRegionType() == Region::RT_REL)
                 updateDynamic(DT_REL, newshdr->sh_addr);
-            else if (newSecs[i]->getRegionType() == Region::RT_PLTREL)
+            else if (newSec->getRegionType() == Region::RT_PLTREL)
                 updateDynamic(DT_JMPREL, newshdr->sh_addr);
         }
-        else if (newSecs[i]->getRegionType() == Region::RT_RELA ||
-                 newSecs[i]->getRegionType() == Region::RT_PLTRELA) //Relocation section
+        else if (newSec->getRegionType() == Region::RT_RELA ||
+                 newSec->getRegionType() == Region::RT_PLTRELA) //Relocation section
         {
             newshdr->sh_type = SHT_RELA;
             newshdr->sh_flags = SHF_ALLOC;
@@ -1131,12 +1134,12 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             updateDynLinkShdr.push_back(newshdr);
             newdata->d_type = ELF_T_RELA;
             newdata->d_align = 4;
-            if (newSecs[i]->getRegionType() == Region::RT_RELA)
+            if (newSec->getRegionType() == Region::RT_RELA)
                 updateDynamic(DT_RELA, newshdr->sh_addr);
-            else if (newSecs[i]->getRegionType() == Region::RT_PLTRELA)
+            else if (newSec->getRegionType() == Region::RT_PLTRELA)
                 updateDynamic(DT_JMPREL, newshdr->sh_addr);
         }
-        else if (newSecs[i]->getRegionType() == Region::RT_RELR)
+        else if (newSec->getRegionType() == Region::RT_RELR)
         {
             newshdr->sh_type = SHT_RELR;
             newshdr->sh_flags = SHF_ALLOC;
@@ -1147,10 +1150,10 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
                 (sizeof(Elf_Relr) == sizeof(Elf32_Word)) ? ELF_T_WORD : ELF_T_XWORD;
             newdata->d_align = sizeof(Elf_Relr);
             updateDynamic(DT_RELR, newshdr->sh_addr);
-            updateDynamic(DT_RELRSZ, newSecs[i]->getDiskSize());
+            updateDynamic(DT_RELRSZ, newSec->getDiskSize());
             updateDynamic(DT_RELRENT, sizeof(Elf_Relr));
         }
-        else if (newSecs[i]->getRegionType() == Region::RT_STRTAB)    //String table Section
+        else if (newSec->getRegionType() == Region::RT_STRTAB)    //String table Section
         {
             newshdr->sh_type = SHT_STRTAB;
             newshdr->sh_entsize = 1;
@@ -1159,12 +1162,12 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_flags = SHF_ALLOC;
             newdata->d_align = 1;
             dynStrData = newdata;
-            strtabIndex = secNames.size() - 1;
+            strtabIndex = thisSectionIndex;
             newshdr->sh_addralign = 1;
             updateDynamic(DT_STRTAB, newshdr->sh_addr);
-            updateDynamic(DT_STRSZ, newSecs[i]->getDiskSize());
+            updateDynamic(DT_STRSZ, newSec->getDiskSize());
         }
-        else if (newSecs[i]->getRegionType() == Region::RT_SYMTAB) {
+        else if (newSec->getRegionType() == Region::RT_SYMTAB) {
             newshdr->sh_type = SHT_DYNSYM;
             newshdr->sh_entsize = sizeof(Elf_Sym);
             newdata->d_type = ELF_T_SYM;
@@ -1172,10 +1175,10 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             dynsymData = newdata;
             newshdr->sh_link = secNames.size();   //.symtab section should have sh_link = index of .strtab for .dynsym
             newshdr->sh_flags = SHF_ALLOC;
-            dynsymIndex = secNames.size() - 1;
+            dynsymIndex = thisSectionIndex;
             updateDynamic(DT_SYMTAB, newshdr->sh_addr);
         }
-        else if (newSecs[i]->getRegionType() == Region::RT_DYNAMIC) {
+        else if (newSec->getRegionType() == Region::RT_DYNAMIC) {
             newshdr->sh_entsize = sizeof(Elf_Dyn);
             newshdr->sh_type = SHT_DYNAMIC;
             newdata->d_type = ELF_T_DYN;
@@ -1184,9 +1187,9 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_flags = SHF_ALLOC | SHF_WRITE;
             dynSegOff = newshdr->sh_offset;
             dynSegAddr = newshdr->sh_addr;
-            dynSegSize = newSecs[i]->getDiskSize();
+            dynSegSize = newSec->getDiskSize();
         }
-        else if (newSecs[i]->getRegionType() == Region::RT_HASH) {
+        else if (newSec->getRegionType() == Region::RT_HASH) {
             newshdr->sh_entsize = sizeof(Elf_Word);
             newshdr->sh_type = SHT_HASH;
             newdata->d_type = ELF_T_WORD;
@@ -1196,7 +1199,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_info = 0;
             updateDynamic(DT_HASH, newshdr->sh_addr);
         }
-        else if (newSecs[i]->getRegionType() == Region::RT_SYMVERSIONS) {
+        else if (newSec->getRegionType() == Region::RT_SYMVERSIONS) {
             newshdr->sh_type = SHT_GNU_versym;
             newshdr->sh_entsize = sizeof(Elf_Half);
             newshdr->sh_addralign = 2;
@@ -1206,7 +1209,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_flags = SHF_ALLOC;
             updateDynamic(DT_VERSYM, newshdr->sh_addr);
         }
-        else if (newSecs[i]->getRegionType() == Region::RT_SYMVERNEEDED) {
+        else if (newSec->getRegionType() == Region::RT_SYMVERNEEDED) {
             newshdr->sh_type = SHT_GNU_verneed;
             newshdr->sh_entsize = 0;
             newshdr->sh_addralign = 4;
@@ -1217,7 +1220,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_info = verneednum;
             updateDynamic(DT_VERNEED, newshdr->sh_addr);
         }
-        else if (newSecs[i]->getRegionType() == Region::RT_SYMVERDEF) {
+        else if (newSec->getRegionType() == Region::RT_SYMVERDEF) {
             newshdr->sh_type = SHT_GNU_verdef;
             newshdr->sh_entsize = 0;
             newdata->d_type = ELF_T_VDEF;
@@ -1240,10 +1243,10 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
         }
 
         //Set up the data
-        newdata->d_buf = allocate_buffer(newSecs[i]->getDiskSize());
-        memcpy(newdata->d_buf, newSecs[i]->getPtrToRawData(), newSecs[i]->getDiskSize());
+        newdata->d_buf = allocate_buffer(newSec->getDiskSize());
+        memcpy(newdata->d_buf, newSec->getPtrToRawData(), newSec->getDiskSize());
         newdata->d_off = 0;
-        newdata->d_size = newSecs[i]->getDiskSize();
+        newdata->d_size = newSec->getDiskSize();
         if (!newdata->d_align)
             newdata->d_align = newshdr->sh_addralign;
         newshdr->sh_size = newdata->d_size;
@@ -1257,7 +1260,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
         currEndAddress = newshdr->sh_addr + newshdr->sh_size;
 
         rewrite_printf("new section %s addr = %lx off = %lx size = %lx\n",
-                       newSecs[i]->getRegionName().c_str(), (long unsigned int)newshdr->sh_addr, (long unsigned int)newshdr->sh_offset,
+                       newSec->getRegionName().c_str(), (long unsigned int)newshdr->sh_addr, (long unsigned int)newshdr->sh_offset,
                        (long unsigned int)newshdr->sh_size);
 
         newdata->d_version = 1;
@@ -1272,18 +1275,16 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
         shdr = newshdr;
         if (!firstNewLoadSec)
             firstNewLoadSec = shdr;
-        secNameIndex += newSecs[i]->getRegionName().size() + 1;
+        secNameIndex += newSec->getRegionName().size() + 1;
         prevshdr = newshdr;
     }
 
-    for (unsigned i = 0; i < updateDynLinkShdr.size(); i++) {
-        newshdr = updateDynLinkShdr[i];
-        newshdr->sh_link = dynsymIndex;
+    for (const auto &s : updateDynLinkShdr) {
+        s->sh_link = dynsymIndex;
     }
 
-    for (unsigned i = 0; i < updateStrLinkShdr.size(); i++) {
-        newshdr = updateStrLinkShdr[i];
-        newshdr->sh_link = strtabIndex;
+    for (const auto &s : updateStrLinkShdr) {
+        s->sh_link = strtabIndex;
     }
 
 
@@ -1323,10 +1324,10 @@ bool emitElf<ElfTypes>::addSectionHeaderTable(Elf_Shdr *shdr) {
     //Set up the data
     newdata->d_buf = allocate_buffer(secNameIndex);
     char *ptr = (char *) newdata->d_buf;
-    for (unsigned i = 0; i < secNames.size(); i++) {
-        memcpy(ptr, secNames[i].c_str(), secNames[i].length());
-        memcpy(ptr + secNames[i].length(), "\0", 1);
-        ptr += secNames[i].length() + 1;
+    for (const auto &secName : secNames) {
+        memcpy(ptr, secName.c_str(), secName.length());
+        memcpy(ptr + secName.length(), "\0", 1);
+        ptr += secName.length() + 1;
     }
 
     newdata->d_size = secNameIndex;
@@ -1345,8 +1346,8 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
 
     Elf_Shdr *prevshdr = shdr;
     //All of them that are left are non-loadable. stack'em up at the end.
-    for (unsigned i = 0; i < nonLoadableSecs.size(); i++) {
-        secNames.push_back(nonLoadableSecs[i]->getRegionName());
+    for (const auto &sec : nonLoadableSecs) {
+        secNames.push_back(sec->getRegionName());
         // Add a new non-loadable section
         if ((newscn = elf_newscn(newElf)) == NULL) {
             log_elferror(err_func_, "unable to create new section");
@@ -1360,43 +1361,43 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
         //Fill out the new section header
         newshdr = ElfTypes::elf_getshdr(newscn);
         newshdr->sh_name = secNameIndex;
-        secNameIndex += nonLoadableSecs[i]->getRegionName().length() + 1;
-        if (nonLoadableSecs[i]->getRegionType() == Region::RT_TEXT)        //Text Section
+        secNameIndex += sec->getRegionName().length() + 1;
+        if (sec->getRegionType() == Region::RT_TEXT)        //Text Section
         {
             newshdr->sh_type = SHT_PROGBITS;
             newshdr->sh_flags = SHF_EXECINSTR | SHF_WRITE;
             newshdr->sh_entsize = 1;
             newdata->d_type = ELF_T_BYTE;
         }
-        else if (nonLoadableSecs[i]->getRegionType() == Region::RT_DATA)    //Data Section
+        else if (sec->getRegionType() == Region::RT_DATA)    //Data Section
         {
             newshdr->sh_type = SHT_PROGBITS;
             newshdr->sh_flags = SHF_WRITE;
             newshdr->sh_entsize = 1;
             newdata->d_type = ELF_T_BYTE;
         }
-        else if (nonLoadableSecs[i]->getRegionType() == Region::RT_REL)    //Relocations section
+        else if (sec->getRegionType() == Region::RT_REL)    //Relocations section
         {
             newshdr->sh_type = SHT_REL;
             newshdr->sh_flags = SHF_WRITE;
             newshdr->sh_entsize = sizeof(Elf_Rel);
             newdata->d_type = ELF_T_BYTE;
         }
-        else if (nonLoadableSecs[i]->getRegionType() == Region::RT_RELA)    //Relocations section
+        else if (sec->getRegionType() == Region::RT_RELA)    //Relocations section
         {
             newshdr->sh_type = SHT_RELA;
             newshdr->sh_flags = SHF_WRITE;
             newshdr->sh_entsize = sizeof(Elf_Rela);
             newdata->d_type = ELF_T_BYTE;
         }
-        else if (nonLoadableSecs[i]->getRegionType() == Region::RT_SYMTAB) {
+        else if (sec->getRegionType() == Region::RT_SYMTAB) {
             newshdr->sh_type = SHT_SYMTAB;
             newshdr->sh_entsize = sizeof(Elf_Sym);
             newdata->d_type = ELF_T_SYM;
             newshdr->sh_link = secNames.size();   //.symtab section should have sh_link = index of .strtab
             newshdr->sh_flags = 0;
         }
-        else if (nonLoadableSecs[i]->getRegionType() == Region::RT_STRTAB)    //String table Section
+        else if (sec->getRegionType() == Region::RT_STRTAB)    //String table Section
         {
             newshdr->sh_type = SHT_STRTAB;
             newshdr->sh_entsize = 1;
@@ -1418,8 +1419,8 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
         newshdr->sh_addralign = 4;
 
         //Set up the data
-        newdata->d_buf = nonLoadableSecs[i]->getPtrToRawData();
-        newdata->d_size = nonLoadableSecs[i]->getDiskSize();
+        newdata->d_buf = sec->getPtrToRawData();
+        newdata->d_size = sec->getDiskSize();
         newshdr->sh_size = newdata->d_size;
 
         newdata->d_align = 4;
@@ -1472,9 +1473,8 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
     // Copy over the previous library dependencies
     vector<string> elibs;
     obj->getObject()->getDependencies(elibs);
-    for (auto iter = elibs.begin();
-         iter != elibs.end(); ++iter) {
-        addDTNeeded(*iter);
+    for (const auto &elib : elibs) {
+        addDTNeeded(elib);
     }
 
     //Initialize the list of new prereq libraries
@@ -1530,12 +1530,10 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
             obj->getAllNewRegions(newRegs);
 
             Offset lastRegionAddr = 0, lastRegionSize = 0;
-            vector<Region *>::iterator newRegIter;
-            for (newRegIter = newRegs.begin(); newRegIter != newRegs.end();
-                 ++newRegIter) {
-                if ((*newRegIter)->getDiskOffset() > lastRegionAddr) {
-                    lastRegionAddr = (*newRegIter)->getDiskOffset();
-                    lastRegionSize = (*newRegIter)->getDiskSize();
+            for (const auto &region : newRegs) {
+                if (region->getDiskOffset() > lastRegionAddr) {
+                    lastRegionAddr = region->getDiskOffset();
+                    lastRegionSize = region->getDiskSize();
                 }
             }
 
@@ -1546,13 +1544,13 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
         }
     }
 
-    for (auto sym_iter = allSymbols.begin(); sym_iter != allSymbols.end(); ++sym_iter) {
-        if ((*sym_iter)->isInSymtab()) {
-            allSymSymbols.push_back(*sym_iter);
+    for (const auto &s : allSymbols) {
+        if (s->isInSymtab()) {
+            allSymSymbols.push_back(s);
         }
         if (!obj->isStaticBinary()) {
-            if ((*sym_iter)->isInDynSymtab()) {
-                allDynSymbols.push_back(*sym_iter);
+            if (s->isInDynSymtab()) {
+                allDynSymbols.push_back(s);
             }
         }
     }
@@ -1561,21 +1559,21 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
     std::sort(allDynSymbols.begin(), allDynSymbols.end(), sortByOffsetNewIndices());
 
     int max_index = -1;
-    for (i = 0; i < allDynSymbols.size(); i++) {
-        if (max_index < allDynSymbols[i]->getIndex())
-            max_index = allDynSymbols[i]->getIndex();
+    for (const auto &s : allDynSymbols) {
+        if (max_index < s->getIndex())
+            max_index = s->getIndex();
     }
-    for (i = 0; i < allDynSymbols.size(); i++) {
-        if (allDynSymbols[i]->getIndex() == -1) {
+    for (const auto &s : allDynSymbols) {
+        if (s->getIndex() == -1) {
             max_index++;
-            allDynSymbols[i]->setIndex(max_index);
+            s->setIndex(max_index);
         }
 
-        if (allDynSymbols[i]->getStrIndex() == -1) {
+        if (s->getStrIndex() == -1) {
             // New Symbol - append to the list of strings
-            dynsymbolStrs.push_back(allDynSymbols[i]->getMangledName().c_str());
-            allDynSymbols[i]->setStrIndex(dynsymbolNamesLength);
-            dynsymbolNamesLength += allDynSymbols[i]->getMangledName().length() + 1;
+            dynsymbolStrs.push_back(s->getMangledName().c_str());
+            s->setStrIndex(dynsymbolNamesLength);
+            dynsymbolNamesLength += s->getMangledName().length() + 1;
         }
 
     }
@@ -1585,15 +1583,15 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
 
     std::sort(allSymSymbols.begin(), allSymSymbols.end(), sortByOffsetNewIndices());
     max_index = -1;
-    for (i = 0; i < allSymSymbols.size(); i++) {
-        if (max_index < allSymSymbols[i]->getIndex())
-            max_index = allSymSymbols[i]->getIndex();
+    for (const auto &s : allSymSymbols) {
+        if (max_index < s->getIndex())
+            max_index = s->getIndex();
     }
 
-    for (i = 0; i < allSymSymbols.size(); i++) {
-        if (allSymSymbols[i]->getIndex() == -1) {
+    for (const auto &s : allSymSymbols) {
+        if (s->getIndex() == -1) {
             max_index++;
-            allSymSymbols[i]->setIndex(max_index);
+            s->setIndex(max_index);
         }
     }
 
@@ -1609,28 +1607,31 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
        new symbols and string that we create for the new binary (targ*, versions etc).
     */
 
-    for (i = 0; i < allSymSymbols.size(); i++) {
-        createElfSymbol(allSymSymbols[i], symbolNamesLength, symbols);
-        symbolStrs.push_back(allSymSymbols[i]->getMangledName());
-        symbolNamesLength += allSymSymbols[i]->getMangledName().length() + 1;
+    for (const auto &s : allSymSymbols) {
+        createElfSymbol(s, symbolNamesLength, symbols);
+        symbolStrs.push_back(s->getMangledName());
+        symbolNamesLength += s->getMangledName().length() + 1;
     }
     int nTmp = dynsymVector.size();
-    for (i = 0; i < allDynSymbols.size(); i++) {
-        createElfSymbol(allDynSymbols[i], allDynSymbols[i]->getStrIndex(), dynsymbols, true);
-        dynSymNameMapping[allDynSymbols[i]->getMangledName().c_str()] = i + nTmp;
-        dynsymVector.push_back(allDynSymbols[i]);
+    i = 0;
+    for (const auto &s : allDynSymbols) {
+        createElfSymbol(s, s->getStrIndex(), dynsymbols, true);
+        dynSymNameMapping[s->getMangledName().c_str()] = i + nTmp;
+        ++i;
+        dynsymVector.push_back(s);
     }
 
     //reconstruct .symtab section
     Elf_Sym *syms = (Elf_Sym *) malloc(symbols.size() * sizeof(Elf_Sym));
-    for (i = 0; i < symbols.size(); i++)
-        syms[i] = *(symbols[i]);
+    i = 0;
+    for (const auto &s : symbols)
+        syms[i++] = *s;
 
     char *str = (char *) malloc(symbolNamesLength);
     unsigned cur = 0;
-    for (i = 0; i < symbolStrs.size(); i++) {
-        strcpy(&str[cur], symbolStrs[i].c_str());
-        cur += symbolStrs[i].length() + 1;
+    for (const auto &s : symbolStrs) {
+        strcpy(&str[cur], s.c_str());
+        cur += s.length() + 1;
     }
 
     if (!isStripped) {
@@ -1663,8 +1664,9 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
     if (!obj->isStaticBinary()) {
         //reconstruct .dynsym section
         Elf_Sym *dynsyms = (Elf_Sym *) malloc(dynsymbols.size() * sizeof(Elf_Sym));
-        for (i = 0; i < dynsymbols.size(); i++)
-            dynsyms[i] = *(dynsymbols[i]);
+        i = 0;
+        for (const auto &s : dynsymbols)
+            dynsyms[i++] = *s;
 
         Elf_Half *symVers;
         char *verneedSecData, *verdefSecData;
@@ -1706,12 +1708,14 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
         memcpy((void *) dynstr, (void *) olddynStrData, olddynStrSize);
         dynstr[olddynStrSize] = '\0';
         cur = olddynStrSize + 1;
-        for (i = 0; i < dynsymbolStrs.size(); i++) {
-            strcpy(&dynstr[cur], dynsymbolStrs[i].c_str());
-            cur += dynsymbolStrs[i].length() + 1;
-            if (dynSymNameMapping.find(dynsymbolStrs[i]) == dynSymNameMapping.end()) {
-                dynSymNameMapping[dynsymbolStrs[i]] = allDynSymbols.size() + i;
+        i = 0;
+        for (const auto & s : dynsymbolStrs) {
+            strcpy(&dynstr[cur], s.c_str());
+            cur += s.length() + 1;
+            if (dynSymNameMapping.find(s) == dynSymNameMapping.end()) {
+                dynSymNameMapping[s] = allDynSymbols.size() + i;
             }
+            ++i;
         }
 
         string name;
@@ -1781,28 +1785,28 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
 
     unsigned int prev_size = 0;
     unsigned long sec_addr = 0;
-    for (unsigned long nsi = 0; nsi < newSecs.size(); nsi++) {
-	// Update the _DYNAMIC symbol; described in the elf standard as:
-	//  The program header table will have an element of type PT_DYNAMIC.
-	//  This "segment" contains the .dynamic section. A special symbol,
-	//  _DYNAMIC, labels the section
-	if (newSecs[nsi]->getDiskOffset())
-	  sec_addr = newSecs[nsi]->getDiskOffset() + library_adjust;
-	else
-	  sec_addr += prev_size;
-	prev_size = newSecs[nsi]->getDiskSize();
-	if (".dynamic" == newSecs[nsi]->getRegionName()) {
-	    // Found the .dynamic section
-	    for (unsigned long symi = 0; symi < symbolStrs.size(); symi++)
-	      if ("_DYNAMIC" == symbolStrs[symi]) {
-		  // Found the _DYNAMIC symbol
-		  rewrite_printf("update _DYNAMIC symbol from %#lx to %#lx\n",
-				 (unsigned long) syms[symi].st_value, (unsigned long) sec_addr);
-		  syms[symi].st_value = sec_addr;
-		  break;
-	      }
-	    break;
-	}
+    for (const auto &newSec : newSecs) {
+        // Update the _DYNAMIC symbol; described in the elf standard as:
+        //  The program header table will have an element of type PT_DYNAMIC.
+        //  This "segment" contains the .dynamic section. A special symbol,
+        //  _DYNAMIC, labels the section
+        if (newSec->getDiskOffset())
+          sec_addr = newSec->getDiskOffset() + library_adjust;
+        else
+          sec_addr += prev_size;
+        prev_size = newSec->getDiskSize();
+        if (".dynamic" == newSec->getRegionName()) {
+            // Found the .dynamic section
+            for (unsigned long symi = 0; symi < symbolStrs.size(); symi++)
+              if ("_DYNAMIC" == symbolStrs[symi]) {
+                  // Found the _DYNAMIC symbol
+                  rewrite_printf("update _DYNAMIC symbol from %#lx to %#lx\n",
+                                 (unsigned long) syms[symi].st_value, (unsigned long) sec_addr);
+                  syms[symi].st_value = sec_addr;
+                  break;
+              }
+            break;
+        }
     }
 
     return true;
@@ -1813,15 +1817,14 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
                                                    std::unordered_map<std::string, unsigned long> &dynSymNameMapping) {
     vector<relocationEntry> newRels;
     if (isDynRelocs && newSecs.size()) {
-        std::vector<Region *>::iterator i;
-        for (i = newSecs.begin(); i != newSecs.end(); i++) {
-            std::copy((*i)->getRelocations().begin(),
-                      (*i)->getRelocations().end(),
+        for (const auto s : newSecs) {
+            std::copy(s->getRelocations().begin(),
+                      s->getRelocations().end(),
                       std::back_inserter(newRels));
         }
     }
 
-    unsigned i, j, k, l, m;
+    unsigned j, k, l, m;
 
     Elf_Rel *rels = (Elf_Rel *) malloc(sizeof(Elf_Rel) * (relocation_table.size() + newRels.size()));
     Elf_Rela *relas = (Elf_Rela *) malloc(sizeof(Elf_Rela) * (relocation_table.size() + newRels.size()));
@@ -1830,7 +1833,7 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
     l = 0;
     m = 0;
     //reconstruct .rel
-    for (i = 0; i < relocation_table.size(); i++) {
+    for (auto &reloc : relocation_table) {
 
         if (library_adjust) {
             // If we are shifting the library down in memory, we need to update
@@ -1838,44 +1841,44 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
             // found via relocations
 
             // XXX ...ignore the return value
-            emitElfUtils::updateRelocation(obj, relocation_table[i], library_adjust);
+            emitElfUtils::updateRelocation(obj, reloc, library_adjust);
         }
 
-        if ((object->getRelType() == Region::RT_REL) && (relocation_table[i].regionType() == Region::RT_REL)) {
-            rels[j].r_offset = relocation_table[i].rel_addr() + library_adjust;
+        if ((object->getRelType() == Region::RT_REL) && (reloc.regionType() == Region::RT_REL)) {
+            rels[j].r_offset = reloc.rel_addr() + library_adjust;
             unsigned long sym_offset = 0;
-            std::string sym_name = relocation_table[i].name();
+            std::string sym_name = reloc.name();
             if (!sym_name.empty()) {
                 std::unordered_map<string, unsigned long>::iterator it = dynSymNameMapping.find(sym_name);
                 if (it != dynSymNameMapping.end())
                     sym_offset = it->second;
                 else {
-                    Symbol *sym = relocation_table[i].getDynSym();
+                    Symbol *sym = reloc.getDynSym();
                     if (sym)
                         sym_offset = sym->getIndex();
                 }
             }
 
             if (sym_offset) {
-                rels[j].r_info = ElfTypes::makeRelocInfo(sym_offset, relocation_table[i].getRelType());
+                rels[j].r_info = ElfTypes::makeRelocInfo(sym_offset, reloc.getRelType());
             } else {
-                rels[j].r_info = ElfTypes::makeRelocInfo((unsigned long) STN_UNDEF, relocation_table[i].getRelType());
+                rels[j].r_info = ElfTypes::makeRelocInfo((unsigned long) STN_UNDEF, reloc.getRelType());
             }
             j++;
-        } else if ((object->getRelType() == Region::RT_RELA) && (relocation_table[i].regionType() == Region::RT_RELA)) {
-            relas[k].r_offset = relocation_table[i].rel_addr() + library_adjust;
-            relas[k].r_addend = relocation_table[i].addend();
+        } else if ((object->getRelType() == Region::RT_RELA) && (reloc.regionType() == Region::RT_RELA)) {
+            relas[k].r_offset = reloc.rel_addr() + library_adjust;
+            relas[k].r_addend = reloc.addend();
             //if (relas[k].r_addend)
             //   relas[k].r_addend += library_adjust;
             unsigned long sym_offset = 0;
-            std::string sym_name = relocation_table[i].name();
+            std::string sym_name = reloc.name();
             if (!sym_name.empty()) {
                 std::unordered_map<string, unsigned long>::iterator it = dynSymNameMapping.find(sym_name);
                 if (it != dynSymNameMapping.end()) {
                     sym_offset = it->second;
                 }
                 else {
-                    Symbol *sym = relocation_table[i].getDynSym();
+                    Symbol *sym = reloc.getDynSym();
                     if (sym) {
                         it = dynSymNameMapping.find(sym->getMangledName());
                         if (it != dynSymNameMapping.end())
@@ -1884,35 +1887,35 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
                 }
             }
             if (sym_offset) {
-                relas[k].r_info = ElfTypes::makeRelocInfo(sym_offset, relocation_table[i].getRelType());
+                relas[k].r_info = ElfTypes::makeRelocInfo(sym_offset, reloc.getRelType());
             } else {
-                relas[k].r_info = ElfTypes::makeRelocInfo((unsigned long) STN_UNDEF, relocation_table[i].getRelType());
+                relas[k].r_info = ElfTypes::makeRelocInfo((unsigned long) STN_UNDEF, reloc.getRelType());
             }
             k++;
         }
     }
-    for (i = 0; i < newRels.size(); i++) {
-        if ((object->getRelType() == Region::RT_REL) && (newRels[i].regionType() == Region::RT_REL)) {
-            rels[j].r_offset = newRels[i].rel_addr() + library_adjust;
-            if (dynSymNameMapping.find(newRels[i].name()) != dynSymNameMapping.end()) {
-                rels[j].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRels[i].name()],
-                                                         newRels[i].getRelType());
+    for (const auto &newRel : newRels) {
+        if ((object->getRelType() == Region::RT_REL) && (newRel.regionType() == Region::RT_REL)) {
+            rels[j].r_offset = newRel.rel_addr() + library_adjust;
+            if (dynSymNameMapping.find(newRel.name()) != dynSymNameMapping.end()) {
+                rels[j].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRel.name()],
+                                                         newRel.getRelType());
             } else {
                 rels[j].r_info = ElfTypes::makeRelocInfo((unsigned long) (STN_UNDEF),
-                                                         newRels[i].getRelType());
+                                                         newRel.getRelType());
             }
             j++;
             l++;
-        } else if ((object->getRelType() == Region::RT_RELA) && (newRels[i].regionType() == Region::RT_RELA)) {
-            relas[k].r_offset = newRels[i].rel_addr() + library_adjust;
-            relas[k].r_addend = newRels[i].addend();
+        } else if ((object->getRelType() == Region::RT_RELA) && (newRel.regionType() == Region::RT_RELA)) {
+            relas[k].r_offset = newRel.rel_addr() + library_adjust;
+            relas[k].r_addend = newRel.addend();
             //if( relas[k].r_addend ) relas[k].r_addend += library_adjust;
-            if (dynSymNameMapping.find(newRels[i].name()) != dynSymNameMapping.end()) {
-                relas[k].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRels[i].name()],
-                                                          newRels[i].getRelType());
+            if (dynSymNameMapping.find(newRel.name()) != dynSymNameMapping.end()) {
+                relas[k].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRel.name()],
+                                                          newRel.getRelType());
             } else {
                 relas[k].r_info = ElfTypes::makeRelocInfo((unsigned long) (STN_UNDEF),
-                                                          newRels[i].getRelType());
+                                                          newRel.getRelType());
             }
             k++;
             m++;
@@ -2061,11 +2064,10 @@ void emitElf<ElfTypes>::createSymbolVersions(Elf_Half *&symVers, char *&verneedS
                                                std::vector<std::string> &dynStrs) {
 
     //Add all names to the new .dynstr section
-    map<string, unsigned>::iterator iter = versionNames.begin();
-    for (; iter != versionNames.end(); iter++) {
-        iter->second = dynSymbolNamesLength;
-        dynStrs.push_back(iter->first);
-        dynSymbolNamesLength += iter->first.size() + 1;
+    for (auto &versionName : versionNames) {
+        versionName.second = dynSymbolNamesLength;
+        dynStrs.push_back(versionName.first);
+        dynSymbolNamesLength += versionName.first.size() + 1;
     }
 
     //reconstruct .gnu_version section
@@ -2098,46 +2100,44 @@ void emitElf<ElfTypes>::createSymbolVersions(Elf_Half *&symVers, char *&verneedS
 
     //reconstruct .gnu.version_r section
     verneedSecSize = 0;
-    map<string, map<string, unsigned> >::iterator it = verneedEntries.begin();
-    for (; it != verneedEntries.end(); it++)
-        verneedSecSize += sizeof(Elf_Verneed) + sizeof(Elf_Vernaux) * it->second.size();
+    for (const auto &verneedEntry : verneedEntries)
+        verneedSecSize += sizeof(Elf_Verneed) + sizeof(Elf_Vernaux) * verneedEntry.second.size();
 
     verneedSecData = (char *) malloc(verneedSecSize);
     unsigned curpos = 0;
     verneednum = 0;
-    std::vector<std::string>::iterator dit;
-    for (dit = unversionedNeededEntries.begin(); dit != unversionedNeededEntries.end(); dit++) {
+    for (const auto &unneededEntry : unversionedNeededEntries) {
         // account for any substitutions due to rewriting a shared lib
         // no need for self-references
-        if (!(obj->name() == *dit)) {
-            versionNames[*dit] = dynSymbolNamesLength;
-            dynStrs.push_back(*dit);
-            dynSymbolNamesLength += (*dit).size() + 1;
-            addDTNeeded(*dit);
+        if (!(obj->name() == unneededEntry)) {
+            versionNames[unneededEntry] = dynSymbolNamesLength;
+            dynStrs.push_back(unneededEntry);
+            dynSymbolNamesLength += (unneededEntry).size() + 1;
+            addDTNeeded(unneededEntry);
         }
     }
-    for (it = verneedEntries.begin(); it != verneedEntries.end(); it++) {
+    for (auto &verneedEntry : verneedEntries) {
         Elf_Verneed *verneed = reinterpret_cast<Elf_Verneed *>(verneedSecData + curpos);
         verneed->vn_version = 1;
-        verneed->vn_cnt = it->second.size();
+        verneed->vn_cnt = verneedEntry.second.size();
         verneed->vn_file = dynSymbolNamesLength;
-        versionNames[it->first] = dynSymbolNamesLength;
-        dynStrs.push_back(it->first);
-        dynSymbolNamesLength += it->first.size() + 1;
-        addDTNeeded(it->first);
+        versionNames[verneedEntry.first] = dynSymbolNamesLength;
+        dynStrs.push_back(verneedEntry.first);
+        dynSymbolNamesLength += verneedEntry.first.size() + 1;
+        addDTNeeded(verneedEntry.first);
         verneed->vn_aux = sizeof(Elf_Verneed);
-        verneed->vn_next = sizeof(Elf_Verneed) + it->second.size() * sizeof(Elf_Vernaux);
+        verneed->vn_next = sizeof(Elf_Verneed) + verneedEntry.second.size() * sizeof(Elf_Vernaux);
         if (curpos + verneed->vn_next == verneedSecSize)
             verneed->vn_next = 0;
         verneednum++;
         int i = 0;
-        for (iter = it->second.begin(); iter != it->second.end(); iter++) {
+        for (const auto &ver : verneedEntry.second) {
             Elf_Vernaux *vernaux = reinterpret_cast<Elf_Vernaux *>(
                     verneedSecData + curpos + verneed->vn_aux + i * sizeof(Elf_Vernaux));
-            vernaux->vna_hash = elfHash(iter->first.c_str());
+            vernaux->vna_hash = elfHash(ver.first.c_str());
             vernaux->vna_flags = 0;
-            vernaux->vna_other = iter->second;
-            vernaux->vna_name = versionNames[iter->first];
+            vernaux->vna_other = ver.second;
+            vernaux->vna_name = versionNames[ver.first];
             if (i == verneed->vn_cnt - 1)
                 vernaux->vna_next = 0;
             else
@@ -2149,29 +2149,29 @@ void emitElf<ElfTypes>::createSymbolVersions(Elf_Half *&symVers, char *&verneedS
 
     //reconstruct .gnu.version_d section
     verdefSecSize = 0;
-    for (iter = verdefEntries.begin(); iter != verdefEntries.end(); iter++)
-        verdefSecSize += sizeof(Elf_Verdef) + sizeof(Elf_Verdaux) * verdauxEntries[iter->second].size();
+    for (const auto &verdefEntry : verdefEntries)
+        verdefSecSize += sizeof(Elf_Verdef) + sizeof(Elf_Verdaux) * verdauxEntries[verdefEntry.second].size();
 
     verdefSecData = (char *) malloc(verdefSecSize);
     curpos = 0;
     verdefnum = 0;
 
-    for (iter = verdefEntries.begin(); iter != verdefEntries.end(); iter++) {
+    for (const auto &verdefEntry : verdefEntries) {
         Elf_Verdef *verdef = reinterpret_cast<Elf_Verdef *>(verdefSecData + curpos);
         verdef->vd_version = 1;
         verdef->vd_flags = 0;
-        verdef->vd_ndx = iter->second;
-        verdef->vd_cnt = verdauxEntries[iter->second].size();
-        verdef->vd_hash = elfHash(iter->first.c_str());
+        verdef->vd_ndx = verdefEntry.second;
+        verdef->vd_cnt = verdauxEntries[verdefEntry.second].size();
+        verdef->vd_hash = elfHash(verdefEntry.first.c_str());
         verdef->vd_aux = sizeof(Elf_Verdef);
-        verdef->vd_next = sizeof(Elf_Verdef) + verdauxEntries[iter->second].size() * sizeof(Elf_Verdaux);
+        verdef->vd_next = sizeof(Elf_Verdef) + verdauxEntries[verdefEntry.second].size() * sizeof(Elf_Verdaux);
         if (curpos + verdef->vd_next == verdefSecSize)
             verdef->vd_next = 0;
         verdefnum++;
-        for (unsigned i = 0; i < verdauxEntries[iter->second].size(); i++) {
+        for (unsigned i = 0; i < verdauxEntries[verdefEntry.second].size(); i++) {
             Elf_Verdaux *verdaux = reinterpret_cast<Elf_Verdaux *>(
                     verdefSecData + curpos + verdef->vd_aux + i * sizeof(Elf_Verdaux));
-            verdaux->vda_name = versionNames[verdauxEntries[iter->second][i]];
+            verdaux->vda_name = versionNames[verdauxEntries[verdefEntry.second][i]];
             if ((signed) i == verdef->vd_cnt - 1)
                 verdaux->vda_next = 0;
             else

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -1857,112 +1857,93 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
         }
     }
 
-    unsigned j, k, l, m;
 
     Elf_Rel *rels = (Elf_Rel *) malloc(sizeof(Elf_Rel) * (relocation_table.size() + newRels.size()));
     Elf_Rela *relas = (Elf_Rela *) malloc(sizeof(Elf_Rela) * (relocation_table.size() + newRels.size()));
-    j = 0;
-    k = 0;
-    l = 0;
-    m = 0;
+    unsigned numRels{};
+    unsigned numRelas{};
+
+    // new dynsym index for a relocation's symbol, STN_UNDEF if none.
+    // The three lookup strategies preserve the historical per-path behavior.
+    enum class SymLookup { Rel, Rela, NewSection };
+    auto dynSymIndex = [&](const relocationEntry &reloc, SymLookup how) -> unsigned long {
+        const std::string &name{reloc.name()};
+        if (how == SymLookup::NewSection) {
+            auto it = dynSymNameMapping.find(name);
+            return it != dynSymNameMapping.end() ? it->second : STN_UNDEF;
+        }
+        if (name.empty())
+            return STN_UNDEF;
+        auto it = dynSymNameMapping.find(name);
+        if (it != dynSymNameMapping.end())
+            return it->second;
+        Symbol *sym = reloc.getDynSym();
+        if (!sym)
+            return STN_UNDEF;
+        if (how == SymLookup::Rel)
+            return sym->getIndex();     // index 0 is STN_UNDEF
+        it = dynSymNameMapping.find(sym->getMangledName());
+        return it != dynSymNameMapping.end() ? it->second : STN_UNDEF;
+    };
+
     //reconstruct .rel
     for (auto &reloc : relocation_table) {
-
         if (address_adjust) {
             // If we are shifting the library down in memory, we need to update
-            // any relative offsets in the library. These relative offsets are 
+            // any relative offsets in the library. These relative offsets are
             // found via relocations
-
+ 
             // XXX ...ignore the return value
             emitElfUtils::updateRelocation(obj, reloc, address_adjust);
         }
+ 
+        if (object->getRelType() != reloc.regionType())
+            continue;
 
-        if ((object->getRelType() == Region::RT_REL) && (reloc.regionType() == Region::RT_REL)) {
-            rels[j].r_offset = reloc.rel_addr() + address_adjust;
-            unsigned long sym_offset = 0;
-            std::string sym_name = reloc.name();
-            if (!sym_name.empty()) {
-                std::unordered_map<string, unsigned long>::iterator it = dynSymNameMapping.find(sym_name);
-                if (it != dynSymNameMapping.end())
-                    sym_offset = it->second;
-                else {
-                    Symbol *sym = reloc.getDynSym();
-                    if (sym)
-                        sym_offset = sym->getIndex();
-                }
-            }
+        SymLookup how = reloc.regionType() == Region::RT_REL ? SymLookup::Rel : SymLookup::Rela;
+        auto r_info = ElfTypes::makeRelocInfo(dynSymIndex(reloc, how), reloc.getRelType());
 
-            if (sym_offset) {
-                rels[j].r_info = ElfTypes::makeRelocInfo(sym_offset, reloc.getRelType());
-            } else {
-                rels[j].r_info = ElfTypes::makeRelocInfo((unsigned long) STN_UNDEF, reloc.getRelType());
-            }
-            j++;
-        } else if ((object->getRelType() == Region::RT_RELA) && (reloc.regionType() == Region::RT_RELA)) {
-            relas[k].r_offset = reloc.rel_addr() + address_adjust;
-            relas[k].r_addend = reloc.addend();
-            //if (relas[k].r_addend)
-            //   relas[k].r_addend += address_adjust;
-            unsigned long sym_offset = 0;
-            std::string sym_name = reloc.name();
-            if (!sym_name.empty()) {
-                std::unordered_map<string, unsigned long>::iterator it = dynSymNameMapping.find(sym_name);
-                if (it != dynSymNameMapping.end()) {
-                    sym_offset = it->second;
-                } else {
-                    Symbol *sym = reloc.getDynSym();
-                    if (sym) {
-                        it = dynSymNameMapping.find(sym->getMangledName());
-                        if (it != dynSymNameMapping.end())
-                            sym_offset = it->second;
-                    }
-                }
-            }
-            if (sym_offset) {
-                relas[k].r_info = ElfTypes::makeRelocInfo(sym_offset, reloc.getRelType());
-            } else {
-                relas[k].r_info = ElfTypes::makeRelocInfo((unsigned long) STN_UNDEF, reloc.getRelType());
-            }
-            k++;
-        }
+        if (reloc.regionType() == Region::RT_REL) {
+            rels[numRels].r_offset = reloc.rel_addr() + address_adjust;
+            rels[numRels].r_info = r_info;
+            numRels++;
+        } else if (reloc.regionType() == Region::RT_RELA) {
+            relas[numRelas].r_offset = reloc.rel_addr() + address_adjust;
+            relas[numRelas].r_addend = reloc.addend();
+            relas[numRelas].r_info = r_info;
+            numRelas++;
+         }
     }
+    // relocations for the new sections; these grow DT_RELSZ/DT_RELASZ
+    const unsigned numOldRels{numRels};
+    const unsigned numOldRelas{numRelas};
     for (const auto &newRel : newRels) {
-        if ((object->getRelType() == Region::RT_REL) && (newRel.regionType() == Region::RT_REL)) {
-            rels[j].r_offset = newRel.rel_addr() + address_adjust;
-            if (dynSymNameMapping.find(newRel.name()) != dynSymNameMapping.end()) {
-                rels[j].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRel.name()],
-                                                         newRel.getRelType());
-            } else {
-                rels[j].r_info = ElfTypes::makeRelocInfo((unsigned long) (STN_UNDEF),
-                                                         newRel.getRelType());
-            }
-            j++;
-            l++;
-        } else if ((object->getRelType() == Region::RT_RELA) && (newRel.regionType() == Region::RT_RELA)) {
-            relas[k].r_offset = newRel.rel_addr() + address_adjust;
-            relas[k].r_addend = newRel.addend();
-            //if( relas[k].r_addend ) relas[k].r_addend += address_adjust;
-            if (dynSymNameMapping.find(newRel.name()) != dynSymNameMapping.end()) {
-                relas[k].r_info = ElfTypes::makeRelocInfo(dynSymNameMapping[newRel.name()],
-                                                          newRel.getRelType());
-            } else {
-                relas[k].r_info = ElfTypes::makeRelocInfo((unsigned long) (STN_UNDEF),
-                                                          newRel.getRelType());
-            }
-            k++;
-            m++;
+        if (object->getRelType() != newRel.regionType())
+            continue;
+
+       auto r_info = ElfTypes::makeRelocInfo(dynSymIndex(newRel, SymLookup::NewSection), newRel.getRelType());
+
+       if (newRel.regionType() == Region::RT_REL) {
+           rels[numRels].r_offset = newRel.rel_addr() + address_adjust;
+           rels[numRels].r_info = r_info;
+           numRels++;
+       } else if (newRel.regionType() == Region::RT_RELA) {
+           relas[numRelas].r_offset = newRel.rel_addr() + address_adjust;
+           relas[numRelas].r_addend = newRel.addend();
+           relas[numRelas].r_info = r_info;
+           numRelas++;
         }
     }
 
     dyn_hash_map<int, Region *> secTagRegionMapping = object->getTagRegionMapping();
-    int reloc_size, old_reloc_size, dynamic_reloc_size;
+    int old_reloc_size;
     const char *new_name;
     Region::RegionType rtype;
     int dtype;
     int dsize_type;
     void *buffer = NULL;
 
-    reloc_size = j * sizeof(Elf_Rel) + k * sizeof(Elf_Rela);
+    unsigned long reloc_size{numRels * sizeof(Elf_Rel) + numRelas * sizeof(Elf_Rela)};
     if (!reloc_size) {
         return;
     }
@@ -2010,7 +1991,8 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
         old_reloc_size = dynamicSecData[dsize_type][0]->d_un.d_val;
     else
         old_reloc_size = 0;
-    dynamic_reloc_size = old_reloc_size + l * sizeof(Elf64_Rel) + m * sizeof(Elf64_Rela);
+    unsigned long dynamic_reloc_size{old_reloc_size + (numRels - numOldRels) * sizeof(Elf64_Rel)
+                                               + (numRelas - numOldRelas) * sizeof(Elf64_Rela)};
     string name;
     if (secTagRegionMapping.find(dtype) != secTagRegionMapping.end())
         name = secTagRegionMapping[dtype]->getRegionName();

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -367,22 +367,21 @@ void emitElf<ElfTypes>::renameSection(const std::string &oldName) {
 
 template<class ElfTypes>
 bool emitElf<ElfTypes>::driver(std::string fName) {
-    int newfd;
     Region *foundSec = NULL;
     unsigned pgSize = getpagesize();
     rewrite_printf("::driver for emitElf\n");
 
-    string strtmpl = fName + "XXXXXX";
-    auto buf = std::unique_ptr<char[]>(new char[strtmpl.length() + 1]);
-    strncpy(buf.get(), strtmpl.c_str(), strtmpl.length() + 1);
+    string newFName = fName + "XXXXXX";
+    auto buf = std::unique_ptr<char[]>(new char[newFName.length() + 1]);
+    strncpy(buf.get(), newFName.c_str(), newFName.length() + 1);
 
-    newfd = mkstemp(buf.get());
+    auto newfd = mkstemp(buf.get());
 
     if (newfd == -1) {
         log_elferror(err_func_, "error opening file to write symbols");
         return false;
     }
-    strtmpl = buf.get();
+    newFName = buf.get();
 
     fchmod(newfd, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP);
     rewrite_printf("Emitting to temporary file %s\n", buf.get());
@@ -713,7 +712,9 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
     elf_end(newElf);
     close(newfd);
 
-    if (rename(strtmpl.c_str(), fName.c_str())) {
+    if (rename(newFName.c_str(), fName.c_str())) {
+        auto msg{"rename of new elf file (" + newFName + " -> " +  fName + ") failed"};
+        log_elferror(err_func_, msg.c_str());
         return false;
     }
 

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -760,8 +760,10 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     unsigned scncount;
     for (scncount = 1; (scn = elf_nextscn(newElf, scn)); scncount++) {
         shdr = ElfTypes::elf_getshdr(scn);
-        if (shdr->sh_type == SHT_SYMTAB)
+        if (shdr->sh_type == SHT_SYMTAB) {
             shdr->sh_link = symtabStrIndex;     // .symtab -> .strtab, wherever it ended up
+            shdr->sh_info = symtabNumLocals;    // index of first non-local symbol
+        }
         if(dataLinkInfo.count(secNames[scncount]))
         {
             rewrite_printf("update link info of %s\n", secNames[scncount].c_str());
@@ -1662,6 +1664,13 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
     }
 
     //reconstruct .symtab section
+    // ELF requires all STB_LOCAL symbols to precede the others, with sh_info
+    // holding the index of the first non-local.  New symbols were appended
+    // after the originals regardless of binding, so partition them here.
+    auto firstNonLocal = std::stable_partition(symbols.begin(), symbols.end(),
+        [](const Elf_Sym *es) { return ELF64_ST_BIND(es->st_info) == STB_LOCAL; });
+    symtabNumLocals = firstNonLocal - symbols.begin();
+
     Elf_Sym *syms = (Elf_Sym *) malloc(symbols.size() * sizeof(Elf_Sym));
     i = 0;
     for (const auto &s : symbols)

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -1863,27 +1863,21 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
     unsigned numRels{};
     unsigned numRelas{};
 
-    // new dynsym index for a relocation's symbol, STN_UNDEF if none.
-    // The three lookup strategies preserve the historical per-path behavior.
-    enum class SymLookup { Rel, Rela, NewSection };
-    auto dynSymIndex = [&](const relocationEntry &reloc, SymLookup how) -> unsigned long {
+    // new dynsym index for a relocation's symbol, STN_UNDEF if none
+    auto dynSymIndex = [&](const relocationEntry &reloc) -> unsigned long {
         const std::string &name{reloc.name()};
-        if (how == SymLookup::NewSection) {
-            auto it = dynSymNameMapping.find(name);
-            return it != dynSymNameMapping.end() ? it->second : STN_UNDEF;
-        }
         if (name.empty())
             return STN_UNDEF;
         auto it = dynSymNameMapping.find(name);
-        if (it != dynSymNameMapping.end())
-            return it->second;
-        Symbol *sym = reloc.getDynSym();
-        if (!sym)
-            return STN_UNDEF;
-        if (how == SymLookup::Rel)
-            return sym->getIndex();     // index 0 is STN_UNDEF
-        it = dynSymNameMapping.find(sym->getMangledName());
-        return it != dynSymNameMapping.end() ? it->second : STN_UNDEF;
+        if (it == dynSymNameMapping.end()) {
+            Symbol *sym = reloc.getDynSym();
+            if (!sym)
+                return STN_UNDEF;
+            it = dynSymNameMapping.find(sym->getMangledName());
+            if (it == dynSymNameMapping.end())
+                return sym->getIndex() > 0 ? sym->getIndex() : STN_UNDEF;
+        }
+        return it->second;
     };
 
     //reconstruct .rel
@@ -1900,8 +1894,7 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
         if (object->getRelType() != reloc.regionType())
             continue;
 
-        SymLookup how = reloc.regionType() == Region::RT_REL ? SymLookup::Rel : SymLookup::Rela;
-        auto r_info = ElfTypes::makeRelocInfo(dynSymIndex(reloc, how), reloc.getRelType());
+        auto r_info = ElfTypes::makeRelocInfo(dynSymIndex(reloc), reloc.getRelType());
 
         if (reloc.regionType() == Region::RT_REL) {
             rels[numRels].r_offset = reloc.rel_addr() + address_adjust;
@@ -1921,7 +1914,7 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
         if (object->getRelType() != newRel.regionType())
             continue;
 
-       auto r_info = ElfTypes::makeRelocInfo(dynSymIndex(newRel, SymLookup::NewSection), newRel.getRelType());
+       auto r_info = ElfTypes::makeRelocInfo(dynSymIndex(newRel), newRel.getRelType());
 
        if (newRel.regionType() == Region::RT_REL) {
            rels[numRels].r_offset = newRel.rel_addr() + address_adjust;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -356,16 +356,14 @@ typename emitElf<ElfTypes>::Elf_Off emitElf<ElfTypes>::findLastLoadableSec() {
     return lastLoadableSecStart;
 }
 
-// Rename an old section. Lengths of old and new names must match.
-// Only renames the FIRST matching section encountered.
+// Renames 1st oldName section by changing 2nd char to 'o'
 template<class ElfTypes>
-void emitElf<ElfTypes>::renameSection(const std::string &oldStr, const std::string &newStr, bool renameAll) {
-    assert(oldStr.length() == newStr.length());
-    for (unsigned k = 0; k < secNames.size(); k++) {
-        if (secNames[k] == oldStr) {
-            secNames[k].replace(0, oldStr.length(), newStr);
-            if (!renameAll)
-                break;
+void emitElf<ElfTypes>::renameSection(const std::string &oldName) {
+    assert(oldName.length() >= 2);
+    for (auto &secName : secNames)  {
+        if (secName == oldName)  {
+            secName[1] = 'o';
+            break;
         }
     }
 }
@@ -536,9 +534,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
                 (shdr->sh_addr >= moveSecAddrRange[i][0] && shdr->sh_addr < moveSecAddrRange[i][1])) {
                 newshdr->sh_type = SHT_PROGBITS;
                 changeMapping[sectionNumber] = 1;
-                string newName = ".o";
-                newName.append(name, 2, strlen(name));
-                renameSection(name, newName, false);
+                renameSection(name);
             }
         }
 
@@ -572,9 +568,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
             // Change the data to update the relocation addr
             newshdr->sh_type = SHT_PROGBITS;
             changeMapping[sectionNumber] = 1;
-            string newName = ".o";
-            newName.append(name, 2, strlen(name));
-            renameSection(name, newName, false);
+            renameSection(name);
         }
 
         // Only need to rewrite data section
@@ -582,16 +576,11 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
             && foundSec->getRegionType() == Region::RT_DATA) {
             // Clear TLS flag
             newshdr->sh_flags &= ~SHF_TLS;
-
-            string newName = ".o";
-            newName.append(name, 2, strlen(name));
-            renameSection(name, newName, false);
+            renameSection(name);
         }
 
         if (isStaticBinary && ((strcmp(name, ".rel.plt") == 0) || (strcmp(name, ".rela.plt") == 0 ))) {
-            string newName = ".o";
-            newName.append(name, 2, strlen(name));
-            renameSection(name, newName, false);
+            renameSection(name);
             // The old sections are no longer REL or RELA, change to PROGBITS
             newshdr->sh_type = SHT_PROGBITS;
 

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -439,6 +439,26 @@ void emitElf<ElfTypes>::renameSection(const std::string &oldName) {
     }
 }
 
+class emitElfResourceMgr
+{
+    private:
+        int  fd{-1};
+        std::string fn;
+        Elf* elf{};
+    public:
+        emitElfResourceMgr(int f, std::string s) : fd(f), fn(s) {}
+        ~emitElfResourceMgr() { closeElf(); closeFd(); unlink(); }
+        emitElfResourceMgr(const emitElfResourceMgr&) = delete;
+        emitElfResourceMgr(const emitElfResourceMgr&&) = delete;
+        emitElfResourceMgr& operator=(const emitElfResourceMgr&) = delete;
+        emitElfResourceMgr& operator=(const emitElfResourceMgr&&) = delete;
+        void setElf(Elf *e) { elf = e; }
+        void noUnlink() { fn = ""; }
+        void closeFd()  { if (fd == -1) return;   close(fd);            fd = -1; }
+        void unlink()   { if (fn.empty()) return; ::unlink(fn.c_str()); noUnlink(); }
+        void closeElf() { if (!elf) return;       elf_end(elf);         elf = nullptr; }
+};
+
 template<class ElfTypes>
 bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols) {
     rewrite_printf("::driver for emitElf\n");
@@ -459,12 +479,13 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     strncpy(buf.get(), newFName.c_str(), newFName.length() + 1);
 
     auto newfd = mkstemp(buf.get());
+    newFName = buf.get();
 
     if (newfd == -1) {
         log_elferror(err_func_, "error opening file to write symbols");
         return false;
     }
-    newFName = buf.get();
+    emitElfResourceMgr emitElfResources(newfd, newFName);
 
     struct stat statBuf;
     decltype(statBuf.st_mode) origFdMode{};
@@ -482,6 +503,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         cerr << "Failed to elf_begin" << endl;
         return false;
     }
+    emitElfResources.setElf(newElf);
 
     addSectionName("");  // section 0 is always ST_NULL with an empty name
     loadSecTotalSize = 0;
@@ -799,15 +821,15 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         log_elferror(err_func_, "elf_update failed");
         return false;
     }
-    elf_end(newElf);
+    emitElfResources.closeElf();
     fchmod(newfd, origFdMode);  // set permission to original file
-    close(newfd);
 
     if (rename(newFName.c_str(), fName.c_str())) {
         auto msg{"rename of new elf file (" + newFName + " -> " +  fName + ") failed"};
         log_elferror(err_func_, msg.c_str());
         return false;
     }
+    emitElfResources.noUnlink();
 
     return true;
 }

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -30,6 +30,7 @@
 
 #include <cstring>
 #include <algorithm>
+#include <numeric>
 #include "emitElf.h"
 #include "emitElfStatic.h"
 #include "common/src/dyninst_filesystem.h"
@@ -459,6 +460,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     }
 
     Region *foundSec = NULL;
+    Region *shstrtabRegion = NULL;
 
     string newFName = fName + "XXXXXX";
     auto buf = std::unique_ptr<char[]>(new char[newFName.length() + 1]);
@@ -542,12 +544,16 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         }
 
         // write the shstrtabsection at the end
-        if (scncount == oldShstrndx)
+        if (scncount == oldShstrndx) {
+            shstrtabRegion = foundSec;
             continue;
+        }
 
         sectionNumber++;
         changeMapping[sectionNumber] = false;
         newNameIndexMapping[name] = sectionNumber;
+        if (foundSec)
+            regionNewIndex[foundSec] = sectionNumber;
 
         newscn = elf_newscn(newElf);
         newshdr = ElfTypes::elf_getshdr(newscn);
@@ -754,6 +760,8 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
 
     //Add the section header table right at the end
     addSectionHeaderTable(newshdr);
+    if (shstrtabRegion)
+        regionNewIndex[shstrtabRegion] = secNames.size() - 1;   // .shstrtab is the last section
 
     // Second iteration to fix the link fields to point to the correct section
     scn = NULL;
@@ -763,6 +771,9 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         if (shdr->sh_type == SHT_SYMTAB) {
             shdr->sh_link = symtabStrIndex;     // .symtab -> .strtab, wherever it ended up
             shdr->sh_info = symtabNumLocals;    // index of first non-local symbol
+            updateSymbolSectionIndices(scn, symtabSymRegions);
+        } else if (shdr->sh_type == SHT_DYNSYM) {
+            updateSymbolSectionIndices(scn, dynsymSymRegions);
         }
         if(dataLinkInfo.count(secNames[scncount]))
         {
@@ -1145,6 +1156,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
 
         auto thisSectionIndex = secNames.size() - 1;
         newNameIndexMapping[newSec->getRegionName()] = thisSectionIndex;
+        regionNewIndex[newSec] = thisSectionIndex;
 
         if (shdr->sh_type == SHT_NOBITS) {
             newshdr->sh_offset = shdr->sh_offset;
@@ -1413,6 +1425,7 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
         //Fill out the new section header
         newshdr = ElfTypes::elf_getshdr(newscn);
         newshdr->sh_name = addSectionName(sec->getRegionName());
+        regionNewIndex[sec] = secNames.size() - 1;
         if (sec->getRegionType() == Region::RT_TEXT)  {        //Text Section
             newshdr->sh_type = SHT_PROGBITS;
             newshdr->sh_flags = SHF_EXECINSTR | SHF_WRITE;
@@ -1539,8 +1552,10 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
     sym->st_shndx = SHN_UNDEF;
 
     symbols.push_back(sym);
+    symtabSymRegions.push_back(nullptr);
     if (!obj->isStaticBinary()) {
         dynsymbols.push_back(sym);
+        dynsymSymRegions.push_back(nullptr);
         dynsymVector.push_back(Symbol::magicEmitElfSymbol());
         versionSymTable.push_back(0);
     }
@@ -1651,6 +1666,7 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
 
     for (const auto &s : allSymSymbols) {
         createElfSymbol(s, symbolNamesLength, symbols);
+        symtabSymRegions.push_back(s->getRegion());
         symbolStrs.push_back(s->getMangledName());
         symbolNamesLength += s->getMangledName().length() + 1;
     }
@@ -1658,6 +1674,7 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
     i = 0;
     for (const auto &s : allDynSymbols) {
         createElfSymbol(s, s->getStrIndex(), dynsymbols, true);
+        dynsymSymRegions.push_back(s->getRegion());
         dynSymNameMapping[s->getMangledName()] = i + nTmp;
         ++i;
         dynsymVector.push_back(s);
@@ -1667,14 +1684,20 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
     // ELF requires all STB_LOCAL symbols to precede the others, with sh_info
     // holding the index of the first non-local.  New symbols were appended
     // after the originals regardless of binding, so partition them here.
-    auto firstNonLocal = std::stable_partition(symbols.begin(), symbols.end(),
-        [](const Elf_Sym *es) { return ELF64_ST_BIND(es->st_info) == STB_LOCAL; });
-    symtabNumLocals = firstNonLocal - symbols.begin();
+    std::vector<size_t> order(symbols.size());
+    std::iota(order.begin(), order.end(), 0);
+    auto firstNonLocal = std::stable_partition(order.begin(), order.end(),
+        [&](size_t k) { return ELF64_ST_BIND(symbols[k]->st_info) == STB_LOCAL; });
+    symtabNumLocals = firstNonLocal - order.begin();
 
     Elf_Sym *syms = (Elf_Sym *) malloc(symbols.size() * sizeof(Elf_Sym));
-    i = 0;
-    for (const auto &s : symbols)
-        syms[i++] = *s;
+    std::vector<Region *> orderedRegions;
+    orderedRegions.reserve(order.size());
+    for (size_t k = 0; k < order.size(); ++k) {
+        syms[k] = *symbols[order[k]];
+        orderedRegions.push_back(symtabSymRegions[order[k]]);
+    }
+    symtabSymRegions = std::move(orderedRegions);
 
     char *str = (char *) malloc(symbolNamesLength);
     unsigned cur = 0;
@@ -2455,6 +2478,39 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
     dynsecSize = curpos;
 }
 
+
+// Symbols were emitted with st_shndx = the Region's number in the original
+// file.  Inserting the new sections renumbers everything after the insertion
+// point, so point each symbol at its Region's index in the new file, and give
+// section symbols the section's new address.
+template<class ElfTypes>
+void emitElf<ElfTypes>::updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions) {
+    Elf_Data *data = elf_getdata(scn, NULL);
+    if (!data || !data->d_buf)
+        return;
+    Elf_Sym *syms = static_cast<Elf_Sym *>(data->d_buf);
+    size_t numSyms = data->d_size / sizeof(Elf_Sym);
+    if (numSyms != symRegions.size()) {
+        // not a table we generated (e.g. .dynsym copied unchanged), leave it alone
+        rewrite_printf("symbol table has %zu entries, %zu regions recorded; st_shndx not updated\n",
+                       numSyms, symRegions.size());
+        return;
+    }
+    for (size_t k = 0; k < numSyms; ++k) {
+        Region *region = symRegions[k];
+        if (!region)
+            continue;
+        auto it = regionNewIndex.find(region);
+        if (it == regionNewIndex.end())
+            continue;
+        syms[k].st_shndx = it->second;
+        if (ELF64_ST_TYPE(syms[k].st_info) == STT_SECTION) {
+            if (Elf_Scn *target = elf_getscn(newElf, it->second))
+                if (Elf_Shdr *targetShdr = ElfTypes::elf_getshdr(target))
+                    syms[k].st_value = targetShdr->sh_addr;
+        }
+    }
+}
 
 template<class ElfTypes>
 void emitElf<ElfTypes>::log_elferror(void (*err_func)(const char *), const char *msg) {

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -614,14 +614,14 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
              object->getStrtabAddr() == shdr->sh_addr) ||
             !strcmp(name, STRTAB_NAME)) {
             symStrData = newdata;
+            symtabStrIndex = sectionNumber;
             updateSymbols(symTabData, symStrData, loadSecTotalSize);
         }
 
-        //Change sh_link for .symtab to point to .strtab
+        // .symtab's sh_link is set to .strtab's index in the link fixup pass below
         if ((object->getSymtabAddr() != 0 &&
              object->getSymtabAddr() == shdr->sh_addr) ||
             !strcmp(name, SYMTAB_NAME)) {
-            newshdr->sh_link = secNames.size();
             changeMapping[sectionNumber] = true;
             symTabData = newdata;
         }
@@ -760,6 +760,8 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     unsigned scncount;
     for (scncount = 1; (scn = elf_nextscn(newElf, scn)); scncount++) {
         shdr = ElfTypes::elf_getshdr(scn);
+        if (shdr->sh_type == SHT_SYMTAB)
+            shdr->sh_link = symtabStrIndex;     // .symtab -> .strtab, wherever it ended up
         if(dataLinkInfo.count(secNames[scncount]))
         {
             rewrite_printf("update link info of %s\n", secNames[scncount].c_str());
@@ -1230,7 +1232,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newdata->d_type = ELF_T_SYM;
             newdata->d_align = 4;
             dynsymData = newdata;
-            newshdr->sh_link = thisSectionIndex + 1;   //.symtab section should have sh_link = index of .strtab for .dynsym
+            updateStrLinkShdr.push_back(newshdr);   // .dynsym -> .dynstr, resolved once .dynstr is created
             newshdr->sh_flags = SHF_ALLOC;
             dynsymIndex = thisSectionIndex;
             updateDynamic(DT_SYMTAB, newshdr->sh_addr);
@@ -1433,14 +1435,14 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
             newshdr->sh_type = SHT_SYMTAB;
             newshdr->sh_entsize = sizeof(Elf_Sym);
             newdata->d_type = ELF_T_SYM;
-            newshdr->sh_link = secNames.size();   //.symtab section should have sh_link = index of .strtab
-            newshdr->sh_flags = 0;
+            newshdr->sh_flags = 0;   // sh_link -> .strtab is set in driver's link fixup pass
         } else if (sec->getRegionType() == Region::RT_STRTAB) {  //String table Section
             newshdr->sh_type = SHT_STRTAB;
             newshdr->sh_entsize = 1;
             newdata->d_type = ELF_T_BYTE;
             newshdr->sh_link = SHN_UNDEF;
             newshdr->sh_flags = 0;
+            symtabStrIndex = secNames.size() - 1;   // index of this section
         }
 
         newshdr->sh_offset = prevshdr->sh_offset + prevshdr->sh_size;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -1991,8 +1991,8 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
         old_reloc_size = dynamicSecData[dsize_type][0]->d_un.d_val;
     else
         old_reloc_size = 0;
-    unsigned long dynamic_reloc_size{old_reloc_size + (numRels - numOldRels) * sizeof(Elf64_Rel)
-                                               + (numRelas - numOldRelas) * sizeof(Elf64_Rela)};
+    unsigned long dynamic_reloc_size{old_reloc_size + (numRels - numOldRels) * sizeof(Elf_Rel)
+                                               + (numRelas - numOldRelas) * sizeof(Elf_Rela)};
     string name;
     if (secTagRegionMapping.find(dtype) != secTagRegionMapping.end())
         name = secTagRegionMapping[dtype]->getRegionName();

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -1123,11 +1123,11 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
         sectionNumber++;
         // Add a new loadable section
         if ((newscn = elf_newscn(newElf)) == NULL) {
-            log_elferror(err_func_, "unable to create new section");
+            log_elferror(err_func_, "unable to create new loabable section");
             return false;
         }
         if ((newdata = elf_newdata(newscn)) == NULL) {
-            log_elferror(err_func_, "unable to create section data");
+            log_elferror(err_func_, "unable to create loabable section data");
             return false;
         }
         memset(newdata, 0, sizeof(Elf_Data));
@@ -1366,11 +1366,11 @@ bool emitElf<ElfTypes>::addSectionHeaderTable(Elf_Shdr *shdr) {
     Elf_Shdr *newshdr;
 
     if ((newscn = elf_newscn(newElf)) == NULL) {
-        log_elferror(err_func_, "unable to create new section");
+        log_elferror(err_func_, "unable to create new section header table");
         return false;
     }
     if ((newdata = elf_newdata(newscn)) == NULL) {
-        log_elferror(err_func_, "unable to create section data");
+        log_elferror(err_func_, "unable to create section header table data");
         return false;
     }
     //Fill out the new section header
@@ -1415,11 +1415,11 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
     for (const auto &sec : nonLoadableSecs) {
         // Add a new non-loadable section
         if ((newscn = elf_newscn(newElf)) == NULL) {
-            log_elferror(err_func_, "unable to create new section");
+            log_elferror(err_func_, "unable to create new nonloadable section");
             return false;
         }
         if ((newdata = elf_newdata(newscn)) == NULL) {
-            log_elferror(err_func_, "unable to create section data");
+            log_elferror(err_func_, "unable to create nonloadable section data");
             return false;
         }
 

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -84,7 +84,7 @@ static int elfSymType(Symbol *sym)
      case Symbol::ST_TLS: return STT_TLS;
      case Symbol::ST_NOTYPE : return STT_NOTYPE;
      case Symbol::ST_UNKNOWN: return sym->getInternalType();
-     case Symbol::ST_CODE: return STT_FUNC;	// in ELF, ST_CODE maps to STT_FUNC
+     case Symbol::ST_CODE: return STT_FUNC;     // in ELF, ST_CODE maps to STT_FUNC
      case Symbol::ST_INDIRECT: return STT_GNU_IFUNC;
      default: return STT_SECTION;
   }
@@ -143,9 +143,7 @@ std::string phdrTypeStr(Elf64_Word phdr_type) {
         default:
             return "<UNKNOWN>";
             break;
-
     }
-
 }
 
 template<class ElfTypes>
@@ -163,8 +161,7 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
     // OPD-based systems
     if (symbol->getPtrOffset()) {
         sym->st_value = symbol->getPtrOffset() + addr_adjust;
-    }
-    else if (symbol->getOffset()) {
+    } else if (symbol->getOffset()) {
         sym->st_value = symbol->getOffset() + addr_adjust;
     }
 
@@ -174,11 +171,9 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
 
     if (symbol->getRegion()) {
         sym->st_shndx = (Elf_Section) symbol->getRegion()->getRegionNumber();
-    }
-    else if (symbol->isAbsolute()) {
+    } else if (symbol->isAbsolute()) {
         sym->st_shndx = SHN_ABS;
-    }
-    else {
+    } else {
         sym->st_shndx = 0;
     }
 
@@ -194,13 +189,11 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                 if (symbol->getLinkage() == Symbol::SL_GLOBAL) {
                     versionSymTable.push_back(1);
 
-                }
-                else {
+                } else {
                     versionSymTable.push_back(0);
                     rewrite_printf( "  local\n");
                 }
-            }
-            else {
+            } else {
                 if (vers->size() > 0) {
                     // new verdef entry
                     rewrite_printf( "verdef: symbol=%s  version=%s ", symbol->getMangledName().c_str(),
@@ -209,8 +202,7 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                         unsigned short index = verdefEntries[(*vers)[0]];
                         if (symbol->getVersionHidden()) index += 0x8000;
                         versionSymTable.push_back(index);
-                    }
-                    else {
+                    } else {
                         unsigned short index = curVersionNum;
                         if (symbol->getVersionHidden()) index += 0x8000;
                         versionSymTable.push_back(index);
@@ -234,8 +226,7 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                 }
                 rewrite_printf( "\n");
             }
-        }
-        else {
+        } else {
             //verneed entry
             rewrite_printf( "need: symbol=%s    filename=%s\n",
                             symbol->getMangledName().c_str(), fileName.c_str());
@@ -258,14 +249,11 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                     if (symbol->getLinkage() == Symbol::SL_GLOBAL) {
                         rewrite_printf( "  global (w/ filename)\n");
                         versionSymTable.push_back(1);
-                    }
-                    else {
-
+                    } else {
                         versionSymTable.push_back(0);
                     }
                 }
-            }
-            else {
+            } else {
                 if (vers) {
                     // There should only be one version string by this time
                     //If the version name already exists then add the same version number to the version symbol table
@@ -279,16 +267,14 @@ bool emitElf<ElfTypes>::createElfSymbol(Symbol *symbol, unsigned strIndex, vecto
                         if (verneedEntries[fileName].find((*vers)[0]) != verneedEntries[fileName].end()) {
                             rewrite_printf( "  vernum: %u\n", verneedEntries[fileName][(*vers)[0]]);
                             versionSymTable.push_back((unsigned short) verneedEntries[fileName][(*vers)[0]]);
-                        }
-                        else {
+                        } else {
                             rewrite_printf( "  new entry #%d: %s [%s]\n",
                                             curVersionNum, (*vers)[0].c_str(), fileName.c_str());
                             versionSymTable.push_back((unsigned short) curVersionNum);
                             verneedEntries[fileName][(*vers)[0]] = curVersionNum;
                             curVersionNum++;
                         }
-                    }
-                    else {
+                    } else {
                         rewrite_printf( "  new entry #%d: %s [%s]\n",
                                         curVersionNum, (*vers)[0].c_str(), fileName.c_str());
                         versionSymTable.push_back((unsigned short) curVersionNum);
@@ -588,9 +574,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
             memcpy(newdata->d_buf, foundSec->getPtrToRawData(), foundSec->getDiskSize());
             newdata->d_size = foundSec->getDiskSize();
             newshdr->sh_size = foundSec->getDiskSize();
-        }
-        else if (olddata->d_buf)     //copy the data buffer from oldElf
-        {
+        } else if (olddata->d_buf) {    //copy the data buffer from oldElf
             newdata->d_buf = allocate_buffer(olddata->d_size);
             memcpy(newdata->d_buf, olddata->d_buf, olddata->d_size);
         }
@@ -641,7 +625,6 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
             changeMapping[sectionNumber] = true;
             symTabData = newdata;
         }
-
 
         if (object->getTextAddr() != 0 &&
             object->getTextAddr() == shdr->sh_addr) {
@@ -871,8 +854,7 @@ void emitElf<ElfTypes>::fixPhdrs() {
             segments[i].p_offset = dynSegOff;
             segments[i].p_memsz = dynSegSize;
             segments[i].p_filesz = segments[i].p_memsz;
-        }
-        else if (old->p_type == PT_PHDR) {
+        } else if (old->p_type == PT_PHDR) {
             segments[i].p_vaddr = old->p_vaddr - offset_adjust + address_adjust;
             segments[i].p_offset = newEhdr->e_phoff;
             segments[i].p_paddr = segments[i].p_vaddr;
@@ -1021,7 +1003,8 @@ void emitElf<ElfTypes>::updateDynamic(unsigned tag, Elf_Addr val) {
     // This is for REL/RELA if it doesn't already exist in the original binary;
     if(dynamicSecData.find(tag) != dynamicSecData.end())
         dynamicSecData[tag][0]->d_tag = tag;
-    else return;
+    else
+        return;
     switch (dynamicSecData[tag][0]->d_tag) {
         case DT_STRSZ:
         case DT_RELSZ:
@@ -1175,12 +1158,10 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
 
         if (newSec->getDiskOffset())
             newshdr->sh_addr = newSec->getDiskOffset() + address_adjust;
-        else if (!prevshdr) {
+        else if (!prevshdr)
             newshdr->sh_addr = zstart + address_adjust;
-        }
-        else {
+        else
             newshdr->sh_addr = prevshdr->sh_addr + prevshdr->sh_size;
-        }
 
         newshdr->sh_link = SHN_UNDEF;
         newshdr->sh_info = 0;
@@ -1206,8 +1187,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
                 updateDynamic(DT_REL, newshdr->sh_addr);
             else if (newSec->getRegionType() == Region::RT_PLTREL)
                 updateDynamic(DT_JMPREL, newshdr->sh_addr);
-        }
-        else if (newSec->getRegionType() == Region::RT_RELA ||
+        } else if (newSec->getRegionType() == Region::RT_RELA ||
                  newSec->getRegionType() == Region::RT_PLTRELA) //Relocation section
         {
             newshdr->sh_type = SHT_RELA;
@@ -1220,9 +1200,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
                 updateDynamic(DT_RELA, newshdr->sh_addr);
             else if (newSec->getRegionType() == Region::RT_PLTRELA)
                 updateDynamic(DT_JMPREL, newshdr->sh_addr);
-        }
-        else if (newSec->getRegionType() == Region::RT_RELR)
-        {
+        } else if (newSec->getRegionType() == Region::RT_RELR) {
             newshdr->sh_type = SHT_RELR;
             newshdr->sh_flags = SHF_ALLOC;
             newshdr->sh_entsize = sizeof(Elf_Relr);
@@ -1234,9 +1212,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             updateDynamic(DT_RELR, newshdr->sh_addr);
             updateDynamic(DT_RELRSZ, newSec->getDiskSize());
             updateDynamic(DT_RELRENT, sizeof(Elf_Relr));
-        }
-        else if (newSec->getRegionType() == Region::RT_STRTAB)    //String table Section
-        {
+        } else if (newSec->getRegionType() == Region::RT_STRTAB) {   //String table Section
             newshdr->sh_type = SHT_STRTAB;
             newshdr->sh_entsize = 1;
             newdata->d_type = ELF_T_BYTE;
@@ -1248,8 +1224,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_addralign = 1;
             updateDynamic(DT_STRTAB, newshdr->sh_addr);
             updateDynamic(DT_STRSZ, newSec->getDiskSize());
-        }
-        else if (newSec->getRegionType() == Region::RT_SYMTAB) {
+        } else if (newSec->getRegionType() == Region::RT_SYMTAB) {
             newshdr->sh_type = SHT_DYNSYM;
             newshdr->sh_entsize = sizeof(Elf_Sym);
             newdata->d_type = ELF_T_SYM;
@@ -1259,8 +1234,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_flags = SHF_ALLOC;
             dynsymIndex = thisSectionIndex;
             updateDynamic(DT_SYMTAB, newshdr->sh_addr);
-        }
-        else if (newSec->getRegionType() == Region::RT_DYNAMIC) {
+        } else if (newSec->getRegionType() == Region::RT_DYNAMIC) {
             newshdr->sh_entsize = sizeof(Elf_Dyn);
             newshdr->sh_type = SHT_DYNAMIC;
             newdata->d_type = ELF_T_DYN;
@@ -1270,8 +1244,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             dynSegOff = newshdr->sh_offset;
             dynSegAddr = newshdr->sh_addr;
             dynSegSize = newSec->getDiskSize();
-        }
-        else if (newSec->getRegionType() == Region::RT_HASH) {
+        } else if (newSec->getRegionType() == Region::RT_HASH) {
             newshdr->sh_entsize = sizeof(Elf_Word);
             newshdr->sh_type = SHT_HASH;
             newdata->d_type = ELF_T_WORD;
@@ -1280,8 +1253,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_flags = SHF_ALLOC;
             newshdr->sh_info = 0;
             updateDynamic(DT_HASH, newshdr->sh_addr);
-        }
-        else if (newSec->getRegionType() == Region::RT_SYMVERSIONS) {
+        } else if (newSec->getRegionType() == Region::RT_SYMVERSIONS) {
             newshdr->sh_type = SHT_GNU_versym;
             newshdr->sh_entsize = sizeof(Elf_Half);
             newshdr->sh_addralign = 2;
@@ -1290,8 +1262,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             updateDynLinkShdr.push_back(newshdr);
             newshdr->sh_flags = SHF_ALLOC;
             updateDynamic(DT_VERSYM, newshdr->sh_addr);
-        }
-        else if (newSec->getRegionType() == Region::RT_SYMVERNEEDED) {
+        } else if (newSec->getRegionType() == Region::RT_SYMVERNEEDED) {
             newshdr->sh_type = SHT_GNU_verneed;
             newshdr->sh_entsize = 0;
             newshdr->sh_addralign = 4;
@@ -1301,8 +1272,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_flags = SHF_ALLOC;
             newshdr->sh_info = verneednum;
             updateDynamic(DT_VERNEED, newshdr->sh_addr);
-        }
-        else if (newSec->getRegionType() == Region::RT_SYMVERDEF) {
+        } else if (newSec->getRegionType() == Region::RT_SYMVERDEF) {
             newshdr->sh_type = SHT_GNU_verdef;
             newshdr->sh_entsize = 0;
             newdata->d_type = ELF_T_VDEF;
@@ -1439,49 +1409,40 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
         //Fill out the new section header
         newshdr = ElfTypes::elf_getshdr(newscn);
         newshdr->sh_name = addSectionName(sec->getRegionName());
-        if (sec->getRegionType() == Region::RT_TEXT)        //Text Section
-        {
+        if (sec->getRegionType() == Region::RT_TEXT)  {        //Text Section
             newshdr->sh_type = SHT_PROGBITS;
             newshdr->sh_flags = SHF_EXECINSTR | SHF_WRITE;
             newshdr->sh_entsize = 1;
             newdata->d_type = ELF_T_BYTE;
-        }
-        else if (sec->getRegionType() == Region::RT_DATA)    //Data Section
-        {
+        } else if (sec->getRegionType() == Region::RT_DATA)  { //Data Section
             newshdr->sh_type = SHT_PROGBITS;
             newshdr->sh_flags = SHF_WRITE;
             newshdr->sh_entsize = 1;
             newdata->d_type = ELF_T_BYTE;
-        }
-        else if (sec->getRegionType() == Region::RT_REL)    //Relocations section
-        {
+        } else if (sec->getRegionType() == Region::RT_REL)  {  //Relocations section
             newshdr->sh_type = SHT_REL;
             newshdr->sh_flags = SHF_WRITE;
             newshdr->sh_entsize = sizeof(Elf_Rel);
             newdata->d_type = ELF_T_BYTE;
-        }
-        else if (sec->getRegionType() == Region::RT_RELA)    //Relocations section
-        {
+        } else if (sec->getRegionType() == Region::RT_RELA) {  //Relocations section
             newshdr->sh_type = SHT_RELA;
             newshdr->sh_flags = SHF_WRITE;
             newshdr->sh_entsize = sizeof(Elf_Rela);
             newdata->d_type = ELF_T_BYTE;
-        }
-        else if (sec->getRegionType() == Region::RT_SYMTAB) {
+        } else if (sec->getRegionType() == Region::RT_SYMTAB) {
             newshdr->sh_type = SHT_SYMTAB;
             newshdr->sh_entsize = sizeof(Elf_Sym);
             newdata->d_type = ELF_T_SYM;
             newshdr->sh_link = secNames.size();   //.symtab section should have sh_link = index of .strtab
             newshdr->sh_flags = 0;
-        }
-        else if (sec->getRegionType() == Region::RT_STRTAB)    //String table Section
-        {
+        } else if (sec->getRegionType() == Region::RT_STRTAB) {  //String table Section
             newshdr->sh_type = SHT_STRTAB;
             newshdr->sh_entsize = 1;
             newdata->d_type = ELF_T_BYTE;
             newshdr->sh_link = SHN_UNDEF;
             newshdr->sh_flags = 0;
         }
+
         newshdr->sh_offset = prevshdr->sh_offset + prevshdr->sh_size;
         if (prevshdr->sh_type == SHT_NOBITS) {
             newshdr->sh_offset = prevshdr->sh_offset;
@@ -1595,7 +1556,7 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
                         "Failed to link to static library code into the binary: " +
                         emitElfStatic::printStaticLinkError(err) + " = "
                         + errMsg;
-		Symtab::setSymtabError(Emit_Error);
+                Symtab::setSymtabError(Emit_Error);
                 symtab_log_perror(linkStaticError.c_str());
                 fprintf(stderr, "##### %s\n", linkStaticError.c_str());
                 return false;
@@ -1615,7 +1576,7 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
             }
 
             if (!emitElfUtils::updateHeapVariables(obj, lastRegionAddr + lastRegionSize)) {
-		fprintf(stderr, "updateHeapVariables returns false\n");
+                fprintf(stderr, "updateHeapVariables returns false\n");
                 return false;
             }
         }
@@ -1717,8 +1678,7 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
             section->setPtrToRawData(syms, symbols.size() * sizeof(Elf_Sym));
         else
             obj->addRegion(0, syms, symbols.size() * sizeof(Elf_Sym), ".symtab", Region::RT_SYMTAB);
-    }
-    else
+    } else
         obj->addRegion(0, syms, symbols.size() * sizeof(Elf_Sym), ".symtab", Region::RT_SYMTAB);
 
     //reconstruct .strtab section
@@ -1728,8 +1688,7 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
             section->setPtrToRawData(str, symbolNamesLength);
         else
             obj->addRegion(0, str, symbolNamesLength, ".strtab", Region::RT_STRTAB);
-    }
-    else
+    } else
         obj->addRegion(0, str, symbolNamesLength, ".strtab", Region::RT_STRTAB);
 
     if (!obj->getAllNewRegions(newSecs))
@@ -1837,16 +1796,13 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
         bool has_dyn = object->hasReladyn() || object->hasReldyn();
         if (!has_plt) {
             createRelocationSections(object->getDynRelocs(), true, dynSymNameMapping);
-        }
-        else if (!has_dyn) {
+        } else if (!has_dyn) {
             createRelocationSections(object->getPLTRelocs(), false, dynSymNameMapping);
             createRelocationSections(object->getDynRelocs(), true, dynSymNameMapping);
-        }
-        else if (object->getRelPLTAddr() < object->getRelDynAddr()) {
+        } else if (object->getRelPLTAddr() < object->getRelDynAddr()) {
             createRelocationSections(object->getPLTRelocs(), false, dynSymNameMapping);
             createRelocationSections(object->getDynRelocs(), true, dynSymNameMapping);
-        }
-        else {
+        } else {
             createRelocationSections(object->getDynRelocs(), true, dynSymNameMapping);
             createRelocationSections(object->getPLTRelocs(), false, dynSymNameMapping);
         }
@@ -1953,8 +1909,7 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
                 std::unordered_map<string, unsigned long>::iterator it = dynSymNameMapping.find(sym_name);
                 if (it != dynSymNameMapping.end()) {
                     sym_offset = it->second;
-                }
-                else {
+                } else {
                     Symbol *sym = reloc.getDynSym();
                     if (sym) {
                         it = dynSymNameMapping.find(sym->getMangledName());
@@ -2325,8 +2280,7 @@ void emitElf<ElfTypes>::createHashSection(Elf_Word *&hashsecData, unsigned &hash
         key = elfHash((*iter)->getMangledName().c_str()) % nbuckets;
         if (lastHash.find(key) != lastHash.end()) {
             hashsecData[2 + nbuckets + lastHash[key]] = i;
-        }
-        else {
+        } else {
             hashsecData[2 + key] = i;
         }
         lastHash[key] = i;
@@ -2360,8 +2314,6 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
         Elf_Off adjust = 0;
         switch(name)
         {
-
-
             case DT_INIT:
             case DT_FINI:
             case DT_DYNINST:
@@ -2480,7 +2432,7 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
 
     if (!object->hasReldyn() && !object->hasReladyn()) {
         if (object->getRelType() == Region::RT_REL) {
- 	    new_dynamic_entries.push_back(pair<long,long>(DT_REL, 0));
+            new_dynamic_entries.push_back(pair<long,long>(DT_REL, 0));
             new_dynamic_entries.push_back(pair<long,long>(DT_RELSZ, 0));
 
             dynamicSecData[DT_REL].push_back(dynsecData + curpos);
@@ -2495,9 +2447,7 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
             dynsecData[curpos].d_tag = DT_NULL;
             dynsecData[curpos].d_un.d_val = 0;
             curpos++;
-
         } else if (object->getRelType() == Region::RT_RELA) {
-
             dynamicSecData[DT_RELA].push_back(dynsecData + curpos);
             dynsecData[curpos].d_tag = DT_NULL;
             dynsecData[curpos].d_un.d_val = 0;
@@ -2510,10 +2460,8 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
             dynsecData[curpos].d_tag = DT_NULL;
             dynsecData[curpos].d_un.d_val = 0;
             curpos++;
-
         }
     }
-
 
     dynsecData[curpos].d_tag = DT_NULL;
     dynsecData[curpos].d_un.d_val = 0;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -432,7 +432,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
     Elf_Shdr *newshdr = NULL, *shdr = NULL;
     std::unordered_map<unsigned, unsigned> secLinkMapping;
     std::unordered_map<unsigned, unsigned> secInfoMapping;
-    std::unordered_map<unsigned, unsigned> changeMapping;
+    std::unordered_map<unsigned, bool> changeMapping;
     std::unordered_map<string, unsigned> newNameIndexMapping;
 
     std::unordered_set<string> updateLinkInfoSecs = {
@@ -459,7 +459,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
             continue;
 
         sectionNumber++;
-        changeMapping[sectionNumber] = 0;
+        changeMapping[sectionNumber] = false;
         newNameIndexMapping[name] = sectionNumber;
 
         newscn = elf_newscn(newElf);
@@ -522,7 +522,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
             if ((m[0] == shdr->sh_addr) ||
                 (m[0] <= shdr->sh_addr && shdr->sh_addr < m[1])) {
                 newshdr->sh_type = SHT_PROGBITS;
-                changeMapping[sectionNumber] = 1;
+                changeMapping[sectionNumber] = true;
                 renameSection(name);
             }
         }
@@ -539,7 +539,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
              object->getSymtabAddr() == shdr->sh_addr) ||
             !strcmp(name, SYMTAB_NAME)) {
             newshdr->sh_link = secNames.size();
-            changeMapping[sectionNumber] = 1;
+            changeMapping[sectionNumber] = true;
             symTabData = newdata;
         }
 
@@ -556,7 +556,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
             dynSegAddr = newshdr->sh_addr;
             // Change the data to update the relocation addr
             newshdr->sh_type = SHT_PROGBITS;
-            changeMapping[sectionNumber] = 1;
+            changeMapping[sectionNumber] = true;
             renameSection(name);
         }
 
@@ -638,7 +638,7 @@ bool emitElf<ElfTypes>::driver(std::string fName) {
 
         rewrite_printf("section %s addr = %lx off = %lx size = %lx\n",
                        name, (long unsigned int)newshdr->sh_addr, (long unsigned int)newshdr->sh_offset, (long unsigned int)newshdr->sh_size);
-        rewrite_printf(" %02u Link(%u) Info(%u) change(%u)\n",
+        rewrite_printf(" %02u Link(%u) Info(%u) change(%d)\n",
                 sectionNumber, secLinkMapping[sectionNumber], secInfoMapping[sectionNumber],
                 changeMapping[sectionNumber]);
 

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -564,6 +564,23 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         if (r && r->isDirty() && r->getDiskSize() != sh->sh_size)
             dirtyDeltas.emplace_back(sh->sh_offset, long(r->getDiskSize()) - long(sh->sh_size));
     }
+    // Shifted sections stay aligned if every shift is a multiple of the
+    // strictest alignment among them (offset_adjust is a page multiple already).
+    Elf_Off firstShifted = insertPointOffset;
+    for (const auto &d : dirtyDeltas)
+        firstShifted = std::min<Elf_Off>(firstShifted, d.first);
+    Elf_Off tailAlign = 1;
+    for (unsigned i = 1; i < oldNumSections; ++i) {
+        auto s = elf_getscn(oldElf, i);
+        auto sh = s ? ElfTypes::elf_getshdr(s) : nullptr;
+        if (sh && sh->sh_type != SHT_NOBITS && sh->sh_offset >= firstShifted && sh->sh_addralign > tailAlign)
+            tailAlign = sh->sh_addralign;
+    }
+    auto alignUp = [](Elf_Off v, Elf_Off a) { return a > 1 ? (v + a - 1) / a * a : v; };
+    for (auto &d : dirtyDeltas)     // a shrink rounds toward zero so nothing overlaps
+        d.second = d.second >= 0 ? long(alignUp(d.second, tailAlign))
+                                 : -long(Elf_Off(-d.second) / tailAlign * tailAlign);
+    Elf_Off insertShift{};          // aligned file space taken by the new loadable sections
     // copied before the new loadable sections are created, but placed after
     // them in the file; shifted once their total size is known
     std::vector<Elf_Shdr *> shiftAfterInsert;
@@ -746,7 +763,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
             // make room for the new loadable sections inserted at insertPointOffset
             if (scncount != lastLoadedSectionIndex && shdr->sh_offset >= insertPointOffset) {
                 if (createdLoadableSections)
-                    newshdr->sh_offset += loadSecTotalSize + extraAlignSize;
+                    newshdr->sh_offset += insertShift;
                 else
                     shiftAfterInsert.push_back(newshdr);
             }
@@ -779,9 +796,11 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
                        sectionNumber))
                 return false;
 
+            insertShift = alignUp(loadSecTotalSize + extraAlignSize, tailAlign);
+
             // earlier-indexed sections that live past the insert point in the file
             for (auto *late : shiftAfterInsert) {
-                late->sh_offset += loadSecTotalSize + extraAlignSize;
+                late->sh_offset += insertShift;
                 if (late->sh_type != SHT_NOBITS && currEndOffset < late->sh_offset + late->sh_size)
                     currEndOffset = late->sh_offset + late->sh_size;
             }
@@ -1225,9 +1244,22 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
         else
             newshdr->sh_addr = prevshdr->sh_addr + prevshdr->sh_size;
 
+        // A section with no address of its own directly follows the previous
+        // one; pad address and offset alike up to its alignment, which keeps
+        // the sh_addr == sh_offset (mod page) relation established below.
+        Elf_Word align = std::max<Elf_Word>(newSec->getMemAlignment(), newSectionAlignment(newSec));
+        if (!newSec->getDiskOffset() && align > 1) {
+            Offset pad = (align - newshdr->sh_addr % align) % align;
+            newshdr->sh_addr += pad;
+            if (prevshdr && newshdr->sh_type != SHT_NOBITS) {
+                newshdr->sh_offset += pad;
+                loadSecTotalSize += pad;
+            }
+        }
+
         newshdr->sh_link = SHN_UNDEF;
         newshdr->sh_info = 0;
-        newshdr->sh_addralign = newSec->getMemAlignment();
+        newshdr->sh_addralign = align;
         newshdr->sh_entsize = 0;
 
         // TLS section
@@ -1330,7 +1362,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_entsize = 0;
             newshdr->sh_addralign = 4;
             newdata->d_type = ELF_T_VNEED;
-            newdata->d_align = 8;
+            newdata->d_align = 4;
             updateStrLinkShdr.push_back(newshdr);
             newshdr->sh_flags = SHF_ALLOC;
             newshdr->sh_info = verneednum;
@@ -1339,7 +1371,7 @@ bool emitElf<ElfTypes>::createLoadableSections(Elf_Shdr *&shdr, unsigned &extraA
             newshdr->sh_type = SHT_GNU_verdef;
             newshdr->sh_entsize = 0;
             newdata->d_type = ELF_T_VDEF;
-            newdata->d_align = 8;
+            newdata->d_align = 4;
             updateStrLinkShdr.push_back(newshdr);
             newshdr->sh_flags = SHF_ALLOC;
             newshdr->sh_info = verdefnum;
@@ -1434,7 +1466,7 @@ bool emitElf<ElfTypes>::addSectionHeaderTable(Elf_Shdr *shdr) {
         newshdr->sh_offset = currEndOffset;
     newshdr->sh_addr = 0;
     newshdr->sh_info = 0;
-    newshdr->sh_addralign = 4;
+    newshdr->sh_addralign = 1;      // a string table has no alignment requirement
 
     //Set up the data
     newdata->d_buf = allocate_buffer(secNameTableTotalBytes);
@@ -1448,7 +1480,7 @@ bool emitElf<ElfTypes>::addSectionHeaderTable(Elf_Shdr *shdr) {
     newdata->d_size = secNameTableTotalBytes;
     newshdr->sh_size = newdata->d_size;
 
-    newdata->d_align = 4;
+    newdata->d_align = 1;
     newdata->d_version = 1;
     return true;
 }
@@ -1519,9 +1551,11 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
         if (newshdr->sh_offset < currEndOffset) {
             newshdr->sh_offset = currEndOffset;
         }
+        newshdr->sh_addralign = std::max<Elf_Word>(4, newSectionAlignment(sec));
+        if (auto rem = newshdr->sh_offset % newshdr->sh_addralign)
+            newshdr->sh_offset += newshdr->sh_addralign - rem;
         newshdr->sh_addr = 0;
         newshdr->sh_info = 0;
-        newshdr->sh_addralign = 4;
 
         //Set up the data
         newdata->d_buf = sec->getPtrToRawData();
@@ -2616,6 +2650,31 @@ void emitElf<ElfTypes>::remapSymtabRefs(const Elf_Shdr *shdr, Elf_Shdr *newshdr,
     }
     default:
         break;
+    }
+}
+
+// natural alignment of a section this emitter generates, from its entry type
+template<class ElfTypes>
+auto emitElf<ElfTypes>::newSectionAlignment(const Region *sec) -> Elf_Word {
+    switch (sec->getRegionType()) {
+    case Region::RT_REL:
+    case Region::RT_PLTREL:
+    case Region::RT_RELA:
+    case Region::RT_PLTRELA:
+    case Region::RT_SYMTAB:
+    case Region::RT_DYNAMIC:
+        return sizeof(Elf_Addr);
+    case Region::RT_RELR:
+        return sizeof(Elf_Relr);
+    case Region::RT_HASH:
+        return sizeof(Elf_Word);
+    case Region::RT_SYMVERSIONS:
+        return sizeof(Elf_Half);
+    case Region::RT_SYMVERNEEDED:
+    case Region::RT_SYMVERDEF:
+        return 4;               // Elf_Verneed/Elf_Verdef hold only 32-bit fields
+    default:
+        return 1;
     }
 }
 

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -490,7 +490,6 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
 
     addSectionName("");  // section 0 is always ST_NULL with an empty name
     loadSecTotalSize = 0;
-    int dirtySecsChange = 0;
     unsigned extraAlignSize = 0;
 
     // Write the Elf header first!
@@ -501,7 +500,6 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     }
     *newEhdr = *oldEhdr;
 
-    unsigned insertPoint = oldNumSections + 1;  // section index of inserted sections
     Elf_Off insertPointOffset{};                // file offset of inserted sections
 
     newEhdr->e_phoff = sizeof(Elf_Ehdr);
@@ -527,21 +525,65 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
 
     auto moveSecAddrRange = object->getMoveSecAddrRange();
 
+    // Region of an old section: by (addr, size), falling back to the name when
+    // that is ambiguous or the match is dirty
+    auto regionForSection = [&](Elf_Shdr *sh) -> Region * {
+        Region *r{};
+        if (!obj->findRegion(r, sh->sh_addr, sh->sh_size) || r->isDirty())
+            obj->findRegion(r, getSectionName(sh));
+        return r;
+    };
+
+    /* File layout is decided by offset, not by section index: the .rela.*
+     * sections of an --emit-relocs link have low indices but sit at the end
+     * of the file, after .symtab and .strtab.  So determine up front where the
+     * new loadable sections are inserted and how much each regenerated (dirty)
+     * section grows, and shift every copied section by exactly the changes
+     * that precede it in the file.
+     */
+    {
+        auto lastScn = elf_getscn(oldElf, lastLoadedSectionIndex);
+        auto lastShdr = lastScn ? ElfTypes::elf_getshdr(lastScn) : nullptr;
+        if (!lastShdr) {
+            log_elferror(err_func_, "cannot read the last loaded section header");
+            return false;
+        }
+        insertPointOffset = lastShdr->sh_offset;
+        if (lastShdr->sh_type != SHT_NOBITS)
+            insertPointOffset += lastShdr->sh_size;
+    }
+    std::vector<std::pair<Elf_Off, long>> dirtyDeltas;   // (old file offset, size change)
+    for (unsigned i = 1; i < oldNumSections; ++i) {
+        if (i == oldShstrndx)
+            continue;                                   // moved to the end, leaves a gap
+        auto s = elf_getscn(oldElf, i);
+        auto sh = s ? ElfTypes::elf_getshdr(s) : nullptr;
+        if (!sh || sh->sh_type == SHT_NOBITS || !sh->sh_offset)
+            continue;                                   // occupies no file space
+        Region *r = regionForSection(sh);
+        if (r && r->isDirty() && r->getDiskSize() != sh->sh_size)
+            dirtyDeltas.emplace_back(sh->sh_offset, long(r->getDiskSize()) - long(sh->sh_size));
+    }
+    // copied before the new loadable sections are created, but placed after
+    // them in the file; shifted once their total size is known
+    std::vector<Elf_Shdr *> shiftAfterInsert;
+
     for (unsigned scncount = 1; (scn = elf_nextscn(oldElf, scn)); scncount++) {
         //copy sections from oldElf to newElf
         shdr = ElfTypes::elf_getshdr(scn);
 
         // resolve section name
         const char *name = getSectionName(shdr);
-        bool result = obj->findRegion(foundSec, shdr->sh_addr, shdr->sh_size);
-        if (!result || foundSec->isDirty()) {
-            result = obj->findRegion(foundSec, name);
-        }
+        foundSec = regionForSection(shdr);
 
         // write the shstrtabsection at the end
         if (scncount == oldShstrndx) {
             shstrtabRegion = foundSec;
             continue;
+        }
+        if (!foundSec) {
+            log_elferror(err_func_, (std::string{"no region for section "} + (name ? name : "")).c_str());
+            return false;
         }
 
         sectionNumber++;
@@ -700,16 +742,22 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
                 newshdr->sh_offset += offset_adjust;
         }
 
-        // shift section offsets after the insertPoint that come after the insertPoint's offset
-        if (scncount > insertPoint && shdr->sh_offset >= insertPointOffset)
-            newshdr->sh_offset += loadSecTotalSize + extraAlignSize;
+        if (newshdr->sh_offset > 0) {
+            // make room for the new loadable sections inserted at insertPointOffset
+            if (scncount != lastLoadedSectionIndex && shdr->sh_offset >= insertPointOffset) {
+                if (createdLoadableSections)
+                    newshdr->sh_offset += loadSecTotalSize + extraAlignSize;
+                else
+                    shiftAfterInsert.push_back(newshdr);
+            }
+            // and for every regenerated section that grew or shrank ahead of this one
+            for (const auto &d : dirtyDeltas)
+                if (d.first < shdr->sh_offset)
+                    newshdr->sh_offset += d.second;
+        }
+        if (newshdr->sh_type != SHT_NOBITS && currEndOffset < newshdr->sh_offset + newshdr->sh_size)
+            currEndOffset = newshdr->sh_offset + newshdr->sh_size;
 
-        if (newshdr->sh_offset > 0)
-            newshdr->sh_offset += dirtySecsChange;
-
-        if (foundSec->isDirty())
-            dirtySecsChange += newshdr->sh_size - shdr->sh_size;
-        
         secLinkMapping[sectionNumber] = shdr->sh_link;
         secInfoMapping[sectionNumber] = shdr->sh_info;
 
@@ -726,15 +774,17 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         //loadable segment
         if (scncount == lastLoadedSectionIndex && !createdLoadableSections) {
             createdLoadableSections = true;
-            insertPoint = scncount;
-            insertPointOffset = shdr->sh_offset;
-            if (shdr->sh_type != SHT_NOBITS)
-                insertPointOffset += shdr->sh_size;
-
 
             if (!createLoadableSections(newshdr, extraAlignSize, newNameIndexMapping,
                        sectionNumber))
                 return false;
+
+            // earlier-indexed sections that live past the insert point in the file
+            for (auto *late : shiftAfterInsert) {
+                late->sh_offset += loadSecTotalSize + extraAlignSize;
+                if (late->sh_type != SHT_NOBITS && currEndOffset < late->sh_offset + late->sh_size)
+                    currEndOffset = late->sh_offset + late->sh_size;
+            }
 
             // Update the heap symbols, now that loadSecTotalSize is set
             updateSymbols(dynsymData, dynStrData, loadSecTotalSize);
@@ -1378,7 +1428,10 @@ bool emitElf<ElfTypes>::addSectionHeaderTable(Elf_Shdr *shdr) {
     newshdr->sh_link = SHN_UNDEF;
     newshdr->sh_flags = 0;
 
+    // after the last section by index, and after the last one by file offset
     newshdr->sh_offset = shdr->sh_offset + shdr->sh_size;
+    if (newshdr->sh_offset < currEndOffset)
+        newshdr->sh_offset = currEndOffset;
     newshdr->sh_addr = 0;
     newshdr->sh_info = 0;
     newshdr->sh_addralign = 4;

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -560,6 +560,13 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         auto sh = s ? ElfTypes::elf_getshdr(s) : nullptr;
         if (!sh || sh->sh_type == SHT_NOBITS || !sh->sh_offset)
             continue;                                   // occupies no file space
+        if (sh->sh_type == SHT_SYMTAB_SHNDX && sh->sh_link == oldSymtabIndex) {
+            // resized to the regenerated .symtab by remapSymtabRefs
+            long delta = long(symtabOrder.size() * sizeof(Elf32_Word)) - long(sh->sh_size);
+            if (delta)
+                dirtyDeltas.emplace_back(sh->sh_offset, delta);
+            continue;
+        }
         Region *r = regionForSection(sh);
         if (r && r->isDirty() && r->getDiskSize() != sh->sh_size)
             dirtyDeltas.emplace_back(sh->sh_offset, long(r->getDiskSize()) - long(sh->sh_size));
@@ -857,6 +864,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     // Second iteration to fix the link fields to point to the correct section
     scn = NULL;
     unsigned scncount;
+    unsigned newSymtabIndex{};
     for (scncount = 1; (scn = elf_nextscn(newElf, scn)); scncount++) {
         shdr = ElfTypes::elf_getshdr(scn);
 
@@ -870,8 +878,9 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         }
 
         if (shdr->sh_type == SHT_SYMTAB) {
+            newSymtabIndex = scncount;
             shdr->sh_link = symtabStrIndex;     // .symtab -> .strtab, wherever it ended up
-            if (updateSymbolSectionIndices(scn, symtabSymRegions))
+            if (updateSymbolSectionIndices(scn, symtabSymRegions, symtabShndxData))
                 shdr->sh_info = symtabNumLocals;    // index of first non-local symbol
         } else if (shdr->sh_type == SHT_DYNSYM) {
             updateSymbolSectionIndices(scn, dynsymSymRegions);
@@ -886,6 +895,14 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
             shdr->sh_info = (shdr->sh_type == SHT_REL || shdr->sh_type == SHT_RELA)
                             ? remapIndex(data.second) : data.second;
         }
+    }
+
+    // a .symtab_shndx created above still has to be linked to .symtab
+    scn = NULL;
+    while ((scn = elf_nextscn(newElf, scn))) {
+        shdr = ElfTypes::elf_getshdr(scn);
+        if (shdr->sh_type == SHT_SYMTAB_SHNDX && shdr->sh_link == SHN_UNDEF)
+            shdr->sh_link = newSymtabIndex;
     }
 
     // libelf does not handle the extended for e_shstrndx, so manually do it here
@@ -1608,6 +1625,47 @@ bool emitElf<ElfTypes>::createNonLoadableSections(Elf_Shdr *&shdr) {
 
         prevshdr = newshdr;
     }
+    // A symbol in a section indexed SHN_LORESERVE or higher needs SHN_XINDEX
+    // and a .symtab_shndx entry.  Make sure the table exists when the file is
+    // that large; the fixup pass fills it along with st_shndx.
+    if (!symtabShndxData && !symtabSymRegions.empty() && secNames.size() + 1 >= SHN_LORESERVE) {
+        if ((newscn = elf_newscn(newElf)) == NULL) {
+            log_elferror(err_func_, "unable to create .symtab_shndx");
+            return false;
+        }
+        if ((newdata = elf_newdata(newscn)) == NULL) {
+            log_elferror(err_func_, "unable to create .symtab_shndx data");
+            return false;
+        }
+        newshdr = ElfTypes::elf_getshdr(newscn);
+        newshdr->sh_name = addSectionName(".symtab_shndx");
+        newshdr->sh_type = SHT_SYMTAB_SHNDX;
+        newshdr->sh_flags = 0;
+        newshdr->sh_addr = 0;
+        newshdr->sh_link = SHN_UNDEF;       // -> .symtab, set in the fixup pass
+        newshdr->sh_info = 0;
+        newshdr->sh_entsize = sizeof(Elf32_Word);
+        newshdr->sh_addralign = sizeof(Elf32_Word);
+        newshdr->sh_offset = prevshdr->sh_type == SHT_NOBITS ? prevshdr->sh_offset
+                                                             : prevshdr->sh_offset + prevshdr->sh_size;
+        if (newshdr->sh_offset < currEndOffset)
+            newshdr->sh_offset = currEndOffset;
+        if (auto rem = newshdr->sh_offset % newshdr->sh_addralign)
+            newshdr->sh_offset += newshdr->sh_addralign - rem;
+
+        newdata->d_size = symtabSymRegions.size() * sizeof(Elf32_Word);
+        newdata->d_buf = allocate_buffer(newdata->d_size);
+        memset(newdata->d_buf, 0, newdata->d_size);
+        newdata->d_type = ELF_T_WORD;
+        newdata->d_align = sizeof(Elf32_Word);
+        newdata->d_off = 0;
+        newdata->d_version = 1;
+        newshdr->sh_size = newdata->d_size;
+        currEndOffset = newshdr->sh_offset + newshdr->sh_size;
+        symtabShndxData = newdata;
+        prevshdr = newshdr;
+    }
+
     shdr = prevshdr;
     return true;
 }
@@ -2597,7 +2655,8 @@ void emitElf<ElfTypes>::createDynamicSection(void *dynData_, unsigned size, Elf_
 // section symbols the section's new address.  Returns false if the table is
 // not one this emitter generated (left untouched).
 template<class ElfTypes>
-bool emitElf<ElfTypes>::updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions) {
+bool emitElf<ElfTypes>::updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions,
+                                                     Elf_Data *shndxData) {
     Elf_Data *data = elf_getdata(scn, NULL);
     if (!data || !data->d_buf)
         return false;
@@ -2626,7 +2685,22 @@ bool emitElf<ElfTypes>::updateSymbolSectionIndices(Elf_Scn *scn, const std::vect
         auto it = regionNewIndex.find(region);
         if (it == regionNewIndex.end())
             continue;
-        syms[k].st_shndx = it->second;
+        unsigned newIndex = it->second;
+        Elf32_Word *shndx = shndxData && shndxData->d_size >= (k + 1) * sizeof(Elf32_Word)
+                            ? static_cast<Elf32_Word *>(shndxData->d_buf) : nullptr;
+        if (newIndex >= SHN_LORESERVE) {
+            // does not fit st_shndx: SHN_XINDEX there, the index in the parallel table
+            syms[k].st_shndx = SHN_XINDEX;
+            if (shndx)
+                shndx[k] = newIndex;
+            else
+                rewrite_printf("symbol %zu is in section %u but its table has no SHT_SYMTAB_SHNDX\n",
+                               k, newIndex);
+        } else {
+            syms[k].st_shndx = newIndex;
+            if (shndx)
+                shndx[k] = 0;
+        }
         if (isSectionSym || region == newDynamicRegion) {
             if (Elf_Scn *target = elf_getscn(newElf, it->second))
                 if (Elf_Shdr *targetShdr = ElfTypes::elf_getshdr(target))
@@ -2674,17 +2748,13 @@ void emitElf<ElfTypes>::remapSymtabRefs(const Elf_Shdr *shdr, Elf_Shdr *newshdr,
         newshdr->sh_info = newIndex(shdr->sh_info);     // the group signature symbol
         break;
     case SHT_SYMTAB_SHNDX: {
-        // parallel to .symtab: permute it the same way; new symbols get SHN_UNDEF
-        auto *old = static_cast<const Elf32_Word *>(newdata->d_buf);
-        size_t oldCount = newdata->d_size / sizeof(Elf32_Word);
-        std::vector<Elf32_Word> shndx(symtabOrder.size(), SHN_UNDEF);
-        for (size_t k = 0; k < symtabOrder.size(); ++k)
-            if (symtabOrder[k] < oldCount)
-                shndx[k] = old[symtabOrder[k]];
-        newdata->d_size = shndx.size() * sizeof(Elf32_Word);
+        // parallel to .symtab, so resize it to the regenerated table; the
+        // entries are old section indices and are rewritten in the fixup pass
+        newdata->d_size = symtabOrder.size() * sizeof(Elf32_Word);
         newshdr->sh_size = newdata->d_size;
         newdata->d_buf = allocate_buffer(newdata->d_size);
-        memcpy(newdata->d_buf, shndx.data(), newdata->d_size);
+        memset(newdata->d_buf, 0, newdata->d_size);
+        symtabShndxData = newdata;
         break;
     }
     default:

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -585,6 +585,18 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     // them in the file; shifted once their total size is known
     std::vector<Elf_Shdr *> shiftAfterInsert;
 
+    // Inserting and moving sections renumbers everything after them; headers
+    // copied from the old file still name sections by their old index.
+    std::vector<unsigned> oldToNewIndex(oldNumSections, 0);
+    std::vector<unsigned> newToOldIndex(1, 0);
+    auto remapIndex = [&](unsigned old) -> unsigned {
+        if (old == SHN_UNDEF || old >= oldNumSections)
+            return old;                     // SHN_XINDEX and friends pass through
+        if (!oldToNewIndex[old])
+            rewrite_printf("old section %u has no counterpart in the new file\n", old);
+        return oldToNewIndex[old] ? oldToNewIndex[old] : old;
+    };
+
     for (unsigned scncount = 1; (scn = elf_nextscn(oldElf, scn)); scncount++) {
         //copy sections from oldElf to newElf
         shdr = ElfTypes::elf_getshdr(scn);
@@ -608,6 +620,10 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         newNameIndexMapping[name] = sectionNumber;
         if (foundSec)
             regionNewIndex[foundSec] = sectionNumber;
+        oldToNewIndex[scncount] = sectionNumber;
+        if (newToOldIndex.size() <= sectionNumber)
+            newToOldIndex.resize(sectionNumber + 1, 0);
+        newToOldIndex[sectionNumber] = scncount;
 
         newscn = elf_newscn(newElf);
         newshdr = ElfTypes::elf_getshdr(newscn);
@@ -665,7 +681,11 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         for (const auto &m : moveSecAddrRange) {
             if ((m[0] == shdr->sh_addr) ||
                 (m[0] <= shdr->sh_addr && shdr->sh_addr < m[1])) {
+                // superseded by a regenerated section; keep the bytes, drop the meaning
                 newshdr->sh_type = SHT_PROGBITS;
+                newshdr->sh_link = SHN_UNDEF;
+                newshdr->sh_info = 0;
+                newshdr->sh_flags &= ~SHF_INFO_LINK;
                 changeMapping[sectionNumber] = true;
                 renameSection(name);
             }
@@ -699,6 +719,8 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
             dynSegAddr = newshdr->sh_addr;
             // Change the data to update the relocation addr
             newshdr->sh_type = SHT_PROGBITS;
+            newshdr->sh_link = SHN_UNDEF;
+            newshdr->sh_info = 0;
             changeMapping[sectionNumber] = true;
             renameSection(name);
         }
@@ -715,6 +737,9 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
             renameSection(name);
             // The old sections are no longer REL or RELA, change to PROGBITS
             newshdr->sh_type = SHT_PROGBITS;
+            newshdr->sh_link = SHN_UNDEF;
+            newshdr->sh_info = 0;
+            newshdr->sh_flags &= ~SHF_INFO_LINK;
 
         }
 
@@ -827,12 +852,23 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
     addSectionHeaderTable(newshdr);
     if (shstrtabRegion)
         regionNewIndex[shstrtabRegion] = secNames.size() - 1;   // .shstrtab is the last section
+    oldToNewIndex[oldShstrndx] = secNames.size() - 1;
 
     // Second iteration to fix the link fields to point to the correct section
     scn = NULL;
     unsigned scncount;
     for (scncount = 1; (scn = elf_nextscn(newElf, scn)); scncount++) {
         shdr = ElfTypes::elf_getshdr(scn);
+
+        // a copied header still names its sh_link section, and for a relocation
+        // section the sh_info target, by old index
+        if (scncount < newToOldIndex.size() && newToOldIndex[scncount]) {
+            shdr->sh_link = remapIndex(shdr->sh_link);
+            if ((shdr->sh_flags & SHF_INFO_LINK) ||
+                shdr->sh_type == SHT_REL || shdr->sh_type == SHT_RELA)
+                shdr->sh_info = remapIndex(shdr->sh_info);
+        }
+
         if (shdr->sh_type == SHT_SYMTAB) {
             shdr->sh_link = symtabStrIndex;     // .symtab -> .strtab, wherever it ended up
             if (updateSymbolSectionIndices(scn, symtabSymRegions))
@@ -842,10 +878,13 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         }
         if(dataLinkInfo.count(secNames[scncount]))
         {
+            // a regenerated section inherits the sh_info of the one it replaces:
+            // a section index for relocation sections, a count otherwise
             rewrite_printf("update link info of %s\n", secNames[scncount].c_str());
             auto & data = dataLinkInfo[secNames[scncount]];
             //shdr->sh_link = data.first;
-            shdr->sh_info = data.second;
+            shdr->sh_info = (shdr->sh_type == SHT_REL || shdr->sh_type == SHT_RELA)
+                            ? remapIndex(data.second) : data.second;
         }
     }
 

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -1879,7 +1879,7 @@ void emitElf<ElfTypes>::createRelocationSections(std::vector<relocationEntry> &r
                 return STN_UNDEF;
             it = dynSymNameMapping.find(sym->getMangledName());
             if (it == dynSymNameMapping.end())
-                return sym->getIndex() > 0 ? sym->getIndex() : STN_UNDEF;
+                return STN_UNDEF;
         }
         return it->second;
     };

--- a/symtabAPI/src/emitElf.C
+++ b/symtabAPI/src/emitElf.C
@@ -344,6 +344,8 @@ bool emitElf<ElfTypes>::getSectionAndSegmentInfo() {
             continue;                   // .shstrtab shstrndx section always moved, ignore
         auto scn{elf_getscn(oldElf, i)};
         auto shdr{ElfTypes::elf_getshdr(scn)};
+        if (shdr && shdr->sh_type == SHT_SYMTAB)
+            oldSymtabIndex = i;
         if (!shdr || !(shdr->sh_flags & SHF_ALLOC))
             continue;                   // not allocated, so no address
         if (maxSectionAlignment < shdr->sh_addralign)
@@ -576,6 +578,7 @@ bool emitElf<ElfTypes>::driver(std::string fName, std::set<Symbol *> &allSymbols
         } else if (olddata->d_buf) {    //copy the data buffer from oldElf
             newdata->d_buf = allocate_buffer(olddata->d_size);
             memcpy(newdata->d_buf, olddata->d_buf, olddata->d_size);
+            remapSymtabRefs(shdr, newshdr, newdata);
         }
 
         if (newshdr->sh_entsize && (newshdr->sh_size % newshdr->sh_entsize != 0)) {
@@ -1639,8 +1642,10 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
             max_index = s->getIndex();
     }
 
+    std::unordered_set<Symbol *> newSymSymbols;
     for (const auto &s : allSymSymbols) {
         if (s->getIndex() == -1) {
+            newSymSymbols.insert(s);
             max_index++;
             s->setIndex(max_index);
         }
@@ -1678,18 +1683,29 @@ bool emitElf<ElfTypes>::createSymbolTables(set<Symbol *> &allSymbols) {
     // ELF requires all STB_LOCAL symbols to precede the others, with sh_info
     // holding the index of the first non-local.  New symbols were appended
     // after the originals regardless of binding, so partition them here.
-    std::vector<size_t> order(symbols.size());
-    std::iota(order.begin(), order.end(), 0);
-    auto firstNonLocal = std::stable_partition(order.begin(), order.end(),
+    symtabOrder.assign(symbols.size(), 0);
+    std::iota(symtabOrder.begin(), symtabOrder.end(), 0);
+    auto firstNonLocal = std::stable_partition(symtabOrder.begin(), symtabOrder.end(),
         [&](size_t k) { return ELF64_ST_BIND(symbols[k]->st_info) == STB_LOCAL; });
-    symtabNumLocals = firstNonLocal - order.begin();
+    symtabNumLocals = firstNonLocal - symtabOrder.begin();
+
+    // Sections that index into .symtab (.rela.* from --emit-relocs, SHT_GROUP,
+    // .symtab_shndx) are copied verbatim by the driver, which uses this map to
+    // follow the renumbering.  getIndex() is still the old st index here.
+    // symbols[0] is the null entry, not in allSymSymbols; it stays at index 0.
+    symtabIndexMap.clear();
+    for (size_t k = 1; k < symtabOrder.size(); ++k) {
+        Symbol *s = allSymSymbols[symtabOrder[k] - 1];
+        if (!newSymSymbols.count(s))
+            symtabIndexMap[s->getIndex()] = k;
+    }
 
     Elf_Sym *syms = (Elf_Sym *) malloc(symbols.size() * sizeof(Elf_Sym));
     std::vector<Region *> orderedRegions;
-    orderedRegions.reserve(order.size());
-    for (size_t k = 0; k < order.size(); ++k) {
-        syms[k] = *symbols[order[k]];
-        orderedRegions.push_back(symtabSymRegions[order[k]]);
+    orderedRegions.reserve(symtabOrder.size());
+    for (size_t k = 0; k < symtabOrder.size(); ++k) {
+        syms[k] = *symbols[symtabOrder[k]];
+        orderedRegions.push_back(symtabSymRegions[symtabOrder[k]]);
     }
     symtabSymRegions = std::move(orderedRegions);
 
@@ -2492,6 +2508,62 @@ bool emitElf<ElfTypes>::updateSymbolSectionIndices(Elf_Scn *scn, const std::vect
         }
     }
     return true;
+}
+
+// A copied section that indexes into the old .symtab must follow the
+// renumbering done when locals were partitioned to the front of the new one.
+template<class ElfTypes>
+void emitElf<ElfTypes>::remapSymtabRefs(const Elf_Shdr *shdr, Elf_Shdr *newshdr, Elf_Data *newdata) {
+    if (!oldSymtabIndex || shdr->sh_link != oldSymtabIndex || !newdata->d_buf)
+        return;
+
+    auto newIndex = [&](unsigned old) -> unsigned {
+        if (old == STN_UNDEF)
+            return STN_UNDEF;
+        auto it = symtabIndexMap.find(old);
+        if (it == symtabIndexMap.end()) {
+            rewrite_printf("symbol %u referenced by %s is no longer in .symtab\n",
+                           old, getSectionName(shdr));
+            return STN_UNDEF;
+        }
+        return it->second;
+    };
+
+    switch (shdr->sh_type) {
+    case SHT_REL: {
+        auto *rels = static_cast<Elf_Rel *>(newdata->d_buf);
+        for (size_t k = 0; k < newdata->d_size / sizeof(Elf_Rel); ++k)
+            rels[k].r_info = ElfTypes::makeRelocInfo(newIndex(ElfTypes::relocSym(rels[k].r_info)),
+                                                     ElfTypes::relocType(rels[k].r_info));
+        break;
+    }
+    case SHT_RELA: {
+        auto *relas = static_cast<Elf_Rela *>(newdata->d_buf);
+        for (size_t k = 0; k < newdata->d_size / sizeof(Elf_Rela); ++k)
+            relas[k].r_info = ElfTypes::makeRelocInfo(newIndex(ElfTypes::relocSym(relas[k].r_info)),
+                                                      ElfTypes::relocType(relas[k].r_info));
+        break;
+    }
+    case SHT_GROUP:
+        newshdr->sh_info = newIndex(shdr->sh_info);     // the group signature symbol
+        break;
+    case SHT_SYMTAB_SHNDX: {
+        // parallel to .symtab: permute it the same way; new symbols get SHN_UNDEF
+        auto *old = static_cast<const Elf32_Word *>(newdata->d_buf);
+        size_t oldCount = newdata->d_size / sizeof(Elf32_Word);
+        std::vector<Elf32_Word> shndx(symtabOrder.size(), SHN_UNDEF);
+        for (size_t k = 0; k < symtabOrder.size(); ++k)
+            if (symtabOrder[k] < oldCount)
+                shndx[k] = old[symtabOrder[k]];
+        newdata->d_size = shndx.size() * sizeof(Elf32_Word);
+        newshdr->sh_size = newdata->d_size;
+        newdata->d_buf = allocate_buffer(newdata->d_size);
+        memcpy(newdata->d_buf, shndx.data(), newdata->d_size);
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 template<class ElfTypes>

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -45,11 +45,6 @@
 #include <unordered_set>
 #include <vector>
 
-using std::cerr;
-using std::cout;
-using std::endl;
-using std::vector;
-
 extern const char *STRTAB_NAME;
 extern const char *SYMTAB_NAME;
 extern const char *INTERP_NAME;
@@ -228,7 +223,7 @@ namespace Dyninst {
             unsigned dynSegSize{};
 
             //Section Names for all sections
-            vector<std::string> secNames;
+            std::vector<std::string> secNames;
             unsigned secNameIndex{};
             Offset currEndOffset{};
             Address currEndAddress{};
@@ -247,7 +242,7 @@ namespace Dyninst {
 
             void (*err_func_)(const char*);
 
-            bool createElfSymbol(Symbol *symbol, unsigned strIndex, vector<Elf_Sym *> &symbols,
+            bool createElfSymbol(Symbol *symbol, unsigned strIndex, std::vector<Elf_Sym *> &symbols,
                                  bool dynSymFlag = false);
             // Find the start address of the last section that falls within the
             // last loadable (PT_LOAD) segment. This is where new loadable

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -257,17 +257,20 @@ namespace Dyninst {
             unsigned loadSecTotalSize{};
 
             bool isStripped{};
+
+            const char *sectionNameTable{};
+            const char *getSectionName(Elf_Shdr *shdr)
+                        {return sectionNameTable ? &sectionNameTable[shdr->sh_name] : nullptr;}
             int library_adjust{};
+            unsigned lastLoadedSectionIndex{};  // last section contained in last LOAD segment
+            Elf_Word maxSegmentAlignment{};
             ObjectELF *object;
 
             void (*err_func_)(const char*);
 
             bool createElfSymbol(Symbol *symbol, unsigned strIndex, std::vector<Elf_Sym *> &symbols,
                                  bool dynSymFlag = false);
-            // Find the start address of the last section that falls within the
-            // last loadable (PT_LOAD) segment. This is where new loadable
-            // sections are appended. Also sets TLSExists as a side effect.
-            Elf_Off findLastLoadableSec();
+            void getSectionAndSegmentInfo();
             void renameSection(const std::string &oldName);
             void fixPhdrs();
 

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -175,30 +175,30 @@ namespace Dyninst {
             bool driver(std::string fName);
 
         private:
-            Elf_X *oldElfHandle;
-            Elf *newElf;
-            Elf *oldElf;
-            Symtab *obj;
+            Elf_X *oldElfHandle{};
+            Elf *newElf{};
+            Elf *oldElf{};
+            Symtab *obj{};
             //New Section & Program Headers
-            Elf_Ehdr *newEhdr;
-            Elf_Ehdr *oldEhdr;
+            Elf_Ehdr *newEhdr{};
+            Elf_Ehdr *oldEhdr{};
 
-            Elf_Phdr *newPhdr;
-            Elf_Phdr *oldPhdr;
-            Offset phdr_offset;
+            Elf_Phdr *newPhdr{};
+            Elf_Phdr *oldPhdr{};
+            Offset phdr_offset{};
 
             //important data sections in the
             //new Elf that need updated
-            Elf_Data *textData;
-            Elf_Data *symStrData;
-            Elf_Data *dynStrData;
-            char *olddynStrData;
-            unsigned olddynStrSize;
-            Elf_Data *symTabData;
-            Elf_Data *dynsymData;
-            Elf_Data *dynData;
+            Elf_Data *textData{};
+            Elf_Data *symStrData{};
+            Elf_Data *dynStrData{};
+            char *olddynStrData{};
+            unsigned olddynStrSize{};
+            Elf_Data *symTabData{};
+            Elf_Data *dynsymData{};
+            Elf_Data *dynData{};
 
-            Elf_Scn *phdrs_scn;
+            Elf_Scn *phdrs_scn{};
 
             std::vector<Region *>nonLoadableSecs;
             std::vector<Region *> newSecs;
@@ -213,31 +213,36 @@ namespace Dyninst {
             std::map<unsigned, std::vector<std::string> > verdauxEntries;
             std::map<std::string, unsigned> versionNames;
             std::vector<Elf_Half> versionSymTable;
-            int curVersionNum, verneednum, verdefnum{};
+            int curVersionNum{2};
+            int verneednum{};
+            int verdefnum{};
 
             // Needed when adding a new segment
-            Elf_Off newSegmentStart;
-            Elf_Shdr *firstNewLoadSec;// initialize to NULL
+            Elf_Off newSegmentStart{};
+            Elf_Shdr *firstNewLoadSec{};
 
-            Elf_Off dynSegOff, dynSegAddr, phdrSegOff, phdrSegAddr;
-            unsigned dynSegSize;
+            Elf_Off dynSegOff{};
+            Elf_Off dynSegAddr{};
+            Elf_Off phdrSegOff{};
+            Elf_Off phdrSegAddr{};
+            unsigned dynSegSize{};
 
             //Section Names for all sections
             vector<std::string> secNames;
-            unsigned secNameIndex;
-            Offset currEndOffset;
-            Address currEndAddress;
+            unsigned secNameIndex{};
+            Offset currEndOffset{};
+            Address currEndAddress{};
 
             // Pointer to all relocatable code and data allocated during a static link,
             // to be deleted after written out
-            char *linkedStaticData;
+            char *linkedStaticData{};
 
             //flags
             // Expand NOBITS sections within the object file to their size
-            unsigned loadSecTotalSize;
+            unsigned loadSecTotalSize{};
 
-            bool isStripped;
-            int library_adjust;
+            bool isStripped{};
+            int library_adjust{};
             ObjectELF *object;
 
             void (*err_func_)(const char*);
@@ -265,9 +270,9 @@ namespace Dyninst {
 
             void updateSymbols(Elf_Data* symtabData,Elf_Data* strData, unsigned long loadSecsSize);
 
-            bool hasRewrittenTLS;
-            bool TLSExists;
-            Elf_Shdr *newTLSData;
+            bool hasRewrittenTLS{};
+            bool TLSExists{};
+            Elf_Shdr *newTLSData{};
 
             void updateDynamic(unsigned tag, Elf_Addr val);
 
@@ -285,7 +290,7 @@ namespace Dyninst {
 
             void log_elferror(void (*err_func)(const char *), const char* msg);
 
-            bool isStaticBinary;
+            bool isStaticBinary{};
             std::vector<void*> buffers;
             char* allocate_buffer(size_t);
 

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -258,7 +258,7 @@ namespace Dyninst {
             // last loadable (PT_LOAD) segment. This is where new loadable
             // sections are appended. Also sets TLSExists as a side effect.
             Elf_Off findLastLoadableSec();
-            void renameSection(const std::string &oldStr, const std::string &newStr, bool renameAll=true);
+            void renameSection(const std::string &oldName);
             void fixPhdrs();
 
             bool addSectionHeaderTable(Elf_Shdr *shdr);

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -45,6 +45,16 @@
 #include <unordered_set>
 #include <vector>
 
+#ifndef STT_GNU_IFUNC
+#define STT_GNU_IFUNC 10
+#endif
+#ifndef STB_GNU_UNIQUE
+#define STB_GNU_UNIQUE 10
+#endif
+#ifndef PT_GNU_PROPERTY
+#define PT_GNU_PROPERTY 0x6474e553
+#endif
+
 extern const char *STRTAB_NAME;
 extern const char *SYMTAB_NAME;
 extern const char *INTERP_NAME;

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -234,7 +234,17 @@ namespace Dyninst {
 
             //Section Names for all sections
             std::vector<std::string> secNames;
-            unsigned secNameIndex{};
+            unsigned secNameTableTotalBytes{};
+
+            // add name to secNames, update total bytes including null
+            // returns old total bytes (the offset of just added name)
+            unsigned addSectionName(std::string name)  {
+                auto oldOffset{secNameTableTotalBytes};
+                secNameTableTotalBytes += name.size() + 1;
+                secNames.push_back(std::move(name));
+                return oldOffset;
+            }
+
             Offset currEndOffset{};
             Address currEndAddress{};
 

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -80,23 +80,23 @@ namespace Dyninst {
         };
 
         struct ElfTypes32 {
-            typedef Elf32_Ehdr Elf_Ehdr;
-            typedef Elf32_Phdr Elf_Phdr;
-            typedef Elf32_Shdr Elf_Shdr;
-            typedef Elf32_Dyn Elf_Dyn;
-            typedef Elf32_Half Elf_Half;
-            typedef Elf32_Addr Elf_Addr;
-            typedef Elf32_Off Elf_Off;
-            typedef Elf32_Word Elf_Word;
-            typedef Elf32_Sym Elf_Sym;
-            typedef Elf32_Section Elf_Section;
-            typedef Elf32_Rel Elf_Rel;
-            typedef Elf32_Rela Elf_Rela;
-            typedef Elf32_Word Elf_Relr;
-            typedef Elf32_Verneed Elf_Verneed;
-            typedef Elf32_Vernaux Elf_Vernaux;
-            typedef Elf32_Verdef Elf_Verdef;
-            typedef Elf32_Verdaux Elf_Verdaux;
+            using Elf_Ehdr = Elf32_Ehdr;
+            using Elf_Phdr = Elf32_Phdr;
+            using Elf_Shdr = Elf32_Shdr;
+            using Elf_Dyn = Elf32_Dyn;
+            using Elf_Half = Elf32_Half;
+            using Elf_Addr = Elf32_Addr;
+            using Elf_Off = Elf32_Off;
+            using Elf_Word = Elf32_Word;
+            using Elf_Sym = Elf32_Sym;
+            using Elf_Section = Elf32_Section;
+            using Elf_Rel = Elf32_Rel;
+            using Elf_Rela = Elf32_Rela;
+            using Elf_Relr = Elf32_Word;
+            using Elf_Verneed = Elf32_Verneed;
+            using Elf_Vernaux = Elf32_Vernaux;
+            using Elf_Verdef = Elf32_Verdef;
+            using Elf_Verdaux = Elf32_Verdaux;
 
             Elf_Ehdr *elf_newehdr(Elf *elf) { return elf32_newehdr(elf); }
 
@@ -112,23 +112,23 @@ namespace Dyninst {
         };
 
         struct ElfTypes64 {
-            typedef Elf64_Ehdr Elf_Ehdr;
-            typedef Elf64_Phdr Elf_Phdr;
-            typedef Elf64_Shdr Elf_Shdr;
-            typedef Elf64_Dyn Elf_Dyn;
-            typedef Elf64_Half Elf_Half;
-            typedef Elf64_Addr Elf_Addr;
-            typedef Elf64_Off Elf_Off;
-            typedef Elf64_Word Elf_Word;
-            typedef Elf64_Sym Elf_Sym;
-            typedef Elf64_Section Elf_Section;
-            typedef Elf64_Rel Elf_Rel;
-            typedef Elf64_Rela Elf_Rela;
-            typedef Elf64_Xword Elf_Relr;
-            typedef Elf64_Verneed Elf_Verneed;
-            typedef Elf64_Vernaux Elf_Vernaux;
-            typedef Elf64_Verdef Elf_Verdef;
-            typedef Elf64_Verdaux Elf_Verdaux;
+            using Elf_Ehdr = Elf64_Ehdr;
+            using Elf_Phdr = Elf64_Phdr;
+            using Elf_Shdr = Elf64_Shdr;
+            using Elf_Dyn = Elf64_Dyn;
+            using Elf_Half = Elf64_Half;
+            using Elf_Addr = Elf64_Addr;
+            using Elf_Off = Elf64_Off;
+            using Elf_Word = Elf64_Word;
+            using Elf_Sym = Elf64_Sym;
+            using Elf_Section = Elf64_Section;
+            using Elf_Rel = Elf64_Rel;
+            using Elf_Rela = Elf64_Rela;
+            using Elf_Relr = Elf64_Xword;
+            using Elf_Verneed = Elf64_Verneed;
+            using Elf_Vernaux = Elf64_Vernaux;
+            using Elf_Verdef = Elf64_Verdef;
+            using Elf_Verdaux = Elf64_Verdaux;
 
             Elf_Ehdr *elf_newehdr(Elf *elf) { return elf64_newehdr(elf); }
 
@@ -147,23 +147,23 @@ namespace Dyninst {
         public:
             emitElf(Elf_X *pX, bool i, ObjectELF *pObject, void (*pFunction)(const char *), Symtab *pSymtab);
 
-            typedef typename ElfTypes::Elf_Ehdr Elf_Ehdr;
-            typedef typename ElfTypes::Elf_Phdr Elf_Phdr;
-            typedef typename ElfTypes::Elf_Shdr Elf_Shdr;
-            typedef typename ElfTypes::Elf_Dyn Elf_Dyn;
-            typedef typename ElfTypes::Elf_Half Elf_Half;
-            typedef typename ElfTypes::Elf_Addr Elf_Addr;
-            typedef typename ElfTypes::Elf_Off Elf_Off;
-            typedef typename ElfTypes::Elf_Word Elf_Word;
-            typedef typename ElfTypes::Elf_Sym Elf_Sym;
-            typedef typename ElfTypes::Elf_Section Elf_Section;
-            typedef typename ElfTypes::Elf_Rel Elf_Rel;
-            typedef typename ElfTypes::Elf_Rela Elf_Rela;
-            typedef typename ElfTypes::Elf_Relr Elf_Relr;
-            typedef typename ElfTypes::Elf_Verneed Elf_Verneed;
-            typedef typename ElfTypes::Elf_Vernaux Elf_Vernaux;
-            typedef typename ElfTypes::Elf_Verdef Elf_Verdef;
-            typedef typename ElfTypes::Elf_Verdaux Elf_Verdaux;
+            using typename ElfTypes::Elf_Ehdr;
+            using typename ElfTypes::Elf_Phdr;
+            using typename ElfTypes::Elf_Shdr;
+            using typename ElfTypes::Elf_Dyn;
+            using typename ElfTypes::Elf_Half;
+            using typename ElfTypes::Elf_Addr;
+            using typename ElfTypes::Elf_Off;
+            using typename ElfTypes::Elf_Word;
+            using typename ElfTypes::Elf_Sym;
+            using typename ElfTypes::Elf_Section;
+            using typename ElfTypes::Elf_Rel;
+            using typename ElfTypes::Elf_Rela;
+            using typename ElfTypes::Elf_Relr;
+            using typename ElfTypes::Elf_Verneed;
+            using typename ElfTypes::Elf_Vernaux;
+            using typename ElfTypes::Elf_Verdef;
+            using typename ElfTypes::Elf_Verdaux;
 
             ~emitElf() {
                 if( linkedStaticData ) delete[] linkedStaticData;

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -262,9 +262,13 @@ namespace Dyninst {
             const char *sectionNameTable{};
             const char *getSectionName(Elf_Shdr *shdr)
                         {return sectionNameTable ? &sectionNameTable[shdr->sh_name] : nullptr;}
-            int library_adjust{};
+            Elf_Off  address_adjust{}; // amount every address from old image moves
+            Elf_Off offset_adjust{};   // amount every file offset from old image moves
             unsigned lastLoadedSectionIndex{};  // last section contained in last LOAD segment
-            Elf_Word maxSegmentAlignment{};
+            Elf_Off maxSegmentAlignment{};
+            Elf_Off maxSectionAlignment{};
+            unsigned offset0LoadSegmentIndex{};   // index of first LOAD segment
+            bool foundOffset0LoadSegment() const { return offset0LoadSegmentIndex < oldNumSegments; }
             ObjectELF *object;
 
             void (*err_func_)(const char*);

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -294,7 +294,7 @@ namespace Dyninst {
             bool createElfSymbol(Symbol *symbol, unsigned strIndex, std::vector<Elf_Sym *> &symbols,
                                  bool dynSymFlag = false);
             bool getSectionAndSegmentInfo();
-            void updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions);
+            bool updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions);
             void renameSection(const std::string &oldName);
             void fixPhdrs();
 

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -208,6 +208,13 @@ namespace Dyninst {
             unsigned symtabStrIndex{};
             // number of STB_LOCAL symbols at the start of the new .symtab (its sh_info)
             unsigned symtabNumLocals{};
+            // Region each emitted .symtab / .dynsym entry refers to (nullptr if none),
+            // parallel to the emitted symbol arrays; used to fix st_shndx once the
+            // new file's section indices are known
+            std::vector<Region *> symtabSymRegions;
+            std::vector<Region *> dynsymSymRegions;
+            // Region -> its section index in the new file
+            std::unordered_map<Region *, unsigned> regionNewIndex;
 
             std::vector<Region *>nonLoadableSecs;
             std::vector<Region *> newSecs;
@@ -283,6 +290,7 @@ namespace Dyninst {
             bool createElfSymbol(Symbol *symbol, unsigned strIndex, std::vector<Elf_Sym *> &symbols,
                                  bool dynSymFlag = false);
             bool getSectionAndSegmentInfo();
+            void updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions);
             void renameSection(const std::string &oldName);
             void fixPhdrs();
 

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -206,6 +206,8 @@ namespace Dyninst {
             // index in the new file of the string table used by .symtab;
             // SHN_UNDEF (0) until the section is seen or created
             unsigned symtabStrIndex{};
+            // number of STB_LOCAL symbols at the start of the new .symtab (its sh_info)
+            unsigned symtabNumLocals{};
 
             std::vector<Region *>nonLoadableSecs;
             std::vector<Region *> newSecs;

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -256,6 +256,9 @@ namespace Dyninst {
 
             bool isStripped{};
 
+            unsigned oldNumSections{};
+            unsigned oldShstrndx{};
+            unsigned oldNumSegments{};
             const char *sectionNameTable{};
             const char *getSectionName(Elf_Shdr *shdr)
                         {return sectionNameTable ? &sectionNameTable[shdr->sh_name] : nullptr;}
@@ -269,7 +272,7 @@ namespace Dyninst {
             bool createSymbolTables(std::set<Symbol *> &allSymbols);
             bool createElfSymbol(Symbol *symbol, unsigned strIndex, std::vector<Elf_Sym *> &symbols,
                                  bool dynSymFlag = false);
-            void getSectionAndSegmentInfo();
+            bool getSectionAndSegmentInfo();
             void renameSection(const std::string &oldName);
             void fixPhdrs();
 

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -203,6 +203,10 @@ namespace Dyninst {
 
             Elf_Scn *phdrs_scn{};
 
+            // index in the new file of the string table used by .symtab;
+            // SHN_UNDEF (0) until the section is seen or created
+            unsigned symtabStrIndex{};
+
             std::vector<Region *>nonLoadableSecs;
             std::vector<Region *> newSecs;
             std::map<unsigned, std::vector<Elf_Dyn *> > dynamicSecData;

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -215,6 +215,10 @@ namespace Dyninst {
             std::vector<Region *> dynsymSymRegions;
             // Region -> its section index in the new file
             std::unordered_map<Region *, unsigned> regionNewIndex;
+            // when .dynamic is regenerated, symbols in the original (_DYNAMIC)
+            // are retargeted to the new one
+            Region *oldDynamicRegion{};
+            Region *newDynamicRegion{};
 
             std::vector<Region *>nonLoadableSecs;
             std::vector<Region *> newSecs;

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -175,9 +175,7 @@ namespace Dyninst {
                 for(auto *b : buffers) free(b);
             }
 
-            bool createSymbolTables(std::set<Symbol *> &allSymbols);
-
-            bool driver(std::string fName);
+            bool driver(std::string fName, std::set<Symbol *> &allSymbols);
 
         private:
             Elf_X *oldElfHandle{};
@@ -268,6 +266,7 @@ namespace Dyninst {
 
             void (*err_func_)(const char*);
 
+            bool createSymbolTables(std::set<Symbol *> &allSymbols);
             bool createElfSymbol(Symbol *symbol, unsigned strIndex, std::vector<Elf_Sym *> &symbols,
                                  bool dynSymFlag = false);
             void getSectionAndSegmentInfo();

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -307,6 +307,7 @@ namespace Dyninst {
             bool getSectionAndSegmentInfo();
             bool updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions);
             void remapSymtabRefs(const Elf_Shdr *shdr, Elf_Shdr *newshdr, Elf_Data *newdata);
+            static Elf_Word newSectionAlignment(const Region *sec);
             void renameSection(const std::string &oldName);
             void fixPhdrs();
 

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -114,6 +114,8 @@ namespace Dyninst {
             Elf_Shdr *elf_getshdr(Elf_Scn *scn) { return elf32_getshdr(scn); }
 
             Elf32_Word makeRelocInfo(Elf32_Word sym, Elf32_Word type) { return ELF32_R_INFO(sym, type); }
+            static Elf32_Word relocSym(Elf32_Word info)  { return ELF32_R_SYM(info); }
+            static Elf32_Word relocType(Elf32_Word info) { return ELF32_R_TYPE(info); }
         };
 
         struct ElfTypes64 {
@@ -146,6 +148,8 @@ namespace Dyninst {
             Elf_Shdr *elf_getshdr(Elf_Scn *scn) { return elf64_getshdr(scn); }
 
             Elf64_Xword makeRelocInfo(Elf64_Word sym, Elf64_Word type) { return ELF64_R_INFO(sym, type); }
+            static Elf64_Word relocSym(Elf64_Xword info)  { return ELF64_R_SYM(info); }
+            static Elf64_Word relocType(Elf64_Xword info) { return ELF64_R_TYPE(info); }
         };
 
         template<class ElfTypes = ElfTypes64> class emitElf : public ElfTypes {
@@ -208,6 +212,13 @@ namespace Dyninst {
             unsigned symtabStrIndex{};
             // number of STB_LOCAL symbols at the start of the new .symtab (its sh_info)
             unsigned symtabNumLocals{};
+            // section index of .symtab in the old file, 0 if none
+            unsigned oldSymtabIndex{};
+            // old .symtab index -> index in the regenerated .symtab, for every
+            // original symbol that survived
+            std::unordered_map<unsigned, unsigned> symtabIndexMap;
+            // new .symtab position -> position before the local-first partition
+            std::vector<size_t> symtabOrder;
             // Region each emitted .symtab / .dynsym entry refers to (nullptr if none),
             // parallel to the emitted symbol arrays; used to fix st_shndx once the
             // new file's section indices are known
@@ -277,7 +288,7 @@ namespace Dyninst {
             unsigned oldShstrndx{};
             unsigned oldNumSegments{};
             const char *sectionNameTable{};
-            const char *getSectionName(Elf_Shdr *shdr)
+            const char *getSectionName(const Elf_Shdr *shdr)
                         {return sectionNameTable ? &sectionNameTable[shdr->sh_name] : nullptr;}
             Elf_Off  address_adjust{}; // amount every address from old image moves
             Elf_Off offset_adjust{};   // amount every file offset from old image moves
@@ -295,6 +306,7 @@ namespace Dyninst {
                                  bool dynSymFlag = false);
             bool getSectionAndSegmentInfo();
             bool updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions);
+            void remapSymtabRefs(const Elf_Shdr *shdr, Elf_Shdr *newshdr, Elf_Data *newdata);
             void renameSection(const std::string &oldName);
             void fixPhdrs();
 

--- a/symtabAPI/src/emitElf.h
+++ b/symtabAPI/src/emitElf.h
@@ -202,6 +202,7 @@ namespace Dyninst {
             char *olddynStrData{};
             unsigned olddynStrSize{};
             Elf_Data *symTabData{};
+            Elf_Data *symtabShndxData{};   // .symtab_shndx of the new file, if it has one
             Elf_Data *dynsymData{};
             Elf_Data *dynData{};
 
@@ -305,7 +306,8 @@ namespace Dyninst {
             bool createElfSymbol(Symbol *symbol, unsigned strIndex, std::vector<Elf_Sym *> &symbols,
                                  bool dynSymFlag = false);
             bool getSectionAndSegmentInfo();
-            bool updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions);
+            bool updateSymbolSectionIndices(Elf_Scn *scn, const std::vector<Region *> &symRegions,
+                                            Elf_Data *shndxData = nullptr);
             void remapSymtabRefs(const Elf_Shdr *shdr, Elf_Shdr *newshdr, Elf_Data *newdata);
             static Elf_Word newSectionAlignment(const Region *sec);
             void renameSection(const std::string &oldName);

--- a/symtabAPI/src/emitElfStatic-aarch64.C
+++ b/symtabAPI/src/emitElfStatic-aarch64.C
@@ -168,7 +168,7 @@ bool emitElfStatic::updateTOC(Symtab *, LinkMap &, Offset){
 
 
 inline
-static bool adjustValInRegion(Region *reg, Offset offInReg, Offset addressWidth, int adjust) {
+static bool adjustValInRegion(Region *reg, Offset offInReg, Offset addressWidth, Offset adjust) {
     Offset newValue;
     unsigned char *oldValues;
 
@@ -178,7 +178,7 @@ static bool adjustValInRegion(Region *reg, Offset offInReg, Offset addressWidth,
     return reg->patchData(offInReg, &newValue, addressWidth);
 }
 
-bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int library_adjust) {
+bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, Offset address_adjust) {
     // Currently, only verified on x86 and x86_64 -- this may work on other architectures
     Region *targetRegion = obj->findEnclosingRegion(rel.rel_addr());
     if( NULL == targetRegion ) {
@@ -190,13 +190,13 @@ bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int libra
     /*switch( rel.getCategory( obj->getAddressWidth() ))
     {
         case relocationEntry::relative:
-            rel.setAddend(rel.addend() + library_adjust);
+            rel.setAddend(rel.addend() + address_adjust);
             break;
 
         case relocationEntry::jump_slot:
             if( !adjustValInRegion(targetRegion,
                         rel.rel_addr() - targetRegion->getDiskOffset(),
-                        addressWidth, library_adjust) )
+                        addressWidth, address_adjust) )
             {
                 rewrite_printf("Failed to update relocation\n");
                 return false;
@@ -216,12 +216,12 @@ bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int libra
         switch(rel.getRelType()) {
             case R_AARCH64_RELATIVE:
             case R_AARCH64_IRELATIVE:
-                rel.setAddend(rel.addend() + library_adjust);
+                rel.setAddend(rel.addend() + address_adjust);
                 break;
             case R_AARCH64_JUMP_SLOT:
                 if( !adjustValInRegion(targetRegion,
                            rel.rel_addr() - targetRegion->getDiskOffset(),
-                           addressWidth, library_adjust) )
+                           addressWidth, address_adjust) )
                 {
                     rewrite_printf("Failed to update relocation\n");
                     return false;
@@ -251,7 +251,7 @@ bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int libra
     // section before outputting the patched GOT data -- this will require some refactoring.
 
     //rewrite_printf("WARNING: updateRelocation is not implemented on this architecture\n");
-    //(void) obj; (void) rel; (void) library_adjust; //silence warnings
+    //(void) obj; (void) rel; (void) address_adjust; //silence warnings
 
     return true;
 }

--- a/symtabAPI/src/emitElfStatic-ppc64.C
+++ b/symtabAPI/src/emitElfStatic-ppc64.C
@@ -1181,7 +1181,7 @@ void emitElfStatic::createStub(unsigned *stub, Offset stubOffset, Offset newTOC,
   
 }
 
-bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int library_adjust) {
+bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, Offset address_adjust) {
     // Currently, only verified on x86 and x86_64 -- this may work on other architectures
     Region *targetRegion = obj->findEnclosingRegion(rel.rel_addr());
     if( NULL == targetRegion ) {
@@ -1196,7 +1196,7 @@ bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int libra
         switch(rel.getRelType()) {
             case R_PPC64_IRELATIVE:
             case R_PPC64_RELATIVE:
-                rel.setAddend(rel.addend() + library_adjust);
+                rel.setAddend(rel.addend() + address_adjust);
                 break;
             default:
                 break;

--- a/symtabAPI/src/emitElfStatic-riscv64.C
+++ b/symtabAPI/src/emitElfStatic-riscv64.C
@@ -176,7 +176,7 @@ bool emitElfStatic::updateTOC(Symtab *, LinkMap &, Offset){
 }
 
 inline
-static bool adjustValInRegion(Region *reg, Offset offInReg, Offset addressWidth, int adjust) {
+static bool adjustValInRegion(Region *reg, Offset offInReg, Offset addressWidth, Offset adjust) {
     Offset newValue;
     unsigned char *oldValues;
 
@@ -186,7 +186,7 @@ static bool adjustValInRegion(Region *reg, Offset offInReg, Offset addressWidth,
     return reg->patchData(offInReg, &newValue, addressWidth);
 }
 
-bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int library_adjust) {
+bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, Offset address_adjust) {
     Region *targetRegion = obj->findEnclosingRegion(rel.rel_addr());
     if (targetRegion == NULL) {
         rewrite_printf("Failed to find enclosing Region for relocation");
@@ -196,11 +196,11 @@ bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int libra
     switch (rel.getRelType()) {
         case R_RISCV_RELATIVE:
         case R_RISCV_IRELATIVE:
-            rel.setAddend(rel.addend() + library_adjust);
+            rel.setAddend(rel.addend() + address_adjust);
             break;
         case R_RISCV_JUMP_SLOT:
             if (!adjustValInRegion(targetRegion, rel.rel_addr() - targetRegion->getDiskOffset(),
-                        addressWidth, library_adjust))
+                        addressWidth, address_adjust))
             {
                 rewrite_printf("Failed to update relocation\n");
                 return false;

--- a/symtabAPI/src/emitElfStatic-stub.C
+++ b/symtabAPI/src/emitElfStatic-stub.C
@@ -153,7 +153,7 @@ bool emitElfStatic::updateTOC(Symtab *, LinkMap &, Offset ) {
     assert(!EMIT_STATIC_ASSERT);
     return false;
 }
-bool emitElfUtils::updateRelocation(Symtab *, relocationEntry &, int) {
+bool emitElfUtils::updateRelocation(Symtab *, relocationEntry &, Offset) {
     assert(!EMIT_STATIC_ASSERT);
     return false;
 }

--- a/symtabAPI/src/emitElfStatic-x86.C
+++ b/symtabAPI/src/emitElfStatic-x86.C
@@ -655,7 +655,7 @@ Offset emitElfStatic::allocStubRegions(LinkMap &lmap, Offset) {
 }
 
 inline
-static bool adjustValInRegion(Region *reg, Offset offInReg, Offset addressWidth, int adjust) {
+static bool adjustValInRegion(Region *reg, Offset offInReg, Offset addressWidth, Offset adjust) {
     Offset newValue;
     unsigned char *oldValues;
 
@@ -665,7 +665,7 @@ static bool adjustValInRegion(Region *reg, Offset offInReg, Offset addressWidth,
     return reg->patchData(offInReg, &newValue, addressWidth);
 }
 
-bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int library_adjust) {
+bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, Offset address_adjust) {
     // Currently, only verified on x86 and x86_64 -- this may work on other architectures
     Region *targetRegion = obj->findEnclosingRegion(rel.rel_addr());
     if( NULL == targetRegion ) {
@@ -678,12 +678,12 @@ bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int libra
         switch(rel.getRelType()) {
             case R_X86_64_IRELATIVE:
             case R_X86_64_RELATIVE:
-                rel.setAddend(rel.addend() + library_adjust);
+                rel.setAddend(rel.addend() + address_adjust);
                 break;
             case R_X86_64_JUMP_SLOT:
                 if( !adjustValInRegion(targetRegion,
                            rel.rel_addr() - targetRegion->getDiskOffset(),
-                           addressWidth, library_adjust) )
+                           addressWidth, address_adjust) )
                 {
                     rewrite_printf("Failed to update relocation\n");
                     return false;
@@ -701,7 +701,7 @@ bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int libra
                 // On x86, addends are stored in their target location
                 if( !adjustValInRegion(targetRegion,
                            rel.rel_addr() - targetRegion->getDiskOffset(),
-                           addressWidth, library_adjust) )
+                           addressWidth, address_adjust) )
                 {
                     rewrite_printf("Failed to update relocation\n");
                     return false;
@@ -710,7 +710,7 @@ bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int libra
             case R_386_JMP_SLOT:
                 if( !adjustValInRegion(targetRegion,
                            rel.rel_addr() - targetRegion->getDiskOffset(),
-                           addressWidth, library_adjust) )
+                           addressWidth, address_adjust) )
                 {
                     rewrite_printf("Failed to update relocation\n");
                     return false;
@@ -738,7 +738,7 @@ bool emitElfUtils::updateRelocation(Symtab *obj, relocationEntry &rel, int libra
     // section before outputting the patched GOT data -- this will require some refactoring.
 
     //rewrite_printf("WARNING: updateRelocation is not implemented on this architecture\n");
-    //(void) obj; (void) rel; (void) library_adjust; //silence warnings
+    //(void) obj; (void) rel; (void) address_adjust; //silence warnings
 
     return true;
 }

--- a/symtabAPI/src/emitElfStatic.h
+++ b/symtabAPI/src/emitElfStatic.h
@@ -82,7 +82,7 @@ class emitElfUtils {
         Symtab *obj, vector<Region*> & sections);
     static bool sort_reg(const Region*a, const Region*b);
     static bool updateHeapVariables(Symtab *obj, unsigned long loadSecsSize);
-    static bool updateRelocation(Symtab *obj, relocationEntry &rel, int library_adjust);
+    static bool updateRelocation(Symtab *obj, relocationEntry &rel, Offset address_adjust);
 };
 
 class emitElfStatic {


### PR DESCRIPTION
This is a large set of fixes that cleans up the emitElf functionality and it also fixes several bugs in the code.  There are many commits that modernize the code, cleans it up so it is easier to understand, and refactors many aspects to remove redundancy.  It also fixes several bugs the produce incorrect ELF objects.  The number of warnings reported by readelf is reduced to an expected couple.  Some of these are not issues with ELF produced by current tool chains, but are with specially crafted binaries or if the tool chain changes.  The bugs fixed include:

- rewritten binaries respect alignment requirement of the original ELF's sections and segments instead of forcing to various fixed alignment values that could violate original alignment constraints
- the .tbss is no longer chosen as the point to insert after as it appears to contribute to the address space, but it does not
- setting the linkage for the symbol table to the string table based on the actual section number instead of assuming it was the next section; although generally correct, it is not required
- adjusted RELR relocations in all cases
- fixed the RELR generation code to use the correct type for 32-bit ELF files so the RELR section contained valid data
- set the permissions of the resulting ELF to the values of the original file
- support ELF files with extended ELF header values that are stored in the NULL section's data
- clear no longer valid sh_link and sh_info fields of old rewritten sections
- correctly handle ELF files that need a .symtab_shndx section
- in the case of failure, no longer leak a file descriptor, and the memory managed by libelf
- updated the _DYNAMIC point to be correct so other tools that depend on can work
- sort symbol so that SHT_LOCAL symbol types come before others to meet ELF's requirement
- fixed garbage symbol index of -1 for unindexed symbols instead of STN_UNDEF
- fixed st_shndx and section-symbol values for sections after newly inserted sections
- section renames now replace the 2nd character of the name with '#', the previous value of 'o' would fail if a future tool chain produced a section name with a 'o' as the 2nd character
- detect additional errors and return the failure instead of producing invalid ELF files, and in the case of failure the remove the partially written ELF file 

Fixes #1764