### PR TITLE
GitHubCI: make OpenSSF scorecard workflow dispatchable

### DIFF
--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -7,6 +7,8 @@ on:
   schedule:
     # Weekly on Saturdays at 1:30AM local time
     - cron:  '30 1 * * 6'
+  workflow_dispatch:
+
 
 jobs:
   analysis:


### PR DESCRIPTION
This was inadvertently removed by #2372.