### PR TITLE
parseAPI: guard NULL callee when handling call work elements

### DIFF
--- a/parseAPI/src/Parser.C
+++ b/parseAPI/src/Parser.C
@@ -1495,6 +1495,15 @@ Parser::parse_frame_one_iteration(ParseFrame &frame, bool recursive) {
             } else {
                 ct = _parse_data->findFunc(frame.codereg, work->target());
             }
+            if (!ct) {
+                // The target is not code in this frame's region and no
+                // function exists there: e.g. a bogus cross-region target
+                // in a binary with overlapping regions. Skip the work
+                // element rather than dereference a NULL function.
+                parsing_printf("[%s] call target %lx has no function in frame's region; skipping work element\n",
+                        FILE__, work->target());
+                continue;
+            }
             bool frame_not_created = (frame_status(ct->region(),ct->addr())==ParseFrame::BAD_LOOKUP);
             parsing_printf("\tframe %lx, not created %d\n", ct->addr(), frame_not_created);
 


### PR DESCRIPTION
Parser::parse_frame_one_iteration dereferences the Function looked up for a call work element before its existing NULL check (the CALL_BLOCKED path below tests 'ct' only after frame_status(ct->...) has already run). When the call target is not code in the frame's region and no function exists there -- e.g. a bogus cross-region target in a binary with overlapping regions (an unlinked object file, where every section is based at 0) -- both createAndRecordFunc and findFunc return NULL and the parser crashes.

Concretely: rewriting a statically linked binary loads every member of libc.a, and parsing loadmsgcat.o crashed here intermittently (~60% of runs; whether it fires depends on the pointer-ordered ambiguous region lookup in SymtabCodeSource::lookup_region, i.e. on ASLR and allocation order). Skip the work element instead of dereferencing NULL.

The next PR (#2352) removes the root cause (placeholder control-flow targets derived from unrelocated displacements); this guard remains the backstop for any other source of unresolvable cross-region targets, e.g. relocations whose symbol cannot be resolved and which are therefore not attached to the code region.